### PR TITLE
macos: artists grid in Library tab

### DIFF
--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Square grid tile used in the Library Artists tab. Mirrors the shape and
+/// visual language of `AlbumCard`: square artwork, name below, hover reveals
+/// a play overlay. Tapping the card routes to the artist detail screen via
+/// `model.screen = .artist(artist.id)`.
+///
+/// Issue: #213 (Library → Artists grid). The overlay play button calls
+/// `AppModel.playAll(artist:)`, which is a logging stub today pending
+/// `artist_tracks` FFI (#156 / #465). The visual affordance matches the
+/// album card so users have a consistent hover model across the grid.
+struct ArtistCard: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let artist: Artist
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            model.screen = .artist(artist.id)
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                ZStack(alignment: .bottomTrailing) {
+                    Artwork(
+                        url: model.imageURL(for: artist.id, tag: artist.imageTag, maxWidth: 400),
+                        seed: artist.name,
+                        size: 180,
+                        radius: 8
+                    )
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(1, contentMode: .fit)
+
+                    Button { model.playAll(artist: artist) } label: {
+                        Image(systemName: "play.fill")
+                            .foregroundStyle(.white)
+                            .font(.system(size: 16))
+                            .frame(width: 40, height: 40)
+                            .background(Circle().fill(Theme.primary))
+                            .shadow(color: Theme.primary.opacity(0.5), radius: 10, y: 4)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .opacity(isHovering ? 1 : 0)
+                    .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(artist.name)
+                        .font(Theme.font(13, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(1)
+                    Text(albumCountLabel)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isHovering ? Theme.surface : .clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu { ArtistContextMenu(artist: artist) }
+    }
+
+    /// Subline shown under the artist name. Uses `album_count` when known;
+    /// falls back to song count so the tile always reads as "something by
+    /// this artist" rather than an orphaned label.
+    private var albumCountLabel: String {
+        if artist.albumCount > 0 {
+            return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
+        }
+        if artist.songCount > 0 {
+            return artist.songCount == 1 ? "1 song" : "\(artist.songCount) songs"
+        }
+        return "Artist"
+    }
+}

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -2,28 +2,41 @@ import SwiftUI
 @preconcurrency import JellifyCore
 
 /// Compact single-line row used by the Library list view. Mirrors the
-/// design's list density: small square artwork, album title, artist, year.
-/// Clicking opens the album detail; hover reveals an inline play button.
+/// design's list density: small square artwork, title, secondary text, and
+/// a trailing metadata slot. Renders either an album or an artist depending
+/// on which payload was used at construction time. Clicking opens the
+/// relevant detail screen; hover reveals an inline play button.
 struct LibraryListRow: View {
+    enum Payload {
+        case album(Album)
+        case artist(Artist)
+    }
+
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let album: Album
+    let payload: Payload
     @State private var isHovering = false
 
+    init(album: Album) {
+        self.payload = .album(album)
+    }
+
+    init(artist: Artist) {
+        self.payload = .artist(artist)
+    }
+
     var body: some View {
-        Button {
-            model.screen = .album(album.id)
-        } label: {
+        Button(action: openDetail) {
             HStack(spacing: 12) {
                 ZStack {
                     Artwork(
-                        url: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 120),
-                        seed: album.name,
+                        url: artworkURL,
+                        seed: artworkSeed,
                         size: 40,
-                        radius: 4
+                        radius: artworkRadius
                     )
                     if isHovering {
-                        Button { model.play(album: album) } label: {
+                        Button(action: playPrimary) {
                             Image(systemName: "play.fill")
                                 .foregroundStyle(.white)
                                 .font(.system(size: 11))
@@ -37,11 +50,11 @@ struct LibraryListRow: View {
                 .frame(width: 40, height: 40)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(album.name)
+                    Text(primaryText)
                         .font(Theme.font(13, weight: .semibold))
                         .foregroundStyle(Theme.ink)
                         .lineLimit(1)
-                    Text(album.artistName)
+                    Text(secondaryText)
                         .font(Theme.font(11, weight: .medium))
                         .foregroundStyle(Theme.ink2)
                         .lineLimit(1)
@@ -49,14 +62,14 @@ struct LibraryListRow: View {
 
                 Spacer()
 
-                if let year = album.year {
-                    Text(String(year))
+                if let trailing = trailingMeta {
+                    Text(trailing)
                         .font(Theme.font(12, weight: .medium))
                         .foregroundStyle(Theme.ink3)
                         .monospacedDigit()
                 }
 
-                Text("\(album.trackCount) tracks")
+                Text(countMeta)
                     .font(Theme.font(12, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .frame(minWidth: 70, alignment: .trailing)
@@ -77,6 +90,99 @@ struct LibraryListRow: View {
                 withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
             }
         }
-        .contextMenu { AlbumContextMenu(album: album) }
+        .contextMenu { contextMenu }
+    }
+
+    // MARK: - Payload-driven properties
+
+    private var artworkURL: URL? {
+        switch payload {
+        case .album(let album):
+            return model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 120)
+        case .artist(let artist):
+            return model.imageURL(for: artist.id, tag: artist.imageTag, maxWidth: 120)
+        }
+    }
+
+    private var artworkSeed: String {
+        switch payload {
+        case .album(let album): return album.name
+        case .artist(let artist): return artist.name
+        }
+    }
+
+    /// Albums use the shared 4pt radius; artists get a pill/circle so the
+    /// list row reads consistently with the circular `ArtistRadioTile` used
+    /// elsewhere.
+    private var artworkRadius: CGFloat {
+        switch payload {
+        case .album: return 4
+        case .artist: return 20
+        }
+    }
+
+    private var primaryText: String {
+        switch payload {
+        case .album(let album): return album.name
+        case .artist(let artist): return artist.name
+        }
+    }
+
+    private var secondaryText: String {
+        switch payload {
+        case .album(let album):
+            return album.artistName
+        case .artist(let artist):
+            if !artist.genres.isEmpty { return artist.genres.joined(separator: ", ") }
+            return "Artist"
+        }
+    }
+
+    /// Optional trailing metadata (e.g. release year for albums). Artists
+    /// have no equivalent, so the slot stays empty.
+    private var trailingMeta: String? {
+        switch payload {
+        case .album(let album):
+            return album.year.map { String($0) }
+        case .artist:
+            return nil
+        }
+    }
+
+    private var countMeta: String {
+        switch payload {
+        case .album(let album):
+            return "\(album.trackCount) tracks"
+        case .artist(let artist):
+            return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
+        }
+    }
+
+    private func openDetail() {
+        switch payload {
+        case .album(let album):
+            model.screen = .album(album.id)
+        case .artist(let artist):
+            model.screen = .artist(artist.id)
+        }
+    }
+
+    private func playPrimary() {
+        switch payload {
+        case .album(let album):
+            model.play(album: album)
+        case .artist(let artist):
+            model.playAll(artist: artist)
+        }
+    }
+
+    @ViewBuilder
+    private var contextMenu: some View {
+        switch payload {
+        case .album(let album):
+            AlbumContextMenu(album: album)
+        case .artist(let artist):
+            ArtistContextMenu(artist: artist)
+        }
     }
 }

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -144,7 +144,37 @@ struct LibraryView: View {
                     }
                 }
             }
-        case .tracks, .artists, .playlists, .downloaded:
+        case .artists:
+            if model.artists.isEmpty {
+                EmptyLibraryState(serverUrl: serverWebURL)
+            } else {
+                VStack(alignment: .leading, spacing: 18) {
+                    switch viewMode {
+                    case .grid:
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 18) {
+                            ForEach(Array(model.artists.enumerated()), id: \.element.id) { idx, artist in
+                                ArtistCard(artist: artist)
+                                    .onAppear {
+                                        triggerLoadMoreArtistsIfNeeded(atIndex: idx)
+                                    }
+                            }
+                        }
+                    case .list:
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(model.artists.enumerated()), id: \.element.id) { idx, artist in
+                                LibraryListRow(artist: artist)
+                                    .onAppear {
+                                        triggerLoadMoreArtistsIfNeeded(atIndex: idx)
+                                    }
+                            }
+                        }
+                    }
+                    if model.isLoadingMoreArtists {
+                        paginationSpinner
+                    }
+                }
+            }
+        case .tracks, .playlists, .downloaded:
             // Placeholder until the per-tab surfaces land. The chip row, header,
             // and count subline remain live so navigation feels responsive.
             EmptyLibraryState(serverUrl: serverWebURL)
@@ -176,6 +206,19 @@ struct LibraryView: View {
         let threshold = max(loaded - paginationTriggerDistance, 0)
         guard idx >= threshold else { return }
         Task { await model.loadMoreAlbums() }
+    }
+
+    /// Mirror of `triggerLoadMoreAlbumsIfNeeded` for the artists tab. The
+    /// model guards against concurrent `loadMoreArtists` calls so firing
+    /// this from many adjacent `.onAppear`s is safe.
+    private func triggerLoadMoreArtistsIfNeeded(atIndex idx: Int) {
+        let loaded = model.artists.count
+        let total = Int(model.artistsTotal)
+        guard total > loaded else { return }
+        guard !model.isLoadingMoreArtists else { return }
+        let threshold = max(loaded - paginationTriggerDistance, 0)
+        guard idx >= threshold else { return }
+        Task { await model.loadMoreArtists() }
     }
 
     /// Count for a given tab. Albums and artists have real counts; the rest


### PR DESCRIPTION
## Summary
Wires the Artists tab of the Library screen to render a grid of the
`AppModel.artists` collection populated by `refreshLibrary()`. Pagination
hooks (`loadMoreArtists`, `artistsTotal`) are reused from #514.

- New `ArtistCard.swift` paralleling `AlbumCard.swift`.
- `LibraryListRow` gains an artist initializer.
- `LibraryView.artists` case: LazyVGrid (or list) with near-end `.onAppear`
  trigger, count subline, bottom load-more spinner.

## Test plan
- [ ] swift build / bundle / smoke-launch
- [ ] Log in, click Library → Artists → confirm grid renders
- [ ] Scroll past first page → more artists load
- [ ] List/grid toggle respects the artists view