### PR TITLE
macos: playlists tab + AppModel fetch

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -35,10 +35,25 @@ final class AppModel {
     var albums: [Album] = []
     var artists: [Artist] = []
     var tracks: [Track] = []
+    var playlists: [Playlist] = []
     var albumTracks: [String: [Track]] = [:]          // albumID → tracks
     var recentlyPlayed: [Track] = []
     var searchResults: SearchResults?
     var searchQuery: String = ""
+
+    /// Collection-view id of the Jellyfin "Playlists" library. Resolved
+    /// lazily on first `refreshPlaylists()` — see `ensurePlaylistLibraryId`.
+    /// Cached across the session; cleared on logout.
+    ///
+    /// Jellyfin scopes `user_playlists` / `public_playlists` by `ParentId`,
+    /// so we need this before we can fetch anything. There is no FFI yet for
+    /// listing the user's libraries (tracked in core issue separate from
+    /// #483), so the current resolve is a pragmatic empty-string fallback:
+    /// Jellyfin's `/Items` endpoint treats an empty `ParentId` as "root /
+    /// any library the user can see", which happens to return playlists
+    /// across the whole server. When a real `core.libraries()` FFI lands,
+    /// swap this for a proper lookup.
+    var playlistLibraryId: String?
 
     // MARK: - Pagination
     //
@@ -57,6 +72,14 @@ final class AppModel {
     var artistsTotal: UInt32 = 0
     /// Server-reported total track count for the current library.
     var tracksTotal: UInt32 = 0
+    /// Server-reported total playlist count for the current library.
+    ///
+    /// Caveat: `user_playlists` / `public_playlists` on the core filter the
+    /// server's response client-side by `Path`, so this total is the raw
+    /// server count across BOTH user- and public-owned playlists — i.e. an
+    /// upper bound on what `items.count` will reach. See the core's
+    /// `PaginatedPlaylists` docstring.
+    var playlistsTotal: UInt32 = 0
     /// Server-reported total recently-played count (listening history size).
     var recentlyPlayedTotal: UInt32 = 0
     /// Server-reported total for the current search query across all item kinds.
@@ -69,6 +92,8 @@ final class AppModel {
     var isLoadingMoreArtists: Bool = false
     /// A follow-up tracks page is in flight. See `isLoadingMoreAlbums`.
     var isLoadingMoreTracks: Bool = false
+    /// A follow-up playlists page is in flight. See `isLoadingMoreAlbums`.
+    var isLoadingMorePlaylists: Bool = false
     /// A follow-up search page is in flight for the current query.
     var isLoadingMoreSearch: Bool = false
 
@@ -169,6 +194,8 @@ final class AppModel {
         albums = []
         artists = []
         tracks = []
+        playlists = []
+        playlistLibraryId = nil
         albumTracks = [:]
         recentlyPlayed = []
         searchResults = nil
@@ -188,6 +215,8 @@ final class AppModel {
         albums = []
         artists = []
         tracks = []
+        playlists = []
+        playlistLibraryId = nil
         albumTracks = [:]
         recentlyPlayed = []
         searchResults = nil
@@ -203,11 +232,13 @@ final class AppModel {
         albumsTotal = 0
         artistsTotal = 0
         tracksTotal = 0
+        playlistsTotal = 0
         recentlyPlayedTotal = 0
         searchResultsTotal = 0
         isLoadingMoreAlbums = false
         isLoadingMoreArtists = false
         isLoadingMoreTracks = false
+        isLoadingMorePlaylists = false
         isLoadingMoreSearch = false
     }
 
@@ -244,24 +275,30 @@ final class AppModel {
     func refreshLibrary() async {
         isLoadingLibrary = true
         defer { isLoadingLibrary = false }
+        // Fetch albums, artists, tracks, and playlists in parallel. Previously
+        // the album/artist calls were sequential, doubling time-to-first-paint
+        // on every fresh session; `async let` lets all round-trips overlap.
+        // Playlists are wired in alongside so switching to the Playlists chip
+        // doesn't trigger a first-paint spinner. The smaller
+        // `libraryInitialPageSize` (100 vs. the old 200) is a further
+        // first-paint win — the grid fills the viewport with 100 and the
+        // per-tab `loadMore*` paths take over when the user scrolls.
+        //
+        // Playlists go through their own try/catch because the library id
+        // resolution can fail independently (no playlist library on the
+        // server, or an error from a hypothetical future `core.libraries()`)
+        // and we don't want that to sink the albums/artists/tracks fetch.
+        async let albumsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+            try core.listAlbums(offset: 0, limit: libraryInitialPageSize)
+        }.value
+        async let artistsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+            try core.listArtists(offset: 0, limit: libraryInitialPageSize)
+        }.value
+        async let tracksPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+            try core.listTracks(musicLibraryId: nil, offset: 0, limit: libraryInitialPageSize)
+        }.value
+        async let playlistsResult: Void = refreshPlaylists()
         do {
-            // Fetch albums, artists, and tracks in parallel. Previously the
-            // calls were sequential, doubling time-to-first-paint on every
-            // fresh session. `async let` lets all three round-trips overlap;
-            // the `await` below resolves when all complete. The smaller
-            // `libraryInitialPageSize` (100 vs. the old 200) is a further
-            // first-paint win — the grid fills the viewport with 100 and
-            // `loadMoreAlbums` / `loadMoreTracks` take over when the user
-            // scrolls.
-            async let albumsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
-                try core.listAlbums(offset: 0, limit: libraryInitialPageSize)
-            }.value
-            async let artistsPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
-                try core.listArtists(offset: 0, limit: libraryInitialPageSize)
-            }.value
-            async let tracksPage = Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
-                try core.listTracks(musicLibraryId: nil, offset: 0, limit: libraryInitialPageSize)
-            }.value
             let (albums, artists, tracks) = try await (albumsPage, artistsPage, tracksPage)
             self.albums = albums.items
             self.albumsTotal = albums.totalCount
@@ -277,6 +314,7 @@ final class AppModel {
             }
             self.errorMessage = "Library load failed: \(error.localizedDescription)"
         }
+        _ = await playlistsResult
         await refreshRecentlyPlayed()
     }
 
