### PR TITLE
core: generalize image_url to any ImageType

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -330,11 +330,48 @@ impl JellyfinClient {
     }
 
     /// Build image URL for a track/album/artist primary image.
+    ///
+    /// Retained for backwards compatibility; delegates to
+    /// [`JellyfinClient::image_url_of_type`] with `ImageType::Primary`.
     pub fn image_url(&self, item_id: &str, tag: Option<&str>, max_width: u32) -> Result<Url> {
-        let mut url = self.endpoint(&format!("Items/{item_id}/Images/Primary"))?;
+        self.image_url_of_type(
+            item_id,
+            ImageType::Primary,
+            None,
+            tag,
+            Some(max_width),
+            None,
+        )
+    }
+
+    /// Build a Jellyfin image URL for any [`ImageType`].
+    ///
+    /// Endpoint: `GET /Items/{id}/Images/{type}/{index?}` with optional query
+    /// parameters `maxWidth`, `maxHeight`, `quality`, and `tag`. `index` is
+    /// meaningful for types that are keyed (notably `Backdrop`, which has one
+    /// URL per entry in `BackdropImageTags`).
+    pub fn image_url_of_type(
+        &self,
+        item_id: &str,
+        image_type: ImageType,
+        index: Option<u32>,
+        tag: Option<&str>,
+        max_width: Option<u32>,
+        max_height: Option<u32>,
+    ) -> Result<Url> {
+        let path = match index {
+            Some(i) => format!("Items/{item_id}/Images/{}/{i}", image_type.as_path()),
+            None => format!("Items/{item_id}/Images/{}", image_type.as_path()),
+        };
+        let mut url = self.endpoint(&path)?;
         {
             let mut q = url.query_pairs_mut();
-            q.append_pair("maxWidth", &max_width.to_string());
+            if let Some(w) = max_width {
+                q.append_pair("maxWidth", &w.to_string());
+            }
+            if let Some(h) = max_height {
+                q.append_pair("maxHeight", &h.to_string());
+            }
             q.append_pair("quality", "90");
             if let Some(t) = tag {
                 q.append_pair("tag", t);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -193,6 +193,32 @@ impl JellifyCore {
         })
     }
 
+    /// Build an image URL for any [`ImageType`] (Primary, Backdrop, Thumb, Disc,
+    /// Logo, Banner, Art, Box). `index` is required for keyed types like
+    /// `Backdrop` (one URL per `BackdropImageTags` entry); pass `None` for the
+    /// first/only image.
+    pub fn image_url_of_type(
+        &self,
+        item_id: String,
+        image_type: ImageType,
+        index: Option<u32>,
+        tag: Option<String>,
+        max_width: Option<u32>,
+        max_height: Option<u32>,
+    ) -> std::result::Result<String, JellifyError> {
+        self.with_client(|c| {
+            Ok(c.image_url_of_type(
+                &item_id,
+                image_type,
+                index,
+                tag.as_deref(),
+                max_width,
+                max_height,
+            )?
+            .to_string())
+        })
+    }
+
     // ---------- Playback ----------
 
     /// Returns the fully-authenticated stream URL for a track. The platform

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -99,3 +99,33 @@ impl Paging {
         Self { offset, limit }
     }
 }
+
+/// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
+/// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum ImageType {
+    Primary,
+    Backdrop,
+    Thumb,
+    Disc,
+    Logo,
+    Banner,
+    Art,
+    Box,
+}
+
+impl ImageType {
+    /// Path segment as Jellyfin expects it in the URL.
+    pub fn as_path(&self) -> &'static str {
+        match self {
+            ImageType::Primary => "Primary",
+            ImageType::Backdrop => "Backdrop",
+            ImageType::Thumb => "Thumb",
+            ImageType::Disc => "Disc",
+            ImageType::Logo => "Logo",
+            ImageType::Banner => "Banner",
+            ImageType::Art => "Art",
+            ImageType::Box => "Box",
+        }
+    }
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::client::JellyfinClient;
-use crate::models::Paging;
+use crate::models::{ImageType, Paging};
 use crate::storage::Database;
 use serde_json::json;
 use wiremock::matchers::{method, path};
@@ -133,6 +133,84 @@ fn stream_url_contains_api_key() {
     assert!(s.contains("api_key=mytoken"), "url: {s}");
     assert!(s.contains("DeviceId=dev"), "url: {s}");
     assert!(s.contains("/Audio/track-id/universal"), "url: {s}");
+}
+
+#[test]
+fn image_url_primary_is_backwards_compatible() {
+    let client = mock_client("https://example.com");
+    let url = client.image_url("item-1", Some("tag-1"), 400).unwrap();
+    let s = url.as_str();
+    assert!(
+        s.contains("/Items/item-1/Images/Primary"),
+        "url missing Primary path: {s}"
+    );
+    assert!(s.contains("maxWidth=400"), "url missing maxWidth: {s}");
+    assert!(s.contains("quality=90"), "url missing quality: {s}");
+    assert!(s.contains("tag=tag-1"), "url missing tag: {s}");
+    // No index segment when index is omitted.
+    assert!(
+        !s.contains("/Images/Primary/"),
+        "unexpected index segment: {s}"
+    );
+}
+
+#[test]
+fn image_url_of_type_primary_matches_legacy_shape() {
+    let client = mock_client("https://example.com");
+    let url = client
+        .image_url_of_type(
+            "item-1",
+            ImageType::Primary,
+            None,
+            Some("tag-1"),
+            Some(400),
+            None,
+        )
+        .unwrap();
+    let s = url.as_str();
+    assert!(s.contains("/Items/item-1/Images/Primary"), "url: {s}");
+    assert!(s.contains("maxWidth=400"), "url: {s}");
+    assert!(s.contains("tag=tag-1"), "url: {s}");
+    // Neither index nor maxHeight should leak in when not provided.
+    assert!(!s.contains("maxHeight="), "url: {s}");
+}
+
+#[test]
+fn image_url_of_type_backdrop_includes_index_segment() {
+    let client = mock_client("https://example.com");
+    let url = client
+        .image_url_of_type(
+            "item-2",
+            ImageType::Backdrop,
+            Some(1),
+            Some("bd-tag"),
+            Some(1600),
+            Some(900),
+        )
+        .unwrap();
+    let s = url.as_str();
+    assert!(
+        s.contains("/Items/item-2/Images/Backdrop/1"),
+        "url missing Backdrop/1: {s}"
+    );
+    assert!(s.contains("maxWidth=1600"), "url: {s}");
+    assert!(s.contains("maxHeight=900"), "url: {s}");
+    assert!(s.contains("tag=bd-tag"), "url: {s}");
+}
+
+#[test]
+fn image_url_of_type_thumb_without_index_or_sizes() {
+    let client = mock_client("https://example.com");
+    let url = client
+        .image_url_of_type("item-3", ImageType::Thumb, None, None, None, None)
+        .unwrap();
+    let s = url.as_str();
+    assert!(s.contains("/Items/item-3/Images/Thumb"), "url: {s}");
+    assert!(!s.contains("/Thumb/"), "url should not have index: {s}");
+    assert!(!s.contains("maxWidth="), "url: {s}");
+    assert!(!s.contains("maxHeight="), "url: {s}");
+    assert!(!s.contains("tag="), "url: {s}");
+    assert!(s.contains("quality=90"), "url: {s}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #463

Adds `ImageType` enum and `image_url_of_type` method. Existing `image_url` delegates to it and remains behavior-compatible.