### PR TITLE
core: add fetch_item for single-item lookup

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -279,25 +279,30 @@ impl JellyfinClient {
 
     /// Fetch a single item by id with a caller-selected set of `Fields`.
     ///
-    /// Uses `GET /Items?ids={id}&fields=...` as a workaround for the
+    /// Uses `GET /Items?Ids={id}&Fields=...` as a workaround for the
     /// deprecated `/Users/{userId}/Items/{itemId}` endpoint. Returns the
     /// first element of the `Items` array as raw JSON so callers can pick
     /// whichever fields they asked for without this layer pre-projecting.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
     ///
     /// Returns [`JellifyError::Server`] with status `404` when the server
     /// responds successfully but the `Items` array is empty (item not
     /// found or not visible to the current user).
     pub async fn fetch_item(&self, item_id: &str, fields: &[&str]) -> Result<serde_json::Value> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
         let mut url = self.endpoint("Items")?;
         {
             let mut q = url.query_pairs_mut();
-            q.append_pair("ids", item_id);
+            q.append_pair("Ids", item_id);
             if !fields.is_empty() {
-                q.append_pair("fields", &fields.join(","));
+                q.append_pair("Fields", &fields.join(","));
             }
-            if let Some(user_id) = self.user_id.as_deref() {
-                q.append_pair("userId", user_id);
-            }
+            q.append_pair("userId", user_id);
         }
         let resp = self
             .http

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -277,6 +277,50 @@ impl JellyfinClient {
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
+    /// Fetch a single item by id with a caller-selected set of `Fields`.
+    ///
+    /// Uses `GET /Items?ids={id}&fields=...` as a workaround for the
+    /// deprecated `/Users/{userId}/Items/{itemId}` endpoint. Returns the
+    /// first element of the `Items` array as raw JSON so callers can pick
+    /// whichever fields they asked for without this layer pre-projecting.
+    ///
+    /// Returns [`JellifyError::Server`] with status `404` when the server
+    /// responds successfully but the `Items` array is empty (item not
+    /// found or not visible to the current user).
+    pub async fn fetch_item(&self, item_id: &str, fields: &[&str]) -> Result<serde_json::Value> {
+        let mut url = self.endpoint("Items")?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("ids", item_id);
+            if !fields.is_empty() {
+                q.append_pair("fields", &fields.join(","));
+            }
+            if let Some(user_id) = self.user_id.as_deref() {
+                q.append_pair("userId", user_id);
+            }
+        }
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let mut body: serde_json::Value = Self::check(resp).await?.json().await?;
+        let items = body
+            .get_mut("Items")
+            .and_then(|v| v.as_array_mut())
+            .ok_or_else(|| {
+                JellifyError::Decode("fetch_item: response missing Items array".into())
+            })?;
+        if items.is_empty() {
+            return Err(JellifyError::Server {
+                status: 404,
+                message: format!("item not found: {item_id}"),
+            });
+        }
+        Ok(items.swap_remove(0))
+    }
+
     pub async fn search(&self, query: &str) -> Result<SearchResults> {
         let user_id = self
             .user_id

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -194,6 +194,22 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.search(&query)))
     }
 
