### PR TITLE
core: list_tracks + macOS All Tracks library tab

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -286,6 +286,58 @@ impl JellyfinClient {
         })
     }
 
+    /// All audio tracks in the current user's library, sorted alphabetically
+    /// by `SortName` ascending. Backed by `GET /Users/{id}/Items` with
+    /// `IncludeItemTypes=Audio` and `Recursive=true`.
+    ///
+    /// `music_library_id` is the `MusicLibrary` CollectionFolder id; when
+    /// provided it scopes the query via `ParentId`. When `None`, Jellyfin
+    /// searches across all libraries the user can access — matching the
+    /// behaviour of [`JellyfinClient::recently_played`].
+    ///
+    /// `total_count` on the returned [`PaginatedTracks`] is the server's
+    /// `TotalRecordCount` so callers can drive a "N of M" subline and a
+    /// page-until-done load-more trigger without issuing a separate count
+    /// query.
+    pub async fn list_tracks(
+        &self,
+        music_library_id: Option<&str>,
+        paging: Paging,
+    ) -> Result<PaginatedTracks> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            if let Some(parent) = music_library_id {
+                q.append_pair("ParentId", parent);
+            }
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", "Audio");
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            q.append_pair("SortBy", "SortName");
+            q.append_pair("SortOrder", "Ascending");
+            q.append_pair(
+                "Fields",
+                "ParentId,AlbumId,AlbumArtist,Artists,ProductionYear,RunTimeTicks",
+            );
+        }
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        Ok(PaginatedTracks {
+            items: raw.items.into_iter().map(Track::from).collect(),
+            total_count: raw.total_record_count,
+        })
+    }
+
     /// Recently played audio tracks for the current user, sorted by
     /// `DatePlayed` descending. Jellyfin implicitly omits tracks with a null
     /// `UserData.LastPlayedDate` from this sort, so the result is the user's

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -207,6 +207,26 @@ impl JellifyCore {
         })
     }
 
+    /// Every audio track in the user's library, paginated and sorted by
+    /// `SortName` ascending. Pass `music_library_id` to scope to a single
+    /// `MusicLibrary` CollectionFolder; pass `None` to span every library
+    /// the user can access.
+    ///
+    /// Returns a [`PaginatedTracks`] whose `total_count` is the server's
+    /// `TotalRecordCount` so callers can drive "N of M" sublines and
+    /// near-end load-more triggers without issuing a separate count query.
+    pub fn list_tracks(
+        &self,
+        music_library_id: Option<String>,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.list_tracks(music_library_id.as_deref(), Paging::new(offset, limit)))
+        })
+    }
+
     /// Recently played tracks for the current user, sorted by server-side
     /// `DatePlayed` descending. Pass `music_library_id` to scope to a single
     /// `MusicLibrary` CollectionFolder.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -206,6 +206,127 @@ async fn recently_played_omits_parent_id_when_none() {
 }
 
 #[tokio::test]
