### PR TITLE
macos: album context menu

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 @preconcurrency import JellifyCore
@@ -153,6 +154,98 @@ final class AppModel {
             guard !tracks.isEmpty else { return }
             play(tracks: tracks, startIndex: 0)
         }
+    }
+
+    /// Shuffle an album — loads tracks, randomises order, then plays from top.
+    func shuffle(album: Album) {
+        Task {
+            let tracks = await loadTracks(forAlbum: album.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks.shuffled(), startIndex: 0)
+        }
+    }
+
+    /// Insert an album's tracks immediately after the currently-playing track.
+    /// TODO: #282 — proper Up Next vs Auto Queue separation. For now, the core
+    /// queue is replaced on every `setQueue`, so until we grow an `insertNext`
+    /// primitive this falls back to appending behaviour.
+    func playNext(album: Album) {
+        // TODO: #282 — queue "Up Next" insertion; for now, surface a log.
+        print("[AppModel] playNext(album:) not yet wired — see #282")
+        Task {
+            let tracks = await loadTracks(forAlbum: album.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks, startIndex: 0)
+        }
+    }
+
+    /// Append an album's tracks to the end of the queue.
+    /// TODO: #282 — the core lacks an `appendToQueue` primitive, so this is a
+    /// stub that plays the album outright for now.
+    func addToQueue(album: Album) {
+        // TODO: #282 — queue append. Currently behaves like `play`.
+        print("[AppModel] addToQueue(album:) not yet wired — see #282")
+        play(album: album)
+    }
+
+    /// Toggle the favorite flag for an album on the Jellyfin server.
+    /// TODO: #133, #222 — wire through `set_favorite` / `unset_favorite` on
+    /// the core once the FFI surface exists.
+    func toggleFavorite(album: Album) {
+        // TODO: #133 / #222 — set_favorite FFI not yet wired.
+        print("[AppModel] toggleFavorite(album:) not yet wired — see #133 / #222")
+    }
+
+    /// Enqueue a download of every track on the album.
+    /// TODO: #70, #222 — there is no download engine yet; this is a logging
+    /// stub so the UI action has a landing pad.
+    func enqueueDownload(album: Album) {
+        // TODO: #70 / #222 — download engine not yet wired.
+        print("[AppModel] enqueueDownload(album:) not yet wired — see #70 / #222")
+    }
+
+    /// Present an "Add all to playlist" destination picker.
+    /// TODO: #72, #126, #222 — playlist picker sheet + create-playlist API.
+    func requestAddToPlaylist(album: Album) {
+        // TODO: #72 / #126 / #222 — playlist picker sheet not yet implemented.
+        print("[AppModel] requestAddToPlaylist(album:) not yet wired — see #72 / #126 / #222")
+    }
+
+    /// Navigate to the artist detail screen for this album's artist, if known.
+    func goToArtist(album: Album) {
+        guard let artistID = album.artistId else { return }
+        screen = .artist(artistID)
+    }
+
+    /// Kick off an Instant Mix ("album radio") seeded by this album.
+    /// TODO: #144, #327 — Instant Mix endpoint + modal not yet wired.
+    func startAlbumRadio(album: Album) {
+        // TODO: #144 / #327 — Instant Mix FFI not yet wired.
+        print("[AppModel] startAlbumRadio(album:) not yet wired — see #144 / #327")
+    }
+
+    // MARK: - Sharing
+
+    /// Jellyfin web URL for an album, e.g.
+    /// `https://server.example.com/web/#/details?id=<albumId>`.
+    func webURL(for album: Album) -> URL? {
+        guard !serverURL.isEmpty else { return nil }
+        let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+        return URL(string: "\(base)/web/#/details?id=\(album.id)")
+    }
+
+    /// Copy the album's web URL to the system pasteboard.
+    func copyShareLink(album: Album) {
+        guard let url = webURL(for: album) else { return }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(url.absoluteString, forType: .string)
+    }
+
+    /// Open the album in the Jellyfin web UI.
+    func openInJellyfin(album: Album) {
+        guard let url = webURL(for: album) else { return }
+        NSWorkspace.shared.open(url)
     }
 
     func pause() { audio.pause() }

