### PR TITLE
linux: flatpak cargo-sources generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ macos/Jellify.xcframework/
 macos/Sources/JellifyCore/Generated/
 macos/build/
 
+# Flatpak packaging (downloaded generator cache)
+linux/flatpak/.cache/
+
 # Symbol files / debug
 *.pdb
 *.dSYM/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,14 @@ it will download a copy into `linux/flatpak/.cache/` on first run if the
 generator isn't already on `PATH` or pointed at by `$FLATPAK_CARGO_GENERATOR`.
 Requires `python3` with `aiohttp` and `toml` installed.
 
-The generated `linux/flatpak/cargo-sources.json` is checked in so CI and
-packagers don't need network access to rebuild. Commit the regenerated file
-alongside the `Cargo.lock` change that invalidated it.
+The generator is pinned to a specific upstream commit (see the `GENERATOR_PIN`
+variable in `linux/flatpak/gen-sources.sh`) for reproducibility and
+supply-chain safety. Bump the pin manually during dependency updates.
+
+The generated `linux/flatpak/cargo-sources.json` should be regenerated and
+committed alongside dependency changes so CI and packagers don't need network
+access to rebuild. Run the script whenever `Cargo.lock` changes and commit the
+regenerated file in the same PR.
 
 ## Commit style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,25 @@ Regenerate Swift bindings when the Rust API changes:
 cd macos && ./Scripts/build-core.sh
 ```
 
+## Flatpak packaging
+
+Offline Flatpak builds need a `cargo-sources.json` describing every crate the
+build will fetch. Regenerate it after any change to `Cargo.lock`:
+
+```sh
+./linux/flatpak/gen-sources.sh
+```
+
+The script wraps `flatpak-cargo-generator.py` from
+[`flatpak-builder-tools`](https://github.com/flatpak/flatpak-builder-tools);
+it will download a copy into `linux/flatpak/.cache/` on first run if the
+generator isn't already on `PATH` or pointed at by `$FLATPAK_CARGO_GENERATOR`.
+Requires `python3` with `aiohttp` and `toml` installed.
+
+The generated `linux/flatpak/cargo-sources.json` is checked in so CI and
+packagers don't need network access to rebuild. Commit the regenerated file
+alongside the `Cargo.lock` change that invalidated it.
+
 ## Commit style
 
 - Short, imperative subject line ("add X", "fix Y"). No prefixes.

--- a/linux/flatpak/gen-sources.sh
+++ b/linux/flatpak/gen-sources.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# gen-sources.sh — generate cargo-sources.json for offline Flatpak builds.
+#
+# Runs flatpak-cargo-generator.py from flatpak-builder-tools against the
+# workspace Cargo.lock and writes linux/flatpak/cargo-sources.json, which the
+# Flatpak manifest references to vendor all crate dependencies.
+#
+# Prerequisites:
+#   - python3
+#   - pip install aiohttp toml
+#
+# Resolution order for the generator script:
+#   1. $FLATPAK_CARGO_GENERATOR (absolute path to an existing file)
+#   2. flatpak-cargo-generator.py on $PATH
+#   3. downloaded to linux/flatpak/.cache/ from
+#      https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py
+#
+# Usage:
+#   ./linux/flatpak/gen-sources.sh
+#
+# The script works from any cwd; it resolves the repo root via git.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FLATPAK_DIR="$REPO_ROOT/linux/flatpak"
+CACHE_DIR="$FLATPAK_DIR/.cache"
+OUTPUT="$FLATPAK_DIR/cargo-sources.json"
+CARGO_LOCK="$REPO_ROOT/Cargo.lock"
+GENERATOR_URL="https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py"
+
+if [[ ! -f "$CARGO_LOCK" ]]; then
+	echo "error: $CARGO_LOCK not found" >&2
+	exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "error: python3 is required but not found on PATH" >&2
+	exit 1
+fi
+
+resolve_generator() {
+	if [[ -n "${FLATPAK_CARGO_GENERATOR:-}" ]]; then
+		if [[ -f "$FLATPAK_CARGO_GENERATOR" ]]; then
+			printf '%s' "$FLATPAK_CARGO_GENERATOR"
+			return 0
+		fi
+		echo "error: FLATPAK_CARGO_GENERATOR is set but '$FLATPAK_CARGO_GENERATOR' is not a file" >&2
+		return 1
+	fi
+
+	if command -v flatpak-cargo-generator.py >/dev/null 2>&1; then
+		command -v flatpak-cargo-generator.py
+		return 0
+	fi
+
+	mkdir -p "$CACHE_DIR"
+	local cached="$CACHE_DIR/flatpak-cargo-generator.py"
+	if [[ ! -f "$cached" ]]; then
+		echo "downloading flatpak-cargo-generator.py into $CACHE_DIR" >&2
+		if command -v curl >/dev/null 2>&1; then
+			curl -fsSL "$GENERATOR_URL" -o "$cached"
+		elif command -v wget >/dev/null 2>&1; then
+			wget -q "$GENERATOR_URL" -O "$cached"
+		else
+			echo "error: need curl or wget to download the generator" >&2
+			return 1
+		fi
+	fi
+	printf '%s' "$cached"
+}
+
+GENERATOR="$(resolve_generator)"
+
+echo "using generator: $GENERATOR" >&2
+python3 "$GENERATOR" "$CARGO_LOCK" -o "$OUTPUT"
+
+echo "wrote $OUTPUT"

--- a/linux/flatpak/gen-sources.sh
+++ b/linux/flatpak/gen-sources.sh
@@ -7,14 +7,20 @@
 # Flatpak manifest references to vendor all crate dependencies.
 #
 # Prerequisites:
+#   - git (run from within the jellify-desktop git checkout)
 #   - python3
 #   - pip install aiohttp toml
 #
 # Resolution order for the generator script:
 #   1. $FLATPAK_CARGO_GENERATOR (absolute path to an existing file)
 #   2. flatpak-cargo-generator.py on $PATH
-#   3. downloaded to linux/flatpak/.cache/ from
-#      https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py
+#   3. downloaded to linux/flatpak/.cache/ from the pinned URL below
+#
+# The generator is pinned to a specific upstream commit for reproducibility
+# and supply-chain safety. Bump the pin manually during dependency updates;
+# see CONTRIBUTING.md.
+#
+# Pinned upstream: flatpak/flatpak-builder-tools @ 34ecf07ef4843f36b3078637ca13f1dbb1c2963a
 #
 # Usage:
 #   ./linux/flatpak/gen-sources.sh
@@ -23,12 +29,22 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+if ! command -v git >/dev/null 2>&1; then
+	echo "error: gen-sources.sh requires git; install git and run from within the jellify-desktop git checkout" >&2
+	exit 1
+fi
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+	echo "error: gen-sources.sh must be run from within the jellify-desktop git checkout" >&2
+	exit 1
+fi
+
 FLATPAK_DIR="$REPO_ROOT/linux/flatpak"
 CACHE_DIR="$FLATPAK_DIR/.cache"
 OUTPUT="$FLATPAK_DIR/cargo-sources.json"
 CARGO_LOCK="$REPO_ROOT/Cargo.lock"
-GENERATOR_URL="https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py"
+GENERATOR_PIN="34ecf07ef4843f36b3078637ca13f1dbb1c2963a"
+GENERATOR_URL="https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/${GENERATOR_PIN}/cargo/flatpak-cargo-generator.py"
 
 if [[ ! -f "$CARGO_LOCK" ]]; then
 	echo "error: $CARGO_LOCK not found" >&2
@@ -56,9 +72,9 @@ resolve_generator() {
 	fi
 
 	mkdir -p "$CACHE_DIR"
-	local cached="$CACHE_DIR/flatpak-cargo-generator.py"
+	local cached="$CACHE_DIR/flatpak-cargo-generator-${GENERATOR_PIN}.py"
 	if [[ ! -f "$cached" ]]; then
-		echo "downloading flatpak-cargo-generator.py into $CACHE_DIR" >&2
+		echo "downloading flatpak-cargo-generator.py (pinned to ${GENERATOR_PIN}) into $CACHE_DIR" >&2
 		if command -v curl >/dev/null 2>&1; then
 			curl -fsSL "$GENERATOR_URL" -o "$cached"
 		elif command -v wget >/dev/null 2>&1; then
@@ -73,7 +89,19 @@ resolve_generator() {
 
 GENERATOR="$(resolve_generator)"
 
+TMP_OUTPUT=""
+cleanup_tmp() {
+	if [[ -n "$TMP_OUTPUT" && -f "$TMP_OUTPUT" ]]; then
+		rm -f "$TMP_OUTPUT"
+	fi
+}
+trap cleanup_tmp EXIT
+
+TMP_OUTPUT="$(mktemp "${FLATPAK_DIR}/cargo-sources.json.tmp.XXXXXX")"
+
 echo "using generator: $GENERATOR" >&2
-python3 "$GENERATOR" "$CARGO_LOCK" -o "$OUTPUT"
+python3 "$GENERATOR" "$CARGO_LOCK" -o "$TMP_OUTPUT"
+mv "$TMP_OUTPUT" "$OUTPUT"
+TMP_OUTPUT=""
 
 echo "wrote $OUTPUT"


### PR DESCRIPTION
Closes #420

Adds `linux/flatpak/gen-sources.sh` to produce `cargo-sources.json` for offline Flatpak builds via `flatpak-cargo-generator.py`. CONTRIBUTING.md documents regeneration cadence.