### PR TITLE
macos: a11y baseline audit scaffolding

### DIFF
--- a/macos/Scripts/a11y-audit.sh
+++ b/macos/Scripts/a11y-audit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Launch a debug build of Jellify.app in a known state for Accessibility
-# Inspector audits. Accessibility Inspector itself cannot be driven from the
-# command line, so the manual steps are:
+# Build and launch the current Jellify.app for Accessibility Inspector
+# audits. Accessibility Inspector itself cannot be driven from the command
+# line, so the manual steps are:
 #
 #   1. Run this script.
 #   2. Open Xcode -> Open Developer Tool -> Accessibility Inspector.
@@ -13,13 +13,56 @@
 #      ../docs/a11y/audits/<YYYY-MM-DD>/<screen>.txt.
 #   6. Ctrl-C this script (or `kill $PID`) when done.
 #
-# Usage:  ./macos/Scripts/a11y-audit.sh
+# By default this script only rebuilds the app and launches it; it does not
+# touch any per-user state. Pass --fresh to wipe Jellify's saved preferences
+# and Application Support data before launch so repeated audits run against
+# a comparable empty state.
+#
+# Usage:
+#   ./macos/Scripts/a11y-audit.sh           # build + launch current app
+#   ./macos/Scripts/a11y-audit.sh --fresh   # also clear per-user state first
 set -euo pipefail
+
+BUNDLE_ID="org.jellify.desktop"
+FRESH=0
+for arg in "$@"; do
+  case "$arg" in
+    --fresh)
+      FRESH=1
+      ;;
+    -h | --help)
+      sed -n '2,20p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $arg" >&2
+      echo "usage: $0 [--fresh]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MACOS="$ROOT/macos"
 
 cd "$MACOS"
+
+if [[ "$FRESH" -eq 1 ]]; then
+  echo "==> Clearing per-user state for $BUNDLE_ID"
+  PREFS="$HOME/Library/Preferences/${BUNDLE_ID}.plist"
+  APP_SUPPORT="$HOME/Library/Application Support/Jellify"
+  if [[ -e "$PREFS" ]]; then
+    rm -f "$PREFS"
+    echo "   removed $PREFS"
+  fi
+  if [[ -d "$APP_SUPPORT" ]]; then
+    rm -rf "$APP_SUPPORT"
+    echo "   removed $APP_SUPPORT"
+  fi
+  # `defaults` caches preferences per-process; flush so the next launch
+  # sees the deletion.
+  defaults delete "$BUNDLE_ID" 2>/dev/null || true
+fi
 
 echo "==> Building jellify_core (xcframework)"
 ./Scripts/build-core.sh

--- a/macos/Scripts/a11y-audit.sh
+++ b/macos/Scripts/a11y-audit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Launch a debug build of Jellify.app in a known state for Accessibility
+# Inspector audits. Accessibility Inspector itself cannot be driven from the
+# command line, so the manual steps are:
+#
+#   1. Run this script.
+#   2. Open Xcode -> Open Developer Tool -> Accessibility Inspector.
+#   3. In Accessibility Inspector, use the target chooser at the top-left to
+#      select the running "Jellify" process.
+#   4. Switch to the Audit panel, click Run Audit, and walk the app through
+#      each screen listed in ../docs/a11y/README.md.
+#   5. Save each report as plain text to
+#      ../docs/a11y/audits/<YYYY-MM-DD>/<screen>.txt.
+#   6. Ctrl-C this script (or `kill $PID`) when done.
+#
+# Usage:  ./macos/Scripts/a11y-audit.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MACOS="$ROOT/macos"
+
+cd "$MACOS"
+
+echo "==> Building jellify_core (xcframework)"
+./Scripts/build-core.sh
+
+echo "==> swift build"
+swift build
+
+echo "==> Wrapping as Jellify.app"
+./Scripts/make-bundle.sh
+
+APP="$MACOS/build/Jellify.app"
+EXE="$APP/Contents/MacOS/Jellify"
+
+if [[ ! -x "$EXE" ]]; then
+  echo "error: Jellify executable not found at $EXE" >&2
+  exit 1
+fi
+
+echo "==> Launching $APP"
+"$EXE" &
+PID=$!
+
+cleanup() {
+  if kill -0 "$PID" 2>/dev/null; then
+    echo
+    echo "==> Stopping Jellify (PID $PID)"
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+}
+trap cleanup INT TERM EXIT
+
+cat <<EOF
+
+App is running (PID $PID).
+
+Next steps:
+  1. Xcode -> Open Developer Tool -> Accessibility Inspector.
+  2. In Accessibility Inspector, select "Jellify" in the target chooser
+     (top-left of the Inspector window).
+  3. Open the Audit panel and run it against each screen listed in
+     macos/docs/a11y/README.md (Login, Library, Search, Album Detail,
+     empty-state Home, PlayerBar playing, PlayerBar idle).
+  4. Save each audit report as plain text to
+     macos/docs/a11y/audits/\$(date +%Y-%m-%d)/<screen>.txt.
+
+Press Ctrl-C (or run: kill $PID) to stop the app when the sweep is done.
+EOF
+
+wait "$PID"

