### PR TITLE
macos: network offline banner

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -12,6 +12,7 @@ final class AppModel {
     // MARK: - Core
     let core: JellifyCore
     let audio: AudioEngine
+    let network: NetworkMonitor
 
     // MARK: - Session
     var session: Session?
@@ -44,10 +45,21 @@ final class AppModel {
         )
         self.core = core
         self.audio = AudioEngine(core: core)
+        self.network = NetworkMonitor()
         self.status = core.status()
         self.audio.onTrackEnded = { [weak self] in
             self?.handleTrackEnded()
         }
+    }
+
+    // MARK: - Network
+
+    /// Re-evaluates network reachability and, if a session exists, kicks off a
+    /// library refetch. Wired to the offline banner's `Retry` button.
+    func retryNetwork() {
+        network.retry()
+        guard session != nil else { return }
+        Task { await refreshLibrary() }
     }
 
     // MARK: - Session

--- a/macos/Sources/Jellify/Components/OfflineBanner.swift
+++ b/macos/Sources/Jellify/Components/OfflineBanner.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Banner shown at the top of the content column when the system is offline.
+///
+/// Design tokens: `danger` background at 10% opacity, a 3pt `danger` left
+/// border, and a `Retry` action that re-evaluates network state and refetches
+/// the library via `AppModel`. The banner hides automatically when
+/// connectivity returns (debounced by `NetworkMonitor`).
+struct OfflineBanner: View {
+    let onRetry: () -> Void
+
+    private let message = "You're offline. Playing from downloaded tracks only."
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.danger)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 12)
+
+            Button(action: onRetry) {
+                Text("Retry")
+                    .font(Theme.font(12, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Theme.danger.opacity(0.25))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Theme.danger, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Retry network connection")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.danger.opacity(0.10))
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Theme.danger)
+                .frame(width: 3)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+        .accessibilityAddTraits(.isStaticText)
+    }
+}
+
+#Preview("Offline banner") {
+    OfflineBanner(onRetry: {})
+        .frame(width: 720)
+        .padding()
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/NetworkMonitor.swift
+++ b/macos/Sources/Jellify/NetworkMonitor.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Network
+import Observation
+
+/// Publishes the system's reachability state. Uses `NWPathMonitor` on a background
+/// queue and republishes changes on the main actor so SwiftUI views can bind to
+/// `isOnline` without manual dispatch.
+///
+/// The monitor debounces flaky transitions: a path that reports `satisfied` is
+/// only treated as "online" after the state has held steady for a short window.
+/// Going offline is applied immediately so the banner surfaces right away.
+@Observable
+@MainActor
+final class NetworkMonitor {
+    /// `true` when the system reports a usable network path. Starts `true`
+    /// optimistically so the banner does not flash on cold launch.
+    var isOnline: Bool = true
+
+    private var monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "com.jellify.network-monitor")
+    private var stableOnlineTask: Task<Void, Never>?
+
+    init() {
+        self.monitor = NWPathMonitor()
+        start()
+    }
+
+    private func start() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let satisfied = path.status == .satisfied
+            Task { @MainActor in
+                self.apply(satisfied: satisfied)
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    private func apply(satisfied: Bool) {
+        stableOnlineTask?.cancel()
+        stableOnlineTask = nil
+
+        if !satisfied {
+            // Offline is applied immediately so users see the banner fast.
+            if isOnline { isOnline = false }
+            return
+        }
+
+        // Debounce coming back online to avoid flicker on flaky networks.
+        stableOnlineTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 750_000_000) // 0.75s
+            guard let self, !Task.isCancelled else { return }
+            if !self.isOnline { self.isOnline = true }
+        }
+    }
+
+    /// Force a fresh path evaluation. Cancels the existing monitor and starts a
+    /// new one so the next `pathUpdateHandler` fires with a current snapshot.
+    func retry() {
+        stableOnlineTask?.cancel()
+        stableOnlineTask = nil
+        monitor.cancel()
+        monitor = NWPathMonitor()
+        start()
+    }
+}

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -8,7 +8,7 @@ struct MainShell: View {
             HStack(spacing: 0) {
                 Sidebar()
                 Divider().background(Theme.border)
-                mainContent
+                contentColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -16,6 +16,19 @@ struct MainShell: View {
             PlayerBar()
         }
         .background(Theme.bg)
+    }
+
+    @ViewBuilder
+    private var contentColumn: some View {
+        VStack(spacing: 0) {
+            if !model.network.isOnline {
+                OfflineBanner(onRetry: { model.retryNetwork() })
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            mainContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .animation(.easeInOut(duration: 0.2), value: model.network.isOnline)
     }
 
     @ViewBuilder

--- a/macos/Sources/Jellify/Theme/Theme.swift
+++ b/macos/Sources/Jellify/Theme/Theme.swift
@@ -23,6 +23,9 @@ enum Theme {
     static let accentHot = Color(hex: 0xFF066F)
     static let teal = Color(hex: 0x57E9C9)
 
+    // Status
+    static let danger = Color(hex: 0xFF4757)
+
     // Borders
     static let border = Color(rgba: (126, 114, 175, 0.18))
     static let borderStrong = Color(rgba: (126, 114, 175, 0.35))


### PR DESCRIPTION
Closes #300

Adds a banner at the top of the content column when `NWPathMonitor` reports offline. Message: "You're offline. Playing from downloaded tracks only." Retry action re-evaluates network and refetches. Hides automatically when connectivity returns.

## Summary
- `NetworkMonitor` (`macos/Sources/Jellify/NetworkMonitor.swift`): `@Observable` / `@MainActor` wrapper around `NWPathMonitor`. Subscribes on a background queue and republishes on the main actor. Offline transitions apply immediately; coming back online is debounced (0.75s stable window) to avoid flicker on flaky networks.
- `OfflineBanner` (`macos/Sources/Jellify/Components/OfflineBanner.swift`): `danger` bg at 10% tint, 3pt `danger` left border, `Retry` button. Merged a11y element with a VoiceOver label that announces the full message.
- `Theme.danger` token added (`macos/Sources/Jellify/Theme/Theme.swift`).
- `AppModel` owns `NetworkMonitor` and exposes `retryNetwork()` which cancels + restarts the path monitor and kicks off a library refetch when logged in.
- `MainShell` mounts the banner conditionally above the main content pane with a short ease-in/out transition.

## Test plan
- [x] `./Scripts/build-core.sh` succeeds
- [x] `swift build` succeeds
- [x] `./Scripts/make-bundle.sh` succeeds
- [x] App launches cleanly
- [ ] Toggle Wi-Fi off -> banner appears within ~1s with `danger` accent
- [ ] Toggle Wi-Fi on -> banner disappears after ~0.75s stable window
- [ ] Click Retry while online -> library refetches
- [ ] VoiceOver announces full message when banner is focused