+async fn list_tracks_builds_query_and_parses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Aria", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Sunrise",
+                    "AlbumArtist": "Colleen", "Artists": ["Colleen"],
+                    "ProductionYear": 2019,
+                    "RunTimeTicks": 1800000000u64,
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 9876
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .list_tracks(Some("lib-1"), Paging::new(100, 50))
+        .await
+        .unwrap();
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total_count, 9876);
+    assert_eq!(page.items[0].name, "Aria");
+    assert_eq!(page.items[0].artist_name, "Colleen");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("StartIndex=100"), "query: {q}");
+    assert!(q.contains("Limit=50"), "query: {q}");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
+    assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+    assert!(q.contains("ParentId=lib-1"), "query: {q}");
+    let fields = get
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "Fields")
+        .map(|(_, v)| v.into_owned())
+        .expect("expected Fields query param");
+    assert!(
+        fields.split(',').any(|f| f == "ParentId"),
+        "Fields should include ParentId, got: {fields}"
+    );
+}
+
+#[tokio::test]
+async fn list_tracks_omits_parent_id_when_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client.list_tracks(None, Paging::new(0, 100)).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(!q.contains("ParentId="), "unexpected ParentId: {q}");
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Limit=100"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
+    assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+}
+
+#[tokio::test]
+async fn list_tracks_requires_authenticated_session() {
+    // No MockServer routes registered: the guard must short-circuit before
+    // any HTTP call. Pointing at a live MockServer means a regression would
+    // surface as an unmatched-route error instead of silently hitting a real
+    // host.
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .list_tracks(Some("lib-1"), Paging::new(0, 50))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn albums_uses_paging() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -34,6 +34,7 @@ final class AppModel {
     // MARK: - Library
     var albums: [Album] = []
     var artists: [Artist] = []
+    var tracks: [Track] = []
     var albumTracks: [String: [Track]] = [:]          // albumID → tracks
     var recentlyPlayed: [Track] = []
     var searchResults: SearchResults?
@@ -54,6 +55,8 @@ final class AppModel {
     var albumsTotal: UInt32 = 0
     /// Server-reported total artist count for the current library.
     var artistsTotal: UInt32 = 0
+    /// Server-reported total track count for the current library.
+    var tracksTotal: UInt32 = 0
     /// Server-reported total recently-played count (listening history size).
     var recentlyPlayedTotal: UInt32 = 0
     /// Server-reported total for the current search query across all item kinds.
@@ -64,6 +67,8 @@ final class AppModel {
     var isLoadingMoreAlbums: Bool = false
     /// A follow-up artists page is in flight. See `isLoadingMoreAlbums`.
     var isLoadingMoreArtists: Bool = false
+    /// A follow-up tracks page is in flight. See `isLoadingMoreAlbums`.
+    var isLoadingMoreTracks: Bool = false
     /// A follow-up search page is in flight for the current query.
     var isLoadingMoreSearch: Bool = false
 
@@ -163,6 +168,7 @@ final class AppModel {
         session = nil
         albums = []
         artists = []
+        tracks = []
         albumTracks = [:]
         recentlyPlayed = []
         searchResults = nil
@@ -181,6 +187,7 @@ final class AppModel {
         try? core.logout()
         albums = []
         artists = []
+        tracks = []
         albumTracks = [:]
         recentlyPlayed = []
         searchResults = nil
@@ -195,10 +202,12 @@ final class AppModel {
     private func resetPaginationState() {
         albumsTotal = 0
         artistsTotal = 0
+        tracksTotal = 0
         recentlyPlayedTotal = 0
         searchResultsTotal = 0
         isLoadingMoreAlbums = false
         isLoadingMoreArtists = false
+        isLoadingMoreTracks = false
         isLoadingMoreSearch = false
     }
 
@@ -236,24 +245,30 @@ final class AppModel {
         isLoadingLibrary = true
         defer { isLoadingLibrary = false }
         do {
-            // Fetch albums and artists in parallel. Previously the two calls
-            // were sequential, doubling time-to-first-paint on every fresh
-            // session. `async let` lets both round-trips overlap; the
-            // `await` below resolves when both complete. The smaller
+            // Fetch albums, artists, and tracks in parallel. Previously the
+            // calls were sequential, doubling time-to-first-paint on every
+            // fresh session. `async let` lets all three round-trips overlap;
+            // the `await` below resolves when all complete. The smaller
             // `libraryInitialPageSize` (100 vs. the old 200) is a further
             // first-paint win — the grid fills the viewport with 100 and
-            // `loadMoreAlbums` takes over when the user scrolls.
+            // `loadMoreAlbums` / `loadMoreTracks` take over when the user
+            // scrolls.
             async let albumsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
                 try core.listAlbums(offset: 0, limit: libraryInitialPageSize)
             }.value
             async let artistsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
                 try core.listArtists(offset: 0, limit: libraryInitialPageSize)
             }.value
-            let (albums, artists) = try await (albumsPage, artistsPage)
+            async let tracksPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+                try core.listTracks(musicLibraryId: nil, offset: 0, limit: libraryInitialPageSize)
+            }.value
+            let (albums, artists, tracks) = try await (albumsPage, artistsPage, tracksPage)
             self.albums = albums.items
             self.albumsTotal = albums.totalCount
             self.artists = artists.items
             self.artistsTotal = artists.totalCount
+            self.tracks = tracks.items
+            self.tracksTotal = tracks.totalCount
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }
@@ -305,6 +320,51 @@ final class AppModel {
             }.value
             self.artists.append(contentsOf: page.items)
             self.artistsTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Refetch the first page of library tracks for the All Tracks tab.
+    /// Called from `refreshLibrary` (inline as an `async let`) on session
+    /// establishment, and available for an explicit retry path later.
+    /// Matches `refreshRecentlyPlayed` in shape — stores items + total.
+    func refreshTracks() async {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+                try core.listTracks(musicLibraryId: nil, offset: 0, limit: libraryInitialPageSize)
+            }.value
+            self.tracks = page.items
+            self.tracksTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Fetch the next page of tracks and append to `tracks`. Mirror of
+    /// `loadMoreAlbums` — see its docs for the trigger contract.
+    func loadMoreTracks() async {
+        guard !isLoadingMoreTracks else { return }
+        guard tracksTotal == 0 || tracks.count < Int(tracksTotal) else { return }
+        isLoadingMoreTracks = true
+        defer { isLoadingMoreTracks = false }
+        let offset = UInt32(tracks.count)
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryPageSize] in
+                try core.listTracks(musicLibraryId: nil, offset: offset, limit: libraryPageSize)
+            }.value
+            self.tracks.append(contentsOf: page.items)
+            self.tracksTotal = page.totalCount
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }

--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Compact single-line row used by the Library Tracks tab. Mirrors the
+/// density of `LibraryListRow` (small square artwork, primary + secondary
+/// text, trailing metadata) but surfaces track-specific fields: artist on the
+/// secondary line and right-aligned duration.
+///
+/// Clicking / double-clicking plays the track as a one-track queue via
+/// `AppModel.play(tracks:startIndex:)`. Hover reveals an inline play button
+/// for parity with the album row affordance. Right-click opens a context
+/// menu with the standard track actions (play / play next / queue / share).
+struct TrackListRow: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let track: Track
+    /// Full track list the row was rendered from, so tap-to-play can hand
+    /// the entire ordered list to `AppModel.play` and index into it. This
+    /// matches the `AlbumDetailView.trackList` contract.
+    let tracks: [Track]
+    let index: Int
+    @State private var isHovering = false
+
+    private var isActive: Bool {
+        model.status.currentTrack?.id == track.id
+    }
+
+    private var isPlaying: Bool {
+        isActive && model.status.state == .playing
+    }
+
+    var body: some View {
+        Button {
+            model.play(tracks: tracks, startIndex: index)
+        } label: {
+            HStack(spacing: 12) {
+                ZStack {
+                    Artwork(
+                        url: model.imageURL(
+                            for: track.albumId ?? track.id,
+                            tag: track.imageTag,
+                            maxWidth: 120
+                        ),
+                        seed: track.albumName ?? track.name,
+                        size: 40,
+                        radius: 4
+                    )
+                    if isPlaying {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.black.opacity(0.55))
+                            .frame(width: 40, height: 40)
+                        EqualizerIcon()
+                            .foregroundStyle(Theme.accent)
+                    } else if isHovering {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.black.opacity(0.45))
+                            .frame(width: 40, height: 40)
+                        Image(systemName: "play.fill")
+                            .foregroundStyle(.white)
+                            .font(.system(size: 13))
+                            .transition(.opacity)
+                    }
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(track.name)
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .lineLimit(1)
+                    Text(track.artistName)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if let album = track.albumName {
+                    Text(album)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .lineLimit(1)
+                        .frame(maxWidth: 240, alignment: .trailing)
+                }
+
+                Text(track.durationFormatted)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+                    .frame(minWidth: 48, alignment: .trailing)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.rowHover : .clear))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if reduceMotion {
+                isHovering = hovering
+            } else {
+                withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+            }
+        }
+        .accessibilityLabel("\(track.name) by \(track.artistName)")
+    }
+}

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -174,7 +174,29 @@ struct LibraryView: View {
                     }
                 }
             }