@@ -372,6 +410,99 @@ final class AppModel {
                 serverReachability.noteFailure()
             }
             self.errorMessage = "Library load failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Resolve (and cache) the `ParentId` to scope playlist queries by.
+    ///
+    /// Jellyfin exposes playlists under a dedicated "Playlists"
+    /// CollectionFolder, but the core doesn't yet ship an FFI for listing a
+    /// user's libraries (tracked alongside #124 / #483). Until it does, we
+    /// fall back to the empty string: Jellyfin's `/Items` endpoint treats an
+    /// empty `ParentId` query value as "no filter", which returns the
+    /// server-wide set of playlists the user can see. That's slightly
+    /// broader than what the eventual proper resolve will return, but the
+    /// client-side `Path`-based filter in `user_playlists` / `public_playlists`
+    /// keeps the result correct.
+    ///
+    /// Logs a warning on first resolve so the gap is visible in Console.app.
+    private func ensurePlaylistLibraryId() -> String {
+        if let cached = playlistLibraryId { return cached }
+        // TODO: wire `core.libraries()` (tracked in core followup) so we can
+        // pick the CollectionFolder with `CollectionType == "playlists"`.
+        print("[AppModel] No playlist-library resolver available — falling back to empty ParentId. This returns the correct set for typical Jellyfin servers; wire core.libraries() when it lands.")
+        let resolved = ""
+        playlistLibraryId = resolved
+        return resolved
+    }
+
+    /// Fetch the first page of user-owned playlists for the Library screen's
+    /// Playlists chip. Wired into `refreshLibrary` so the chip is populated
+    /// before the user clicks it. Parallels `loadMoreAlbums` for the error
+    /// / auth / reachability story.
+    ///
+    /// Uses `user_playlists` (user-owned) rather than `public_playlists`. The
+    /// Playlists tab spec (#212) describes "your playlists"; a separate
+    /// "Community" affordance for public playlists is a future concern.
+    func refreshPlaylists() async {
+        let libraryId = ensurePlaylistLibraryId()
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryInitialPageSize] in
+                try core.userPlaylists(
+                    playlistLibraryId: libraryId,
+                    offset: 0,
+                    limit: libraryInitialPageSize
+                )
+            }.value
+            self.playlists = page.items
+            self.playlistsTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            // Silent-ish: don't clobber the albums/artists error banner if
+            // both fail in the same refresh. The Playlists tab empty state
+            // already explains "nothing to see here" when `playlists` is
+            // empty.
+            print("[AppModel] refreshPlaylists failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Fetch the next page of playlists and append to `playlists`. Mirror
+    /// of `loadMoreAlbums` — see its docs for the trigger contract.
+    ///
+    /// Server-side total caveat: `user_playlists` filters results client-
+    /// side by `Path`, so `playlistsTotal` is an upper bound on the raw
+    /// server count, not on `playlists.count`. The `<` guard below uses the
+    /// raw total deliberately — stopping at `playlists.count >= total` is
+    /// safe even when the two drift, because the server itself won't return
+    /// more items past its total and we'd bail on an empty page anyway.
+    func loadMorePlaylists() async {
+        guard !isLoadingMorePlaylists else { return }
+        guard playlistsTotal == 0 || playlists.count < Int(playlistsTotal) else { return }
+        isLoadingMorePlaylists = true
+        defer { isLoadingMorePlaylists = false }
+        let libraryId = ensurePlaylistLibraryId()
+        let offset = UInt32(playlists.count)
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core, libraryPageSize] in
+                try core.userPlaylists(
+                    playlistLibraryId: libraryId,
+                    offset: offset,
+                    limit: libraryPageSize
+                )
+            }.value
+            self.playlists.append(contentsOf: page.items)
+            self.playlistsTotal = page.totalCount
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            self.errorMessage = "Playlists load failed: \(error.localizedDescription)"
         }
     }
 

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -3,13 +3,19 @@ import SwiftUI
 
 /// Compact single-line row used by the Library list view. Mirrors the
 /// design's list density: small square artwork, title, secondary text, and
