### PR TITLE
macos: breadcrumbs in top bar (#316)

### DIFF
--- a/macos/Sources/Jellify/Components/Breadcrumbs.swift
+++ b/macos/Sources/Jellify/Components/Breadcrumbs.swift
@@ -17,7 +17,8 @@ struct Breadcrumbs: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { idx, segment in
+            ForEach(segments.indices, id: \.self) { idx in
+                let segment = segments[idx]
                 let isLast = idx == segments.count - 1
                 if isLast {
                     Text(segment)

--- a/macos/Sources/Jellify/Components/Breadcrumbs.swift
+++ b/macos/Sources/Jellify/Components/Breadcrumbs.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Breadcrumb trail for the top bar. Renders a path like
+/// `Jellify › Library › Albums › The Deep End` where each non-final segment is
+/// a tappable control that jumps up to that depth via `onTap(index)`. The
+/// final segment is non-interactive (you are already there) and styled as the
+/// current location in `Theme.ink`; preceding segments use `Theme.ink2`.
+///
+/// This is intentionally a pure presentation component: it takes a `[String]`
+/// and a closure. Navigation-model integration lives in the caller. A preview
+/// at the bottom exercises the component with representative paths.
+struct Breadcrumbs: View {
+    /// The ordered segments to display, leaf last.
+    let segments: [String]
+    /// Called when a non-final segment at the given zero-based index is tapped.
+    var onTap: (Int) -> Void = { _ in }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { idx, segment in
+                let isLast = idx == segments.count - 1
+                if isLast {
+                    Text(segment)
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(1)
+                } else {
+                    Button {
+                        onTap(idx)
+                    } label: {
+                        Text(segment)
+                            .font(Theme.font(12, weight: .medium))
+                            .foregroundStyle(Theme.ink2)
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Navigate to \(segment)")
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Breadcrumbs")
+    }
+}
+
+#Preview("Breadcrumbs") {
+    VStack(alignment: .leading, spacing: 20) {
+        Breadcrumbs(segments: ["Jellify"])
+        Breadcrumbs(segments: ["Jellify", "Library"])
+        Breadcrumbs(segments: ["Jellify", "Library", "Albums"])
+        Breadcrumbs(segments: ["Jellify", "Library", "Albums", "The Deep End"])
+    }
+    .padding(24)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -11,9 +11,6 @@ struct MainShell: View {
                 Divider().background(Theme.border)
                 contentColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    // Screen swaps should be instant when Reduce Motion is on.
-                    // Otherwise, keep SwiftUI's default implicit behavior.
-                    .animation(reduceMotion ? nil : .default, value: model.screen)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -25,12 +22,16 @@ struct MainShell: View {
     @ViewBuilder
     private var contentColumn: some View {
         VStack(spacing: 0) {
+            topBar
             if !model.network.isOnline {
                 OfflineBanner(onRetry: { model.retryNetwork() })
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
             mainContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Screen swaps should be instant when Reduce Motion is on.
+                // Otherwise, keep SwiftUI's default implicit behavior.
+                .animation(reduceMotion ? nil : .default, value: model.screen)
         }
         .animation(.easeInOut(duration: 0.2), value: model.network.isOnline)
     }
@@ -46,6 +47,77 @@ struct MainShell: View {
             AlbumDetailView(albumID: id)
         default:
             LibraryView()
+        }
+    }
+
+    @ViewBuilder
+    private var topBar: some View {
+        HStack {
+            Breadcrumbs(segments: breadcrumbSegments) { idx in
+                navigate(toBreadcrumbDepth: idx)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 12)
+        .background(Theme.bgAlt.opacity(0.4))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.border).frame(height: 1)
+        }
+    }
+
+    /// Builds the breadcrumb trail for the current screen. The root segment is
+    /// always "Jellify"; subsequent segments describe where in the app the
+    /// user has navigated.
+    private var breadcrumbSegments: [String] {
+        var segments: [String] = ["Jellify"]
+        switch model.screen {
+        case .home:
+            segments.append("Home")
+        case .library:
+            segments.append("Library")
+        case .search:
+            segments.append("Search")
+        case .album(let id):
+            segments.append("Library")
+            segments.append("Albums")
+            if let album = model.albums.first(where: { $0.id == id }) {
+                segments.append(album.name)
+            } else {
+                segments.append("Album")
+            }
+        case .artist(let id):
+            segments.append("Library")
+            segments.append("Artists")
+            if let artist = model.artists.first(where: { $0.id == id }) {
+                segments.append(artist.name)
+            } else {
+                segments.append("Artist")
+            }
+        case .playlist:
+            segments.append("Playlists")
+        case .settings:
+            segments.append("Settings")
+        }
+        return segments
+    }
+
+    /// Handles a tap on a breadcrumb segment at `idx`. The root ("Jellify")
+    /// and the common "Library" parent both return the user to the library.
+    private func navigate(toBreadcrumbDepth idx: Int) {
+        let segment = breadcrumbSegments[safe: idx] ?? ""
+        switch segment {
+        case "Jellify", "Library", "Albums", "Artists":
+            model.screen = .library
+        case "Home":
+            model.screen = .home
+        case "Search":
+            model.screen = .search
+        case "Settings":
+            model.screen = .settings
+        default:
+            // Final/unknown segments are non-navigable; do nothing.
+            break
         }
     }
 }

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -94,7 +94,7 @@ struct MainShell: View {
             } else {
                 segments.append("Artist")
             }
-        case .playlist:
+        case .playlist(_):
             segments.append("Playlists")
         case .settings:
             segments.append("Settings")
@@ -102,22 +102,31 @@ struct MainShell: View {
         return segments
     }
 
-    /// Handles a tap on a breadcrumb segment at `idx`. The root ("Jellify")
-    /// and the common "Library" parent both return the user to the library.
+    /// Handles a tap on a breadcrumb segment at `idx`. Navigation is driven by
+    /// the current `model.screen` and the tapped index, so the component stays
+    /// agnostic of label strings (no brittle title matching). Index 0 is the
+    /// root ("Jellify") and always returns to the library. For nested screens
+    /// (e.g. album/artist detail), intermediate indices pop to the library;
+    /// the final index is the current location and is a no-op.
     private func navigate(toBreadcrumbDepth idx: Int) {
-        let segment = breadcrumbSegments[safe: idx] ?? ""
-        switch segment {
-        case "Jellify", "Library", "Albums", "Artists":
+        // Index 0 is always the root and pops to library.
+        guard idx > 0 else {
             model.screen = .library
-        case "Home":
-            model.screen = .home
-        case "Search":
-            model.screen = .search
-        case "Settings":
-            model.screen = .settings
-        default:
-            // Final/unknown segments are non-navigable; do nothing.
+            return
+        }
+
+        switch model.screen {
+        case .home, .library, .search, .settings, .playlist:
+            // Shape: ["Jellify", <current>] — only the final index, which is
+            // the current location and non-navigable. Nothing to do.
             break
+        case .album, .artist:
+            // Shape: ["Jellify", "Library", "<Albums|Artists>", <name>].
+            // idx 1 = "Library" and idx 2 = the section both pop to library;
+            // idx 3 is the current location and is a no-op.
+            if idx < 3 {
+                model.screen = .library
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #316

Adds Breadcrumbs component ("Jellify › Library › …") in the top bar. Each segment is tappable; last segment is styled as current position.