### PR TITLE
macos: signing, notarization, and DMG pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           xcode-version: latest-stable
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
       - name: Build xcframework
         working-directory: macos

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -1,0 +1,286 @@
+# Jellify macOS Distribution
+
+End-to-end pipeline for producing a signed, notarized, stapled `Jellify-<version>.dmg`
+that passes Gatekeeper and launches cleanly on a fresh Mac.
+
+---
+
+## **MANUAL PREREQUISITE — Apple Developer Program enrollment (issue #175)**
+
+**This step is a multi-day, non-engineering task. The engineering pipeline
+below cannot be exercised end-to-end until it is done. Start it first.**
+
+1. Enroll at <https://developer.apple.com/programs/>. Individual
+   enrollment is $99/year; organizational enrollment can take 1–4 weeks.
+2. In the developer portal (**Certificates, IDs & Profiles →
+   Certificates**) request a **Developer ID Application** certificate.
+   - This is the cert used to sign `.app` bundles and `.dmg` files for
+     distribution *outside* the Mac App Store.
+   - **Do not** request **Developer ID Installer** — we ship a DMG, not
+     a `.pkg`.
+   - **Do not** request **Apple Distribution** / **Mac App Distribution**
+     — those are MAS-only.
+3. On a secure Mac, generate a CSR via **Keychain Access → Certificate
+   Assistant → Request a Certificate from a Certificate Authority**.
+   Upload the `.certSigningRequest`, download the resulting `.cer`,
+   double-click it to import into your login keychain.
+4. Export the resulting identity as a `.p12` from **Keychain Access → My
+   Certificates**. Select both the certificate *and* its private key
+   (if the key is missing from the selection, the Export menu item is
+   greyed out). Set a long random password. Store the `.p12` + password
+   in 1Password under `jellify-desktop / Apple Developer ID`.
+5. From the portal's **Membership** page, record the **Team ID**. Save
+   it in the same 1Password entry.
+6. (Related to issue #176) In **Identifiers → + → App IDs → macOS App**,
+   register the bundle identifier `org.jellify.desktop` exactly. A
+   mismatch between the cert's recognized identifiers and the bundle ID
+   is a common notarization surprise.
+
+Once the certificate is in your login keychain the engineering pipeline
+below will just work.
+
+---
+
+## Environment variables
+
+All scripts read their secrets from the environment. Nothing touches
+disk outside of the keychain-stored credentials and local build outputs.
+
+| Variable        | Used by                            | Example                                                      |
+| --------------- | ---------------------------------- | ------------------------------------------------------------ |
+| `VERSION`       | `make-bundle.sh`, `make-dmg.sh`    | `0.1.0` (semver, matches a git tag)                          |
+| `BUILD`         | `make-bundle.sh`                   | `1234` (monotonic build number, typically CI run number)     |
+| `DEVELOPER_ID`  | `sign.sh`, `make-dmg.sh`           | `Developer ID Application: Jane Doe (TEAMID123)`             |
+| `NOTARY_PROFILE`| `notarize.sh`                      | `jellify-notary` (keychain profile name)                     |
+
+If `VERSION` / `BUILD` are unset, the scripts fall back to
+`git describe --tags --abbrev=0` and `git rev-list --count HEAD` so local
+dev builds still produce a sensibly-named bundle.
+
+### One-time notary profile bootstrap
+
+Store notary credentials in the keychain so the scripts never see raw
+secrets:
+
+```sh
+xcrun notarytool store-credentials jellify-notary \
+    --apple-id       "$APPLE_ID" \
+    --team-id        "$APPLE_TEAM_ID" \
+    --password       "$APPLE_NOTARY_APP_PASSWORD"
+```
+
+- `APPLE_ID` — the Apple ID associated with your developer account.
+- `APPLE_TEAM_ID` — the 10-character team ID from the portal.
+- `APPLE_NOTARY_APP_PASSWORD` — an **app-specific password** created at
+  <https://appleid.apple.com> → Sign-In and Security → App-Specific
+  Passwords. (Your real Apple ID password will not work.)
+
+This only needs to run once per machine. The profile is stored in the
+login keychain under the name `jellify-notary`.
+
+### Tooling install
+
+```sh
+brew install create-dmg jq shellcheck
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+```
+
+`shellcheck` is dev-only. `jq` is required by `notarize.sh`. Xcode
+command line tools must be present (`xcode-select --install`).
+
+---
+
+## Files
+
+| Path                                         | Purpose                                                        |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| `macos/Resources/Info.plist`                 | Info.plist template with `$VERSION`/`$BUILD` placeholders      |
+| `macos/Resources/Jellify.entitlements`       | Hardened-runtime entitlements applied at signing time          |
+| `macos/Scripts/build-core.sh`                | Builds the Rust core as a universal `arm64 + x86_64` xcframework|
+| `macos/Scripts/make-bundle.sh`               | Assembles `Jellify.app` and injects Info.plist version fields  |
+| `macos/Scripts/sign.sh`                      | Codesigns the bundle inside-out with the hardened runtime      |
+| `macos/Scripts/make-dmg.sh`                  | Produces `Jellify-<version>.dmg` via `create-dmg`              |
+| `macos/Scripts/notarize.sh`                  | Submits to Apple's notary, waits, staples the ticket           |
+
+---
+
+## The release flow — run locally
+
+Each script is idempotent and cleans up after itself on failure, so a
+partial run can be retried from any step.
+
+```sh
+# 1. Build the Rust core as a universal xcframework.
+./macos/Scripts/build-core.sh --release
+
+# 2. Compile Swift for both architectures.
+cd macos
+swift build -c release --arch arm64 --arch x86_64
+cd ..
+
+# 3. Assemble Jellify.app. Picks up $VERSION / $BUILD (or git fallback).
+VERSION=0.1.0 BUILD=1 ./macos/Scripts/make-bundle.sh --release --universal
+
+# 4. Code-sign inside-out with the hardened runtime.
+DEVELOPER_ID="Developer ID Application: Your Name (TEAMID123)" \
+    ./macos/Scripts/sign.sh macos/build/Jellify.app
+
+# 5. Produce the DMG (signed with the same identity).
+DEVELOPER_ID="Developer ID Application: Your Name (TEAMID123)" \
+    VERSION=0.1.0 \
+    ./macos/Scripts/make-dmg.sh
+
+# 6. Submit for notarization and staple the ticket on success.
+./macos/Scripts/notarize.sh macos/build/Jellify-0.1.0.dmg
+```
+
+After step 6, the DMG is shippable. `spctl --assess --type open
+--context context:primary-signature -v macos/build/Jellify-0.1.0.dmg`
+should report `accepted`.
+
+---
+
+## Bundle layout (after step 4)
+
+```
+Jellify.app/
+├── Contents/
+│   ├── Info.plist           (rendered from Resources/Info.plist)
+│   ├── MacOS/
+│   │   └── Jellify          (universal Mach-O, signed + hardened runtime)
+│   ├── Resources/
+│   │   ├── AppIcon.icns     (optional — soft-dependency on icon pipeline)
+│   │   └── Jellify_Jellify.bundle/   (SPM-processed fonts bundle)
+│   └── _CodeSignature/
+```
+
+No `Frameworks/` directory yet. Sparkle ships in BATCH-19 (see
+ROADMAP) and will live at `Contents/Frameworks/Sparkle.framework`.
+`sign.sh` already handles it correctly when present.
+
+---
+
+## What each script does in detail
+
+### `build-core.sh`
+
+Builds `libjellify_core.a` for both `aarch64-apple-darwin` and
+`x86_64-apple-darwin` (in release mode; LTO is pinned in `Cargo.toml`),
+then fuses them into a single fat archive with `lipo`. The UniFFI
+Swift binding is regenerated from the arm64 `.dylib` and both the
+headers and the fat static lib go into `macos/Jellify.xcframework`,
+which the SPM `binaryTarget` consumes.
+
+Pass `--arm64-only` during development to skip the x86_64 leg.
+
+### `make-bundle.sh`
+
+Assembles `macos/build/Jellify.app` from the `swift build` output.
+Copies `macos/Resources/Info.plist` into `Contents/Info.plist`, then
+uses `plutil -replace` to inject `$VERSION` and `$BUILD`. Runs
+`plutil -lint` on the result — a drift in the template that breaks
+Core Foundation parsing fails the script loudly.
+
+### `sign.sh`
+
+Signs inside-out in a deterministic order: frameworks → XPC services
+→ loose dylibs → auxiliary helpers → main bundle. Every sign call
+uses `--options runtime --timestamp`. Entitlements are applied to
+bundle-level binaries (frameworks, the app itself); inner helpers
+inherit from the enclosing app.
+
+**Never passes `--deep`.** `--deep` is deprecated, papers over real
+signing bugs, and is correlated with notary rejections.
+
+Verifies with `codesign --verify --strict` and previews the Gatekeeper
+verdict with `spctl`. The Gatekeeper preview will report "rejected,
+source=Unnotarized Developer ID" until `notarize.sh` runs — that's
+expected.
+
+### `make-dmg.sh`
+
+Wraps `create-dmg`. Stages the `.app` in a scratch directory so
+create-dmg doesn't sweep in any sibling junk in `build/`. Signs the
+DMG with `--codesign`. **Does not** pass `--notarize` — notarization
+happens via the dedicated `notarize.sh` so a rejected submission is
+retriable without rebuilding the DMG.
+
+### `notarize.sh`
+
+`xcrun notarytool submit --wait --output-format json`, parses the
+verdict with `jq`, and either staples (success) or dumps the
+detail log (failure). Preserves logs in a temp dir on failure for
+post-mortem; cleans up on success.
+
+---
+
+## Troubleshooting
+
+### `security find-identity` shows no `Developer ID Application`
+
+The certificate isn't installed in the active keychain. Double-click the
+`.cer` or import the `.p12` into **login.keychain**. Run
+`security list-keychains` to check which keychain is searched by default.
+
+### `codesign` says "no identity found"
+
+The name passed in `$DEVELOPER_ID` must exactly match the common name of
+a cert in the keychain. Copy-paste from:
+
+```sh
+security find-identity -v -p codesigning
+```
+
+### `notarytool` rejects with "The signature of the binary is invalid"
+
+Almost always one of:
+1. You built on an old Xcode SDK (pre-15). The notary requires
+   `LC_BUILD_VERSION` loads on every Mach-O — older SDKs emit
+   `LC_VERSION_MIN_MACOSX` instead. Xcode 15+ fixes this.
+2. Something inside `Contents/Frameworks/` was signed *after* the
+   outer app. Rerun `sign.sh`; it orders passes correctly.
+3. You passed `--deep` somewhere. Don't.
+
+### `notarytool` rejects with "The binary uses an SDK older than 10.9"
+
+A very old Rust toolchain or a pre-compiled binary dependency. Update
+Rust (`rustup update`) and rebuild from clean (`cargo clean`).
+
+### `notarytool` rejects with "The executable does not have the
+hardened runtime enabled"
+
+`sign.sh` was not run, or was run with a different tool that didn't set
+`--options runtime`. Re-run `sign.sh` on the bundle.
+
+### `stapler staple` says "Could not find the ticket"
+
+Apple's CDN is eventually-consistent. `notarytool submit --wait`
+returning "Accepted" does not guarantee the ticket is globally visible
+yet. Wait 30 seconds and retry `stapler staple`.
+
+### DMG mounts fine but Gatekeeper says "damaged and can't be opened"
+
+The DMG was downloaded via a browser and the quarantine attribute was
+applied after signing. This is expected for unnotarized builds. Once
+notarized + stapled, Gatekeeper will accept the download without a
+network lookup.
+
+### `create-dmg` hangs / times out
+
+`create-dmg` uses AppleScript to arrange window geometry, which fails
+silently under SSH sessions without a logged-in GUI. Run from a local
+terminal session.
+
+### Entitlements rejected: "Unsupported entitlement"
+
+Check that `Jellify.entitlements` does not contain MAS-only keys like
+`com.apple.application-identifier` or sandbox keys. We are Developer
+ID, not MAS.
+
+---
+
+## CI and auto-update
+
+Intentionally out of scope here. CI wiring, Sparkle appcast/EdDSA key,
+and auto-update delta channel are tracked separately in the BATCH-19
+milestone.

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Info.plist template for Jellify.app.
+
+  Do NOT edit $VERSION / $BUILD in place. `macos/Scripts/make-bundle.sh`
+  copies this file into the bundle and then uses `plutil -replace` to fill
+  in CFBundleShortVersionString / CFBundleVersion from the env vars
+  $VERSION and $BUILD (or, when unset, from `git describe` and the commit
+  count). Keep those string literals unique so `plutil -replace` targets
+  the right keys if anything else ever needs similar substitution.
+
+  Keys intentionally omitted:
+    - LSUIElement: Jellify is a Dock-visible app.
+    - NSMicrophoneUsageDescription / NSCameraUsageDescription / similar
+      TCC usage strings: we do not touch those APIs yet. Apple's notary
+      rejects unused purpose strings on newer tool versions.
+    - App Sandbox keys: we are NOT targeting the Mac App Store. Hardened
+      runtime + notarization is sufficient for Developer ID distribution.
+-->
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>Jellify</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.jellify.desktop</string>
+    <key>CFBundleName</key>
+    <string>Jellify</string>
+    <key>CFBundleDisplayName</key>
+    <string>Jellify</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+
+    <!-- Version fields. These placeholders are overwritten by
+         make-bundle.sh via `plutil -replace` at build time. -->
+    <key>CFBundleShortVersionString</key>
+    <string>$VERSION</string>
+    <key>CFBundleVersion</key>
+    <string>$BUILD</string>
+
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.music</string>
+
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>© 2026 Jellify. GPL-3.0-only.</string>
+    <key>NSSupportsAutomaticTermination</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
+    <true/>
+
+    <!-- Custom URL scheme for Jellyfin OAuth / quick-connect callbacks.
+         The Rust core receives these via the AppDelegate URL handler. -->
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>org.jellify.desktop</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>jellify</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/macos/Resources/Jellify.entitlements
+++ b/macos/Resources/Jellify.entitlements
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Minimal hardened-runtime entitlements for Developer ID distribution.
+
+  We deliberately avoid the App Sandbox (com.apple.security.app-sandbox) —
+  Jellify is shipped outside the Mac App Store, and sandboxing would force
+  the Rust core's SQLite / keyring store into a container path and require
+  user-selected filesystem entitlements for downloads.
+
+  Omitted on purpose:
+    - allow-jit / allow-unsigned-executable-memory: the Rust core is AOT.
+    - device.audio-input: AVPlayer is output-only; TCC doesn't prompt.
+    - files.downloads.read-write: NSSavePanel grants via Powerbox.
+    - app-sandbox: see above.
+-->
+<plist version="1.0">
+<dict>
+    <!-- Outbound network connections to arbitrary Jellyfin servers. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!-- Apple Events, used by MediaPlayer / now-playing integrations and
+         any system services we script (e.g. `osascript` for media keys on
+         older macOS releases). Required under the hardened runtime even
+         when the target is the system itself. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/Scripts/build-core.sh
+++ b/macos/Scripts/build-core.sh
@@ -2,48 +2,125 @@
 # Build the jellify_core Rust library for macOS and wrap it as an XCFramework
 # that the Swift package can consume.
 #
-# For M2 (dev), we build arm64-only. Universal binary (arm64 + x86_64) comes
-# in M4 alongside signing / notarization.
+# By default this builds a universal xcframework (arm64 + x86_64) stitched
+# together with `lipo`. The install base still has a meaningful Intel tail
+# (pre-2020 Macs, Ventura floor) so the shipped DMG must cover both.
 #
-# Usage:  ./macos/Scripts/build-core.sh [--release]
+# Single-arch is still available for dev-loop speed via --arm64-only.
+#
+# Usage:
+#   ./macos/Scripts/build-core.sh                 # universal debug
+#   ./macos/Scripts/build-core.sh --release       # universal release
+#   ./macos/Scripts/build-core.sh --arm64-only    # skip x86_64 (dev only)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MACOS="$ROOT/macos"
-CORE="$ROOT/core"
 PROFILE="debug"
 CARGO_FLAGS=""
+UNIVERSAL=1
 
-if [[ "${1:-}" == "--release" ]]; then
-  PROFILE="release"
-  CARGO_FLAGS="--release"
+for arg in "$@"; do
+    case "$arg" in
+        --release)
+            PROFILE="release"
+            CARGO_FLAGS="--release"
+            ;;
+        --debug)
+            PROFILE="debug"
+            CARGO_FLAGS=""
+            ;;
+        --arm64-only)
+            UNIVERSAL=0
+            ;;
+        -h | --help)
+            sed -n '2,14p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $arg" >&2
+            echo "usage: $0 [--release|--debug] [--arm64-only]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+ARM64_TARGET="aarch64-apple-darwin"
+X86_64_TARGET="x86_64-apple-darwin"
+
+# Per-arch expected artifact paths.
+ARM64_STATIC="$ROOT/target/$ARM64_TARGET/$PROFILE/libjellify_core.a"
+X86_64_STATIC="$ROOT/target/$X86_64_TARGET/$PROFILE/libjellify_core.a"
+UNIVERSAL_DIR="$ROOT/target/universal-apple-darwin/$PROFILE"
+UNIVERSAL_STATIC="$UNIVERSAL_DIR/libjellify_core.a"
+
+# Scratch dirs we might touch; cleaned up on failure so a re-run isn't
+# bitten by a half-written xcframework.
+GEN="$MACOS/build/generated"
+HEADERS="$MACOS/build/Headers"
+XCF="$MACOS/Jellify.xcframework"
+
+cleanup_on_failure() {
+    local code=$?
+    if [[ $code -ne 0 ]]; then
+        echo "==> build-core.sh failed (exit $code); cleaning scratch dirs" >&2
+        rm -rf "$GEN" "$HEADERS"
+        # Leave the xcframework alone if it was a completed prior run —
+        # only remove it if we started rewriting it this run.
+        if [[ -n "${XCF_IN_PROGRESS:-}" ]]; then
+            rm -rf "$XCF"
+        fi
+    fi
+    return $code
+}
+trap cleanup_on_failure EXIT
+
+echo "==> Building jellify_core ($PROFILE, universal=$UNIVERSAL)"
+(cd "$ROOT" && cargo build $CARGO_FLAGS --target "$ARM64_TARGET" -p jellify_core)
+if [[ ! -f "$ARM64_STATIC" ]]; then
+    echo "error: arm64 static lib not found at $ARM64_STATIC" >&2
+    exit 1
 fi
 
