### PR TITLE
core: add latest_albums endpoint

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -211,6 +211,46 @@ impl JellyfinClient {
         Ok(raw.items.into_iter().map(Album::from).collect())
     }
 
+    /// Fetch the most recently added albums in a library, respecting the
+    /// authenticated user's parental controls (enforced server-side via
+    /// `userId`). Backed by `GET /Items/Latest`.
+    ///
+    /// Notes:
+    /// - The response is a bare `BaseItemDto[]` (not wrapped in
+    ///   `{ Items, TotalRecordCount }` like most library endpoints).
+    /// - `groupItems=true` asks the server to collapse audio children into
+    ///   their parent album when both land in the "recent" window, so the
+    ///   Home "Recently Added" row shows albums rather than loose tracks.
+    /// - `library_id` is the music library's collection id (a "Views" item);
+    ///   callers typically resolve it once at sign-in and cache it.
+    pub async fn latest_albums(&self, library_id: &str, limit: u32) -> Result<Vec<Album>> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint("Items/Latest")?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("userId", user_id);
+            q.append_pair("parentId", library_id);
+            q.append_pair("includeItemTypes", "MusicAlbum");
+            q.append_pair("limit", &limit.max(1).to_string());
+            q.append_pair("groupItems", "true");
+            q.append_pair(
+                "fields",
+                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+            );
+        }
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let items: Vec<RawItem> = Self::check(resp).await?.json().await?;
+        Ok(items.into_iter().map(Album::from).collect())
+    }
+
     pub async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {
         let user_id = self
             .user_id

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -231,13 +231,13 @@ impl JellyfinClient {
         let mut url = self.endpoint("Items/Latest")?;
         {
             let mut q = url.query_pairs_mut();
-            q.append_pair("userId", user_id);
-            q.append_pair("parentId", library_id);
-            q.append_pair("includeItemTypes", "MusicAlbum");
-            q.append_pair("limit", &limit.max(1).to_string());
-            q.append_pair("groupItems", "true");
+            q.append_pair("UserId", user_id);
+            q.append_pair("ParentId", library_id);
+            q.append_pair("IncludeItemTypes", "MusicAlbum");
+            q.append_pair("Limit", &limit.max(1).to_string());
+            q.append_pair("GroupItems", "true");
             q.append_pair(
-                "fields",
+                "Fields",
                 "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
             );
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -177,6 +177,19 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.album_tracks(&album_id)))
     }
 
+    /// Recently added albums for the Home "Recently Added" row.
+    ///
+    /// Server-side filtering respects the user's parental controls; the
+    /// response is grouped by album so loose tracks never appear. Callers
+    /// resolve `library_id` (the music collection view id) once at sign-in.
+    pub fn latest_albums(
+        &self,
+        library_id: String,
+        limit: u32,
+    ) -> std::result::Result<Vec<Album>, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.latest_albums(&library_id, limit)))
+    }
+
     pub fn search(&self, query: String) -> std::result::Result<SearchResults, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.search(&query)))
     }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -2,8 +2,8 @@ use crate::client::JellyfinClient;
 use crate::models::{ImageType, Paging};
 use crate::storage::Database;
 use serde_json::json;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 fn mock_client(base: &str) -> JellyfinClient {
     JellyfinClient::new(base, "test-device".into(), "Test Device".into()).unwrap()
@@ -121,6 +121,80 @@ async fn albums_uses_paging() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let _ = client.albums(Paging::new(10, 50)).await.unwrap();
+}
+
+#[tokio::test]
+async fn latest_albums_builds_expected_query_and_parses_unwrapped_array() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // `/Items/Latest` returns a bare array, not `{ Items, TotalRecordCount }`.
+    Mock::given(method("GET"))
+        .and(path("/Items/Latest"))
+        .and(query_param("userId", "u1"))
+        .and(query_param("parentId", "lib-music"))
+        .and(query_param("includeItemTypes", "MusicAlbum"))
+        .and(query_param("limit", "24"))
+        .and(query_param("groupItems", "true"))
+        .respond_with(|req: &Request| {
+            // Sanity-check that no unexpected extra params were added and that
+            // the five required ones are all present on the actual request.
+            let pairs: std::collections::HashMap<_, _> =
+                req.url.query_pairs().into_owned().collect();
+            assert_eq!(pairs.get("userId").map(String::as_str), Some("u1"));
+            assert_eq!(pairs.get("parentId").map(String::as_str), Some("lib-music"));
+            assert_eq!(
+                pairs.get("includeItemTypes").map(String::as_str),
+                Some("MusicAlbum")
+            );
+            assert_eq!(pairs.get("limit").map(String::as_str), Some("24"));
+            assert_eq!(pairs.get("groupItems").map(String::as_str), Some("true"));
+            ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "Id": "a1", "Name": "The Deep End", "Type": "MusicAlbum",
+                    "AlbumArtist": "Saloli", "Artists": ["Saloli"],
+                    "ProductionYear": 2020, "ChildCount": 8,
+                    "RunTimeTicks": 18000000000u64,
+                    "ImageTags": { "Primary": "abcd" }
+                },
+                {
+                    "Id": "a2", "Name": "Spiral", "Type": "MusicAlbum",
+                    "AlbumArtist": "Colleen", "Artists": ["Colleen"],
+                    "ProductionYear": 2023, "ChildCount": 11,
+                    "ImageTags": {}
+                }
+            ]))
+        })
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let albums = client.latest_albums("lib-music", 24).await.unwrap();
+    assert_eq!(albums.len(), 2);
+    assert_eq!(albums[0].name, "The Deep End");
+    assert_eq!(albums[0].artist_name, "Saloli");
+    assert_eq!(albums[0].year, Some(2020));
+    assert_eq!(albums[0].track_count, 8);
+    assert_eq!(albums[0].image_tag.as_deref(), Some("abcd"));
+    assert_eq!(albums[1].name, "Spiral");
+    assert!(albums[1].image_tag.is_none());
+}
+
+#[tokio::test]
+async fn latest_albums_requires_authenticated_session() {
+    let client = JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    let err = client.latest_albums("lib-music", 24).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
 }
 
 #[test]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -137,24 +137,46 @@ async fn latest_albums_builds_expected_query_and_parses_unwrapped_array() {
     // `/Items/Latest` returns a bare array, not `{ Items, TotalRecordCount }`.
     Mock::given(method("GET"))
         .and(path("/Items/Latest"))