-        case .tracks, .playlists, .downloaded:
+        case .tracks:
+            // Tracks read naturally as a list, not a grid, so `viewMode`
+            // is intentionally ignored here — the All Tracks tab always
+            // renders a dense list. Near-end pagination mirrors the
+            // albums branch.
+            if model.tracks.isEmpty {
+                EmptyLibraryState(serverUrl: serverWebURL)
+            } else {
+                VStack(alignment: .leading, spacing: 18) {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(model.tracks.enumerated()), id: \.element.id) { idx, track in
+                            TrackListRow(track: track, tracks: model.tracks, index: idx)
+                                .onAppear {
+                                    triggerLoadMoreTracksIfNeeded(atIndex: idx)
+                                }
+                        }
+                    }
+                    if model.isLoadingMoreTracks {
+                        paginationSpinner
+                    }
+                }
+            }
+        case .playlists, .downloaded:
             // Placeholder until the per-tab surfaces land. The chip row, header,
             // and count subline remain live so navigation feels responsive.
             EmptyLibraryState(serverUrl: serverWebURL)
@@ -221,13 +243,27 @@ struct LibraryView: View {
         Task { await model.loadMoreArtists() }
     }
 
-    /// Count for a given tab. Albums and artists have real counts; the rest
-    /// are stubs pending their respective FFI/storage work.
+    /// Fire `loadMoreTracks` when the user scrolls into the last
+    /// `paginationTriggerDistance` cells and there are more tracks on the
+    /// server than currently loaded. Mirror of
+    /// `triggerLoadMoreAlbumsIfNeeded`.
+    private func triggerLoadMoreTracksIfNeeded(atIndex idx: Int) {
+        let loaded = model.tracks.count
+        let total = Int(model.tracksTotal)
+        guard total > loaded else { return }
+        let threshold = max(loaded - paginationTriggerDistance, 0)
+        guard idx >= threshold else { return }
+        Task { await model.loadMoreTracks() }
+    }
+
+    /// Count for a given tab. Albums, artists, and tracks have real counts;
+    /// the rest are stubs pending their respective FFI/storage work.
     private func tabCount(for tab: LibraryTab) -> Int {
         switch tab {
         case .albums: return model.albums.count
         case .artists: return model.artists.count
-        case .tracks, .playlists, .downloaded: return 0
+        case .tracks: return model.tracks.count
+        case .playlists, .downloaded: return 0
         }
     }
 