--- a/macos/Sources/Jellify/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Jellify/Components/AlbumContextMenu.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Shared right-click / long-press context menu for album surfaces
+/// (library grid cell + album hero in detail view).
+///
+/// Issue: #311. Many of the backing actions are TODO stubs pending
+/// follow-up FFI work (see individual `AppModel` methods for issue refs).
+struct AlbumContextMenu: View {
+    @Environment(AppModel.self) private var model
+    let album: Album
+
+    var body: some View {
+        Button("Play", systemImage: "play.fill") { model.play(album: album) }
+        Button("Shuffle", systemImage: "shuffle") { model.shuffle(album: album) }
+        Button("Play Next", systemImage: "text.insert") { model.playNext(album: album) }
+        Button("Add to Queue", systemImage: "text.append") { model.addToQueue(album: album) }
+
+        Divider()
+
+        Button("Favorite", systemImage: "heart") { model.toggleFavorite(album: album) }
+        Button("Download", systemImage: "arrow.down.circle") { model.enqueueDownload(album: album) }
+        Button("Add All to Playlist…", systemImage: "plus.rectangle.on.folder") {
+            model.requestAddToPlaylist(album: album)
+        }
+
+        Divider()
+
+        Button("Go to Artist", systemImage: "person") { model.goToArtist(album: album) }
+            .disabled(album.artistId == nil)
+        Button("Start Album Radio", systemImage: "dot.radiowaves.left.and.right") {
+            model.startAlbumRadio(album: album)
+        }
+
+        Divider()
+
+        Button("Share Link", systemImage: "link") { model.copyShareLink(album: album) }
+            .disabled(model.webURL(for: album) == nil)
+        Button("Show in Jellyfin", systemImage: "safari") { model.openInJellyfin(album: album) }
+            .disabled(model.webURL(for: album) == nil)
+    }
+}

--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -75,6 +75,7 @@ struct AlbumDetailView: View {
             .overlay(alignment: .bottom) {
                 Rectangle().fill(Theme.border).frame(height: 1)
             }
+            .contextMenu { AlbumContextMenu(album: album) }
         }
     }
 

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -120,5 +120,6 @@ struct AlbumCard: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        .contextMenu { AlbumContextMenu(album: album) }
     }
 }


### PR DESCRIPTION
Closes #311

Adds a right-click / long-press context menu on album surfaces: the grid cell in `LibraryView` and the hero in `AlbumDetailView`. Menu structure:

- Play
- Shuffle
- Play Next
- Add to Queue
- ——
- Favorite
- Download
- Add All to Playlist…
- ——
- Go to Artist
- Start Album Radio
- ——
- Share Link (copies `https://<server>/web/#/details?id=<albumId>` to pasteboard)
- Show in Jellyfin (opens the same URL in the default browser)

### Wired now
- **Play** — existing `model.play(album:)`.
- **Shuffle** — loads tracks and shuffles before queueing.
- **Go to Artist** — navigates to `.artist(id)` when the album has an `artistId`.
- **Share Link** — `NSPasteboard` copy of the Jellyfin web URL.
- **Show in Jellyfin** — `NSWorkspace.open` of the Jellyfin web URL.

### TODO stubs (logging only, linked to follow-up issues)
- **Play Next / Add to Queue** — #282 (Up Next vs Auto Queue separation; core lacks `insertNext` / `appendToQueue` primitives).
- **Favorite** — #133, #222 (`set_favorite` / `unset_favorite` FFI).
- **Download** — #70, #222 (no download engine yet).
- **Add All to Playlist…** — #72, #126, #222 (playlist picker sheet + create-playlist API).
- **Start Album Radio** — #144, #327 (Instant Mix FFI + modal).

Menu implementation lives in `macos/Sources/Jellify/Components/AlbumContextMenu.swift` so the same content is reused on both surfaces.

### Test plan
- [x] `./Scripts/build-core.sh && swift build` succeeds.
- [x] `./Scripts/make-bundle.sh` produces `Jellify.app`; smoke launch opens the window without crashing.
- [ ] Right-click an album in the library grid: menu appears with all items and correct dividers.
- [ ] Right-click the album hero in detail view: same menu.
- [ ] Select **Play** / **Shuffle** / **Go to Artist** / **Share Link** / **Show in Jellyfin** — confirm each action fires.
- [ ] Select a TODO item (Favorite, Download, Play Next, etc.) — confirm it logs without crashing.
- [ ] **Go to Artist** is disabled on albums without `artistId`.
- [ ] **Share Link** / **Show in Jellyfin** are disabled when `serverURL` is empty.