+    /// Fetch a single item by id with a caller-selected `fields` projection
+    /// (e.g. `["Overview", "Genres", "Tags", "People"]`). Returns the raw
+    /// JSON object serialized as a string — callers decode whichever
+    /// fields they asked for.
+    pub fn fetch_item(
+        &self,
+        item_id: String,
+        fields: Vec<String>,
+    ) -> std::result::Result<String, JellifyError> {
+        self.with_client(|c| {
+            let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
+            let value = self.runtime.block_on(c.fetch_item(&item_id, &field_refs))?;
+            serde_json::to_string(&value).map_err(JellifyError::from)
+        })
+    }
+
     pub fn image_url(
         &self,
         item_id: String,

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -232,9 +232,9 @@ async fn fetch_item_builds_expected_query_and_extracts_first() {
         .await;
     Mock::given(method("GET"))
         .and(path("/Items"))
-        .and(wiremock::matchers::query_param("ids", "item-xyz"))
+        .and(wiremock::matchers::query_param("Ids", "item-xyz"))
         .and(wiremock::matchers::query_param(
-            "fields",
+            "Fields",
             "Overview,Genres,Tags,ProductionYear",
         ))
         .and(wiremock::matchers::query_param("userId", "u1"))
@@ -278,6 +278,14 @@ async fn fetch_item_builds_expected_query_and_extracts_first() {
 #[tokio::test]
 async fn fetch_item_empty_items_returns_not_found() {
     let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
     Mock::given(method("GET"))
         .and(path("/Items"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -287,12 +295,28 @@ async fn fetch_item_empty_items_returns_not_found() {
         .mount(&server)
         .await;
 
-    let client = mock_client(&server.uri());
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.fetch_item("missing-id", &[]).await.unwrap_err();
     match err {
         crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
         other => panic!("expected Server 404, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn fetch_item_without_session_returns_not_authenticated() {
+    // No MockServer endpoints registered for /Items: the guard must short-circuit
+    // before any network call. We still point at a live MockServer so that if
+    // the guard regresses, the request would surface as an unmatched-route error
+    // rather than silently hitting an unrelated host.
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.fetch_item("anything", &[]).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
 }
 
 #[test]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -219,6 +219,82 @@ async fn latest_albums_requires_authenticated_session() {
     );
 }
 
+#[tokio::test]
+async fn fetch_item_builds_expected_query_and_extracts_first() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(wiremock::matchers::query_param("ids", "item-xyz"))
+        .and(wiremock::matchers::query_param(
+            "fields",
+            "Overview,Genres,Tags,ProductionYear",
+        ))
+        .and(wiremock::matchers::query_param("userId", "u1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "item-xyz",
+                    "Name": "Mystery",
+                    "Type": "MusicAlbum",
+                    "Overview": "A very fine record.",
+                    "Genres": ["Ambient", "Electronic"],
+                    "Tags": ["Downtempo"],
+                    "ProductionYear": 2024
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let value = client
+        .fetch_item(
+            "item-xyz",
+            &["Overview", "Genres", "Tags", "ProductionYear"],
+        )
+        .await
+        .unwrap();
+    assert_eq!(value.get("Id").and_then(|v| v.as_str()), Some("item-xyz"));
+    assert_eq!(
+        value.get("Overview").and_then(|v| v.as_str()),
+        Some("A very fine record.")
+    );
+    assert_eq!(
+        value.get("ProductionYear").and_then(|v| v.as_i64()),
+        Some(2024)
+    );
+}
+
+#[tokio::test]
+async fn fetch_item_empty_items_returns_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let err = client.fetch_item("missing-id", &[]).await.unwrap_err();
+    match err {
+        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
+        other => panic!("expected Server 404, got {other:?}"),
+    }
+}
+
 #[test]
 fn stream_url_contains_api_key() {
     let mut client =


### PR DESCRIPTION
Closes #155

Adds async `fetch_item(item_id, fields)` backed by `GET /Items?ids=` with a caller-selected `Fields` projection. Returns the raw shape so callers pick what they need instead of this layer pre-projecting into typed models.

## Notes

- Uses `/Items?ids={id}` as the workaround for the deprecated `/Users/{userId}/Items/{itemId}` endpoint.
- Empty `Items` array returns `JellifyError::Server { status: 404, .. }` so consumers get a consistent "not found" signal.
- UniFFI surface returns a JSON `String` (matches the existing pattern of passing REST-shaped data across the FFI).
- Raw return is `serde_json::Value` on the Rust side; no new typed wire struct needed.

## Test plan

- [x] URL construction test: `ids=`, `fields=`, and `userId=` all present with expected values; first element extracted from `Items`.
- [x] Empty `Items` array produces a 404 `Server` error.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (13 passed)