### PR TITLE
macos: auth expired sheet

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -47,6 +47,13 @@ final class AppModel {
     var isLoadingLibrary = false
     var errorMessage: String?
 
+    /// Set when a core call fails because the server rejected our token
+    /// (HTTP 401) or the core reports no-longer-authenticated. Drives the
+    /// modal prompt in `MainShell`. Reset after the user dismisses the sheet
+    /// or signs back in. Auto-reauth (reissuing credentials silently) is
+    /// tracked separately in #440 — this flag only powers the prompt.
+    var authExpired: Bool = false
+
     init() throws {
         let core = try JellifyCore(
             config: CoreConfig(dataDir: "", deviceName: "Jellify macOS")
@@ -112,6 +119,48 @@ final class AppModel {
         stopPolling()
     }
 
+    /// Drop the stored access token (keychain + in-memory session) without
+    /// clearing the remembered server URL / username, so the user can re-auth
+    /// against the same server by re-entering only their password. Called
+    /// when the user taps "Sign in" on the auth-expired sheet. Note: the
+    /// caller still owns toggling `authExpired` off and nilling `session`.
+    func forgetToken() {
+        audio.stop()
+        try? core.logout()
+        albums = []
+        artists = []
+        albumTracks = [:]
+        stopPolling()
+    }
+
+    /// Flag the session as expired. The UI surfaces this via the auth-expired
+    /// modal in `MainShell`. Idempotent — second hits within a session are
+    /// no-ops while the prompt is still visible.
+    func markAuthExpired() {
+        guard !authExpired else { return }
+        audio.stop()
+        stopPolling()
+        authExpired = true
+    }
+
+    /// Inspect an error from a core call and, if it looks like a 401 or the
+    /// core's `NotAuthenticated` variant, mark the session expired and return
+    /// `true` so the caller knows to skip its generic error surfacing.
+    ///
+    /// `JellifyError` is a `flat_error` in uniffi, so on the Swift side we
+    /// only get the `thiserror` Display string. The variants we care about
+    /// are:
+    /// - `NotAuthenticated` → `"not logged in"`
+    /// - `Server { status: 401, .. }` → `"server returned an error: 401 ..."`
+    private func handleAuthError(_ error: Error) -> Bool {
+        let description = error.localizedDescription
+        let isNotAuthenticated = description.contains("not logged in")
+        let isServer401 = description.contains("server returned an error: 401")
+        guard isNotAuthenticated || isServer401 else { return false }
+        markAuthExpired()
+        return true
+    }
+
     // MARK: - Library
 
     func refreshLibrary() async {
@@ -128,6 +177,7 @@ final class AppModel {
             self.artists = artists
             serverReachability.noteSuccess()
         } catch {
+            if handleAuthError(error) { return }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
@@ -145,6 +195,7 @@ final class AppModel {
             serverReachability.noteSuccess()
             return tracks
         } catch {
+            if handleAuthError(error) { return [] }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
@@ -173,6 +224,7 @@ final class AppModel {
             self.searchResults = results
             serverReachability.noteSuccess()
         } catch {
+            if handleAuthError(error) { return }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
@@ -194,6 +246,7 @@ final class AppModel {
             try audio.play(track: first)
             errorMessage = nil
         } catch {
+            if handleAuthError(error) { return }
             errorMessage = "Couldn't start playback: \(error.localizedDescription)"
         }
     }
@@ -518,6 +571,7 @@ final class AppModel {
         do {
             try audio.play(track: track)
         } catch {
+            if handleAuthError(error) { return }
             errorMessage = "Playback failed: \(error.localizedDescription)"
         }
     }

--- a/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
+++ b/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Modal sheet shown when a server call returns 401 on a token that used to
+/// be valid. Offers a single "Sign in" CTA that drops the stored token and
+/// bounces the user back to `LoginView` with the server URL and username
+/// prefilled (stored on `AppModel` from the last successful sign-in).
+///
+/// This is strictly a prompt — silent re-auth using a remembered password is
+/// tracked separately in #440. See issue #303.
+struct AuthExpiredSheet: View {
+    let onSignIn: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "lock.slash")
+                .font(.system(size: 36, weight: .semibold))
+                .foregroundStyle(Theme.accent)
+                .accessibilityHidden(true)
+                .padding(.top, 8)
+
+            VStack(spacing: 8) {
+                Text("Your session expired")
+                    .font(Theme.font(18, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+
+                Text("Please sign in again to continue listening.")
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Button(action: onSignIn) {
+                Text("Sign in")
+                    .font(Theme.font(14, weight: .bold))
+                    .frame(width: 260, height: 40)
+                    .foregroundStyle(Theme.bg)
+                    .background(Theme.ink)
+                    .clipShape(RoundedRectangle(cornerRadius: 22))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Sign in again")
+        }
+        .padding(32)
+        .frame(width: 360)
+        .background(Theme.bg)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+}
+
+#Preview("Auth expired sheet") {
+    AuthExpiredSheet(onSignIn: {})
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/LoginView.swift
+++ b/macos/Sources/Jellify/Screens/LoginView.swift
@@ -58,6 +58,13 @@ struct LoginView: View {
             }
             .padding(40)
         }
+        .onAppear {
+            // After an auth-expired bounce (#303), the server URL and
+            // username live on AppModel from the last successful sign-in.
+            // Prefill so the user only needs to re-enter their password.
+            if url.isEmpty, !model.serverURL.isEmpty { url = model.serverURL }
+            if username.isEmpty, !model.username.isEmpty { username = model.username }
+        }
     }
 
     @ViewBuilder

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -5,6 +5,7 @@ struct MainShell: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
+        @Bindable var model = model
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 Sidebar()
@@ -17,6 +18,17 @@ struct MainShell: View {
             PlayerBar()
         }
         .background(Theme.bg)
+        // Auth-expired prompt — see #303. One-shot modal; on "Sign in" we
+        // drop the stored token and clear the session so `RootView` routes
+        // back to `LoginView`, which prefills the remembered server URL and
+        // username so the user only needs to re-enter their password.
+        .sheet(isPresented: $model.authExpired) {
+            AuthExpiredSheet {
+                model.forgetToken()
+                model.session = nil
+                model.authExpired = false
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes #303

## Summary
- New `AuthExpiredSheet` modal shown from `MainShell` via `.sheet(isPresented: $model.authExpired)` when the server rejects our session token with HTTP 401 (or the core surfaces `NotAuthenticated`).
- `AppModel` grows `authExpired`, `markAuthExpired()`, `forgetToken()`, and a central `handleAuthError(_:)` helper. Error paths in `refreshLibrary`, `loadTracks`, `search`, `play`, and `playCurrent` now consult that helper before surfacing the generic error message, so a 401 flips the flag instead of showing a "Library load failed: server returned an error: 401" toast.
- On "Sign in" tap: we drop the stored token (`forgetToken()` calls `core.logout()` which cleans keychain + in-memory client), nil out `session` so `RootView` swaps back to `LoginView`, and reset the flag. `LoginView` now prefills server URL and username from `AppModel` (persisted from the last successful sign-in) so the user only has to re-enter their password.

Silent auto-reauth using a remembered password is intentionally not in this PR — that's tracked separately in #440.

## Test plan
- [x] `cargo test -p jellify_core` — 18 passed
- [x] `./macos/Scripts/build-core.sh && swift build` — clean build
- [x] `./macos/Scripts/make-bundle.sh` + launch `Jellify.app` — runs cleanly, no crash
- [ ] Manual: sign in, revoke token on server (or wait for expiry), trigger a library refresh, confirm the sheet appears
- [ ] Manual: tap "Sign in", confirm login screen shows with server URL + username prefilled and focus ready for password