### PR TITLE
macos: respect Reduce Motion for ambient animations

### DIFF
--- a/macos/Sources/Jellify/Components/TrackRow.swift
+++ b/macos/Sources/Jellify/Components/TrackRow.swift
@@ -68,20 +68,38 @@ struct TrackRow: View {
 }
 
 /// Tiny three-bar equalizer visual for the "now playing" row.
+/// Respects Reduce Motion: swaps to a static three-bar glyph when on.
 struct EqualizerIcon: View {
-    @State private var phase: Double = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Static heights used when Reduce Motion is enabled — chosen to read as
+    /// a recognizable EQ glyph without implying motion.
+    private let staticHeights: [CGFloat] = [9, 12, 7]
+
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
+        if reduceMotion {
             HStack(alignment: .bottom, spacing: 2) {
                 ForEach(0..<3, id: \.self) { i in
-                    let height = 4 + CGFloat(abs(sin(t * 3 + Double(i) * 0.7))) * 10
                     Rectangle()
-                        .frame(width: 3, height: height)
-                        .animation(.linear(duration: 0.1), value: height)
+                        .frame(width: 3, height: staticHeights[i])
                 }
             }
             .frame(height: 14)
+            .accessibilityLabel("Now playing")
+        } else {
+            TimelineView(.animation) { timeline in
+                let t = timeline.date.timeIntervalSinceReferenceDate
+                HStack(alignment: .bottom, spacing: 2) {
+                    ForEach(0..<3, id: \.self) { i in
+                        let height = 4 + CGFloat(abs(sin(t * 3 + Double(i) * 0.7))) * 10
+                        Rectangle()
+                            .frame(width: 3, height: height)
+                            .animation(.linear(duration: 0.1), value: height)
+                    }
+                }
+                .frame(height: 14)
+            }
+            .accessibilityLabel("Now playing")
         }
     }
 }

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -27,6 +27,7 @@ struct JellifyApp: App {
 
 struct RootView: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Group {
@@ -37,5 +38,7 @@ struct RootView: View {
             }
         }
         .background(Theme.bg)
+        // Login <-> main shell swap is instant under Reduce Motion.
+        .animation(reduceMotion ? nil : .default, value: model.session != nil)
     }
 }

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -61,6 +61,7 @@ struct LibraryView: View {
 
 struct AlbumCard: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let album: Album
     @State private var isHovering = false
 
@@ -90,8 +91,8 @@ struct AlbumCard: View {
                     .buttonStyle(.plain)
                     .padding(8)
                     .opacity(isHovering ? 1 : 0)
-                    .offset(y: isHovering ? 0 : 8)
-                    .animation(.easeOut(duration: 0.15), value: isHovering)
+                    .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainShell: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(spacing: 0) {
@@ -10,6 +11,9 @@ struct MainShell: View {
                 Divider().background(Theme.border)
                 mainContent
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    // Screen swaps should be instant when Reduce Motion is on.
+                    // Otherwise, keep SwiftUI's default implicit behavior.
+                    .animation(reduceMotion ? nil : .default, value: model.screen)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 


### PR DESCRIPTION
Closes #339

All animations gated on `Environment(\.accessibilityReduceMotion)`. Ambient loops (EQ bars) swap to a static glyph when Reduce Motion is on. Progress-bar state updates (non-animated) unchanged.

## Sites audited

| File | Change |
| --- | --- |
| `JellifyApp.swift` | Login <-> MainShell swap: `.animation(reduceMotion ? nil : .default, value: session != nil)` |
| `Screens/MainShell.swift` | Screen (home/library/search/album) swap: same pattern, keyed on `model.screen` |
| `Screens/LibraryView.swift` | `AlbumCard` hover play-button fade + rise: animation nil'd and offset collapsed to 0 when reduceMotion |
| `Components/TrackRow.swift` | `EqualizerIcon` branches on reduceMotion; under reduceMotion emits a static three-bar glyph with no `TimelineView` (no continuous redraws) |

## Notes on what's not animated

- `LoginView` has no purple wash animation (background is a flat `Theme.bg`) so there was nothing to gate.
- `PlayerBar` progress capsule updates via state from `AppModel.status` but uses no implicit animation; it transitions on each poll tick rather than animating between values.
- No `.rotationEffect`/vinyl-spin or `repeatForever` loops exist in the current macOS source.

## Verify

```
cd macos
./Scripts/build-core.sh && swift build
./Scripts/make-bundle.sh
./build/Jellify.app/Contents/MacOS/Jellify
```

Swift build: clean. App launches. Manual visual verification under `System Settings > Accessibility > Display > Reduce motion` is pending (dev machine does not currently have the setting enabled).