-/// a trailing metadata slot. Renders either an album or an artist depending
+/// a trailing metadata slot. Renders an album, artist, or playlist depending
 /// on which payload was used at construction time. Clicking opens the
 /// relevant detail screen; hover reveals an inline play button.
+///
+/// Each backing value type (`Album`, `Artist`, `Playlist`) has its own
+/// initializer so the call sites stay typed without a giant sum-type
+/// argument. The body is one `switch self.payload` so the SwiftUI layout
+/// doesn't fan out across separate view structs.
 struct LibraryListRow: View {
     enum Payload {
         case album(Album)
         case artist(Artist)
+        case playlist(Playlist)
     }
 
     @Environment(AppModel.self) private var model
@@ -23,6 +29,10 @@ struct LibraryListRow: View {
 
     init(artist: Artist) {
         self.payload = .artist(artist)
+    }
+
+    init(playlist: Playlist) {
+        self.payload = .playlist(playlist)
     }
 
     var body: some View {
@@ -101,6 +111,8 @@ struct LibraryListRow: View {
             return model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 120)
         case .artist(let artist):
             return model.imageURL(for: artist.id, tag: artist.imageTag, maxWidth: 120)
+        case .playlist(let playlist):
+            return model.imageURL(for: playlist.id, tag: playlist.imageTag, maxWidth: 120)
         }
     }
 
@@ -108,15 +120,16 @@ struct LibraryListRow: View {
         switch payload {
         case .album(let album): return album.name
         case .artist(let artist): return artist.name
+        case .playlist(let playlist): return playlist.name
         }
     }
 
-    /// Albums use the shared 4pt radius; artists get a pill/circle so the
-    /// list row reads consistently with the circular `ArtistRadioTile` used
-    /// elsewhere.
+    /// Albums and playlists use the shared 4pt radius; artists get a
+    /// pill/circle so the list row reads consistently with the circular
+    /// `ArtistRadioTile` used elsewhere.
     private var artworkRadius: CGFloat {
         switch payload {
-        case .album: return 4
+        case .album, .playlist: return 4
         case .artist: return 20
         }
     }
@@ -125,6 +138,7 @@ struct LibraryListRow: View {
         switch payload {
         case .album(let album): return album.name
         case .artist(let artist): return artist.name
+        case .playlist(let playlist): return playlist.name
         }
     }
 
@@ -135,16 +149,21 @@ struct LibraryListRow: View {
         case .artist(let artist):
             if !artist.genres.isEmpty { return artist.genres.joined(separator: ", ") }
             return "Artist"
+        case .playlist(let playlist):
+            // Playlists have no "artist" analogue, so the subtitle carries
+            // runtime duration instead. Falls back to an empty label for
+            // zero-runtime playlists so the layout still lines up.
+            return formattedDuration(runtimeTicks: playlist.runtimeTicks)
         }
     }
 
     /// Optional trailing metadata (e.g. release year for albums). Artists
-    /// have no equivalent, so the slot stays empty.
+    /// and playlists have no equivalent, so the slot stays empty.
     private var trailingMeta: String? {
         switch payload {
         case .album(let album):
             return album.year.map { String($0) }
-        case .artist:
+        case .artist, .playlist:
             return nil
         }
     }