@@ -237,7 +273,8 @@ struct LibraryView: View {
         switch tab {
         case .albums: return Int(model.albumsTotal)
         case .artists: return Int(model.artistsTotal)
-        case .tracks, .playlists, .downloaded: return 0
+        case .tracks: return Int(model.tracksTotal)
+        case .playlists, .downloaded: return 0
         }
     }
 


### PR DESCRIPTION
## Summary
Adds the library-wide `list_tracks` core endpoint and wires the Tracks tab
in Library to render the full audio catalog. Closes the "Tracks chip shows
empty state" gap.

- core: `list_tracks(music_library_id, paging) -> PaginatedTracks` backed by
  `/Users/{id}/Items?IncludeItemTypes=Audio&Recursive=true&SortBy=SortName`.
  UniFFI-exposed. Three wiremock tests.
- AppModel: `tracks` / `tracksTotal` / `isLoadingMoreTracks` state,
  `refreshTracks()` and `loadMoreTracks()` with debounce, wired into
  `refreshLibrary` as a parallel `async let`. Cleared on logout/forgetToken.
- New `TrackListRow.swift` for the library Tracks list.
- `LibraryView.tracks` case renders a scrollable list with near-end
  pagination, count subline, bottom spinner.

## Test plan
- [ ] `cargo test --workspace --all-features`
- [ ] `cargo clippy -D warnings`
- [ ] swift build / bundle / smoke-launch
- [ ] Log in -> Library -> Tracks -> list renders with full library
- [ ] Scroll past 100 -> more tracks load