### PR TITLE
linux: bootstrap gtk-rs + libadwaita crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # Linux crate pulls in gtk4-rs + libadwaita which require GTK4 and
+      # libadwaita system libs for pkg-config to resolve during build.
+      - name: Install GTK4 + libadwaita system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libadwaita-1-dev build-essential pkg-config
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +241,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cairo-rs"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +303,16 @@ checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -360,6 +405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +447,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deadpool"
@@ -440,6 +500,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +537,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -592,6 +683,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk4-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,10 +780,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glib"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-build-tools"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7029c2651d9b5d5a3eea93ec8a1995665c6d3a69ce9bf6042ad9064d134736d8"
+dependencies = [
+ "gio",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gobject-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "goblin"
@@ -646,6 +888,112 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "graphene-rs"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b"
+dependencies = [
+ "glib",
+ "graphene-sys",
+ "libc",
+]
+
+[[package]]
+name = "graphene-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gsk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
+dependencies = [
+ "cairo-rs",
+ "gdk4",
+ "glib",
+ "graphene-rs",
+ "gsk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk4-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk4"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6"
+dependencies = [
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "graphene-rs",
+ "gsk4",
+ "gtk4-macros",
+ "gtk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "gsk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
 ]
 
 [[package]]
@@ -1003,6 +1351,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jellify-desktop"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "gio",
+ "glib",
+ "glib-build-tools",
+ "gtk4",
+ "jellify_core",
+ "libadwaita",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "jellify_core"
 version = "0.1.0"
 dependencies = [
@@ -1064,6 +1429,37 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libadwaita"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191"
+dependencies = [
+ "gdk4",
+ "gio",
+ "glib",
+ "gtk4",
+ "libadwaita-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "libadwaita-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db"
+dependencies = [
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "libc"
@@ -1129,6 +1525,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1224,6 +1629,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pango"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1737,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1532,6 +1976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +2160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2299,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
@@ -1993,6 +2474,57 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2163,7 +2695,7 @@ dependencies = [
  "paste",
  "serde",
  "textwrap",
- "toml",
+ "toml 0.5.11",
  "uniffi_meta",
  "uniffi_udl",
 ]
@@ -2217,7 +2749,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml",
+ "toml 0.5.11",
  "uniffi_meta",
 ]
 
@@ -2313,6 +2845,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -2707,6 +3245,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "core",
     "examples/cli",
+    "linux",
 ]
 
 [workspace.package]

--- a/linux/Cargo.toml
+++ b/linux/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "jellify-desktop"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Jellify — native GTK4 + libadwaita Jellyfin music player for Linux"
+
+[[bin]]
+name = "jellify-desktop"
+path = "src/main.rs"
+
+[dependencies]
+# Core (in-process; no FFI on Linux)
+jellify_core = { path = "../core" }
+
+# GNOME 46 / libadwaita 1.5 stack — pinned to match the Flatpak runtime we
+# target (org.gnome.Platform//46). Bumping these means bumping the runtime
+# in linux/flatpak too.
+gtk4 = { version = "0.9", features = ["v4_12"] }
+libadwaita = { version = "0.7", features = ["v1_5"] }
+glib = "0.20"
+gio = "0.20"
+
+# Async bridging for shuttling core calls off the main loop.
+async-channel = "2"
+
+# Workspace utilities
+tokio = { workspace = true }
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[build-dependencies]
+glib-build-tools = "0.20"

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,0 +1,69 @@
+# Jellify — Linux
+
+Native GTK4 + libadwaita Jellyfin music player. Consumes the shared `../core`
+crate in-process (no FFI on Linux).
+
+## Build requirements
+
+Target stack is GNOME 46 / libadwaita 1.5. Audio playback, MPRIS2, notifications,
+and individual screens land in follow-up batches; this crate currently produces
+just the application shell.
+
+### Fedora 40+
+
+```sh
+sudo dnf install \
+  gtk4-devel libadwaita-devel \
+  gstreamer1-devel gstreamer1-plugins-base-devel \
+  libsecret-devel \
+  pkgconf-pkg-config
+```
+
+### Ubuntu 24.04+ / Debian trixie+
+
+```sh
+sudo apt install \
+  libgtk-4-dev libadwaita-1-dev \
+  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+  libsecret-1-dev \
+  pkg-config
+```
+
+(`libgstreamer*` is not strictly required by this bootstrap batch but will be
+needed as soon as the GStreamer playback engine lands — installing now avoids
+revisiting.)
+
+### Rust toolchain
+
+```sh
+rustup toolchain install stable
+```
+
+The MSRV is pinned via the workspace `rust-version` field.
+
+## Build
+
+From the repo root:
+
+```sh
+cargo build -p jellify-desktop
+```
+
+Or from this directory:
+
+```sh
+cd linux && cargo build
+```
+
+Running `cargo check` (no link step) is useful on machines without the GTK dev
+packages installed — it validates the Rust sources against published crate
+metadata without requiring `pkg-config` to resolve native libraries.
+
+## Run
+
+```sh
+cargo run -p jellify-desktop
+```
+
+Launching a second instance is a no-op — primary-instance registration routes
+subsequent invocations to the first process, which raises its existing window.

--- a/linux/build.rs
+++ b/linux/build.rs
@@ -1,0 +1,16 @@
+//! Build script — compiles the app's `gresource` bundle via `glib-build-tools`
+//! so UI XML templates and (future) CSS / icons are embedded in the binary
+//! and loadable at runtime via `gio::resources_register_include!`.
+//!
+//! `source_dirs` lists the directories the gresource manifest's relative
+//! paths are resolved against. The UI composite template lives in `src/`
+//! alongside the matching Rust module (per the bootstrap layout); add
+//! `resources/` as the conventional home for future icons and CSS.
+
+fn main() {
+    glib_build_tools::compile_resources(
+        &["src", "resources"],
+        "resources/resources.gresource.xml",
+        "resources.gresource",
+    );
+}

--- a/linux/resources/resources.gresource.xml
+++ b/linux/resources/resources.gresource.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Resources bundled into the `jellify-desktop` binary at build time by
+  `build.rs` (glib-build-tools). Referenced paths are resolved against the
+  `source_dirs` passed to `compile_resources` — currently `src/` and
+  `resources/`.
+
+  As more UI lands (sidebar, screens, icons, CSS), add entries here rather
+  than loading ad-hoc files at runtime so the Flatpak binary stays
+  self-contained.
+-->
+<gresources>
+  <gresource prefix="/org/jellify/Desktop">
+    <file preprocess="xml-stripblanks" compressed="true">window.ui</file>
+  </gresource>
+</gresources>

--- a/linux/src/main.rs
+++ b/linux/src/main.rs
@@ -1,0 +1,75 @@
+//! Jellify — Linux desktop entrypoint.
+//!
+//! Boots an `adw::Application` under app-id `org.jellify.Desktop`. Primary
+//! instance registration is handled by `gio::Application` itself: the first
+//! process acquires the D-Bus name; subsequent invocations hand off to it
+//! and exit. The first process then receives `activate` (or `open`) signals
+//! and raises / focuses the existing `JellifyWindow` rather than creating
+//! a second one.
+//!
+//! `ApplicationFlags::HANDLES_OPEN` is reserved for a future `jellify://`
+//! deep-link URL scheme (tracked in research/09-linux-port.md); it does not
+//! mean we currently handle file opens.
+//!
+//! Audio playback (GStreamer), MPRIS2, notifications, and individual screens
+//! are follow-up batches — this boot sequence intentionally just presents
+//! an empty shell window.
+
+mod model;
+mod window;
+
+use adw::prelude::*;
+use gio::ApplicationFlags;
+use libadwaita as adw;
+use tracing::info;
+
+use crate::window::JellifyWindow;
+
+/// App id — must match the gresource prefix, the `.desktop` entry, and the
+/// Flatpak manifest. Changing this is a migration for users (settings keys
+/// rebase, D-Bus paths move).
+const APP_ID: &str = "org.jellify.Desktop";
+
+fn main() -> glib::ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    // Register the compiled gresource bundle. Produced by `build.rs` via
+    // `glib-build-tools`; consumed here so every main-loop template lookup
+    // sees it. Must run before any `CompositeTemplate`-backed widget
+    // constructs so the window's `resource = "/org/jellify/Desktop/window.ui"`
+    // binding can resolve.
+    gio::resources_register_include!("resources.gresource")
+        .expect("failed to register compiled gresource bundle");
+
+    let app = adw::Application::builder()
+        .application_id(APP_ID)
+        .flags(ApplicationFlags::HANDLES_OPEN)
+        .resource_base_path("/org/jellify/Desktop")
+        .build();
+
+    app.connect_activate(|app| {
+        // `activate` fires on first launch AND on every subsequent invocation
+        // once primary-instance registration routes them here. Reuse the
+        // existing window rather than creating a second one — this is what
+        // gives us "second launch raises the first window" behaviour.
+        if let Some(existing) = app.active_window() {
+            existing.present();
+            return;
+        }
+
+        let window = JellifyWindow::new(app);
+        window.present();
+        info!("jellify-desktop activated");
+    });
+
+    // `open` is reserved for `jellify://` deep links (HANDLES_OPEN). Until
+    // the URL scheme lands, treat it like `activate` so users who invoke
+    // the binary with stray positional args still get a window.
+    app.connect_open(|app, _files, _hint| {
+        app.activate();
+    });
+
+    app.run()
+}

--- a/linux/src/model.rs
+++ b/linux/src/model.rs
@@ -1,0 +1,329 @@
+//! App-wide model — owns the shared [`jellify_core::JellifyCore`] and the
+//! `gio::ListStore`s that back `gtk::ListView` / `gtk::GridView` widgets.
+//!
+//! Threading model:
+//! - `AppModel` lives on the GTK main loop (held behind `Rc<_>` on the
+//!   window). Its methods are `&self`-only.
+//! - `JellifyCore` is `Send + Sync` and internally runs blocking Jellyfin
+//!   HTTP calls on its own Tokio runtime via `block_on`. Screens that need
+//!   to invoke a core method dispatch it to a worker via `gio::spawn_blocking`
+//!   (to be added in a follow-up batch) and post results back to the main
+//!   loop through `async-channel` + `glib::MainContext::spawn_local`.
+//! - The wrapper GObjects below (`AlbumObject`, `ArtistObject`,
+//!   `TrackObject`) are main-loop-only and carry only `Clone`-friendly data
+//!   snapshots — never a `JellifyCore` handle — so they can be safely held
+//!   by `gio::ListStore` and bound to `SignalListItemFactory` rows.
+//!
+//! No network calls are issued in this bootstrap batch: `AppModel::new`
+//! just constructs the core and empty list stores. Screens added in later
+//! batches will populate the stores on sign-in.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use gio::prelude::*;
+use glib::subclass::prelude::*;
+use jellify_core::{Album, Artist, CoreConfig, JellifyCore, Track};
+
+/// Device name reported to the Jellyfin server during authentication.
+/// Shows up under "Dashboard → Sessions" on the server; matches the macOS
+/// client's pattern so admins can visually distinguish Linux desktops.
+const DEVICE_NAME: &str = "Jellify Desktop (Linux)";
+
+/// Top-level app state. One instance per window, held by the window behind
+/// `Rc<AppModel>`. Children reach it via `window.model()`.
+pub struct AppModel {
+    /// Shared Rust core — HTTP client, SQLite cache, auth, queue. Held as
+    /// `Arc` because the same handle is shared with any worker thread that
+    /// issues blocking core calls on behalf of the UI.
+    pub core: Arc<JellifyCore>,
+
+    /// Backing store for the Library → Albums grid. Populated by the
+    /// library screen once a session is active.
+    pub albums: gio::ListStore,
+    /// Backing store for the Library → Artists grid.
+    pub artists: gio::ListStore,
+    /// Backing store for the Now Playing queue sidebar.
+    pub queue: gio::ListStore,
+}
+
+impl std::fmt::Debug for AppModel {
+    // `JellifyCore` intentionally does not implement `Debug` (it owns a
+    // Tokio runtime and locked HTTP client state). Derive a minimal
+    // manual impl so containers holding `AppModel` — notably the window's
+    // `OnceCell<Rc<AppModel>>` inside the `CompositeTemplate`-derived
+    // imp struct — can still derive `Debug` themselves.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppModel")
+            .field("albums_len", &self.albums.n_items())
+            .field("artists_len", &self.artists.n_items())
+            .field("queue_len", &self.queue.n_items())
+            .finish_non_exhaustive()
+    }
+}
+
+impl AppModel {
+    /// Construct a fresh `AppModel`, initializing the core against the
+    /// default XDG data directory (`$XDG_DATA_HOME/jellify-desktop/`, by
+    /// convention via `core::storage::default_data_dir`). Follow-up
+    /// batches may switch to an explicit `glib::user_data_dir()` path so
+    /// the sandboxed Flatpak case stays deterministic.
+    pub fn new() -> Result<Self> {
+        let core = JellifyCore::new(CoreConfig {
+            // Empty string = use core's default (`dirs::data_dir`), which
+            // today resolves to `$XDG_DATA_HOME/jellify-desktop/` on Linux.
+            data_dir: String::new(),
+            device_name: DEVICE_NAME.to_string(),
+        })
+        .map_err(|e| anyhow::anyhow!("core init: {e}"))
+        .context("JellifyCore::new failed")?;
+
+        Ok(Self {
+            core,
+            albums: gio::ListStore::new::<AlbumObject>(),
+            artists: gio::ListStore::new::<ArtistObject>(),
+            queue: gio::ListStore::new::<TrackObject>(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper GObjects
+//
+// `gtk::ListView`, `gtk::GridView`, and the `SignalListItemFactory` machinery
+// require each row to be a GObject so they can be bound via properties. The
+// wrappers below expose the fields a row template typically reads — enough
+// for the bootstrap batch; follow-up batches will add computed properties
+// (e.g. formatted duration, cached artwork URIs) as screens need them.
+//
+// Storage layout: each wrapper keeps the core record in a private field
+// (accessed via property getters) rather than re-exposing every field
+// individually, which minimizes boilerplate while still giving GTK the
+// property access it needs for bindings.
+// ---------------------------------------------------------------------------
+
+// ---------- AlbumObject ----------
+
+mod album_imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Default, glib::Properties)]
+    #[properties(wrapper_type = super::AlbumObject)]
+    pub struct AlbumObject {
+        #[property(get = Self::id)]
+        pub _id: std::marker::PhantomData<String>,
+        #[property(get = Self::name)]
+        pub _name: std::marker::PhantomData<String>,
+        #[property(get = Self::artist_name)]
+        pub _artist_name: std::marker::PhantomData<String>,
+        #[property(get = Self::year)]
+        pub _year: std::marker::PhantomData<i32>,
+        #[property(get = Self::track_count)]
+        pub _track_count: std::marker::PhantomData<u32>,
+
+        pub inner: RefCell<Option<Album>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AlbumObject {
+        const NAME: &'static str = "JellifyAlbumObject";
+        type Type = super::AlbumObject;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for AlbumObject {}
+
+    impl AlbumObject {
+        fn with_inner<T: Default>(&self, f: impl FnOnce(&Album) -> T) -> T {
+            self.inner.borrow().as_ref().map(f).unwrap_or_default()
+        }
+
+        fn id(&self) -> String {
+            self.with_inner(|a| a.id.clone())
+        }
+        fn name(&self) -> String {
+            self.with_inner(|a| a.name.clone())
+        }
+        fn artist_name(&self) -> String {
+            self.with_inner(|a| a.artist_name.clone())
+        }
+        /// Returns `0` when the album has no year set — callers hide the
+        /// label in that case. UniFFI models expose `Option<i32>` but
+        /// `glib::Properties` doesn't derive optional scalars cleanly, so
+        /// we flatten.
+        fn year(&self) -> i32 {
+            self.with_inner(|a| a.year.unwrap_or(0))
+        }
+        fn track_count(&self) -> u32 {
+            self.with_inner(|a| a.track_count)
+        }
+    }
+}
+
+glib::wrapper! {
+    /// GObject wrapper around a [`jellify_core::Album`]. Backs rows in the
+    /// Library → Albums grid.
+    pub struct AlbumObject(ObjectSubclass<album_imp::AlbumObject>);
+}
+
+impl AlbumObject {
+    pub fn new(album: Album) -> Self {
+        let obj: Self = glib::Object::new();
+        obj.imp().inner.replace(Some(album));
+        obj
+    }
+
+    /// Clone of the underlying core record. Used by detail screens that
+    /// need the full struct (genres, runtime, etc.) rather than the
+    /// GObject-exposed subset.
+    pub fn snapshot(&self) -> Option<Album> {
+        self.imp().inner.borrow().clone()
+    }
+}
+
+// ---------- ArtistObject ----------
+
+mod artist_imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Default, glib::Properties)]
+    #[properties(wrapper_type = super::ArtistObject)]
+    pub struct ArtistObject {
+        #[property(get = Self::id)]
+        pub _id: std::marker::PhantomData<String>,
+        #[property(get = Self::name)]
+        pub _name: std::marker::PhantomData<String>,
+        #[property(get = Self::album_count)]
+        pub _album_count: std::marker::PhantomData<u32>,
+        #[property(get = Self::song_count)]
+        pub _song_count: std::marker::PhantomData<u32>,
+
+        pub inner: RefCell<Option<Artist>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ArtistObject {
+        const NAME: &'static str = "JellifyArtistObject";
+        type Type = super::ArtistObject;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for ArtistObject {}
+
+    impl ArtistObject {
+        fn with_inner<T: Default>(&self, f: impl FnOnce(&Artist) -> T) -> T {
+            self.inner.borrow().as_ref().map(f).unwrap_or_default()
+        }
+
+        fn id(&self) -> String {
+            self.with_inner(|a| a.id.clone())
+        }
+        fn name(&self) -> String {
+            self.with_inner(|a| a.name.clone())
+        }
+        fn album_count(&self) -> u32 {
+            self.with_inner(|a| a.album_count)
+        }
+        fn song_count(&self) -> u32 {
+            self.with_inner(|a| a.song_count)
+        }
+    }
+}
+
+glib::wrapper! {
+    /// GObject wrapper around a [`jellify_core::Artist`]. Backs rows in
+    /// the Library → Artists grid.
+    pub struct ArtistObject(ObjectSubclass<artist_imp::ArtistObject>);
+}
+
+impl ArtistObject {
+    pub fn new(artist: Artist) -> Self {
+        let obj: Self = glib::Object::new();
+        obj.imp().inner.replace(Some(artist));
+        obj
+    }
+
+    pub fn snapshot(&self) -> Option<Artist> {
+        self.imp().inner.borrow().clone()
+    }
+}
+
+// ---------- TrackObject ----------
+
+mod track_imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Default, glib::Properties)]
+    #[properties(wrapper_type = super::TrackObject)]
+    pub struct TrackObject {
+        #[property(get = Self::id)]
+        pub _id: std::marker::PhantomData<String>,
+        #[property(get = Self::name)]
+        pub _name: std::marker::PhantomData<String>,
+        #[property(get = Self::artist_name)]
+        pub _artist_name: std::marker::PhantomData<String>,
+        #[property(get = Self::album_name)]
+        pub _album_name: std::marker::PhantomData<String>,
+        #[property(get = Self::runtime_seconds)]
+        pub _runtime_seconds: std::marker::PhantomData<f64>,
+        #[property(get = Self::is_favorite)]
+        pub _is_favorite: std::marker::PhantomData<bool>,
+
+        pub inner: RefCell<Option<Track>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TrackObject {
+        const NAME: &'static str = "JellifyTrackObject";
+        type Type = super::TrackObject;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for TrackObject {}
+
+    impl TrackObject {
+        fn with_inner<T: Default>(&self, f: impl FnOnce(&Track) -> T) -> T {
+            self.inner.borrow().as_ref().map(f).unwrap_or_default()
+        }
+
+        fn id(&self) -> String {
+            self.with_inner(|t| t.id.clone())
+        }
+        fn name(&self) -> String {
+            self.with_inner(|t| t.name.clone())
+        }
+        fn artist_name(&self) -> String {
+            self.with_inner(|t| t.artist_name.clone())
+        }
+        fn album_name(&self) -> String {
+            self.with_inner(|t| t.album_name.clone().unwrap_or_default())
+        }
+        fn runtime_seconds(&self) -> f64 {
+            self.with_inner(|t| t.duration_seconds())
+        }
+        fn is_favorite(&self) -> bool {
+            self.with_inner(|t| t.is_favorite)
+        }
+    }
+}
+
+glib::wrapper! {
+    /// GObject wrapper around a [`jellify_core::Track`]. Backs rows in
+    /// the queue sidebar, album track lists, and playlist track lists.
+    pub struct TrackObject(ObjectSubclass<track_imp::TrackObject>);
+}
+
+impl TrackObject {
+    pub fn new(track: Track) -> Self {
+        let obj: Self = glib::Object::new();
+        obj.imp().inner.replace(Some(track));
+        obj
+    }
+
+    pub fn snapshot(&self) -> Option<Track> {
+        self.imp().inner.borrow().clone()
+    }
+}

--- a/linux/src/window.rs
+++ b/linux/src/window.rs
@@ -1,0 +1,122 @@
+//! `JellifyWindow` — the top-level app window.
+//!
+//! Subclasses `AdwApplicationWindow` via `glib::subclass` so we get a proper
+//! GObject type (required for composite templates) while keeping the
+//! libadwaita integration (adaptive sizing, runtime color-scheme plumbing).
+//!
+//! The UI layout comes from `window.ui` via `CompositeTemplate`. Template
+//! children (`header_bar`, `navigation_view`) are wired through
+//! `#[template_child]` so the imp block can reach them without a runtime
+//! builder lookup.
+//!
+//! The window owns the shared [`AppModel`]; child screens (once added in
+//! follow-up batches) reach the model via `window.model()`. We hold
+//! `AppModel` behind `Rc<_>` rather than `Arc<_>` because everything in the
+//! GTK world runs on a single main thread — the `Arc<JellifyCore>` *inside*
+//! `AppModel` is what crosses thread boundaries when we dispatch core calls
+//! to a worker.
+
+use std::cell::OnceCell;
+use std::rc::Rc;
+
+use adw::subclass::prelude::*;
+use glib::subclass::InitializingObject;
+use libadwaita as adw;
+
+use crate::model::AppModel;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk4::CompositeTemplate)]
+    #[template(resource = "/org/jellify/Desktop/window.ui")]
+    pub struct JellifyWindow {
+        #[template_child]
+        pub header_bar: gtk4::TemplateChild<adw::HeaderBar>,
+        #[template_child]
+        pub navigation_view: gtk4::TemplateChild<adw::NavigationView>,
+
+        /// Shared app state — set once in `setup_model`. `OnceCell` so we can
+        /// initialize it lazily after the window exists (construction order
+        /// matters: the imp's `Default` runs before we have a core handle).
+        pub model: OnceCell<Rc<AppModel>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for JellifyWindow {
+        const NAME: &'static str = "JellifyWindow";
+        type Type = super::JellifyWindow;
+        type ParentType = adw::ApplicationWindow;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for JellifyWindow {
+        fn constructed(&self) {
+            self.parent_constructed();
+            // Hook for future wiring: sidebar signals, GActions, geometry
+            // restore from `gio::Settings`, etc. Intentionally empty in the
+            // bootstrap batch so the shell compiles against a minimal
+            // composite template.
+        }
+    }
+
+    impl WidgetImpl for JellifyWindow {}
+    impl WindowImpl for JellifyWindow {}
+    impl ApplicationWindowImpl for JellifyWindow {}
+    impl AdwApplicationWindowImpl for JellifyWindow {}
+}
+
+glib::wrapper! {
+    /// Top-level `AdwApplicationWindow` for Jellify. Created once per primary
+    /// instance in `main.rs::activate`.
+    pub struct JellifyWindow(ObjectSubclass<imp::JellifyWindow>)
+        @extends adw::ApplicationWindow, gtk4::ApplicationWindow, gtk4::Window, gtk4::Widget,
+        @implements gio::ActionGroup, gio::ActionMap, gtk4::Accessible, gtk4::Buildable,
+                    gtk4::ConstraintTarget, gtk4::Native, gtk4::Root, gtk4::ShortcutManager;
+}
+
+impl JellifyWindow {
+    /// Build a new window bound to the running `adw::Application` and lazily
+    /// initialize the shared [`AppModel`]. Model construction is allowed to
+    /// fail (e.g. if the SQLite DB under the XDG data dir can't be opened);
+    /// we log and keep presenting the shell in that case so the user still
+    /// sees *something* rather than a silent no-op, and so UI developers
+    /// running without a writable data dir aren't blocked.
+    pub fn new(app: &adw::Application) -> Self {
+        let window: Self = glib::Object::builder().property("application", app).build();
+        window.setup_model();
+        window
+    }
+
+    /// Access the shared [`AppModel`]. Panics if the model failed to
+    /// initialize — screens that depend on it should only be pushed onto the
+    /// navigation view after a successful session handshake, at which point
+    /// this is guaranteed to be `Some`.
+    pub fn model(&self) -> Rc<AppModel> {
+        self.imp()
+            .model
+            .get()
+            .cloned()
+            .expect("AppModel not initialized — called model() before setup_model succeeded")
+    }
+
+    fn setup_model(&self) {
+        match AppModel::new() {
+            Ok(model) => {
+                // OnceCell::set returns Err if already set; on first init
+                // we are the only caller so it's safe to discard.
+                let _ = self.imp().model.set(Rc::new(model));
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "failed to initialize AppModel");
+            }
+        }
+    }
+}

--- a/linux/src/window.ui
+++ b/linux/src/window.ui
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Composite template for `JellifyWindow`. Kept intentionally minimal for the
+  bootstrap batch — later batches land the sidebar (AdwNavigationSplitView),
+  mini-player, and per-screen content pages under this AdwNavigationView root.
+-->
+<interface>
+  <requires lib="gtk" version="4.12"/>
+  <requires lib="Adw" version="1.5"/>
+  <template class="JellifyWindow" parent="AdwApplicationWindow">
+    <property name="title" translatable="yes">Jellify</property>
+    <property name="default-width">1100</property>
+    <property name="default-height">720</property>
+    <property name="content">
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwHeaderBar" id="header_bar">
+            <property name="title-widget">
+              <object class="AdwWindowTitle">
+                <property name="title" translatable="yes">Jellify</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwNavigationView" id="navigation_view">
+            <property name="vexpand">true</property>
+            <child>
+              <object class="AdwNavigationPage">
+                <property name="title" translatable="yes">Jellify</property>
+                <property name="tag">root</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="icon-name">folder-music-symbolic</property>
+                    <property name="title" translatable="yes">Jellify</property>
+                    <property name="description" translatable="yes">Connect to a Jellyfin server to browse your music library.</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </property>
+  </template>
+</interface>


### PR DESCRIPTION
## Summary

Scaffolds the `linux/` workspace member that produces the `jellify-desktop` binary — GNOME 46 / libadwaita 1.5 target, consuming `jellify_core` in-process (no FFI).

- `adw::Application` entry under app-id `org.jellify.Desktop` with `HANDLES_OPEN` + primary-instance registration (second launch raises the first window).
- `JellifyWindow` — `AdwApplicationWindow` subclass via `glib::subclass`, driven by a `CompositeTemplate` (`window.ui` with `AdwHeaderBar` + `AdwNavigationView`).
- `AppModel` owning `Arc<JellifyCore>` (behind `Rc<AppModel>` on the main loop) plus `gio::ListStore`s for albums / artists / queue.
- Wrapper GObjects (`AlbumObject`, `ArtistObject`, `TrackObject`) using `glib::Properties` so `gtk::GridView` / `gtk::ListView` can bind rows.
- `build.rs` compiles `resources/resources.gresource.xml` via `glib-build-tools`; `window.ui` is the first bundled resource.
- GNOME 46 pin: `gtk4 0.9 / v4_12`, `libadwaita 0.7 / v1_5`, `glib 0.20`, `gio 0.20`, `glib-build-tools 0.20`.
- `linux/README.md` documents the Fedora 40 / Ubuntu 24.04 dev-package lists.

No screens, GStreamer, or MPRIS2 — those are follow-up batches. The bootstrap presents an empty `AdwStatusPage` shell.

Closes #390, #391, #392, #393, #394, #395

## Test plan

- [x] `cargo build --workspace` at the repo root (core + CLI still green).
- [x] `cargo build -p jellify-desktop` produces `target/debug/jellify-desktop`.
- [x] `cargo clippy -p jellify-desktop --no-deps` — no warnings.
- [x] `cargo fmt --check -p jellify-desktop` — clean.
- [ ] Fedora 40 / Ubuntu 24.04 runner (handled by CI wiring in a follow-up).
- [ ] Manual: launch twice → second invocation raises the first window.

## Local verification notes

Verified on macOS against Homebrew's `gtk4 4.22` / `libadwaita 1.9` — the pinned `v4_12` / `v1_5` feature gates are the minimum floor, so the newer Homebrew versions satisfy them. Final CI on a Fedora 40 runner (targeting the actual GNOME 46 stack) will validate the canonical target; the README lists the matching `dnf` / `apt` package sets.