-echo "==> Building jellify_core ($PROFILE)"
-TARGET="aarch64-apple-darwin"
-(cd "$ROOT" && cargo build $CARGO_FLAGS --target "$TARGET" -p jellify_core)
+if [[ "$UNIVERSAL" -eq 1 ]]; then
+    # Ensure the x86_64 target is installed; fail with a clear message if not.
+    if ! rustup target list --installed 2>/dev/null | grep -q "^$X86_64_TARGET$"; then
+        echo "error: $X86_64_TARGET rustup target is not installed." >&2
+        echo "       run: rustup target add $X86_64_TARGET" >&2
+        echo "       (or pass --arm64-only for a dev build)" >&2
+        exit 1
+    fi
 
-STATIC="$ROOT/target/$TARGET/$PROFILE/libjellify_core.a"
-if [[ ! -f "$STATIC" ]]; then
-  echo "error: static lib not found at $STATIC" >&2
-  exit 1
+    (cd "$ROOT" && cargo build $CARGO_FLAGS --target "$X86_64_TARGET" -p jellify_core)
+    if [[ ! -f "$X86_64_STATIC" ]]; then
+        echo "error: x86_64 static lib not found at $X86_64_STATIC" >&2
+        exit 1
+    fi
+
+    echo "==> Fusing universal static lib via lipo"
+    mkdir -p "$UNIVERSAL_DIR"
+    lipo -create "$ARM64_STATIC" "$X86_64_STATIC" -output "$UNIVERSAL_STATIC"
+    # Sanity check: lipo -info should report both arches.
+    lipo -info "$UNIVERSAL_STATIC"
+    STATIC="$UNIVERSAL_STATIC"
+else
+    STATIC="$ARM64_STATIC"
 fi
 
 echo "==> Building uniffi-bindgen"
 (cd "$ROOT" && cargo build $CARGO_FLAGS --bin uniffi-bindgen -p jellify_core)
 