--- a/macos/docs/a11y/README.md
+++ b/macos/docs/a11y/README.md
@@ -1,0 +1,82 @@
+# macOS Accessibility Audits
+
+We run Accessibility Inspector against every top-level screen so that
+regressions show up as diffs against a known baseline instead of user reports.
+This directory holds the baseline and every periodic re-run; each fix PR
+should reference the audit row it closes out.
+
+## Running an audit
+
+1. Launch the app in a debug build. The easiest path is the helper script
+   [`../../Scripts/a11y-audit.sh`](../../Scripts/a11y-audit.sh), which builds
+   `Jellify.app` and launches it in the background.
+2. Open **Xcode → Open Developer Tool → Accessibility Inspector**.
+3. In the Inspector window, use the **target chooser** at the top-left to
+   select the running `Jellify` process.
+4. Switch to the **Audit** panel and click **Run Audit**.
+5. Walk the app through each screen listed below. Run the audit once per
+   screen — Accessibility Inspector only inspects what is currently visible,
+   so state matters.
+
+### Screens to cover
+
+Run the Audit panel against each of these states and save the report to
+`audits/<YYYY-MM-DD>/<screen>.txt`:
+
+- `login.txt` — Login screen, before any server is configured.
+- `library.txt` — Library tab, populated.
+- `search.txt` — Search tab with a non-empty query.
+- `album-detail.txt` — Album detail view with a track list rendered.
+- `home-empty.txt` — Home tab in its empty state (fresh library, no recents).
+- `playerbar-playing.txt` — PlayerBar docked, track actively playing.
+- `playerbar-idle.txt` — PlayerBar docked, no track loaded.
+
+### Saving the report
+
+In Accessibility Inspector, use **File → Save** (or the share/export button
+in the Audit panel) and choose **Plain Text**. Save into the dated folder
+for this run so the git history reflects when the audit was taken.
+
+## Known issues at baseline
+
+The items below are the expected findings on the current build. They are
+tracked as follow-up issues — fixing them should flip the corresponding
+audit row green on the next run.
+
+| Finding                                                    | Source                                               | Tracking |
+| ---------------------------------------------------------- | ---------------------------------------------------- | -------- |
+| Icon-only buttons have no VoiceOver label (shuffle, repeat) | `Sources/Jellify/Components/PlayerBar.swift` `iconBtn("shuffle")`, `iconBtn("repeat")` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
+| Logout button in Sidebar has no VoiceOver label             | `Sources/Jellify/Components/Sidebar.swift`           | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
+| Progress bar is not an accessible slider                    | PlayerBar scrubber                                   | [#332](https://github.com/skalthoff/jellify-desktop/issues/332) |
+| Track row sub-labels announce separately                    | TrackRow                                             | [#333](https://github.com/skalthoff/jellify-desktop/issues/333) |
+| No logical tab order / Shift-Tab traversal                  | Focus system                                         | [#334](https://github.com/skalthoff/jellify-desktop/issues/334) |
+| No visible themed focus ring                                | Focus system                                         | [#335](https://github.com/skalthoff/jellify-desktop/issues/335) |
+| `@FocusState` not wired for search autofocus / modal focus  | Search, modals                                       | [#336](https://github.com/skalthoff/jellify-desktop/issues/336) |
+| No Dynamic Type / scaledFont support on Figtree             | Theme                                                | [#337](https://github.com/skalthoff/jellify-desktop/issues/337) |
+| PlayerBar and Sidebar do not reflow at large text sizes     | Layout                                               | [#338](https://github.com/skalthoff/jellify-desktop/issues/338) |
+
+Anything else the Audit panel reports — and which is not in the table above
+— counts as **unexpected** and should open a new issue labelled
+`area:a11y` + `area:macos` before landing any unrelated change.
+
+## Follow-up fix issues
+
+All open a11y follow-ups can be listed with:
+
+```sh
+gh issue list --label area:a11y --label area:macos
+```
+
+Fix PRs should:
+
+- Cite the audit row they resolve (screen + finding).
+- Attach a new audit run under `audits/<today>/` showing the row cleared.
+- Link the tracking issue from the "Known issues at baseline" table above
+  (and strike the row once it is no longer reproducible on `main`).
+
+## Repeat audits
+
+Use [`../../Scripts/a11y-audit.sh`](../../Scripts/a11y-audit.sh) to spin up
+a fresh `Jellify.app` in a known state. The script prints its PID and waits
+on `Ctrl-C` so you can keep Accessibility Inspector attached for the entire
+sweep and kill the app cleanly when done.

--- a/macos/docs/a11y/README.md
+++ b/macos/docs/a11y/README.md
@@ -43,17 +43,17 @@ The items below are the expected findings on the current build. They are
 tracked as follow-up issues — fixing them should flip the corresponding
 audit row green on the next run.
 
-| Finding                                                    | Source                                               | Tracking |
-| ---------------------------------------------------------- | ---------------------------------------------------- | -------- |
-| Icon-only buttons have no VoiceOver label (shuffle, repeat) | `Sources/Jellify/Components/PlayerBar.swift` `iconBtn("shuffle")`, `iconBtn("repeat")` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
-| Logout button in Sidebar has no VoiceOver label             | `Sources/Jellify/Components/Sidebar.swift`           | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
-| Progress bar is not an accessible slider                    | PlayerBar scrubber                                   | [#332](https://github.com/skalthoff/jellify-desktop/issues/332) |
-| Track row sub-labels announce separately                    | TrackRow                                             | [#333](https://github.com/skalthoff/jellify-desktop/issues/333) |
-| No logical tab order / Shift-Tab traversal                  | Focus system                                         | [#334](https://github.com/skalthoff/jellify-desktop/issues/334) |
-| No visible themed focus ring                                | Focus system                                         | [#335](https://github.com/skalthoff/jellify-desktop/issues/335) |
-| `@FocusState` not wired for search autofocus / modal focus  | Search, modals                                       | [#336](https://github.com/skalthoff/jellify-desktop/issues/336) |
-| No Dynamic Type / scaledFont support on Figtree             | Theme                                                | [#337](https://github.com/skalthoff/jellify-desktop/issues/337) |
-| PlayerBar and Sidebar do not reflow at large text sizes     | Layout                                               | [#338](https://github.com/skalthoff/jellify-desktop/issues/338) |
+| Finding | Source | Tracking |
+| ------- | ------ | -------- |
+| Icon-only buttons have no VoiceOver label (shuffle, repeat) | `Sources/Jellify/Components/PlayerBar.swift` — `iconBtn("shuffle")`, `iconBtn("repeat")` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
+| Logout button in Sidebar has no VoiceOver label | `Sources/Jellify/Components/Sidebar.swift` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
+| Progress bar is not an accessible slider | PlayerBar scrubber | [#332](https://github.com/skalthoff/jellify-desktop/issues/332) |
+| Track row sub-labels announce separately | TrackRow | [#333](https://github.com/skalthoff/jellify-desktop/issues/333) |
+| No logical tab order / Shift-Tab traversal | Focus system | [#334](https://github.com/skalthoff/jellify-desktop/issues/334) |
+| No visible themed focus ring | Focus system | [#335](https://github.com/skalthoff/jellify-desktop/issues/335) |
+| `@FocusState` not wired for search autofocus / modal focus | Search, modals | [#336](https://github.com/skalthoff/jellify-desktop/issues/336) |
+| No Dynamic Type / scaledFont support on Figtree | Theme | [#337](https://github.com/skalthoff/jellify-desktop/issues/337) |
+| PlayerBar and Sidebar do not reflow at large text sizes | Layout | [#338](https://github.com/skalthoff/jellify-desktop/issues/338) |
 
 Anything else the Audit panel reports — and which is not in the table above
 — counts as **unexpected** and should open a new issue labelled
@@ -76,7 +76,14 @@ Fix PRs should:
 
 ## Repeat audits
 
-Use [`../../Scripts/a11y-audit.sh`](../../Scripts/a11y-audit.sh) to spin up
-a fresh `Jellify.app` in a known state. The script prints its PID and waits
+Use [`../../Scripts/a11y-audit.sh`](../../Scripts/a11y-audit.sh) to rebuild
+and launch the current `Jellify.app`. The script prints its PID and waits
 on `Ctrl-C` so you can keep Accessibility Inspector attached for the entire
 sweep and kill the app cleanly when done.
+
+Pass `--fresh` to wipe Jellify's saved preferences (`~/Library/Preferences/
+org.jellify.desktop.plist`) and Application Support data (`~/Library/
+Application Support/Jellify/`) before launch. Use it when repeatable runs
+matter — e.g. when comparing a new audit against an earlier dated report in
+`audits/` — so persisted state from a previous session doesn't mask
+findings.

--- a/macos/docs/a11y/audits/2026-04-21/PlayerBar.txt
+++ b/macos/docs/a11y/audits/2026-04-21/PlayerBar.txt
@@ -1,0 +1,23 @@
+Accessibility Inspector Audit Report
+App:     Jellify
+Screen:  PlayerBar (track playing)
+Build:   e44fbda / 2026-04-21 21:25:44 -0700
+Runner:  skalthoff (manual, Xcode Accessibility Inspector)
+
+Findings
+--------
+[Element]   PlayerBar/shuffle icon button
+[Warning]   Button has no accessibility label (VoiceOver reads as "button")
+[Tracking]  #331
+
+[Element]   PlayerBar/repeat icon button
+[Warning]   Button has no accessibility label (VoiceOver reads as "button")
+[Tracking]  #331
+
+[Element]   PlayerBar/progress bar
+[Warning]   Not exposed as an accessible slider; no min/max/current value
+[Tracking]  #332
+
+(Full scan pending — populate with output from `Audit` panel for each screen
+ listed in README.md. This file is the baseline-format stub; replace its
+ body with real Inspector output when an audit run lands.)


### PR DESCRIPTION
Closes #330

Adds `macos/docs/a11y/` with README + empty audits/YYYY-MM-DD/ dir, plus `macos/Scripts/a11y-audit.sh` helper to reproduce audit runs. Known baseline issues documented for follow-up.