### PR TITLE
core: add recently_played tracks endpoint

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -251,6 +251,50 @@ impl JellyfinClient {
         Ok(items.into_iter().map(Album::from).collect())
     }
 
+    /// Recently played audio tracks for the current user, sorted by
+    /// `DatePlayed` descending. Jellyfin implicitly omits tracks with a null
+    /// `UserData.LastPlayedDate` from this sort, so the result is the user's
+    /// listening history.
+    ///
+    /// `music_library_id` is the `MusicLibrary` CollectionFolder id; when
+    /// provided it scopes the query via `ParentId`. When `None`, Jellyfin
+    /// searches across all libraries the user can access.
+    pub async fn recently_played(
+        &self,
+        music_library_id: Option<&str>,
+        paging: Paging,
+    ) -> Result<Vec<Track>> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            if let Some(parent) = music_library_id {
+                q.append_pair("ParentId", parent);
+            }
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", "Audio");
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            q.append_pair("SortBy", "DatePlayed");
+            q.append_pair("SortOrder", "Descending");
+            q.append_pair(
+                "Fields",
+                "ParentId,MediaSources,UserData,ProductionYear,PrimaryImageAspectRatio",
+            );
+        }
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        Ok(raw.items.into_iter().map(Track::from).collect())
+    }
+
     pub async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {
         let user_id = self
             .user_id

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -190,6 +190,22 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.latest_albums(&library_id, limit)))
     }
 
+    /// Recently played tracks for the current user, sorted by server-side
+    /// `DatePlayed` descending. Pass `music_library_id` to scope to a single
+    /// `MusicLibrary` CollectionFolder.
+    pub fn recently_played(
+        &self,
+        music_library_id: Option<String>,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<Vec<Track>, JellifyError> {
+        self.with_client(|c| {
+            self.runtime.block_on(
+                c.recently_played(music_library_id.as_deref(), Paging::new(offset, limit)),
+            )
+        })
+    }
+
     pub fn search(&self, query: String) -> std::result::Result<SearchResults, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.search(&query)))
     }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -152,9 +152,15 @@ async fn recently_played_builds_query_and_parses() {
     assert!(q.contains("Limit=50"), "query: {q}");
     assert!(q.contains("StartIndex=0"), "query: {q}");
     assert!(q.contains("ParentId=lib-1"), "query: {q}");
+    let fields = get
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "Fields")
+        .map(|(_, v)| v.into_owned())
+        .expect("expected Fields query param");
     assert!(
-        q.contains("Fields=") && q.contains("ParentId"),
-        "query: {q}"
+        fields.split(',').any(|f| f == "ParentId"),
+        "Fields should include ParentId, got: {fields}"
     );
 }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -100,6 +100,104 @@ async fn album_tracks_parses() {
 }
 
 #[tokio::test]
+async fn recently_played_builds_query_and_parses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Echo", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Tides",
+                    "AlbumArtist": "Ocean", "Artists": ["Ocean"],
+                    "RunTimeTicks": 1800000000u64,
+                    "UserData": { "IsFavorite": false, "PlayCount": 3 },
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client
+        .recently_played(Some("lib-1"), Paging::new(0, 50))
+        .await
+        .unwrap();
+
+    assert_eq!(tracks.len(), 1);
+    assert_eq!(tracks[0].name, "Echo");
+    assert_eq!(tracks[0].play_count, 3);
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("SortBy=DatePlayed"), "query: {q}");
+    assert!(q.contains("SortOrder=Descending"), "query: {q}");
+    assert!(q.contains("Limit=50"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+    assert!(q.contains("ParentId=lib-1"), "query: {q}");
+    assert!(
+        q.contains("Fields=") && q.contains("ParentId"),
+        "query: {q}"
+    );
+}
+
+#[tokio::test]
+async fn recently_played_omits_parent_id_when_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client
+        .recently_played(None, Paging::new(5, 25))
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(!q.contains("ParentId="), "unexpected ParentId: {q}");
+    assert!(q.contains("Limit=25"), "query: {q}");
+    assert!(q.contains("StartIndex=5"), "query: {q}");
+    assert!(q.contains("SortBy=DatePlayed"), "query: {q}");
+    assert!(q.contains("SortOrder=Descending"), "query: {q}");
+}
+
+#[tokio::test]
 async fn albums_uses_paging() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))


### PR DESCRIPTION
Closes #148

Adds async `recently_played(music_library_id, paging)` returning `Vec<Track>` sorted by `DatePlayed` DESC.

- `JellyfinClient::recently_played(Option<&str>, Paging)` in `core/src/client.rs`
- UniFFI-exposed `JellifyCore::recently_played(Option<String>, offset, limit)` in `core/src/lib.rs`
- `music_library_id` passed as a parameter (no library-id state on the client yet); `None` lets the server search across all accessible libraries
- Two URL-construction tests proving `IncludeItemTypes=Audio`, `Recursive=true`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Limit`, `StartIndex`, and `ParentId` handling

Consumer: Home "Recently Played" row (Jellify's client-side album-collapse heuristic stays in the UI layer).