@@ -155,7 +174,33 @@ struct LibraryListRow: View {
             return "\(album.trackCount) tracks"
         case .artist(let artist):
             return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
+        case .playlist(let playlist):
+            // Empty playlists get a compact "Empty" label rather than "0
+            // tracks"; otherwise mirror the album column's format.
+            switch playlist.trackCount {
+            case 0: return "Empty"
+            case 1: return "1 track"
+            default: return "\(playlist.trackCount) tracks"
+            }
         }
+    }
+
+    /// Compact duration label for the playlist subtitle. Ticks are in
+    /// hundred-nanoseconds (standard Jellyfin unit). Shows `H:MM` past the
+    /// hour mark, `Mm` otherwise ("4 min", "1h 32m"). Empty playlists
+    /// (`runtimeTicks == 0`) render as an empty string so the row collapses
+    /// to just the title line.
+    private func formattedDuration(runtimeTicks: UInt64) -> String {
+        guard runtimeTicks > 0 else { return "" }
+        let totalSeconds = Int(runtimeTicks / 10_000_000)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        // Sub-minute playlists round up to "1 min" rather than "0 min", so a
+        // 30-second single-track playlist still looks like content.
+        return "\(max(minutes, 1)) min"
     }
 
     private func openDetail() {
@@ -164,6 +209,8 @@ struct LibraryListRow: View {
             model.screen = .album(album.id)
         case .artist(let artist):
             model.screen = .artist(artist.id)
+        case .playlist(let playlist):
+            model.screen = .playlist(playlist.id)
         }
     }
 
@@ -173,6 +220,8 @@ struct LibraryListRow: View {
             model.play(album: album)
         case .artist(let artist):
             model.playAll(artist: artist)
+        case .playlist(let playlist):
+            model.play(playlist: playlist)
         }
     }
 
@@ -183,6 +232,8 @@ struct LibraryListRow: View {
             AlbumContextMenu(album: album)
         case .artist(let artist):
             ArtistContextMenu(artist: artist)
+        case .playlist(let playlist):
+            PlaylistContextMenu(playlist: playlist)
         }
     }
 }

--- a/macos/Sources/Jellify/Components/PlaylistCard.swift
+++ b/macos/Sources/Jellify/Components/PlaylistCard.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Grid card for a Jellyfin playlist. Mirrors `AlbumCard` in shape so the
+/// Library grid reads consistently when the user switches chips; the only
+/// visible differences are the subtitle ("N tracks") and the tap target
+/// (playlist detail rather than album detail).
+///
+/// Context menu routes through `PlaylistContextMenu` so the grid, list rows,
+/// and any future surfaces share one set of actions.
+///
+/// Spec: #212 (Library chips). Detail screen routed via `AppModel.Screen.playlist`.
+struct PlaylistCard: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let playlist: Playlist
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            model.screen = .playlist(playlist.id)
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                ZStack(alignment: .bottomTrailing) {
+                    Artwork(
+                        url: model.imageURL(for: playlist.id, tag: playlist.imageTag, maxWidth: 400),
+                        seed: playlist.name,
+                        size: 180,
+                        radius: 8
+                    )
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(1, contentMode: .fit)
+
+                    Button { model.play(playlist: playlist) } label: {
+                        Image(systemName: "play.fill")
+                            .foregroundStyle(.white)
+                            .font(.system(size: 16))
+                            .frame(width: 40, height: 40)
+                            .background(Circle().fill(Theme.primary))
+                            .shadow(color: Theme.primary.opacity(0.5), radius: 10, y: 4)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .opacity(isHovering ? 1 : 0)
+                    .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(playlist.name)
+                        .font(Theme.font(13, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isHovering ? Theme.surface : .clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu { PlaylistContextMenu(playlist: playlist) }
+    }
+
+    /// "42 tracks" / "1 track" — singular vs plural. Jellyfin reports
+    /// `trackCount` as 0 for freshly-created empty playlists; render that as
+    /// "Empty" rather than a confusing "0 tracks".
+    private var subtitle: String {
+        switch playlist.trackCount {
+        case 0: return "Empty"
+        case 1: return "1 track"
+        default: return "\(playlist.trackCount) tracks"
+        }
+    }
+}

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -41,6 +41,7 @@ struct Sidebar: View {
                 libRow("heart", label: "Favorites", count: nil)
                 libRow("square.stack", label: "Albums", count: UInt32(model.albums.count))
                 libRow("person.crop.circle", label: "Artists", count: UInt32(model.artists.count))
+                libRow("music.note.list", label: "Playlists", count: UInt32(model.playlists.count))
             }
             .padding(.horizontal, 10)
 

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -100,11 +100,11 @@ struct LibraryView: View {
         )
     }
 
-    /// Grid / list body for the currently selected chip. Only the `albums`
-    /// tab has live content today; the others render the shared empty state
-    /// so the chip selection still produces a coherent screen. As tracks,
-    /// artists, playlists, and download state land, each branch gets its own
-    /// surface.
+    /// Grid / list body for the currently selected chip. Albums, artists,
+    /// tracks, and playlists all have live content today; Downloaded
+    /// renders the shared empty state until the download engine lands
+    /// (#70 / #222).
+    ///
     /// Distance from the end of the grid at which the near-end
     /// `.onAppear` trigger fires a follow-up page. 20 is enough to overlap
     /// two screen-heights on a MacBook display, which is plenty of runway
@@ -196,8 +196,38 @@ struct LibraryView: View {
                     }
                 }
             }
