### PR TITLE
linux: desktop entry file

### DIFF
--- a/linux/data/org.jellify.Desktop.desktop
+++ b/linux/data/org.jellify.Desktop.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Jellify
+Comment=Music player for Jellyfin
+Exec=jellify-desktop %U
+Icon=org.jellify.Desktop
+Type=Application
+Categories=AudioVideo;Audio;Player;GNOME;GTK;
+StartupNotify=true
+Keywords=music;audio;jellyfin;player;
+MimeType=x-scheme-handler/jellify;
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Closes #421

Adds `linux/data/org.jellify.Desktop.desktop`. Required by Flathub and standard Linux desktop environments to expose the app in launchers.