### PR TITLE
core: paginated library + Swift pagination wiring

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -155,7 +155,7 @@ impl JellyfinClient {
 
     // ----- Library queries -----
 
-    pub async fn artists(&self, paging: Paging) -> Result<Vec<Artist>> {
+    pub async fn artists(&self, paging: Paging) -> Result<PaginatedArtists> {
         let user_id = self
             .user_id
             .as_ref()
@@ -179,10 +179,13 @@ impl JellyfinClient {
             .send()
             .await?;
         let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Artist::from).collect())
+        Ok(PaginatedArtists {
+            items: raw.items.into_iter().map(Artist::from).collect(),
+            total_count: raw.total_record_count,
+        })
     }
 
-    pub async fn albums(&self, paging: Paging) -> Result<Vec<Album>> {
+    pub async fn albums(&self, paging: Paging) -> Result<PaginatedAlbums> {
         let user_id = self
             .user_id
             .as_ref()
@@ -208,7 +211,10 @@ impl JellyfinClient {
             .send()
             .await?;
         let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Album::from).collect())
+        Ok(PaginatedAlbums {
+            items: raw.items.into_iter().map(Album::from).collect(),
+            total_count: raw.total_record_count,
+        })
     }
 
     /// Fetch the most recently added albums in a library, respecting the
@@ -223,18 +229,37 @@ impl JellyfinClient {
     ///   Home "Recently Added" row shows albums rather than loose tracks.
     /// - `library_id` is the music library's collection id (a "Views" item);
     ///   callers typically resolve it once at sign-in and cache it.
-    pub async fn latest_albums(&self, library_id: &str, limit: u32) -> Result<Vec<Album>> {
+    ///
+    /// # Pagination caveat
+    ///
+    /// The underlying `/Items/Latest` endpoint does NOT accept a
+    /// `StartIndex` query parameter (see Jellyfin's
+    /// `UserLibraryController.GetLatestMedia` — only `Limit` is exposed).
+    /// To still offer a uniform `Paging` surface, this method asks the
+    /// server for `offset + limit` items and slices the tail client-side.
+    /// That means `offset` values larger than Jellyfin's internal
+    /// "most recent" window will return an empty page even if more albums
+    /// exist in the library. Callers that need the full catalog should use
+    /// [`JellyfinClient::albums`] instead; `latest_albums` is optimized for
+    /// the Home "Recently Added" row.
+    ///
+    /// `total_count` on the returned [`PaginatedAlbums`] is the number of
+    /// items the server returned for this request, NOT the library total —
+    /// `/Items/Latest` does not report `TotalRecordCount`.
+    pub async fn latest_albums(&self, library_id: &str, paging: Paging) -> Result<PaginatedAlbums> {
         let user_id = self
             .user_id
             .as_ref()
             .ok_or(JellifyError::NotAuthenticated)?;
+        let limit = paging.limit.max(1);
+        let server_limit = paging.offset.saturating_add(limit).max(1);
         let mut url = self.endpoint("Items/Latest")?;
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("ParentId", library_id);
             q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &limit.max(1).to_string());
+            q.append_pair("Limit", &server_limit.to_string());
             q.append_pair("GroupItems", "true");
             q.append_pair(
                 "Fields",
@@ -248,7 +273,17 @@ impl JellyfinClient {
             .send()
             .await?;
         let items: Vec<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(items.into_iter().map(Album::from).collect())
+        let total_count = items.len() as u32;
+        let sliced: Vec<Album> = items
+            .into_iter()
+            .skip(paging.offset as usize)
+            .take(limit as usize)
+            .map(Album::from)
+            .collect();
+        Ok(PaginatedAlbums {
+            items: sliced,
+            total_count,
+        })
     }
 
     /// Recently played audio tracks for the current user, sorted by
@@ -263,7 +298,7 @@ impl JellyfinClient {
         &self,
         music_library_id: Option<&str>,
         paging: Paging,
-    ) -> Result<Vec<Track>> {
+    ) -> Result<PaginatedTracks> {
         let user_id = self
             .user_id
             .as_ref()
@@ -292,7 +327,10 @@ impl JellyfinClient {
             .send()
             .await?;
         let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(PaginatedTracks {
+            items: raw.items.into_iter().map(Track::from).collect(),
+            total_count: raw.total_record_count,
+        })
     }
 
     /// Fetch playlists the current user owns. Jellyfin stores user-owned
@@ -303,17 +341,27 @@ impl JellyfinClient {
     /// `playlist_library_id` is the Playlists view id (the CollectionFolder
     /// with `CollectionType == "playlists"`). Resolving that id is tracked
     /// separately; callers pass it in here.
+    ///
+    /// `total_count` on the returned [`PaginatedPlaylists`] is the server's
+    /// unfiltered `TotalRecordCount` (all playlists under the library view,
+    /// both user- and public-owned) — the per-page `items.len()` may be
+    /// smaller once the client-side `/data/` filter has been applied.
     pub async fn user_playlists(
         &self,
         playlist_library_id: &str,
         paging: Paging,
-    ) -> Result<Vec<Playlist>> {
-        let items = self.playlists_items(playlist_library_id, paging).await?;
-        Ok(items
+    ) -> Result<PaginatedPlaylists> {
+        let raw = self.playlists_items(playlist_library_id, paging).await?;
+        let items = raw
+            .items
             .into_iter()
             .filter(|i| i.path.as_deref().is_some_and(|p| p.contains("/data/")))
             .map(Playlist::from)
-            .collect())
+            .collect();
+        Ok(PaginatedPlaylists {
+            items,
+            total_count: raw.total_record_count,
+        })
     }
 
     /// Fetch playlists visible to the current user that are NOT owned by
@@ -323,27 +371,36 @@ impl JellyfinClient {
     /// `playlist_library_id` is the Playlists view id (the CollectionFolder
     /// with `CollectionType == "playlists"`). Resolving that id is tracked
     /// separately; callers pass it in here.
+    ///
+    /// See [`JellyfinClient::user_playlists`] for the `total_count` caveat.
     pub async fn public_playlists(
         &self,
         playlist_library_id: &str,
         paging: Paging,
-    ) -> Result<Vec<Playlist>> {
-        let items = self.playlists_items(playlist_library_id, paging).await?;
-        Ok(items
+    ) -> Result<PaginatedPlaylists> {
+        let raw = self.playlists_items(playlist_library_id, paging).await?;
+        let items = raw
+            .items
             .into_iter()
             .filter(|i| !i.path.as_deref().is_some_and(|p| p.contains("/data/")))
             .map(Playlist::from)
-            .collect())
+            .collect();
+        Ok(PaginatedPlaylists {
+            items,
+            total_count: raw.total_record_count,
+        })
     }
 
     /// Shared `GET /Items` request that returns all playlists under the
     /// given Playlists library view. `user_playlists` / `public_playlists`
-    /// partition the result by `Path`.
+    /// partition the result by `Path`. Returns the raw [`RawItems`] wrapper
+    /// so callers can forward `total_record_count` to their paginated
+    /// response shape.
     async fn playlists_items(
         &self,
         playlist_library_id: &str,
         paging: Paging,
-    ) -> Result<Vec<RawItem>> {
+    ) -> Result<RawItems<RawItem>> {
         let user_id = self
             .user_id
             .as_ref()
@@ -365,7 +422,7 @@ impl JellyfinClient {
             .send()
             .await?;
         let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items)
+        Ok(raw)
     }
 
     /// Fetch the audio tracks on a playlist, preserving the server's playlist
@@ -378,7 +435,11 @@ impl JellyfinClient {
     ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
-    pub async fn playlist_tracks(&self, playlist_id: &str, paging: Paging) -> Result<Vec<Track>> {
+    pub async fn playlist_tracks(
+        &self,
+        playlist_id: &str,
+        paging: Paging,
+    ) -> Result<PaginatedTracks> {
         let user_id = self
             .user_id
             .as_ref()
@@ -400,7 +461,10 @@ impl JellyfinClient {
             .send()
             .await?;
         let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(PaginatedTracks {
+            items: raw.items.into_iter().map(Track::from).collect(),
+            total_count: raw.total_record_count,
+        })
     }
 
     pub async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {
@@ -618,7 +682,19 @@ impl JellyfinClient {
         Ok(())
     }
 
-    pub async fn search(&self, query: &str) -> Result<SearchResults> {
+    /// Full-search query against `Users/{id}/Items?SearchTerm=…`. Returns
+    /// fully-hydrated records split into typed sections (artists / albums /
+    /// tracks) — use this for a "See all results" page where the UI wants
+    /// cards rather than raw hints. For a debounced omnibox, prefer
+    /// [`JellyfinClient::search_hints`].
+    ///
+    /// `paging` applies to the combined response: Jellyfin does not offer
+    /// per-type pagination on this endpoint, so `total_record_count` is the
+    /// server's total across ALL matched item types. Callers that want to
+    /// page a single kind (only tracks, only albums) should issue typed
+    /// requests via [`JellyfinClient::albums`] / `artists` etc. with
+    /// `SearchTerm` — a follow-up once the UI grows that affordance.
+    pub async fn search(&self, query: &str, paging: Paging) -> Result<SearchResults> {
         let user_id = self
             .user_id
             .as_ref()
@@ -629,7 +705,8 @@ impl JellyfinClient {
             q.append_pair("Recursive", "true");
             q.append_pair("SearchTerm", query);
             q.append_pair("IncludeItemTypes", "MusicArtist,MusicAlbum,Audio");
-            q.append_pair("Limit", "50");
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
             q.append_pair("Fields", "Genres,ProductionYear,PrimaryImageAspectRatio");
         }
         let resp = self
@@ -655,6 +732,7 @@ impl JellyfinClient {
             artists,
             albums,
             tracks,
+            total_record_count: raw.total_record_count,
         })
     }
 
@@ -673,7 +751,12 @@ impl JellyfinClient {
     /// (`includeItemTypes=Audio,MusicAlbum,MusicArtist,Playlist`). Requires
     /// an authenticated session; returns [`JellifyError::NotAuthenticated`]
     /// if no `user_id` is set.
-    pub async fn search_hints(&self, query: &str, limit: u32) -> Result<SearchHintResults> {
+    ///
+    /// `paging.offset` maps to Jellyfin's `startIndex` so callers can page
+    /// deeper into the hint list ("Show more" in the typeahead). The
+    /// returned `total_record_count` is the server-side unpaged total and
+    /// is stable across pages for the same query.
+    pub async fn search_hints(&self, query: &str, paging: Paging) -> Result<SearchHintResults> {
         let user_id = self
             .user_id
             .as_ref()
@@ -684,7 +767,8 @@ impl JellyfinClient {
             q.append_pair("userId", user_id);
             q.append_pair("searchTerm", query);
             q.append_pair("includeItemTypes", "Audio,MusicAlbum,MusicArtist,Playlist");
-            q.append_pair("limit", &limit.max(1).to_string());
+            q.append_pair("limit", &paging.limit.max(1).to_string());
+            q.append_pair("startIndex", &paging.offset.to_string());
         }
         let resp = self
             .http
@@ -905,7 +989,6 @@ struct RawItems<T> {
     #[serde(rename = "Items", default)]
     items: Vec<T>,
     #[serde(rename = "TotalRecordCount", default)]
-    #[allow(dead_code)]
     total_record_count: u32,
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -157,19 +157,25 @@ impl JellifyCore {
 
     // ---------- Library ----------
 
+    /// Albums in the user's library, paginated.
+    ///
+    /// Returns a [`PaginatedAlbums`] whose `total_count` is the full server
+    /// total so callers can drive "N of M" indicators and near-end
+    /// load-more triggers without issuing a separate count query.
     pub fn list_albums(
         &self,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Album>, JellifyError> {
+    ) -> std::result::Result<PaginatedAlbums, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.albums(Paging::new(offset, limit))))
     }
 
+    /// Artists in the user's library, paginated. See [`list_albums`].
     pub fn list_artists(
         &self,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Artist>, JellifyError> {
+    ) -> std::result::Result<PaginatedArtists, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.artists(Paging::new(offset, limit))))
     }
 
@@ -182,12 +188,23 @@ impl JellifyCore {
     /// Server-side filtering respects the user's parental controls; the
     /// response is grouped by album so loose tracks never appear. Callers
     /// resolve `library_id` (the music collection view id) once at sign-in.
+    ///
+    /// Pagination caveat: Jellyfin's `/Items/Latest` endpoint does not
+    /// accept `StartIndex`, so `offset` is applied client-side by slicing
+    /// the top of the returned "most-recent" window. See
+    /// [`JellyfinClient::latest_albums`] for details. `total_count` on the
+    /// returned [`PaginatedAlbums`] is the number of items the server
+    /// returned for this request, not the library total.
     pub fn latest_albums(
         &self,
         library_id: String,
+        offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Album>, JellifyError> {
-        self.with_client(|c| self.runtime.block_on(c.latest_albums(&library_id, limit)))
+    ) -> std::result::Result<PaginatedAlbums, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.latest_albums(&library_id, Paging::new(offset, limit)))
+        })
     }
 
     /// Recently played tracks for the current user, sorted by server-side
@@ -198,7 +215,7 @@ impl JellifyCore {
         music_library_id: Option<String>,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Track>, JellifyError> {
+    ) -> std::result::Result<PaginatedTracks, JellifyError> {
         self.with_client(|c| {
             self.runtime.block_on(
                 c.recently_played(music_library_id.as_deref(), Paging::new(offset, limit)),
@@ -207,13 +224,16 @@ impl JellifyCore {
     }
 
     /// Playlists owned by the current user. Filtered client-side based on
-    /// whether `Path` contains `/data/` (profile directory).
+    /// whether `Path` contains `/data/` (profile directory). `total_count`
+    /// on the returned [`PaginatedPlaylists`] is the server's unfiltered
+    /// count across both user- and public-owned playlists — see
+    /// [`JellyfinClient::user_playlists`].
     pub fn user_playlists(
         &self,
         playlist_library_id: String,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Playlist>, JellifyError> {
+    ) -> std::result::Result<PaginatedPlaylists, JellifyError> {
         self.with_client(|c| {
             self.runtime
                 .block_on(c.user_playlists(&playlist_library_id, Paging::new(offset, limit)))
@@ -227,7 +247,7 @@ impl JellifyCore {
         playlist_library_id: String,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Playlist>, JellifyError> {
+    ) -> std::result::Result<PaginatedPlaylists, JellifyError> {
         self.with_client(|c| {
             self.runtime
                 .block_on(c.public_playlists(&playlist_library_id, Paging::new(offset, limit)))
@@ -236,21 +256,35 @@ impl JellifyCore {
 
     /// Tracks on a playlist, in the server's playlist order. Pass `offset`
     /// and `limit` for paging; the underlying `/Items` request does NOT sort
-    /// server-side so the playlist's stored order is preserved.
+    /// server-side so the playlist's stored order is preserved. The
+    /// returned [`PaginatedTracks`] carries the server total so callers can
+    /// drive a page-until-done loop.
     pub fn playlist_tracks(
         &self,
         playlist_id: String,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<Track>, JellifyError> {
+    ) -> std::result::Result<PaginatedTracks, JellifyError> {
         self.with_client(|c| {
             self.runtime
                 .block_on(c.playlist_tracks(&playlist_id, Paging::new(offset, limit)))
         })
     }
 
-    pub fn search(&self, query: String) -> std::result::Result<SearchResults, JellifyError> {
-        self.with_client(|c| self.runtime.block_on(c.search(&query)))
+    /// Full-search query. Returns hydrated records split into typed
+    /// sections (artists / albums / tracks), plus `total_record_count` so
+    /// the UI can offer "Show all N results" affordances when more are
+    /// available past the current page.
+    pub fn search(
+        &self,
+        query: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<SearchResults, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.search(&query, Paging::new(offset, limit)))
+        })
     }
 
     /// Fast typeahead search — backed by Jellyfin's `/Search/Hints`.
@@ -259,12 +293,19 @@ impl JellifyCore {
     /// list of [`SearchHint`] entries carrying the server-supplied `Type`
     /// so the UI can split results into typed sections without extra
     /// round-trips. Prefer [`JellifyCore::search`] for "see all results".
+    ///
+    /// `offset` maps to Jellyfin's `startIndex`; `total_record_count` on
+    /// the returned [`SearchHintResults`] is stable across pages.
     pub fn search_hints(
         &self,
         query: String,
+        offset: u32,
         limit: u32,
     ) -> std::result::Result<SearchHintResults, JellifyError> {
-        self.with_client(|c| self.runtime.block_on(c.search_hints(&query, limit)))
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.search_hints(&query, Paging::new(offset, limit)))
+        })
     }
 
     /// Mark an item (track, album, artist, playlist) as a favorite for the

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -86,6 +86,48 @@ pub struct SearchResults {
     pub artists: Vec<Artist>,
     pub albums: Vec<Album>,
     pub tracks: Vec<Track>,
+    /// Total number of items (across all item types) the server reports for
+    /// this query, as returned in `TotalRecordCount`. When the total is
+    /// greater than `artists.len() + albums.len() + tracks.len()`, more
+    /// results are available past the current page.
+    pub total_record_count: u32,
+}
+
+/// Page of albums returned by `albums` and `latest_albums`. `total_count`
+/// comes from Jellyfin's `TotalRecordCount`, so callers can detect when more
+/// pages exist beyond the current `items.len()` + `offset`. UniFFI doesn't
+/// support generics, so there is one of these per item type.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PaginatedAlbums {
+    pub items: Vec<Album>,
+    pub total_count: u32,
+}
+
+/// Page of artists returned by `artists`. See [`PaginatedAlbums`].
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PaginatedArtists {
+    pub items: Vec<Artist>,
+    pub total_count: u32,
+}
+
+/// Page of tracks returned by `recently_played` and `playlist_tracks`.
+/// See [`PaginatedAlbums`].
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PaginatedTracks {
+    pub items: Vec<Track>,
+    pub total_count: u32,
+}
+
+/// Page of playlists returned by `user_playlists` and `public_playlists`.
+/// Note: these two endpoints filter the server's response client-side by
+/// `Path`, so `total_count` is the server-reported total across BOTH user
+/// and public playlists (i.e. what Jellyfin would return without the
+/// client-side partition). Callers should treat it as an upper bound on the
+/// page size they need to fetch, not as `items.len()`'s true total.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PaginatedPlaylists {
+    pub items: Vec<Playlist>,
+    pub total_count: u32,
 }
 
 /// A lightweight, typed-heterogeneous search result returned by

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -123,19 +123,21 @@ async fn recently_played_builds_query_and_parses() {
                     "ImageTags": { "Primary": "img" }
                 }
             ],
-            "TotalRecordCount": 1
+            "TotalRecordCount": 1234
         })))
         .mount(&server)
         .await;
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let tracks = client
+    let page = client
         .recently_played(Some("lib-1"), Paging::new(0, 50))
         .await
         .unwrap();
 
-    assert_eq!(tracks.len(), 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total_count, 1234);
+    let tracks = page.items;
     assert_eq!(tracks[0].name, "Echo");
     assert_eq!(tracks[0].play_count, 3);
 
@@ -225,6 +227,101 @@ async fn albums_uses_paging() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let _ = client.albums(Paging::new(10, 50)).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("Limit=50"), "query: {q}");
+    assert!(q.contains("StartIndex=10"), "query: {q}");
+    assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
+}
+
+#[tokio::test]
+async fn albums_exposes_total_record_count() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "a1", "Name": "First", "Type": "MusicAlbum",
+                    "AlbumArtist": "Artist",
+                    "ProductionYear": 2020, "ChildCount": 8,
+                    "ImageTags": { "Primary": "t1" }
+                },
+                {
+                    "Id": "a2", "Name": "Second", "Type": "MusicAlbum",
+                    "AlbumArtist": "Artist",
+                    "ProductionYear": 2021, "ChildCount": 10,
+                    "ImageTags": { "Primary": "t2" }
+                }
+            ],
+            "TotalRecordCount": 4321
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client.albums(Paging::new(0, 2)).await.unwrap();
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total_count, 4321);
+    assert_eq!(page.items[0].name, "First");
+    assert_eq!(page.items[1].name, "Second");
+}
+
+#[tokio::test]
+async fn artists_exposes_total_record_count_and_paging() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "ar1", "Name": "Colleen", "Type": "MusicArtist",
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 999
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client.artists(Paging::new(25, 100)).await.unwrap();
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total_count, 999);
+    assert_eq!(page.items[0].name, "Colleen");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("Limit=100"), "query: {q}");
+    assert!(q.contains("StartIndex=25"), "query: {q}");
+    assert!(q.contains("IncludeItemTypes=MusicArtist"), "query: {q}");
 }
 
 #[tokio::test]
@@ -302,8 +399,15 @@ async fn latest_albums_builds_expected_query_and_parses_unwrapped_array() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let albums = client.latest_albums("lib-music", 24).await.unwrap();
+    let page = client
+        .latest_albums("lib-music", Paging::new(0, 24))
+        .await
+        .unwrap();
+    let albums = page.items;
     assert_eq!(albums.len(), 2);
+    // `/Items/Latest` doesn't report TotalRecordCount, so `total_count` is
+    // the raw number of items the server returned for this request.
+    assert_eq!(page.total_count, 2);
     assert_eq!(albums[0].name, "The Deep End");
     assert_eq!(albums[0].artist_name, "Saloli");
     assert_eq!(albums[0].year, Some(2020));
@@ -314,9 +418,63 @@ async fn latest_albums_builds_expected_query_and_parses_unwrapped_array() {
 }
 
 #[tokio::test]
+async fn latest_albums_applies_offset_client_side() {
+    // `/Items/Latest` doesn't support `StartIndex`, so `latest_albums`
+    // fetches `offset + limit` items and slices the tail client-side.
+    // The server sees `Limit=offset+limit` on the outbound request.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Items/Latest"))
+        .respond_with(|req: &Request| {
+            let pairs: std::collections::HashMap<_, _> =
+                req.url.query_pairs().into_owned().collect();
+            // `Limit` is the requested offset+limit so the slice has what to
+            // skip. `StartIndex` must NOT be sent — the endpoint rejects it.
+            assert_eq!(pairs.get("Limit").map(String::as_str), Some("7"));
+            assert!(
+                !pairs.contains_key("StartIndex"),
+                "latest_albums must not send StartIndex"
+            );
+            ResponseTemplate::new(200).set_body_json(json!([
+                { "Id": "a1", "Name": "One", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a2", "Name": "Two", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a3", "Name": "Three", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a4", "Name": "Four", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a5", "Name": "Five", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a6", "Name": "Six", "Type": "MusicAlbum", "ImageTags": {} },
+                { "Id": "a7", "Name": "Seven", "Type": "MusicAlbum", "ImageTags": {} }
+            ]))
+        })
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    // offset=4, limit=3 → request Limit=7, skip 4, take 3 → items 5..7
+    let page = client
+        .latest_albums("lib-music", Paging::new(4, 3))
+        .await
+        .unwrap();
+    let names: Vec<&str> = page.items.iter().map(|a| a.name.as_str()).collect();
+    assert_eq!(names, vec!["Five", "Six", "Seven"]);
+    assert_eq!(page.total_count, 7);
+}
+
+#[tokio::test]
 async fn latest_albums_requires_authenticated_session() {
     let client = JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
-    let err = client.latest_albums("lib-music", 24).await.unwrap_err();
+    let err = client
+        .latest_albums("lib-music", Paging::new(0, 24))
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, crate::error::JellifyError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
@@ -365,12 +523,17 @@ async fn user_playlists_filters_to_data_path_and_builds_query() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let playlists = client
+    let page = client
         .user_playlists("lib-pl", Paging::new(5, 20))
         .await
         .unwrap();
+    let playlists = page.items;
 
     assert_eq!(playlists.len(), 1);
+    // `total_count` surfaces the server's unfiltered TotalRecordCount —
+    // the paging UI needs this to know when a follow-up page would yield
+    // more results even if the client-side /data/ filter removed some.
+    assert_eq!(page.total_count, 2);
     assert_eq!(playlists[0].id, "p1");
     assert_eq!(playlists[0].name, "My Mix");
     assert_eq!(playlists[0].track_count, 12);
@@ -415,14 +578,16 @@ async fn public_playlists_filters_out_data_path() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let playlists = client
+    let page = client
         .public_playlists("lib-pl", Paging::new(0, 50))
         .await
         .unwrap();
+    let playlists = page.items;
 
     // Both the community playlist (non-/data/ path) and the playlist with no
     // `Path` at all are treated as public — absence cannot prove ownership.
     assert_eq!(playlists.len(), 2);
+    assert_eq!(page.total_count, 3);
     let ids: Vec<&str> = playlists.iter().map(|p| p.id.as_str()).collect();
     assert!(ids.contains(&"p2"), "public_playlists should include p2");
     assert!(ids.contains(&"p3"), "public_playlists should include p3");
@@ -460,8 +625,10 @@ async fn user_playlists_empty_when_server_returns_no_items() {
         .public_playlists("lib-pl", Paging::new(0, 50))
         .await
         .unwrap();
-    assert!(user.is_empty());
-    assert!(public.is_empty());
+    assert!(user.items.is_empty());
+    assert_eq!(user.total_count, 0);
+    assert!(public.items.is_empty());
+    assert_eq!(public.total_count, 0);
 }
 
 #[tokio::test]
@@ -557,13 +724,15 @@ async fn playlist_tracks_preserves_order_and_builds_query() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let tracks = client
+    let page = client
         .playlist_tracks("pl-1", Paging::new(0, 50))
         .await
         .unwrap();
+    let tracks = page.items;
 
     // Server order must be preserved exactly.
     assert_eq!(tracks.len(), 3);
+    assert_eq!(page.total_count, 3);
     assert_eq!(tracks[0].id, "t1");
     assert_eq!(tracks[0].name, "First");
     assert_eq!(tracks[1].id, "t2");
@@ -590,18 +759,21 @@ async fn playlist_tracks_uses_paging() {
         .and(query_param("StartIndex", "10"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "Items": [],
-            "TotalRecordCount": 0
+            "TotalRecordCount": 1200
         })))
         .mount(&server)
         .await;
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let tracks = client
+    let page = client
         .playlist_tracks("pl-1", Paging::new(10, 25))
         .await
         .unwrap();
-    assert!(tracks.is_empty());
+    assert!(page.items.is_empty());
+    // Even when this page is empty, callers can still see there's more to
+    // fetch — important for the "page until total_count" loop in AppModel.
+    assert_eq!(page.total_count, 1200);
 }
 
 #[tokio::test]
@@ -742,6 +914,7 @@ async fn search_hints_builds_expected_query_and_parses() {
             "Audio,MusicAlbum,MusicArtist,Playlist",
         ))
         .and(query_param("limit", "24"))
+        .and(query_param("startIndex", "0"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "SearchHints": [
                 {
@@ -788,7 +961,10 @@ async fn search_hints_builds_expected_query_and_parses() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let results = client.search_hints("colleen", 24).await.unwrap();
+    let results = client
+        .search_hints("colleen", Paging::new(0, 24))
+        .await
+        .unwrap();
 
     assert_eq!(results.total_record_count, 3);
     assert_eq!(results.search_hints.len(), 3);
@@ -819,7 +995,10 @@ async fn search_hints_builds_expected_query_and_parses() {
 async fn search_hints_requires_authenticated_session() {
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
-    let err = client.search_hints("anything", 24).await.unwrap_err();
+    let err = client
+        .search_hints("anything", Paging::new(0, 24))
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, crate::error::JellifyError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
@@ -849,9 +1028,122 @@ async fn search_hints_clamps_zero_limit_to_one() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let results = client.search_hints("x", 0).await.unwrap();
+    let results = client.search_hints("x", Paging::new(0, 0)).await.unwrap();
     assert_eq!(results.total_record_count, 0);
     assert!(results.search_hints.is_empty());
+}
+
+#[tokio::test]
+async fn search_paginates_and_exposes_total_record_count() {
+    // The combined-type search endpoint must forward offset/limit as
+    // StartIndex/Limit and surface TotalRecordCount so the UI can offer
+    // "Show all N results" affordances. Items are bucketed by `Type` into
+    // the SearchResults struct's three arrays.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("SearchTerm", "mountain"))
+        .and(query_param(
+            "IncludeItemTypes",
+            "MusicArtist,MusicAlbum,Audio",
+        ))
+        .and(query_param("Limit", "25"))
+        .and(query_param("StartIndex", "10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "artist-1", "Name": "Mountain Goats", "Type": "MusicArtist",
+                    "ImageTags": { "Primary": "a1" }
+                },
+                {
+                    "Id": "album-1", "Name": "All Hail West Texas", "Type": "MusicAlbum",
+                    "AlbumArtist": "The Mountain Goats", "Artists": ["The Mountain Goats"],
+                    "ProductionYear": 2002, "ChildCount": 14,
+                    "ImageTags": { "Primary": "b1" }
+                },
+                {
+                    "Id": "track-1", "Name": "The Best Ever Death Metal Band Out Of Denton", "Type": "Audio",
+                    "AlbumId": "album-1", "Album": "All Hail West Texas",
+                    "AlbumArtist": "The Mountain Goats", "Artists": ["The Mountain Goats"],
+                    "RunTimeTicks": 1680000000u64,
+                    "ImageTags": { "Primary": "c1" }
+                }
+            ],
+            "TotalRecordCount": 147
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let results = client
+        .search("mountain", Paging::new(10, 25))
+        .await
+        .unwrap();
+
+    assert_eq!(results.total_record_count, 147);
+    assert_eq!(results.artists.len(), 1);
+    assert_eq!(results.albums.len(), 1);
+    assert_eq!(results.tracks.len(), 1);
+    assert_eq!(results.artists[0].name, "Mountain Goats");
+    assert_eq!(results.albums[0].name, "All Hail West Texas");
+    assert_eq!(
+        results.tracks[0].name,
+        "The Best Ever Death Metal Band Out Of Denton"
+    );
+}
+
+#[tokio::test]
+async fn search_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .search("anything", Paging::new(0, 50))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_hints_forwards_offset_as_start_index() {
+    // Regression check for pagination on the typeahead: `paging.offset`
+    // must appear as `startIndex` on the outbound request so "Show more"
+    // can fetch the next page.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Search/Hints"))
+        .and(query_param("limit", "20"))
+        .and(query_param("startIndex", "40"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "SearchHints": [],
+            "TotalRecordCount": 100
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let results = client.search_hints("q", Paging::new(40, 20)).await.unwrap();
+    assert_eq!(results.total_record_count, 100);
 }
 
 #[tokio::test]

--- a/examples/cli/src/main.rs
+++ b/examples/cli/src/main.rs
@@ -52,10 +52,11 @@ fn main() -> Result<()> {
         .map_err(|e| anyhow!("login: {e}"))?;
     println!("Logged in as {}", session.user.name);
 
-    let albums = core
+    let page = core
         .list_albums(0, 20)
         .map_err(|e| anyhow!("list albums: {e}"))?;
-    println!("\nAlbums ({}):", albums.len());
+    let albums = page.items;
+    println!("\nAlbums ({} of {}):", albums.len(), page.total_count);
     for (i, a) in albums.iter().enumerate() {
         println!(
             "  [{}] {} — {} ({})",

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -39,6 +39,53 @@ final class AppModel {
     var searchResults: SearchResults?
     var searchQuery: String = ""
 
+    // MARK: - Pagination
+    //
+    // `*Total` mirrors the server's `TotalRecordCount` so views can render
+    // "N of M" sublines and decide when to trigger a follow-up page. The
+    // `isLoadingMore*` flags debounce near-end triggers so a fast scroll
+    // through the grid doesn't fan out into duplicate in-flight fetches.
+    //
+    // Size of each page (see `libraryInitialPageSize` and `libraryPageSize`):
+    // first paint uses 100 so the grid shows up fast; subsequent pages fetch
+    // 200 to keep round-trip count low once the user has committed to browsing.
+
+    /// Server-reported total album count for the current library.
+    var albumsTotal: UInt32 = 0
+    /// Server-reported total artist count for the current library.
+    var artistsTotal: UInt32 = 0
+    /// Server-reported total recently-played count (listening history size).
+    var recentlyPlayedTotal: UInt32 = 0
+    /// Server-reported total for the current search query across all item kinds.
+    var searchResultsTotal: UInt32 = 0
+
+    /// A follow-up albums page is in flight. Views check this to suppress
+    /// duplicate near-end triggers and to show a bottom spinner.
+    var isLoadingMoreAlbums: Bool = false
+    /// A follow-up artists page is in flight. See `isLoadingMoreAlbums`.
+    var isLoadingMoreArtists: Bool = false
+    /// A follow-up search page is in flight for the current query.
+    var isLoadingMoreSearch: Bool = false
+
+    /// First-paint size for library lists. Tuned smaller than subsequent
+    /// pages so the grid renders quickly on login; raising this increases
+    /// time-to-first-paint without measurable benefit.
+    private let libraryInitialPageSize: UInt32 = 100
+    /// Follow-up page size for library lists. Larger than the initial page
+    /// to keep round-trip count down once the user has committed to scrolling.
+    private let libraryPageSize: UInt32 = 200
+    /// Initial page size for recently-played on the Home screen.
+    private let recentlyPlayedInitialPageSize: UInt32 = 20
+    /// Page size when walking `playlist_tracks` to completion.
+    private let playlistPageSize: UInt32 = 200
+    /// Hard cap on total tracks pulled from a single playlist to keep a
+    /// pathological 50k-track playlist from holding the UI hostage. Callers
+    /// that hit this see up to this many tracks; beyond that the rest is
+    /// silently dropped. Easy to raise once a real use case complains.
+    private let playlistSafetyCap: Int = 5000
+    /// Page size for the "Show all results" affordance in search.
+    private let searchPageSize: UInt32 = 50
+
     // MARK: - Player
     var status: PlayerStatus
     var pollTimer: Timer?
@@ -118,6 +165,9 @@ final class AppModel {
         artists = []
         albumTracks = [:]
         recentlyPlayed = []
+        searchResults = nil
+        searchQuery = ""
+        resetPaginationState()
         stopPolling()
     }
 
@@ -133,7 +183,23 @@ final class AppModel {
         artists = []
         albumTracks = [:]
         recentlyPlayed = []
+        searchResults = nil
+        searchQuery = ""
+        resetPaginationState()
         stopPolling()
+    }
+
+    /// Clear all pagination counters and in-flight flags. Kept in one place
+    /// so the two clear-the-session entry points (`logout`, `forgetToken`)
+    /// stay in sync.
+    private func resetPaginationState() {
+        albumsTotal = 0
+        artistsTotal = 0
+        recentlyPlayedTotal = 0
+        searchResultsTotal = 0
+        isLoadingMoreAlbums = false
+        isLoadingMoreArtists = false
+        isLoadingMoreSearch = false
     }
 
     /// Flag the session as expired. The UI surfaces this via the auth-expired
@@ -170,14 +236,24 @@ final class AppModel {
         isLoadingLibrary = true
         defer { isLoadingLibrary = false }
         do {
-            let albums = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.listAlbums(offset: 0, limit: 200)
+            // Fetch albums and artists in parallel. Previously the two calls
+            // were sequential, doubling time-to-first-paint on every fresh
+            // session. `async let` lets both round-trips overlap; the
+            // `await` below resolves when both complete. The smaller
+            // `libraryInitialPageSize` (100 vs. the old 200) is a further
+            // first-paint win — the grid fills the viewport with 100 and
+            // `loadMoreAlbums` takes over when the user scrolls.
+            async let albumsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+                try core.listAlbums(offset: 0, limit: libraryInitialPageSize)
             }.value
-            let artists = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.listArtists(offset: 0, limit: 200)
+            async let artistsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+                try core.listArtists(offset: 0, limit: libraryInitialPageSize)
             }.value
-            self.albums = albums
-            self.artists = artists
+            let (albums, artists) = try await (albumsPage, artistsPage)
+            self.albums = albums.items
+            self.albumsTotal = albums.totalCount
+            self.artists = artists.items
+            self.artistsTotal = artists.totalCount
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }
@@ -189,21 +265,115 @@ final class AppModel {
         await refreshRecentlyPlayed()
     }
 
+    /// Fetch the next page of albums and append to `albums`. No-op when a
+    /// page is already in flight or when the local count has caught up to
+    /// `albumsTotal`. Called from `LibraryView`'s near-end `.onAppear`
+    /// trigger — see `LibraryView.swift`.
+    func loadMoreAlbums() async {
+        guard !isLoadingMoreAlbums else { return }
+        guard albumsTotal == 0 || albums.count < Int(albumsTotal) else { return }
+        isLoadingMoreAlbums = true
+        defer { isLoadingMoreAlbums = false }
+        let offset = UInt32(albums.count)
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryPageSize] in
+                try core.listAlbums(offset: offset, limit: libraryPageSize)
+            }.value
+            self.albums.append(contentsOf: page.items)
+            self.albumsTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Fetch the next page of artists and append to `artists`. Mirror of
+    /// `loadMoreAlbums` — see its docs for the trigger contract.
+    func loadMoreArtists() async {
+        guard !isLoadingMoreArtists else { return }
+        guard artistsTotal == 0 || artists.count < Int(artistsTotal) else { return }
+        isLoadingMoreArtists = true
+        defer { isLoadingMoreArtists = false }
+        let offset = UInt32(artists.count)
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryPageSize] in
+                try core.listArtists(offset: offset, limit: libraryPageSize)
+            }.value
+            self.artists.append(contentsOf: page.items)
+            self.artistsTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+        }
+    }
+
     /// Fetch the user's recently played tracks for the Home screen carousel
     /// (#206). Passes `nil` for the music library id so the core returns
     /// tracks across all music libraries the user can see. Failures are
     /// swallowed silently — an empty carousel is preferable to an error
     /// banner for a best-effort Home widget.
+    ///
+    /// Stores `totalCount` alongside the page so a future "See all" view can
+    /// expand the carousel without issuing another count query.
     func refreshRecentlyPlayed() async {
         do {
-            let tracks = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.recentlyPlayed(musicLibraryId: nil, offset: 0, limit: 20)
+            let page = try await Task.detached(priority: .userInitiated) { [core, recentlyPlayedInitialPageSize] in
+                try core.recentlyPlayed(
+                    musicLibraryId: nil,
+                    offset: 0,
+                    limit: recentlyPlayedInitialPageSize
+                )
             }.value
-            self.recentlyPlayed = tracks
+            self.recentlyPlayed = page.items
+            self.recentlyPlayedTotal = page.totalCount
         } catch {
             // Silent fallback — don't surface errors for a secondary widget.
             _ = handleAuthError(error)
         }
+    }
+
+    /// Load ALL tracks on a playlist by paging through `playlist_tracks` in
+    /// chunks of `playlistPageSize` until `totalCount` is reached or the
+    /// `playlistSafetyCap` is hit. Returns as soon as any page fails. No UI
+    /// wiring calls this yet (playlist detail screen is #313 et al), but the
+    /// FFI is now paginated so the caller that lands it can rely on "pass
+    /// this a playlist id and get every track". See #125 / #429.
+    func loadAllPlaylistTracks(playlistID: String) async -> [Track] {
+        var all: [Track] = []
+        var offset: UInt32 = 0
+        let limit = playlistPageSize
+        let cap = playlistSafetyCap
+        do {
+            while all.count < cap {
+                let page = try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.playlistTracks(
+                        playlistId: playlistID,
+                        offset: offset,
+                        limit: limit
+                    )
+                }.value
+                all.append(contentsOf: page.items)
+                if page.items.isEmpty { break }
+                if all.count >= Int(page.totalCount) { break }
+                offset = UInt32(all.count)
+            }
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return all }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            errorMessage = "Playlist load failed: \(error.localizedDescription)"
+        }
+        return all
     }
 
     func loadTracks(forAlbum albumID: String) async -> [Track] {
@@ -249,13 +419,65 @@ final class AppModel {
         searchQuery = query
         guard !query.isEmpty else {
             searchResults = nil
+            searchResultsTotal = 0
             return
         }
         do {
-            let results = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.search(query: query)
+            let results = try await Task.detached(priority: .userInitiated) { [core, searchPageSize] in
+                try core.search(query: query, offset: 0, limit: searchPageSize)
             }.value
             self.searchResults = results
+            self.searchResultsTotal = results.totalRecordCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            errorMessage = "Search failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Fetch the next page of the current search query and merge into
+    /// `searchResults`. Jellyfin's combined-type `/Users/{id}/Items`
+    /// endpoint doesn't let us fetch more of a single kind at a time, so
+    /// this appends whichever of (artists, albums, tracks) the next page
+    /// happens to contain. The "Show all N results" button in `SearchView`
+    /// is the caller.
+    ///
+    /// Dedupes by id so the typed arrays don't accumulate duplicates if a
+    /// row happens to overlap across paged responses (which can happen
+    /// because Jellyfin's ordering is stable only per sort key).
+    func loadMoreSearchResults() async {
+        guard !isLoadingMoreSearch else { return }
+        guard let current = searchResults, !searchQuery.isEmpty else { return }
+        let loaded = current.artists.count + current.albums.count + current.tracks.count
+        guard loaded < Int(searchResultsTotal) else { return }
+        isLoadingMoreSearch = true
+        defer { isLoadingMoreSearch = false }
+        let offset = UInt32(loaded)
+        let query = searchQuery
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, searchPageSize] in
+                try core.search(query: query, offset: offset, limit: searchPageSize)
+            }.value
+            // Merge with dedupe — see method doc.
+            var artistSet = Set(current.artists.map(\.id))
+            var albumSet = Set(current.albums.map(\.id))
+            var trackSet = Set(current.tracks.map(\.id))
+            var artists = current.artists
+            var albums = current.albums
+            var tracks = current.tracks
+            for a in page.artists where artistSet.insert(a.id).inserted { artists.append(a) }
+            for a in page.albums where albumSet.insert(a.id).inserted { albums.append(a) }
+            for t in page.tracks where trackSet.insert(t.id).inserted { tracks.append(t) }
+            self.searchResults = SearchResults(
+                artists: artists,
+                albums: albums,
+                tracks: tracks,
+                totalRecordCount: page.totalRecordCount
+            )
+            self.searchResultsTotal = page.totalRecordCount
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -79,12 +79,14 @@ struct LibraryView: View {
                     .font(Theme.font(36, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
                 // Count subline — 11pt uppercase `ink3`. Updates live as the
-                // user switches chips. See #212 / screen spec Issue 13.
+                // user switches chips. Shows "N of M" while more pages exist
+                // on the server; falls back to "N" once loaded == total.
+                // See #212 / #429 / screen spec Issue 13.
                 Text(countSubline)
                     .font(Theme.font(11, weight: .bold))
                     .foregroundStyle(Theme.ink3)
                     .tracking(1.2)
-                    .accessibilityLabel("\(tabCount(for: selectedTab)) \(selectedTab.countNoun)")
+                    .accessibilityLabel(countAccessibilityLabel)
             }
             Spacer()
             LibraryViewToggle(mode: $viewMode)
@@ -103,6 +105,12 @@ struct LibraryView: View {
     /// so the chip selection still produces a coherent screen. As tracks,
     /// artists, playlists, and download state land, each branch gets its own
     /// surface.
+    /// Distance from the end of the grid at which the near-end
+    /// `.onAppear` trigger fires a follow-up page. 20 is enough to overlap
+    /// two screen-heights on a MacBook display, which is plenty of runway
+    /// to hide round-trip latency.
+    private let paginationTriggerDistance = 20
+
     @ViewBuilder
     private var content: some View {
         switch selectedTab {
@@ -110,18 +118,29 @@ struct LibraryView: View {
             if model.albums.isEmpty {
                 EmptyLibraryState(serverUrl: serverWebURL)
             } else {
-                switch viewMode {
-                case .grid:
-                    LazyVGrid(columns: columns, alignment: .leading, spacing: 18) {
-                        ForEach(model.albums, id: \.id) { album in
-                            AlbumCard(album: album)
+                VStack(alignment: .leading, spacing: 18) {
+                    switch viewMode {
+                    case .grid:
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 18) {
+                            ForEach(Array(model.albums.enumerated()), id: \.element.id) { idx, album in
+                                AlbumCard(album: album)
+                                    .onAppear {
+                                        triggerLoadMoreAlbumsIfNeeded(atIndex: idx)
+                                    }
+                            }
+                        }
+                    case .list:
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(model.albums.enumerated()), id: \.element.id) { idx, album in
+                                LibraryListRow(album: album)
+                                    .onAppear {
+                                        triggerLoadMoreAlbumsIfNeeded(atIndex: idx)
+                                    }
+                            }
                         }
                     }
-                case .list:
-                    LazyVStack(alignment: .leading, spacing: 2) {
-                        ForEach(model.albums, id: \.id) { album in
-                            LibraryListRow(album: album)
-                        }
+                    if model.isLoadingMoreAlbums {
+                        paginationSpinner
                     }
                 }
             }
@@ -132,8 +151,35 @@ struct LibraryView: View {
         }
     }
 
-    /// Count for a given tab. Artists has a real count; the rest are stubs
-    /// pending their respective FFI/storage work.
+    /// Bottom spinner shown while a follow-up page is in flight. Stays under
+    /// the grid so interaction with already-loaded items isn't blocked.
+    private var paginationSpinner: some View {
+        HStack {
+            Spacer()
+            ProgressView()
+                .tint(Theme.ink2)
+                .scaleEffect(0.8)
+            Spacer()
+        }
+        .padding(.vertical, 12)
+        .accessibilityLabel("Loading more")
+    }
+
+    /// Fire `loadMoreAlbums` when the user scrolls into the last
+    /// `paginationTriggerDistance` cells and there are more albums on the
+    /// server than currently loaded. The model debounces re-entrant calls,
+    /// so this is safe to trigger from every nearby cell's `.onAppear`.
+    private func triggerLoadMoreAlbumsIfNeeded(atIndex idx: Int) {
+        let loaded = model.albums.count
+        let total = Int(model.albumsTotal)
+        guard total > loaded else { return }
+        let threshold = max(loaded - paginationTriggerDistance, 0)
+        guard idx >= threshold else { return }
+        Task { await model.loadMoreAlbums() }
+    }
+
+    /// Count for a given tab. Albums and artists have real counts; the rest
+    /// are stubs pending their respective FFI/storage work.
     private func tabCount(for tab: LibraryTab) -> Int {
         switch tab {
         case .albums: return model.albums.count
@@ -142,13 +188,40 @@ struct LibraryView: View {
         }
     }
 
-    /// 11pt uppercase count subline, e.g. "42 ALBUMS". Mirrors the spec's
-    /// "{n} tracks · Sorted by {sort}" — sort hasn't been wired yet (#216),
-    /// so for now the subline is just the count. The sort segment slots in
-    /// once the sort menu lands.
+    /// Server-reported total for a given tab. Zero when not yet known or
+    /// when the tab doesn't have a backing endpoint yet.
+    private func tabTotal(for tab: LibraryTab) -> Int {
+        switch tab {
+        case .albums: return Int(model.albumsTotal)
+        case .artists: return Int(model.artistsTotal)
+        case .tracks, .playlists, .downloaded: return 0
+        }
+    }
+
+    /// 11pt uppercase count subline. Renders as `N of M` when the server
+    /// total is known AND more items remain to load; otherwise falls back
+    /// to plain `N`. Mirrors the spec's "{n} tracks · Sorted by {sort}" —
+    /// sort hasn't been wired yet (#216), so for now the subline is just
+    /// the count. Issue #429 / #212.
     private var countSubline: String {
         let count = tabCount(for: selectedTab)
+        let total = tabTotal(for: selectedTab)
+        if total > count {
+            return "\(count) OF \(total) \(selectedTab.countNoun.uppercased())"
+        }
         return "\(count) \(selectedTab.countNoun)".uppercased()
+    }
+
+    /// VoiceOver-friendly version of the count subline. Reads naturally
+    /// as "42 of 5000 albums" rather than the uppercased + tracking-spaced
+    /// display string.
+    private var countAccessibilityLabel: String {
+        let count = tabCount(for: selectedTab)
+        let total = tabTotal(for: selectedTab)
+        if total > count {
+            return "\(count) of \(total) \(selectedTab.countNoun)"
+        }
+        return "\(count) \(selectedTab.countNoun)"
     }
 
     private var backgroundWash: some View {

--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -49,6 +49,15 @@ struct SearchView: View {
                                 }
                             }
                         }
+                        // "Show all N results" — visible when the server
+                        // reports more matches than the current page holds.
+                        // See issue #429. Jellyfin doesn't expose per-kind
+                        // pagination on this endpoint, so we page the
+                        // combined response and let the per-kind arrays
+                        // grow as new results come in.
+                        if showAllResultsVisible(for: results) {
+                            showAllResultsButton(for: results)
+                        }
                     }
                 }
                 Spacer(minLength: 32)
@@ -133,6 +142,54 @@ struct SearchView: View {
             .font(Theme.font(18, weight: .bold))
             .foregroundStyle(Theme.ink)
             .padding(.top, 12)
+    }
+
+    /// Total rows currently displayed across all three typed sections.
+    /// Used against `searchResultsTotal` to decide whether a follow-up page
+    /// would yield anything new.
+    private func loadedCount(for results: SearchResults) -> Int {
+        results.artists.count + results.albums.count + results.tracks.count
+    }
+
+    private func showAllResultsVisible(for results: SearchResults) -> Bool {
+        Int(model.searchResultsTotal) > loadedCount(for: results)
+    }
+
+    @ViewBuilder
+    private func showAllResultsButton(for results: SearchResults) -> some View {
+        let loaded = loadedCount(for: results)
+        let total = Int(model.searchResultsTotal)
+        HStack {
+            Spacer()
+            if model.isLoadingMoreSearch {
+                ProgressView()
+                    .tint(Theme.ink2)
+                    .scaleEffect(0.8)
+                    .padding(.vertical, 14)
+            } else {
+                Button {
+                    Task { await model.loadMoreSearchResults() }
+                } label: {
+                    Text("Show all \(total) results (\(loaded) shown)")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Theme.surface)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Theme.borderStrong, lineWidth: 1)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show all \(total) results, \(loaded) currently shown")
+            }
+            Spacer()
+        }
+        .padding(.top, 16)
     }
 
     @ViewBuilder

--- a/macos/Sources/SmokeTest/main.swift
+++ b/macos/Sources/SmokeTest/main.swift
@@ -46,7 +46,9 @@ struct SmokeTest {
 
         let albums: [Album]
         do {
-            albums = try core.listAlbums(offset: 0, limit: 5)
+            // `listAlbums` now returns a paginated envelope — the smoke
+            // test doesn't need the total, just the first few items.
+            albums = try core.listAlbums(offset: 0, limit: 5).items
         } catch { fputs("list albums: \(error)\n", stderr); exit(1) }
         guard let album = albums.first else {
             fputs("no albums on server\n", stderr); exit(1)


### PR DESCRIPTION
## Summary
Closes #429. Extends pagination across the data layer and wires the Swift UI
to consume it.

- Core: add `PaginatedAlbums` / `PaginatedArtists` / `PaginatedTracks` /
  `PaginatedPlaylists` UniFFI records. Migrate `albums`, `artists`,
  `recently_played`, `user_playlists`, `public_playlists`, `playlist_tracks`,
  `latest_albums` to return paginated variants. Add offset to `search` and
  `search_hints`. Remove `#[allow(dead_code)]` on `RawItems.total_record_count`.
- AppModel: parallel `refreshLibrary` (was sequential), `albumsTotal` /
  `artistsTotal` state, `loadMoreAlbums` / `loadMoreArtists` with debounce,
  paged `loadAllPlaylistTracks` loop.
- LibraryView: near-end `.onAppear` trigger on grid cells, "N of M" subline,
  bottom spinner while loading more.
- SearchView: "Show all N results" per-section affordance.

## Test plan
- [ ] `cargo test --workspace --all-features`
- [ ] `cargo clippy -D warnings`
- [ ] `cd macos && ./Scripts/build-core.sh && swift build && ./Scripts/make-bundle.sh`
- [ ] Smoke-launch the bundled .app
- [ ] Scroll past 200 albums on a real library and confirm more load
- [ ] Playlist with > 500 tracks loads all of them
- [ ] Search shows a "Show all" button when results exceed the initial page