-        .and(query_param("userId", "u1"))
-        .and(query_param("parentId", "lib-music"))
-        .and(query_param("includeItemTypes", "MusicAlbum"))
-        .and(query_param("limit", "24"))
-        .and(query_param("groupItems", "true"))
+        .and(query_param("UserId", "u1"))
+        .and(query_param("ParentId", "lib-music"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(query_param("Limit", "24"))
+        .and(query_param("GroupItems", "true"))
         .respond_with(|req: &Request| {
             // Sanity-check that no unexpected extra params were added and that
-            // the five required ones are all present on the actual request.
+            // the full expected set (including `Fields`) is present on the
+            // actual request. Building a set from `query_pairs` and comparing
+            // to the expected set catches both extra keys and missing ones.
             let pairs: std::collections::HashMap<_, _> =
                 req.url.query_pairs().into_owned().collect();
-            assert_eq!(pairs.get("userId").map(String::as_str), Some("u1"));
-            assert_eq!(pairs.get("parentId").map(String::as_str), Some("lib-music"));
+            assert_eq!(pairs.get("UserId").map(String::as_str), Some("u1"));
+            assert_eq!(pairs.get("ParentId").map(String::as_str), Some("lib-music"));
             assert_eq!(
-                pairs.get("includeItemTypes").map(String::as_str),
+                pairs.get("IncludeItemTypes").map(String::as_str),
                 Some("MusicAlbum")
             );
-            assert_eq!(pairs.get("limit").map(String::as_str), Some("24"));
-            assert_eq!(pairs.get("groupItems").map(String::as_str), Some("true"));
+            assert_eq!(pairs.get("Limit").map(String::as_str), Some("24"));
+            assert_eq!(pairs.get("GroupItems").map(String::as_str), Some("true"));
+            assert_eq!(
+                pairs.get("Fields").map(String::as_str),
+                Some("Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio")
+            );
+            let expected_keys: std::collections::HashSet<&str> = [
+                "UserId",
+                "ParentId",
+                "IncludeItemTypes",
+                "Limit",
+                "GroupItems",
+                "Fields",
+            ]
+            .into_iter()
+            .collect();
+            let actual_keys: std::collections::HashSet<&str> =
+                pairs.keys().map(String::as_str).collect();
+            assert_eq!(
+                actual_keys, expected_keys,
+                "unexpected or missing query params on /Items/Latest request"
+            );
             ResponseTemplate::new(200).set_body_json(json!([
                 {
                     "Id": "a1", "Name": "The Deep End", "Type": "MusicAlbum",


### PR DESCRIPTION
Closes #147

Adds async `latest_albums(limit)` backed by `GET /Items/Latest` filtered to `MusicAlbum` with `groupItems=true`. Exposed via UniFFI for platform consumers (Home 'Recently Added' row).