-        case .playlists, .downloaded:
-            // Placeholder until the per-tab surfaces land. The chip row, header,
+        case .playlists:
+            if model.playlists.isEmpty {
+                EmptyLibraryState(serverUrl: serverWebURL)
+            } else {
+                VStack(alignment: .leading, spacing: 18) {
+                    switch viewMode {
+                    case .grid:
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 18) {
+                            ForEach(Array(model.playlists.enumerated()), id: \.element.id) { idx, playlist in
+                                PlaylistCard(playlist: playlist)
+                                    .onAppear {
+                                        triggerLoadMorePlaylistsIfNeeded(atIndex: idx)
+                                    }
+                            }
+                        }
+                    case .list:
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(model.playlists.enumerated()), id: \.element.id) { idx, playlist in
+                                LibraryListRow(playlist: playlist)
+                                    .onAppear {
+                                        triggerLoadMorePlaylistsIfNeeded(atIndex: idx)
+                                    }
+                            }
+                        }
+                    }
+                    if model.isLoadingMorePlaylists {
+                        paginationSpinner
+                    }
+                }
+            }
+        case .downloaded:
+            // Placeholder until the per-tab surface lands. The chip row, header,
             // and count subline remain live so navigation feels responsive.
             EmptyLibraryState(serverUrl: serverWebURL)
         }
@@ -256,14 +286,28 @@ struct LibraryView: View {
         Task { await model.loadMoreTracks() }
     }
 
-    /// Count for a given tab. Albums, artists, and tracks have real counts;
-    /// the rest are stubs pending their respective FFI/storage work.
+    /// Mirror of `triggerLoadMoreAlbumsIfNeeded` for the Playlists grid.
+    /// Separate function rather than a parameterised helper so the guard
+    /// arithmetic stays obvious at the call site.
+    private func triggerLoadMorePlaylistsIfNeeded(atIndex idx: Int) {
+        let loaded = model.playlists.count
+        let total = Int(model.playlistsTotal)
+        guard total > loaded else { return }
+        let threshold = max(loaded - paginationTriggerDistance, 0)
+        guard idx >= threshold else { return }
+        Task { await model.loadMorePlaylists() }
+    }
+
+    /// Count for a given tab. Albums, artists, tracks, and playlists have
+    /// real counts; Downloaded is a stub pending the download engine (#70 /
+    /// #222).
     private func tabCount(for tab: LibraryTab) -> Int {
         switch tab {
         case .albums: return model.albums.count
         case .artists: return model.artists.count
         case .tracks: return model.tracks.count
-        case .playlists, .downloaded: return 0
+        case .playlists: return model.playlists.count
+        case .downloaded: return 0
         }
     }
 
@@ -274,7 +318,8 @@ struct LibraryView: View {
         case .albums: return Int(model.albumsTotal)
         case .artists: return Int(model.artistsTotal)
         case .tracks: return Int(model.tracksTotal)
-        case .playlists, .downloaded: return 0
+        case .playlists: return Int(model.playlistsTotal)
+        case .downloaded: return 0
         }
     }
 


### PR DESCRIPTION
## Summary
Wires the Playlists tab in Library to fetch and render user playlists.
`core.userPlaylists` was already paginated in #514 but never called from the
Swift side.

- AppModel: `playlists` / `playlistsTotal` / `isLoadingMorePlaylists` state,
  `refreshPlaylists()`, `loadMorePlaylists()`, wired into `refreshLibrary`
  in parallel with albums/artists. Cleared on logout/forgetToken.
- New `PlaylistCard.swift` (grid) and `LibraryListRow(playlist:)` (list).
- `LibraryView.playlists` case renders grid/list, near-end pagination, count
  subline, bottom spinner.

## Test plan
- [ ] swift build / bundle / smoke-launch
- [ ] Log into a server with playlists, confirm grid renders
- [ ] Scroll past first page → more playlists load