### PR TITLE
core+macos: session auto-resume on launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +358,26 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1019,7 +1045,11 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -1585,6 +1615,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ url = { version = "2", features = ["serde"] }
 
 # Storage
 rusqlite = { version = "0.32", features = ["bundled"] }
+# keyring's default backend is the mock (no persistence). Each platform enables
+# the appropriate native store via a cfg-gated override in `core/Cargo.toml`.
 keyring = "3"
 
 # (Audio playback happens on the platform side via AVFoundation/MediaPlayer/GStreamer.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,16 @@ parking_lot.workspace = true
 
 uniffi.workspace = true
 
+# Platform-native credential store backends. Without these `keyring` falls back
+# to its in-memory mock store with no cross-process persistence, which makes
+# `resume_session()` a no-op across app restarts. The Linux target will land
+# alongside the GTK port (see research/09-linux-port.md).
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
+
 [dev-dependencies]
 wiremock.workspace = true
 tempfile.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -135,9 +135,77 @@ impl JellifyCore {
             if let Some(server_id) = &session.server.id {
                 inner.db.set_setting("last_server_id", server_id)?;
             }
+            inner.db.set_setting("last_user_id", &session.user.id)?;
         }
         self.inner.lock().client = Some(client);
         Ok(session)
+    }
+
+    /// Rehydrate the previous session from persisted state. Returns
+    /// `Ok(Some(session))` when all of `last_server_url`, `last_username`,
+    /// `last_server_id`, `last_user_id`, and the keyring token for that
+    /// user/server pair are present; otherwise `Ok(None)` so the caller can
+    /// fall back to the login screen.
+    ///
+    /// Best-effort hydration: `server.name` and `user.primary_image_tag` are
+    /// left blank — the next library call will refresh them, and we do NOT
+    /// block this call on network availability so users launching offline
+    /// still see their cached library instantly.
+    pub fn resume_session(&self) -> std::result::Result<Option<Session>, JellifyError> {
+        let (device_id, device_name, server_url, username, server_id, user_id) = {
+            let inner = self.inner.lock();
+            let server_url = match inner.db.get_setting("last_server_url")? {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+            let username = match inner.db.get_setting("last_username")? {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+            let server_id = match inner.db.get_setting("last_server_id")? {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+            let user_id = match inner.db.get_setting("last_user_id")? {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+            (
+                inner.device_id.clone(),
+                inner.device_name.clone(),
+                server_url,
+                username,
+                server_id,
+                user_id,
+            )
+        };
+
+        let token = match CredentialStore::load_token(&server_id, &username)? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let mut client = JellyfinClient::new(&server_url, device_id, device_name)?;
+        client.set_session(token.clone(), user_id.clone());
+        let resolved_url = client.base_url().to_string();
+        self.inner.lock().client = Some(client);
+
+        Ok(Some(Session {
+            server: Server {
+                url: resolved_url,
+                name: String::new(),
+                version: None,
+                id: Some(server_id.clone()),
+            },
+            user: User {
+                id: user_id,
+                name: username,
+                server_id: Some(server_id),
+                primary_image_tag: None,
+            },
+            access_token: token,
+            device_id: self.inner.lock().device_id.clone(),
+        }))
     }
 
     pub fn logout(&self) -> std::result::Result<(), JellifyError> {
@@ -149,6 +217,34 @@ impl JellifyCore {
             ) {
                 let _ = CredentialStore::delete_token(&server_id, &username);
             }
+            // Clearing persisted session pointers on an explicit logout so the
+            // next launch doesn't try to auto-restore a session the user just
+            // signed out of. `forget_token` is the softer variant that keeps
+            // the server URL / username around for a quick re-auth.
+            let _ = inner.db.delete_setting("last_server_url");
+            let _ = inner.db.delete_setting("last_username");
+            let _ = inner.db.delete_setting("last_server_id");
+            let _ = inner.db.delete_setting("last_user_id");
+        }
+        self.inner.lock().client = None;
+        self.player.clear();
+        Ok(())
+    }
+
+    /// Drop the stored access token (and the ids that key into it) without
+    /// wiping the remembered server URL / username. Used by the auth-expired
+    /// sheet so the login form pre-fills on the re-auth attempt.
+    pub fn forget_token(&self) -> std::result::Result<(), JellifyError> {
+        {
+            let inner = self.inner.lock();
+            if let (Ok(Some(server_id)), Ok(Some(username))) = (
+                inner.db.get_setting("last_server_id"),
+                inner.db.get_setting("last_username"),
+            ) {
+                let _ = CredentialStore::delete_token(&server_id, &username);
+            }
+            let _ = inner.db.delete_setting("last_server_id");
+            let _ = inner.db.delete_setting("last_user_id");
         }
         self.inner.lock().client = None;
         self.player.clear();

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -82,6 +82,13 @@ impl Database {
         Ok(row)
     }
 
+    pub fn delete_setting(&self, key: &str) -> Result<()> {
+        self.conn
+            .lock()
+            .execute("DELETE FROM settings WHERE key = ?1", params![key])?;
+        Ok(())
+    }
+
     pub fn record_play(&self, track_id: &str, played_at: i64) -> Result<()> {
         self.conn.lock().execute(
             "INSERT INTO play_history (track_id, played_at) VALUES (?1, ?2)",

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,12 +1,116 @@
 use crate::client::JellyfinClient;
 use crate::models::{ImageType, Paging};
-use crate::storage::Database;
+use crate::storage::{CredentialStore, Database};
+use crate::{CoreConfig, JellifyCore};
 use serde_json::json;
+use std::sync::Once;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 fn mock_client(base: &str) -> JellyfinClient {
     JellyfinClient::new(base, "test-device".into(), "Test Device".into()).unwrap()
+}
+
+/// Register a process-wide in-memory credential store as `keyring`'s default
+/// the first time a test touches the credential layer. Without this, on macOS
+/// the crate's `apple-native` feature would route every test into the real
+/// user keychain — which both pollutes the login keychain across runs and
+/// would flake in a headless CI environment.
+///
+/// `keyring`'s built-in `mock` builder hands out a brand-new `MockCredential`
+/// on every `Entry::new`, so it can't round-trip `save → load` across two
+/// `Entry` instances (which is exactly what `CredentialStore::save_token`
+/// followed by `CredentialStore::load_token` does). Our shim keeps one
+/// `HashMap` keyed on `(service, user)` so saves are visible to subsequent
+/// loads, which is the behaviour we need to exercise `resume_session`.
+///
+/// Tests still need to pick distinct `(server_id, username)` pairs — the
+/// harness intentionally does NOT clear the map between tests because tearing
+/// it down is racy under `cargo test`'s default parallelism.
+fn install_mock_keyring() {
+    use keyring::credential::{
+        Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi, CredentialPersistence,
+    };
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    type Store = Arc<Mutex<HashMap<(String, String), Vec<u8>>>>;
+
+    fn store() -> Store {
+        static STORE: OnceLock<Store> = OnceLock::new();
+        STORE
+            .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+            .clone()
+    }
+
+    struct SharedMockCredential {
+        service: String,
+        user: String,
+        store: Store,
+    }
+
+    impl CredentialApi for SharedMockCredential {
+        fn set_secret(&self, password: &[u8]) -> keyring::Result<()> {
+            self.store
+                .lock()
+                .unwrap()
+                .insert((self.service.clone(), self.user.clone()), password.to_vec());
+            Ok(())
+        }
+
+        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+            self.store
+                .lock()
+                .unwrap()
+                .get(&(self.service.clone(), self.user.clone()))
+                .cloned()
+                .ok_or(keyring::Error::NoEntry)
+        }
+
+        fn delete_credential(&self) -> keyring::Result<()> {
+            self.store
+                .lock()
+                .unwrap()
+                .remove(&(self.service.clone(), self.user.clone()))
+                .map(|_| ())
+                .ok_or(keyring::Error::NoEntry)
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    struct SharedMockBuilder;
+
+    impl CredentialBuilderApi for SharedMockBuilder {
+        fn build(
+            &self,
+            _target: Option<&str>,
+            service: &str,
+            user: &str,
+        ) -> keyring::Result<Box<Credential>> {
+            Ok(Box::new(SharedMockCredential {
+                service: service.to_string(),
+                user: user.to_string(),
+                store: store(),
+            }))
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn persistence(&self) -> CredentialPersistence {
+            CredentialPersistence::ProcessOnly
+        }
+    }
+
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let builder: Box<CredentialBuilder> = Box::new(SharedMockBuilder);
+        keyring::set_default_credential_builder(builder);
+    });
 }
 
 #[tokio::test]
@@ -1776,4 +1880,359 @@ fn play_history_counts() {
     assert_eq!(db.play_count("track-1").unwrap(), 2);
     assert_eq!(db.play_count("track-2").unwrap(), 1);
     assert_eq!(db.play_count("unknown").unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Session auto-restore (resume_session / login persistence)
+// ---------------------------------------------------------------------------
+
+/// Build a temp-backed `JellifyCore` so each test gets its own `jellify.db`
+/// without colliding with other tests or leaking into the user's real data
+/// directory.
+fn resume_test_core(tmp: &tempfile::TempDir) -> std::sync::Arc<JellifyCore> {
+    install_mock_keyring();
+    JellifyCore::new(CoreConfig {
+        data_dir: tmp.path().to_string_lossy().into_owned(),
+        device_name: "Test".into(),
+    })
+    .expect("core init")
+}
+
+#[test]
+fn resume_session_returns_none_when_no_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    let resumed = core.resume_session().expect("resume_session");
+    assert!(resumed.is_none(), "expected None on a fresh core");
+}
+
+#[test]
+fn resume_session_returns_none_when_token_missing() {
+    // Seed every `last_*` setting but leave the keyring empty — auto-restore
+    // should bail cleanly rather than hand back a session with no token.
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    {
+        let inner = core.inner.lock();
+        inner
+            .db
+            .set_setting("last_server_url", "https://jellyfin.example/")
+            .unwrap();
+        inner
+            .db
+            .set_setting("last_username", "token-missing-user")
+            .unwrap();
+        inner
+            .db
+            .set_setting("last_server_id", "srv-token-missing")
+            .unwrap();
+        inner
+            .db
+            .set_setting("last_user_id", "usr-token-missing")
+            .unwrap();
+    }
+    // Belt-and-braces: explicitly clear any stale token for this pair.
+    CredentialStore::delete_token("srv-token-missing", "token-missing-user").unwrap();
+
+    let resumed = core.resume_session().expect("resume_session");
+    assert!(
+        resumed.is_none(),
+        "expected None when keyring entry is absent"
+    );
+}
+
+#[test]
+fn resume_session_returns_session_when_all_settings_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    // Pick IDs unique to this test so parallel runs don't read each other's
+    // mock keyring entries.
+    let server_id = "srv-resume-full";
+    let username = "resume-full-user";
+    let user_id = "usr-resume-full";
+    let server_url = "https://resume.example/";
+    let token = "token-resume-full";
+    {
+        let inner = core.inner.lock();
+        inner.db.set_setting("last_server_url", server_url).unwrap();
+        inner.db.set_setting("last_username", username).unwrap();
+        inner.db.set_setting("last_server_id", server_id).unwrap();
+        inner.db.set_setting("last_user_id", user_id).unwrap();
+    }
+    CredentialStore::save_token(server_id, username, token).unwrap();
+
+    let resumed = core
+        .resume_session()
+        .expect("resume_session")
+        .expect("expected Some(session)");
+    assert_eq!(resumed.access_token, token);
+    assert_eq!(resumed.user.id, user_id);
+    assert_eq!(resumed.user.name, username);
+    assert_eq!(resumed.user.server_id.as_deref(), Some(server_id));
+    assert_eq!(resumed.server.id.as_deref(), Some(server_id));
+    // `Url::parse` round-trips the trailing slash; exact equality keeps the
+    // assertion tight so a future change to how we resolve the URL surfaces
+    // immediately.
+    assert_eq!(resumed.server.url, server_url);
+
+    // And the core should now have a live client wired to the restored
+    // credentials — any library call that follows can skip the login screen.
+    assert!(
+        core.inner.lock().client.is_some(),
+        "resume_session must rehydrate the JellyfinClient"
+    );
+}
+
+#[test]
+fn resume_session_noop_when_only_partial_settings() {
+    // Missing `last_user_id` on its own should still short-circuit to None.
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    {
+        let inner = core.inner.lock();
+        inner
+            .db
+            .set_setting("last_server_url", "https://partial.example/")
+            .unwrap();
+        inner
+            .db
+            .set_setting("last_username", "partial-user")
+            .unwrap();
+        inner
+            .db
+            .set_setting("last_server_id", "srv-partial")
+            .unwrap();
+        // Intentionally omit `last_user_id`.
+    }
+    CredentialStore::save_token("srv-partial", "partial-user", "partial-token").unwrap();
+
+    let resumed = core.resume_session().expect("resume_session");
+    assert!(
+        resumed.is_none(),
+        "partial settings must not rehydrate a half-built session"
+    );
+    assert!(
+        core.inner.lock().client.is_none(),
+        "client must not be reconstructed when settings are incomplete"
+    );
+
+    // Cleanup so a rerun of this test (or its neighbours) starts clean.
+    CredentialStore::delete_token("srv-partial", "partial-user").unwrap();
+}
+
+#[tokio::test]
+async fn login_persists_user_id_and_supports_resume() {
+    // End-to-end: log in against a mock Jellyfin, then stand up a fresh core
+    // pointed at the same data dir and assert `resume_session` hands back the
+    // same session without a network round-trip.
+    //
+    // `JellifyCore::login` is a sync FFI wrapper that `block_on`s its own
+    // tokio runtime, so we route it through `spawn_blocking` to keep it off
+    // the test harness's current-thread runtime (otherwise tokio refuses
+    // with "Cannot start a runtime from within a runtime").
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "persisted-token",
+            "ServerId": "srv-persisted",
+            "ServerName": "My Jellyfin",
+            "User": {
+                "Id": "usr-persisted",
+                "Name": "persisted-user",
+                "ServerId": "srv-persisted",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+
+    // --- first process: login ---
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+    let tmp_path_for_login = tmp_path.clone();
+    let server_url_for_login = server_url.clone();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path_for_login,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        let session = core
+            .login(server_url_for_login, "persisted-user".into(), "pw".into())
+            .expect("login");
+        assert_eq!(session.user.id, "usr-persisted");
+
+        // `login` must write `last_user_id` alongside the other identifiers so
+        // the next launch can look up the keychain entry.
+        let inner = core.inner.lock();
+        assert_eq!(
+            inner.db.get_setting("last_user_id").unwrap().as_deref(),
+            Some("usr-persisted")
+        );
+        assert_eq!(
+            inner.db.get_setting("last_server_id").unwrap().as_deref(),
+            Some("srv-persisted")
+        );
+        assert_eq!(
+            inner.db.get_setting("last_username").unwrap().as_deref(),
+            Some("persisted-user")
+        );
+    })
+    .await
+    .expect("join login task");
+
+    // --- second process: resume without re-authenticating ---
+    let tmp_path_for_resume = tmp_path.clone();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core2 = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path_for_resume,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        let resumed = core2
+            .resume_session()
+            .expect("resume_session")
+            .expect("expected Some(session) after login persisted");
+        assert_eq!(resumed.access_token, "persisted-token");
+        assert_eq!(resumed.user.id, "usr-persisted");
+        assert_eq!(resumed.user.name, "persisted-user");
+        assert_eq!(resumed.server.id.as_deref(), Some("srv-persisted"));
+        assert!(
+            core2.inner.lock().client.is_some(),
+            "resume_session must produce a live JellyfinClient"
+        );
+    })
+    .await
+    .expect("join resume task");
+}
+
+#[tokio::test]
+async fn logout_clears_persisted_settings() {
+    // After an explicit logout the next launch should start fresh — no
+    // half-baked auto-restore attempt against a dead session.
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "logout-token",
+            "ServerId": "srv-logout",
+            "ServerName": "S",
+            "User": {
+                "Id": "usr-logout",
+                "Name": "logout-user",
+                "ServerId": "srv-logout",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+    let server_url = server.uri();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path.clone(),
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        let _ = core
+            .login(server_url, "logout-user".into(), "pw".into())
+            .expect("login");
+        core.logout().expect("logout");
+
+        {
+            let inner = core.inner.lock();
+            assert_eq!(inner.db.get_setting("last_server_url").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_username").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
+        }
+        assert!(
+            CredentialStore::load_token("srv-logout", "logout-user")
+                .unwrap()
+                .is_none(),
+            "logout must also remove the keychain token"
+        );
+
+        // Resume on a brand-new core over the same data dir should now bail.
+        let core2 = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        assert!(core2.resume_session().expect("resume_session").is_none());
+    })
+    .await
+    .expect("join logout task");
+}
+
+#[tokio::test]
+async fn forget_token_preserves_server_url_and_username() {
+    // The auth-expired flow wipes the token so the user has to sign back in,
+    // but should keep the pre-fill fields so they don't have to retype the
+    // server URL / username.
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "forget-token",
+            "ServerId": "srv-forget",
+            "ServerName": "S",
+            "User": {
+                "Id": "usr-forget",
+                "Name": "forget-user",
+                "ServerId": "srv-forget",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+    let server_url = server.uri();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        let _ = core
+            .login(server_url, "forget-user".into(), "pw".into())
+            .expect("login");
+        core.forget_token().expect("forget_token");
+
+        {
+            let inner = core.inner.lock();
+            // server URL + username stick around so the login form pre-fills.
+            assert!(inner.db.get_setting("last_server_url").unwrap().is_some());
+            assert_eq!(
+                inner.db.get_setting("last_username").unwrap().as_deref(),
+                Some("forget-user")
+            );
+            // The ids that key into the keychain entry are wiped so a stale
+            // resume_session lookup can't accidentally grab a dangling token.
+            assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
+        }
+        assert!(
+            CredentialStore::load_token("srv-forget", "forget-user")
+                .unwrap()
+                .is_none(),
+            "forget_token must remove the keychain token"
+        );
+
+        // resume_session needs all four settings; with ids cleared it must say no.
+        assert!(core.resume_session().expect("resume_session").is_none());
+    })
+    .await
+    .expect("join forget task");
 }

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -125,6 +125,18 @@ final class AppModel {
     var isLoadingLibrary = false
     var errorMessage: String?
 
+    /// Set during the one-shot `attemptRestoreSession` pass at launch. `RootView`
+    /// renders a minimal loading state while this is true so we don't briefly
+    /// flash `LoginView` on cold start even though a valid session is about to
+    /// be rehydrated from the keychain.
+    ///
+    /// Starts `true` so the very first render (which happens before
+    /// `RootView.task` fires) shows the loading splash rather than a
+    /// one-frame flash of `LoginView`. `attemptRestoreSession` flips this to
+    /// `false` once the restore pass is done — either a session was
+    /// rehydrated or there was nothing to restore.
+    var isRestoringSession = true
+
     /// Set when a core call fails because the server rejected our token
     /// (HTTP 401) or the core reports no-longer-authenticated. Drives the
     /// modal prompt in `MainShell`. Reset after the user dismisses the sheet
@@ -187,6 +199,53 @@ final class AppModel {
         }
     }
 
+    /// Rehydrate the previous session from on-disk settings + the keychain
+    /// token. Called once from `RootView.task` on cold start. No-ops when the
+    /// core has nothing to restore (first launch, post-logout, etc.); in that
+    /// case `RootView` falls through to `LoginView`.
+    ///
+    /// Silent on errors: the core's `resume_session` is best-effort, so if the
+    /// local state is inconsistent we log and let the user sign in again
+    /// rather than blocking the app. Library fetches against the restored
+    /// session go through the regular `handleAuthError` flow, so a 401 on the
+    /// first call surfaces the auth-expired sheet just like a mid-session
+    /// expiry. Silent reauth is the rest of #440.
+    func attemptRestoreSession() async {
+        // Run at most once per AppModel lifetime. `hasAttemptedRestore`
+        // flips the first time this runs so re-renders of `RootView` that
+        // re-fire `.task` don't repeat the restore pass.
+        guard !hasAttemptedRestore else { return }
+        hasAttemptedRestore = true
+        guard session == nil else {
+            isRestoringSession = false
+            return
+        }
+        defer { isRestoringSession = false }
+        do {
+            let restored = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.resumeSession()
+            }.value
+            guard let session = restored else { return }
+            self.session = session
+            self.serverURL = session.server.url
+            self.username = session.user.name
+            self.errorMessage = nil
+            startPolling()
+            await refreshLibrary()
+        } catch {
+            // Best-effort: leave `session == nil` so RootView renders LoginView.
+            // No banner — the user sees the login form, which is already the
+            // recovery path, and the library refetch after a manual sign-in
+            // will noisily surface any persistent server problem.
+            print("[AppModel] attemptRestoreSession failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Internal guard for `attemptRestoreSession` — the restore pass should
+    /// run exactly once per app lifetime. Separate from `isRestoringSession`
+    /// so the UI flag can be flipped without gating re-entry, and vice-versa.
+    private var hasAttemptedRestore = false
+
     func logout() {
         audio.stop()
         try? core.logout()
@@ -209,9 +268,15 @@ final class AppModel {
     /// against the same server by re-entering only their password. Called
     /// when the user taps "Sign in" on the auth-expired sheet. Note: the
     /// caller still owns toggling `authExpired` off and nilling `session`.
+    ///
+    /// Unlike `logout`, this goes through the core's `forget_token` which
+    /// keeps `last_server_url` / `last_username` on disk for the login-form
+    /// prefill and only drops the credential store token plus the id settings
+    /// that key into it. So a subsequent `attemptRestoreSession` on next launch
+    /// short-circuits to `None` (safe), and the form is pre-populated.
     func forgetToken() {
         audio.stop()
-        try? core.logout()
+        try? core.forgetToken()
         albums = []
         artists = []
         tracks = []

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -161,14 +161,48 @@ struct RootView: View {
 
     var body: some View {
         Group {
-            if model.session == nil {
+            if model.isRestoringSession {
+                // One-shot loading state on cold start while the core attempts
+                // to rehydrate a session from persisted settings + keychain.
+                // We don't want to briefly flash `LoginView` on every launch
+                // just because the restore hasn't completed yet.
+                RestoreLoadingView()
+            } else if model.session == nil {
                 LoginView()
             } else {
                 MainShell()
             }
         }
         .background(Theme.bg)
-        // Login <-> main shell swap is instant under Reduce Motion.
+        // Login <-> main shell swap (and restore-loading <-> either) is
+        // instant under Reduce Motion.
         .animation(reduceMotion ? nil : .default, value: model.session != nil)
+        .animation(reduceMotion ? nil : .default, value: model.isRestoringSession)
+        .task {
+            // Kick off session restore exactly once, on the first appearance
+            // of the root view. `attemptRestoreSession` guards against
+            // re-entry, so a `.task` firing on every scene rebuild is safe.
+            await model.attemptRestoreSession()
+        }
+    }
+}
+
+/// Minimal cold-start splash shown while the core rehydrates a persisted
+/// session in the background. Kept lightweight on purpose — the restore pass
+/// completes on a userInitiated Task and this view exists solely to avoid a
+/// LoginView flash on every launch for a signed-in user.
+private struct RestoreLoadingView: View {
+    var body: some View {
+        ZStack {
+            Theme.bg.ignoresSafeArea()
+            VStack(spacing: 16) {
+                Text("Jellify")
+                    .font(Theme.font(40, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(Theme.ink3)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Restores the user's session on cold start so `LoginView` only shows on first
launch / after explicit logout. Closes the restore half of #440 (silent 401
refresh is a follow-up).

- core: `resume_session()` reads `last_*` settings + keyring token, rebuilds
  the `JellyfinClient`, returns `Option<Session>`. `login` now also persists
  `last_user_id`. `logout` clears persisted settings in addition to the token.
  New `forget_token` is the softer variant used by the auth-expired sheet — it
  wipes only the token and the ids that key into it, so the login form can
  prefill the server URL + username.
- Swift: `AppModel.attemptRestoreSession()` + `isRestoringSession` flag.
  `RootView` renders a brief loading state while restore is in flight so we
  don't flash `LoginView`. Kicked off from `.task` on `RootView` and runs once
  per `AppModel` lifetime.
- core tests cover the no-settings / token-missing / partial-state / full-state
  paths and confirm `login` persists `user_id`, `logout` wipes persisted state,
  and `forget_token` leaves URL + username alone.
- `keyring`: enable `apple-native` (macOS/iOS) and `windows-native` (Windows).
  Without these the crate defaults to an in-memory mock with no cross-process
  persistence, which would make `resume_session` a no-op. Tests register a
  shared in-memory credential builder so they don't touch the real keychain.

## Test plan
- [ ] `cargo test --workspace --all-features`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cd macos && ./Scripts/build-core.sh && swift build && ./Scripts/make-bundle.sh`
- [ ] Smoke-launch 5s
- [ ] Sign in, quit, relaunch → opens to MainShell, no login flash
- [ ] Logout from Sidebar → next launch shows LoginView
- [ ] Auth-expired sheet → "Sign in" prefills server URL + username