-# The library was built for $TARGET above; that's where the dylib lives.
+# The library was built for arm64 above; that's where the dylib lives.
 # (When building only the uniffi-bindgen bin, cargo doesn't materialize the
 # cdylib for the host target, so we can't rely on target/$PROFILE/ for it.)
-DYLIB="$ROOT/target/$TARGET/$PROFILE/libjellify_core.dylib"
+DYLIB="$ROOT/target/$ARM64_TARGET/$PROFILE/libjellify_core.dylib"
 BINDGEN="$ROOT/target/$PROFILE/uniffi-bindgen"
 
 if [[ ! -f "$DYLIB" ]]; then
-  echo "error: dylib not found at $DYLIB" >&2
-  exit 1
+    echo "error: dylib not found at $DYLIB" >&2
+    exit 1
 fi
 
-GEN="$MACOS/build/generated"
 echo "==> Generating Swift bindings -> $GEN"
 rm -rf "$GEN"
 mkdir -p "$GEN"
@@ -53,7 +130,6 @@ mkdir -p "$GEN"
 
 # UniFFI produces: <name>.swift, <name>FFI.h, <name>FFI.modulemap.
 # We consume the Swift in our own target and the header+modulemap in the xcframework.
-HEADERS="$MACOS/build/Headers"
 rm -rf "$HEADERS"
 mkdir -p "$HEADERS"
 cp "$GEN"/*.h "$HEADERS/"
@@ -67,13 +143,14 @@ module jellify_coreFFI {
 }
 EOF
 
-XCF="$MACOS/Jellify.xcframework"
 echo "==> Creating $XCF"
+XCF_IN_PROGRESS=1
 rm -rf "$XCF"
 xcodebuild -create-xcframework \
-  -library "$STATIC" \
-  -headers "$HEADERS" \
-  -output "$XCF" >/dev/null
+    -library "$STATIC" \
+    -headers "$HEADERS" \
+    -output "$XCF" >/dev/null
+XCF_IN_PROGRESS=
 
 # Place the generated Swift source where the SPM target picks it up.
 DEST="$MACOS/Sources/JellifyCore/Generated"

--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -1,19 +1,102 @@
 #!/usr/bin/env bash
-# Wrap the swift-build executable as a minimal .app bundle so macOS treats it
-# as a proper GUI process (visible in the Dock, Cmd-Tab, etc.). This is
-# dev-grade packaging — signing and notarization come in M4.
+# Wrap the swift-build executable as a Jellify.app bundle.
+#
+# Info.plist is copied from `macos/Resources/Info.plist` (a real, checked-in
+# template). This script injects `$VERSION` and `$BUILD` via `plutil -replace`
+# before the codesign pass.
+#
+# Resolution order for version metadata:
+#   1. $VERSION / $BUILD env vars (CI and release scripts set these).
+#   2. git describe / commit count (useful for local dev builds).
+#   3. Fallback: 0.0.0-dev / 0.
+#
+# Usage:
+#   ./macos/Scripts/make-bundle.sh                      # debug arm64 build
+#   ./macos/Scripts/make-bundle.sh --release            # release arm64 build
+#   ./macos/Scripts/make-bundle.sh --release --universal # release arm64+x86_64
+#
+# The --universal flag selects the `apple/Products` output tree that
+# `swift build --arch arm64 --arch x86_64` produces.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MACOS="$ROOT/macos"
-BUILD_DIR="$MACOS/.build/arm64-apple-macosx/debug"
-EXE="$BUILD_DIR/Jellify"
+RESOURCES="$MACOS/Resources"
+INFO_TEMPLATE="$RESOURCES/Info.plist"
 APP="$MACOS/build/Jellify.app"
 
-if [[ ! -x "$EXE" ]]; then
-  echo "error: Jellify executable not found at $EXE — run 'swift build' first" >&2
-  exit 1
+PROFILE="debug"
+UNIVERSAL=0
+for arg in "$@"; do
+    case "$arg" in
+        --release) PROFILE="release" ;;
+        --debug)   PROFILE="debug"   ;;
+        --universal) UNIVERSAL=1 ;;
+        -h | --help)
+            sed -n '2,19p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $arg" >&2
+            echo "usage: $0 [--release|--debug] [--universal]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$INFO_TEMPLATE" ]]; then
+    echo "error: Info.plist template not found at $INFO_TEMPLATE" >&2
+    exit 1
 fi
+
+# Pick the swift-build output directory. The universal build puts products
+# under `apple/Products/<Configuration>`; single-arch builds use
+# `<triple>/<profile>`.
+if [[ "$UNIVERSAL" -eq 1 ]]; then
+    CONFIG_CAP="$(tr '[:lower:]' '[:upper:]' <<< "${PROFILE:0:1}")${PROFILE:1}"
+    BUILD_DIR="$MACOS/.build/apple/Products/$CONFIG_CAP"
+else
+    BUILD_DIR="$MACOS/.build/arm64-apple-macosx/$PROFILE"
+fi
+EXE="$BUILD_DIR/Jellify"
+
+if [[ ! -x "$EXE" ]]; then
+    echo "error: Jellify executable not found at $EXE" >&2
+    echo "       run 'swift build' (or './macos/Scripts/build-core.sh --release' + a universal swift build) first" >&2
+    exit 1
+fi
+
+# Resolve version + build.
+VERSION="${VERSION:-}"
+BUILD="${BUILD:-}"
+
+if [[ -z "$VERSION" ]]; then
+    if VERSION_FROM_GIT="$(git -C "$ROOT" describe --tags --abbrev=0 2>/dev/null)"; then
+        # Strip a leading "v" if the tag uses one.
+        VERSION="${VERSION_FROM_GIT#v}"
+    else
+        VERSION="0.0.0-dev"
+    fi
+fi
+
+if [[ -z "$BUILD" ]]; then
+    if BUILD_FROM_GIT="$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null)"; then
+        BUILD="$BUILD_FROM_GIT"
+    else
+        BUILD="0"
+    fi
+fi
+
+# Clean up any half-built bundle on error so reruns start fresh.
+cleanup() {
+    if [[ -n "${TMP_PLIST:-}" && -f "$TMP_PLIST" ]]; then
+        rm -f "$TMP_PLIST"
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Building $APP ($PROFILE)"
+echo "    version: $VERSION (build $BUILD)"
 
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS"
@@ -24,49 +107,27 @@ cp "$EXE" "$APP/Contents/MacOS/Jellify"
 # Copy SPM-processed resources (fonts bundle) next to the executable.
 BUNDLE="$BUILD_DIR/Jellify_Jellify.bundle"
 if [[ -d "$BUNDLE" ]]; then
-  cp -R "$BUNDLE" "$APP/Contents/Resources/"
+    cp -R "$BUNDLE" "$APP/Contents/Resources/"
 fi
 
-# Quoted heredoc delimiter ("EOF") so bash doesn't try to expand backticks or
-# variables in the body — the XML comment below mentions MPNowPlayingInfoCenter
-# and friends, which would otherwise be parsed as command substitution.
-cat > "$APP/Contents/Info.plist" <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key>
-    <string>Jellify</string>
-    <key>CFBundleIdentifier</key>
-    <string>org.jellify.desktop</string>
-    <key>CFBundleName</key>
-    <string>Jellify</string>
-    <key>CFBundleDisplayName</key>
-    <string>Jellify</string>
-    <key>CFBundleVersion</key>
-    <string>0.1.0</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
-    <key>NSHighResolutionCapable</key>
-    <true/>
-    <key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-    <!--
-      Classifies the app as a music player. macOS uses this for App Store
-      categorization and (more relevantly here) to mark the app as a media
-      producer, which is what MPNowPlayingInfoCenter / Control Center
-      expect. AVAudioSession is iOS-only — background playback on macOS is
-      automatic for a regular GUI app as long as it doesn't set
-      LSBackgroundOnly or LSUIElement. See issue #47.
-    -->
-    <key>LSApplicationCategoryType</key>
-    <string>public.app-category.music</string>
-</dict>
-</plist>
-EOF
+# Copy the app icon if it has been produced. This is intentionally soft:
+# the icon pipeline is tracked in a separate issue and we don't want to
+# block dev builds on it.
+if [[ -f "$RESOURCES/AppIcon.icns" ]]; then
+    cp "$RESOURCES/AppIcon.icns" "$APP/Contents/Resources/AppIcon.icns"
+fi
+
+# Drop the template into the bundle, then patch $VERSION / $BUILD in place.
+TMP_PLIST="$APP/Contents/Info.plist"
+cp "$INFO_TEMPLATE" "$TMP_PLIST"
+
+plutil -replace CFBundleShortVersionString -string "$VERSION" "$TMP_PLIST"
+plutil -replace CFBundleVersion            -string "$BUILD"   "$TMP_PLIST"
+
+# Fail loudly if the template drifted into something Core Foundation can't
+# parse — this is the check issue #177 asks for.
+plutil -lint "$TMP_PLIST" >/dev/null
+
+TMP_PLIST=""  # disarm cleanup; the bundle owns it now
 
 echo "==> Built $APP"

--- a/macos/Scripts/make-dmg.sh
+++ b/macos/Scripts/make-dmg.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Build a distribution DMG from a signed Jellify.app.
+#
+# Uses `create-dmg` (`brew install create-dmg`). We sign the DMG with the
+# same identity the app was signed with, but deliberately do NOT pass
+# `--notarize` to create-dmg — notarization happens via
+# `macos/Scripts/notarize.sh` as a separate, retriable step. Driving
+# notarization from two places leads to double-submissions and opaque
+# failure modes.
+#
+# Layout assumptions:
+#   - App bundle is at build/Jellify.app (or passed as $1).
+#   - Output DMG goes to build/Jellify-$VERSION.dmg.
+#   - Optional cosmetic assets (volume icon + background image) live in
+#     macos/Resources/. They're soft-optional; a missing background just
+#     drops the arguments.
+#
+# Usage:
+#   VERSION=0.1.0 DEVELOPER_ID="Developer ID Application: Jane (TEAMID)" \
+#     ./macos/Scripts/make-dmg.sh                      # uses build/Jellify.app
+#   ./macos/Scripts/make-dmg.sh path/to/Jellify.app
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$MACOS_DIR/.." && pwd)"
+RESOURCES="$MACOS_DIR/Resources"
+BUILD_DIR="$MACOS_DIR/build"
+
+APP="${1:-$BUILD_DIR/Jellify.app}"
+
+if [[ ! -d "$APP" ]]; then
+    echo "error: Jellify.app not found at $APP" >&2
+    echo "       pass an explicit path or run make-bundle.sh first" >&2
+    exit 1
+fi
+if ! command -v create-dmg >/dev/null 2>&1; then
+    echo "error: create-dmg not installed (brew install create-dmg)" >&2
+    exit 1
+fi
+
+# Resolve version — same order as make-bundle.sh so the DMG filename and
+# CFBundleShortVersionString stay in lockstep.
+VERSION="${VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+    if VERSION_FROM_GIT="$(git -C "$ROOT_DIR" describe --tags --abbrev=0 2>/dev/null)"; then
+        VERSION="${VERSION_FROM_GIT#v}"
+    else
+        VERSION="0.0.0-dev"
+    fi
+fi
+
+IDENTITY="${DEVELOPER_ID:-}"
+DMG_NAME="Jellify-$VERSION.dmg"
+DMG_PATH="$BUILD_DIR/$DMG_NAME"
+
+# create-dmg expects to be pointed at a staging directory containing
+# exactly the files that should appear in the mounted volume. Anything
+# else in build/ would otherwise get swept in.
+STAGE="$(mktemp -d -t jellify-dmg.XXXXXX)"
+
+cleanup() {
+    local code=$?
+    rm -rf "$STAGE"
+    # Half-built DMGs are useless; scrub on failure so a rerun is clean.
+    if [[ $code -ne 0 && -f "$DMG_PATH" ]]; then
+        rm -f "$DMG_PATH"
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Preparing DMG staging"
+cp -R "$APP" "$STAGE/"
+
+mkdir -p "$BUILD_DIR"
+rm -f "$DMG_PATH"
+# create-dmg also writes a "rw.<target>.dmg" scratch file next to the
+# output; clean stale ones up front.
+rm -f "$BUILD_DIR"/rw.*.dmg 2>/dev/null || true
+
+CREATE_DMG_ARGS=(
+    --volname          "Jellify"
+    --window-pos       200 120
+    --window-size      660 400
+    --icon-size        96
+    --icon             "Jellify.app" 180 170
+    --hide-extension   "Jellify.app"
+    --app-drop-link    480 170
+)
+
+if [[ -f "$RESOURCES/AppIcon.icns" ]]; then
+    CREATE_DMG_ARGS+=( --volicon "$RESOURCES/AppIcon.icns" )
+fi
+if [[ -f "$RESOURCES/dmg-background.png" ]]; then
+    CREATE_DMG_ARGS+=( --background "$RESOURCES/dmg-background.png" )
+fi
+if [[ -n "$IDENTITY" ]]; then
+    CREATE_DMG_ARGS+=( --codesign "$IDENTITY" )
+else
+    echo "warning: DEVELOPER_ID not set — DMG will not be signed." >&2
+    echo "         notarization will reject an unsigned DMG. Set DEVELOPER_ID" >&2
+    echo "         and re-run before shipping." >&2
+fi
+
+echo "==> Building $DMG_PATH"
+create-dmg "${CREATE_DMG_ARGS[@]}" "$DMG_PATH" "$STAGE/"
+
+if [[ ! -f "$DMG_PATH" ]]; then
+    echo "error: create-dmg exited 0 but $DMG_PATH is missing" >&2
+    exit 1
+fi
+
+echo "==> Built $DMG_PATH"
+echo "    next step: ./macos/Scripts/notarize.sh \"$DMG_PATH\""

--- a/macos/Scripts/notarize.sh
+++ b/macos/Scripts/notarize.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Submit a signed artifact (DMG or zipped .app) to Apple's notary service,
+# wait for the verdict, and staple the ticket on success.
+#
+# Uses a keychain profile (see the one-time bootstrap below). The profile
+# name defaults to `jellify-notary` but can be overridden via $NOTARY_PROFILE.
+#
+# One-time local bootstrap (do this once per machine):
+#
+#   xcrun notarytool store-credentials jellify-notary \
+#     --apple-id       "$APPLE_ID" \
+#     --team-id        "$APPLE_TEAM_ID" \
+#     --password       "$APPLE_NOTARY_APP_PASSWORD"
+#
+# Create the app-specific password at https://appleid.apple.com (Sign-In
+# and Security → App-Specific Passwords). Team ID is on your Membership
+# page in the developer portal.
+#
+# Usage:
+#   ./macos/Scripts/notarize.sh path/to/Jellify-0.1.0.dmg
+#   NOTARY_PROFILE=other-profile ./macos/Scripts/notarize.sh some.dmg
+set -euo pipefail
+
+usage() {
+    sed -n '2,21p' "${BASH_SOURCE[0]}"
+}
+
+if [[ $# -lt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 2
+fi
+
+TARGET="$1"
+PROFILE="${NOTARY_PROFILE:-jellify-notary}"
+
+if [[ ! -e "$TARGET" ]]; then
+    echo "error: target not found: $TARGET" >&2
+    exit 1
+fi
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "error: xcrun not in PATH — install Xcode command line tools" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq not installed (brew install jq)" >&2
+    exit 1
+fi
+
+# Work inside a temp dir so a failed / cancelled run doesn't litter logs
+# alongside the target artifact.
+SCRATCH="$(mktemp -d -t jellify-notarize.XXXXXX)"
+LOG="$SCRATCH/submit.json"
+LOG_DETAIL="$SCRATCH/detail.json"
+
+cleanup() {
+    local code=$?
+    # Preserve logs on failure — they're the only clue to *why* notarization
+    # was rejected. Success path: purge.
+    if [[ $code -ne 0 ]]; then
+        echo "" >&2
+        echo "==> notarize.sh failed (exit $code)." >&2
+        echo "    submission log: $LOG" >&2
+        echo "    detail log:     $LOG_DETAIL" >&2
+    else
+        rm -rf "$SCRATCH"
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Submitting $TARGET to Apple notary"
+echo "    keychain profile: $PROFILE"
+echo "    (this blocks until Apple returns a verdict — usually 1-10 min)"
+
+set +e
+xcrun notarytool submit "$TARGET" \
+    --keychain-profile "$PROFILE" \
+    --wait \
+    --output-format json \
+    > "$LOG"
+submit_exit=$?
+set -e
+
+if [[ $submit_exit -ne 0 ]]; then
+    echo "error: notarytool submit exited with status $submit_exit" >&2
+    cat "$LOG" >&2 || true
+    exit 1
+fi
+
+STATUS="$(jq -r '.status // ""' "$LOG")"
+SUB_ID="$(jq -r '.id // ""' "$LOG")"
+
+echo "==> Verdict: $STATUS"
+echo "    submission id: $SUB_ID"
+
+if [[ "$STATUS" != "Accepted" ]]; then
+    if [[ -n "$SUB_ID" ]]; then
+        echo "==> Fetching detail log for rejected submission"
+        xcrun notarytool log "$SUB_ID" --keychain-profile "$PROFILE" "$LOG_DETAIL" || true
+        if [[ -s "$LOG_DETAIL" ]]; then
+            jq . "$LOG_DETAIL" || cat "$LOG_DETAIL"
+        fi
+    fi
+    exit 1
+fi
+
+echo "==> Stapling notarization ticket to $TARGET"
+xcrun stapler staple "$TARGET"
+xcrun stapler validate "$TARGET"
+
+echo "==> $TARGET is notarized and stapled."

--- a/macos/Scripts/sign.sh
+++ b/macos/Scripts/sign.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Code-sign a Jellify.app bundle inside-out with the hardened runtime.
+#
+# Uses the Developer ID Application identity named in $DEVELOPER_ID
+# (falls back to the literal "Developer ID Application" which lets
+# codesign auto-pick the unique cert in the keychain when there is only
+# one).
+#
+# Run order matters: every nested Mach-O (frameworks, XPC services,
+# embedded dylibs) must be signed before the enclosing bundle. We
+# explicitly avoid `--deep`; it papers over real problems and is the
+# most common cause of notary rejections.
+#
+# Usage:
+#   DEVELOPER_ID="Developer ID Application: Jane Doe (TEAMID123)" \
+#     ./macos/Scripts/sign.sh path/to/Jellify.app
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTITLEMENTS="$MACOS_DIR/Resources/Jellify.entitlements"
+
+usage() {
+    sed -n '2,16p' "${BASH_SOURCE[0]}"
+}
+
+if [[ $# -lt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 2
+fi
+
+APP="$1"
+IDENTITY="${DEVELOPER_ID:-Developer ID Application}"
+
+if [[ ! -d "$APP" ]]; then
+    echo "error: bundle not found: $APP" >&2
+    exit 1
+fi
+if [[ ! -f "$ENTITLEMENTS" ]]; then
+    echo "error: entitlements file not found: $ENTITLEMENTS" >&2
+    exit 1
+fi
+if ! command -v codesign >/dev/null 2>&1; then
+    echo "error: codesign not in PATH — install Xcode command line tools" >&2
+    exit 1
+fi
+
+# Detect "no identity" early so we don't partially sign the bundle.
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then
+    echo "warning: no 'Developer ID Application' identity visible in the default keychain." >&2
+    echo "         set DEVELOPER_ID to your cert's exact common name, or install one." >&2
+    echo "         continuing anyway — codesign will produce the definitive error." >&2
+fi
+
+echo "==> Signing $APP"
+echo "    identity:    $IDENTITY"
+echo "    entitlements: $ENTITLEMENTS"
+
+# Any non-zero exit below leaves the bundle partially signed, which is a
+# landmine. Emit a loud reminder to rebuild from scratch before retrying.
+on_fail() {
+    local code=$?
+    if [[ $code -ne 0 ]]; then
+        echo "" >&2
+        echo "==> sign.sh failed (exit $code) — bundle at $APP is partially signed." >&2
+        echo "    rerun make-bundle.sh to regenerate from scratch before retrying." >&2
+    fi
+}
+trap on_fail EXIT
+
+sign_one() {
+    # Sign a single path with the hardened runtime + entitlements.
+    # Entitlements are applied to bundle-level binaries (frameworks, the
+    # app itself). Inner helper binaries (XPC / loose Mach-O) are signed
+    # without entitlements — they inherit from the enclosing app.
+    local target="$1"
+    local with_ents="${2:-yes}"
+
+    if [[ "$with_ents" == "yes" ]]; then
+        codesign \
+            --force \
+            --timestamp \
+            --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$IDENTITY" \
+            "$target"
+    else
+        codesign \
+            --force \
+            --timestamp \
+            --options runtime \
+            --sign "$IDENTITY" \
+            "$target"
+    fi
+}
+
+# 1. Frameworks/*.framework — includes Sparkle once we ship it.
+if [[ -d "$APP/Contents/Frameworks" ]]; then
+    while IFS= read -r -d '' fw; do
+        echo "    -> framework: ${fw#"$APP/"}"
+        sign_one "$fw" yes
+    done < <(find "$APP/Contents/Frameworks" -maxdepth 2 -type d -name "*.framework" -print0 2>/dev/null)
+
+    # 2. Nested XPC services (Sparkle's Installer / Downloader live here).
+    while IFS= read -r -d '' xpc; do
+        echo "    -> xpc: ${xpc#"$APP/"}"
+        sign_one "$xpc" no
+    done < <(find "$APP/Contents/Frameworks" -type d -name "*.xpc" -print0 2>/dev/null)
+
+    # 3. Loose dylibs that aren't inside a framework bundle.
+    while IFS= read -r -d '' dylib; do
+        echo "    -> dylib: ${dylib#"$APP/"}"
+        sign_one "$dylib" no
+    done < <(find "$APP/Contents/Frameworks" -type f \( -name "*.dylib" -o -name "*.so" \) -print0 2>/dev/null)
+fi
+
+# 4. Auxiliary helper executables under Contents/MacOS that aren't the
+#    main binary. There usually aren't any, but guard for the future.
+MAIN_EXE="$APP/Contents/MacOS/Jellify"
+if [[ -d "$APP/Contents/MacOS" ]]; then
+    while IFS= read -r -d '' helper; do
+        if [[ "$helper" == "$MAIN_EXE" ]]; then
+            continue
+        fi
+        echo "    -> helper: ${helper#"$APP/"}"
+        sign_one "$helper" no
+    done < <(find "$APP/Contents/MacOS" -type f -perm +111 -print0 2>/dev/null)
+fi
+
+# 5. Finally, the main app bundle itself.
+echo "    -> bundle: $APP"
+sign_one "$APP" yes
+
+# 6. Verification. `--strict` rejects nested bundles with mismatched seals
+#    (the classic notarization failure mode).
+echo "==> Verifying signature"
+codesign --verify --strict --verbose=2 "$APP"
+
+# spctl's Developer ID verdict requires the app to have been notarized +
+# stapled; run it anyway so the user sees what Gatekeeper will say.
+# A "rejected: source=Unnotarized Developer ID" result is expected
+# before notarize.sh + stapler runs.
+echo "==> Gatekeeper preview (will say 'rejected' until notarization + stapling):"
+spctl --assess --type execute --verbose=2 "$APP" || true
+
+# Disarm failure trap now that we finished cleanly.
+trap - EXIT
+echo "==> Signed $APP"


### PR DESCRIPTION
## Summary

Implements the Developer ID distribution pipeline for the macOS app. Adds
the Info.plist template (with `$VERSION`/`$BUILD` placeholders patched in by
`plutil -replace`), minimal hardened-runtime entitlements, a universal
(arm64 + x86_64) xcframework build, and the three-script release chain:
`sign.sh` (inside-out codesigning, no `--deep`), `make-dmg.sh` (`create-dmg`
with optional cosmetic assets), and `notarize.sh` (`notarytool submit --wait`
with `jq`-driven verdict parsing and stapling).

`macos/DISTRIBUTION.md` documents the full flow end-to-end, including the
required env vars, the one-time `notarytool store-credentials` bootstrap,
and the most common notary rejection modes.

**Manual prerequisite — #175.** Apple Developer Program enrollment and the
Developer ID Application certificate issuance are a multi-day,
non-engineering task. The scripts here assume the certificate is already
installed in the user's login keychain. `DISTRIBUTION.md` leads with a
prominent block walking through the one-time enrollment flow. The engineering
deliverables (#176-#182) land green regardless.

## Test plan

- [x] `bash -n macos/Scripts/*.sh` passes on every script.
- [x] `shellcheck macos/Scripts/*.sh` clean (v0.11.0 installed locally).
- [x] `plutil -lint` accepts `Info.plist` and `Jellify.entitlements`.
- [x] `plutil -replace CFBundleShortVersionString` / `CFBundleVersion`
      round-trips correctly against a disposable copy of the template.
- [x] `--help` output is trimmed to the usage block on every new script.
- [ ] End-to-end sign + notarize + staple — blocked on #175 (cert).

Closes #175, #176, #177, #178, #179, #180, #181, #182.