### PR TITLE
core: add playback/session/library APIs

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1,5 +1,6 @@
 use crate::error::{JellifyError, Result};
 use crate::models::*;
+use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client as HttpClient, Response};
 use serde::{Deserialize, Serialize};
@@ -8,6 +9,19 @@ use url::Url;
 const CLIENT_NAME: &str = "Jellify Desktop";
 const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Per-client memoization of the library-resolution lookups behind
+/// [`JellyfinClient::music_library_id`] and
+/// [`JellyfinClient::playlist_library_id`]. Both endpoints are hit once at
+/// sign-in by the UI and then again by nearly every library query, so a
+/// plain in-memory cache pays for itself immediately. Invalidated on
+/// [`JellyfinClient::set_session`] so re-auth against a different user or
+/// server picks up fresh ids.
+#[derive(Default)]
+struct LibraryCache {
+    music: Option<String>,
+    playlist: Option<String>,
+}
+
 pub struct JellyfinClient {
     http: HttpClient,
     base_url: Url,
@@ -15,6 +29,7 @@ pub struct JellyfinClient {
     device_name: String,
     token: Option<String>,
     user_id: Option<String>,
+    library_cache: Mutex<LibraryCache>,
 }
 
 impl JellyfinClient {
@@ -36,6 +51,7 @@ impl JellyfinClient {
             device_name,
             token: None,
             user_id: None,
+            library_cache: Mutex::new(LibraryCache::default()),
         })
     }
 
@@ -58,6 +74,9 @@ impl JellyfinClient {
     pub fn set_session(&mut self, token: String, user_id: String) {
         self.token = Some(token);
         self.user_id = Some(user_id);
+        // Library ids are tied to `(server, user)`, so re-auth must drop
+        // the memoized lookups before the new session resumes traffic.
+        *self.library_cache.lock() = LibraryCache::default();
     }
 
     fn auth_header(&self) -> String {
@@ -978,6 +997,243 @@ impl JellyfinClient {
         Ok(())
     }
 
+    /// Report that playback of an item has just started. Backed by
+    /// `POST /Sessions/Playing` with a `PlaybackStartInfo` body.
+    ///
+    /// Jellyfin uses this to mark the session as "Now Playing" — other
+    /// clients (Jellyfin Web etc.) then surface this device in the
+    /// remote-control panel. Callers send it once per track load, right
+    /// after the audio engine has begun decoding.
+    ///
+    /// Serialises every field in PascalCase to match the server's
+    /// `PlaybackStartInfo` DTO. Optional fields are omitted when `None` so
+    /// unused flags don't flip the server's default behaviour.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn report_playback_started(&self, info: PlaybackStartInfo) -> Result<()> {
+        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        let url = self.endpoint("Sessions/Playing")?;
+        let resp = self
+            .http
+            .post(url)
+            .headers(self.build_headers()?)
+            .json(&info)
+            .send()
+            .await?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
+    /// Register this session's capabilities with the server. Backed by
+    /// `POST /Sessions/Capabilities/Full` with a `ClientCapabilitiesDto`
+    /// body.
+    ///
+    /// Called once post-auth (and whenever the device profile changes) so
+    /// Jellyfin knows we're a music playback target. Populates the
+    /// remote-control surface Jellyfin Web exposes — without this the
+    /// "Play on macOS" option never appears.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn post_capabilities(&self, caps: ClientCapabilities) -> Result<()> {
+        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        let url = self.endpoint("Sessions/Capabilities/Full")?;
+        let resp = self
+            .http
+            .post(url)
+            .headers(self.build_headers()?)
+            .json(&caps)
+            .send()
+            .await?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
+    /// Resolve the playable media source and transcoding strategy for an
+    /// item. Backed by `POST /Items/{itemId}/PlaybackInfo`.
+    ///
+    /// This is the canonical pre-stream hop: the server inspects the
+    /// client's `DeviceProfile`, decides direct-play vs. transcode, and
+    /// returns both a `PlaySessionId` (to echo on subsequent
+    /// `/Sessions/Playing*` reports) and the `TranscodingUrl` to hit when
+    /// direct play is not viable.
+    ///
+    /// `opts.user_id` is filled in from the current session when the
+    /// caller leaves it `None` — Jellyfin requires `UserId` either in the
+    /// body or as a query arg, and we prefer the body.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
+    pub async fn playback_info(
+        &self,
+        item_id: &str,
+        opts: PlaybackInfoOpts,
+    ) -> Result<PlaybackInfoResponse> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        // Fill in the user id from the live session if the caller did not
+        // override it. Jellyfin accepts either the body's `UserId` or a
+        // `?userId=` query param; the body wins when both are supplied.
+        let mut body = opts;
+        if body.user_id.is_none() {
+            body.user_id = Some(user_id.clone());
+        }
+        let url = self.endpoint(&format!("Items/{item_id}/PlaybackInfo"))?;
+        let resp = self
+            .http
+            .post(url)
+            .headers(self.build_headers()?)
+            .json(&body)
+            .send()
+            .await?;
+        Self::check(resp).await?.json().await.map_err(Into::into)
+    }
+
+    // ----- Library resolution -----
+
+    /// Fetch every user view visible to the current user. Backed by
+    /// `GET /UserViews?userId={id}`.
+    ///
+    /// Each entry is a top-level library (Music, Playlists, Movies, ...).
+    /// Callers typically filter by `collection_type` — `"music"` for the
+    /// music library id, `"playlists"` for the playlists library id.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
+    pub async fn user_views(&self) -> Result<Vec<Library>> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint("UserViews")?;
+        url.query_pairs_mut().append_pair("userId", user_id);
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let raw: RawItems<RawLibrary> = Self::check(resp).await?.json().await?;
+        Ok(raw.items.into_iter().map(Library::from).collect())
+    }
+
+    /// Resolve the music library's id — the CollectionFolder with
+    /// `CollectionType == "music"`. Cached on the client after the first
+    /// call; invalidated on [`JellyfinClient::set_session`].
+    ///
+    /// Errors with [`JellifyError::NotAuthenticated`] if no session is
+    /// active, or [`JellifyError::Server`] with status 404 when the
+    /// server has no music library (a genuinely empty install).
+    pub async fn music_library_id(&self) -> Result<String> {
+        if let Some(id) = self.library_cache.lock().music.clone() {
+            return Ok(id);
+        }
+        let views = self.user_views().await?;
+        let id = views
+            .into_iter()
+            .find(|v| v.collection_type.as_deref() == Some("music"))
+            .map(|v| v.id)
+            .ok_or_else(|| JellifyError::Server {
+                status: 404,
+                message: "no music library found in user views".into(),
+            })?;
+        self.library_cache.lock().music = Some(id.clone());
+        Ok(id)
+    }
+
+    /// Resolve the playlists library's id — the ManualPlaylistsFolder with
+    /// `CollectionType == "playlists"`. Backed by
+    /// `GET /Items?userId={id}&includeItemTypes=ManualPlaylistsFolder&excludeItemTypes=CollectionFolder`
+    /// (the view's own id isn't surfaced by `/UserViews`). Cached on the
+    /// client after the first call; invalidated on
+    /// [`JellyfinClient::set_session`].
+    ///
+    /// Errors with [`JellifyError::NotAuthenticated`] if no session is
+    /// active, or [`JellifyError::Server`] with status 404 when the
+    /// server has no playlist library (rare — Jellyfin synthesises one
+    /// the first time a playlist is created).
+    pub async fn playlist_library_id(&self) -> Result<String> {
+        if let Some(id) = self.library_cache.lock().playlist.clone() {
+            return Ok(id);
+        }
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint("Items")?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("userId", user_id);
+            q.append_pair("includeItemTypes", "ManualPlaylistsFolder");
+            q.append_pair("excludeItemTypes", "CollectionFolder");
+        }
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        let raw: RawItems<RawLibrary> = Self::check(resp).await?.json().await?;
+        let id = raw
+            .items
+            .into_iter()
+            .find(|item| item.collection_type.as_deref() == Some("playlists"))
+            .map(|item| item.id)
+            .ok_or_else(|| JellifyError::Server {
+                status: 404,
+                message: "no playlist library found".into(),
+            })?;
+        self.library_cache.lock().playlist = Some(id.clone());
+        Ok(id)
+    }
+
+    // ----- Playlist mutation -----
+
+    /// Remove one or more entries from a playlist. Backed by
+    /// `DELETE /Playlists/{playlistId}/Items?entryIds=...`.
+    ///
+    /// The `entry_ids` here are `PlaylistItemId` values — the per-entry
+    /// id Jellyfin exposes on playlist children, NOT the underlying item
+    /// id. A single item appearing twice in a playlist has two distinct
+    /// `PlaylistItemId`s, which is why the controller keys the delete on
+    /// entry ids rather than item ids.
+    ///
+    /// Server responds 204 on success, 403 when the caller is not the
+    /// playlist owner (or lacks an edit share), 404 when the playlist
+    /// doesn't exist or an `entryId` isn't in it. Callers should treat
+    /// 404 as "already gone" rather than fatal.
+    ///
+    /// Returns `Ok(())` without contacting the server when `entry_ids` is
+    /// empty — saves a pointless round-trip for multi-select UIs where
+    /// the selection can be cleared after checkbox toggles.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn remove_from_playlist(
+        &self,
+        playlist_id: &str,
+        entry_ids: &[String],
+    ) -> Result<()> {
+        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        if entry_ids.is_empty() {
+            return Ok(());
+        }
+        let mut url = self.endpoint(&format!("Playlists/{playlist_id}/Items"))?;
+        url.query_pairs_mut()
+            .append_pair("entryIds", &entry_ids.join(","));
+        let resp = self
+            .http
+            .delete(url)
+            .headers(self.build_headers()?)
+            .send()
+            .await?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
     // ----- Streaming -----
 
     /// Fetch the full audio payload for a track, authenticated. Returns the
@@ -1222,6 +1478,29 @@ pub struct NamedItem {
     pub id: String,
     #[serde(rename = "Name", default)]
     pub name: String,
+}
+
+/// A trimmed `BaseItemDto` used by library-resolution endpoints
+/// (`/UserViews`, `GET /Items?includeItemTypes=ManualPlaylistsFolder`).
+/// Only the fields the client needs to partition libraries by type.
+#[derive(Debug, Default, Deserialize)]
+pub struct RawLibrary {
+    #[serde(rename = "Id")]
+    pub id: String,
+    #[serde(rename = "Name", default)]
+    pub name: String,
+    #[serde(rename = "CollectionType")]
+    pub collection_type: Option<String>,
+}
+
+impl From<RawLibrary> for Library {
+    fn from(r: RawLibrary) -> Self {
+        Library {
+            id: r.id,
+            name: r.name,
+            collection_type: r.collection_type,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -596,6 +596,88 @@ impl JellifyCore {
         })
     }
 
+    /// Report that playback of an item has started — backed by
+    /// `POST /Sessions/Playing`. Jellyfin surfaces this session as a
+    /// "Now Playing on macOS" remote-control target in Jellyfin Web.
+    /// Callers send this once per track load.
+    pub fn report_playback_started(
+        &self,
+        info: PlaybackStartInfo,
+    ) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.report_playback_started(info)))
+    }
+
+    /// Register this session as a playback target with the server —
+    /// backed by `POST /Sessions/Capabilities/Full`. Called once post-auth
+    /// (and whenever the device profile changes). Without this, Jellyfin
+    /// Web cannot offer "Play on macOS" for this session.
+    pub fn post_capabilities(
+        &self,
+        caps: ClientCapabilities,
+    ) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.post_capabilities(caps)))
+    }
+
+    /// Resolve the playable media source and transcoding strategy for an
+    /// item. Backed by `POST /Items/{id}/PlaybackInfo`. Returns the
+    /// `PlaySessionId` the caller should echo on subsequent
+    /// `/Sessions/Playing*` reports.
+    pub fn playback_info(
+        &self,
+        item_id: String,
+        opts: PlaybackInfoOpts,
+    ) -> std::result::Result<PlaybackInfoResponse, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.playback_info(&item_id, opts)))
+    }
+
+    // ---------- Library resolution ----------
+
+    /// Every top-level library the current user can browse. Backed by
+    /// `GET /UserViews`. Callers typically filter by `collection_type`
+    /// (`"music"`, `"playlists"`) to find the library ids they need.
+    pub fn user_views(&self) -> std::result::Result<Vec<Library>, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.user_views()))
+    }
+
+    /// Resolve (and cache) the user's music library id. Every music-scoped
+    /// query below the top level (albums, artists, tracks, genres, years)
+    /// is parented to this id, so callers typically resolve it once at
+    /// sign-in and hand it to subsequent requests.
+    pub fn music_library_id(&self) -> std::result::Result<String, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.music_library_id()))
+    }
+
+    /// Resolve (and cache) the user's playlists library id. Used as the
+    /// `ParentId` for `user_playlists` / `public_playlists`.
+    pub fn playlist_library_id(&self) -> std::result::Result<String, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.playlist_library_id()))
+    }
+
+    // ---------- Playlist mutation ----------
+
+    /// Remove entries from a playlist. `entry_ids` are `PlaylistItemId`
+    /// values — each playlist child carries its own `PlaylistItemId`,
+    /// which is distinct from the underlying `ItemId` because a single
+    /// item can appear in the same playlist multiple times.
+    pub fn remove_from_playlist(
+        &self,
+        playlist_id: String,
+        entry_ids: Vec<String>,
+    ) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.remove_from_playlist(&playlist_id, &entry_ids))
+        })
+    }
+
+    /// A default macOS [`DeviceProfile`] advertising direct-play for
+    /// FLAC / ALAC / MP3 / AAC / Opus / OGG / WAV with an MP3 320
+    /// transcode fallback. Intended as a one-liner for UIs that don't
+    /// need custom codec policies.
+    pub fn default_macos_device_profile(&self) -> DeviceProfile {
+        DeviceProfile::default_macos_profile()
+    }
+
     pub fn mark_state(&self, state: PlaybackState) {
         self.player.mark_state(state);
     }

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -198,6 +198,282 @@ impl Paging {
     }
 }
 
+// ============================================================================
+// Library resolution
+// ============================================================================
+
+/// A single entry in Jellyfin's `GET /UserViews` response. Represents a
+/// top-level library the current user can browse (Music, Playlists, Movies,
+/// TV Shows, ...). Callers typically filter by `collection_type` to find
+/// the music or playlist library.
+///
+/// `collection_type` is the server's `CollectionType` string (`"music"`,
+/// `"playlists"`, etc.). Left as a raw string so we don't have to
+/// exhaustively enumerate every possible Jellyfin library kind.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct Library {
+    pub id: String,
+    pub name: String,
+    pub collection_type: Option<String>,
+}
+
+// ============================================================================
+// Device profile — describes what this client can direct-play vs. transcode.
+// Shared by `POST /Sessions/Capabilities/Full` and `POST /Items/{id}/PlaybackInfo`.
+// ============================================================================
+
+/// A single direct-play container/codec combination the client supports.
+/// Corresponds to Jellyfin's `DirectPlayProfile` DTO.
+///
+/// `kind` is `"Audio"` / `"Video"` — we only emit `Audio` rules here since
+/// Jellify Desktop is a music app.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct DirectPlayProfile {
+    pub container: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_codec: Option<String>,
+    #[serde(rename = "Type")]
+    pub kind: String,
+}
+
+/// A single transcoding target the client will accept when the source
+/// cannot be direct-played. Corresponds to Jellyfin's `TranscodingProfile`
+/// DTO.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct TranscodingProfile {
+    pub container: String,
+    pub audio_codec: String,
+    pub protocol: String,
+    pub context: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_audio_channels: Option<String>,
+    #[serde(rename = "Type")]
+    pub kind: String,
+}
+
+/// Jellyfin's `DeviceProfile` DTO. Describes which containers/codecs the
+/// client can direct-play and which it needs transcoded, plus bitrate
+/// caps. Sent on every `POST /Items/{id}/PlaybackInfo` and
+/// `POST /Sessions/Capabilities/Full` call.
+///
+/// Only the fields a music client needs are included here — Jellify Desktop
+/// never touches video, subtitles, or DLNA codec profiles, so those array
+/// fields are simply omitted from the payload (Jellyfin treats a missing
+/// key the same as an empty array).
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeviceProfile {
+    pub name: String,
+    pub max_streaming_bitrate: u32,
+    pub max_static_bitrate: u32,
+    pub music_streaming_transcoding_bitrate: u32,
+    pub direct_play_profiles: Vec<DirectPlayProfile>,
+    pub transcoding_profiles: Vec<TranscodingProfile>,
+}
+
+impl DeviceProfile {
+    /// AVFoundation / CoreAudio on macOS natively plays FLAC, ALAC (in m4a),
+    /// MP3, AAC (in m4a/aac), Opus/OGG, and WAV — so we advertise those as
+    /// direct-play containers. Anything else falls back to a 320 kbps MP3
+    /// transcode, which is the universally-safe audio codec Jellyfin will
+    /// emit when asked.
+    ///
+    /// The bitrate caps are music-centric: ~320 kbps for typical streaming
+    /// and a generous `max_static_bitrate` so high-resolution direct plays
+    /// (24-bit FLAC etc.) are not clamped by a too-low cap. Tweak the cap
+    /// later if users ask for a lower ceiling in settings.
+    pub fn default_macos_profile() -> Self {
+        const AUDIO: &str = "Audio";
+        let direct = |container: &str, codec: Option<&str>| DirectPlayProfile {
+            container: container.to_string(),
+            audio_codec: codec.map(|s| s.to_string()),
+            kind: AUDIO.to_string(),
+        };
+        DeviceProfile {
+            name: "Jellify Desktop (macOS)".to_string(),
+            // 320 kbps ceiling for transcoded music; headroom for direct
+            // plays to stream the original file at full fidelity.
+            max_streaming_bitrate: 320_000,
+            max_static_bitrate: 100_000_000,
+            music_streaming_transcoding_bitrate: 320_000,
+            direct_play_profiles: vec![
+                direct("flac", None),
+                direct("alac", None),
+                direct("m4a", Some("alac")),
+                direct("mp3", None),
+                direct("aac", None),
+                direct("m4a", Some("aac")),
+                direct("opus", None),
+                direct("ogg", Some("opus")),
+                direct("ogg", Some("vorbis")),
+                direct("wav", None),
+            ],
+            transcoding_profiles: vec![TranscodingProfile {
+                container: "mp3".to_string(),
+                audio_codec: "mp3".to_string(),
+                protocol: "http".to_string(),
+                context: "Streaming".to_string(),
+                max_audio_channels: Some("2".to_string()),
+                kind: AUDIO.to_string(),
+            }],
+        }
+    }
+}
+
+// ============================================================================
+// Capabilities — sent once post-auth so the server knows we're a playback
+// target and can offer "Play on macOS" from Jellyfin Web.
+// ============================================================================
+
+/// The body for `POST /Sessions/Capabilities/Full`. Sent after auth so the
+/// server registers this session as a music playback target.
+///
+/// `playable_media_types` / `supported_commands` are left as PascalCase
+/// strings the server parses (e.g. `"Audio"`, `"VolumeUp"`, `"Pause"`).
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct ClientCapabilities {
+    pub playable_media_types: Vec<String>,
+    pub supported_commands: Vec<String>,
+    pub supports_media_control: bool,
+    pub supports_persistent_identifier: bool,
+    pub device_profile: DeviceProfile,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_store_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+}
+
+// ============================================================================
+// PlaybackInfo — resolves the right media source + transcode url before
+// every stream.
+// ============================================================================
+
+/// Optional overrides for `POST /Items/{id}/PlaybackInfo`. All fields map
+/// 1:1 onto Jellyfin's `PlaybackInfoDto`. `device_profile` is the only
+/// field callers will almost always populate — the rest default to the
+/// server's preferred behaviour when omitted.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct PlaybackInfoOpts {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time_ticks: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_streaming_bitrate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_direct_play: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_direct_stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_transcoding: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_open_live_stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_profile: Option<DeviceProfile>,
+}
+
+/// A playable media source returned by `PlaybackInfo`. Mirrors the subset
+/// of `MediaSourceInfo` a music client needs to decide between direct play
+/// and transcoding. Anything video/subtitle-related is elided.
+///
+/// `transcoding_url` is the path the client should hit when direct play
+/// is not viable — it's already annotated with the caller's `PlaySessionId`
+/// so callers should pass it through verbatim rather than re-building it.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct MediaSourceInfo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub container: Option<String>,
+    #[serde(default)]
+    pub bitrate: Option<u32>,
+    #[serde(default)]
+    pub size: Option<i64>,
+    #[serde(default)]
+    pub run_time_ticks: Option<i64>,
+    #[serde(default)]
+    pub supports_direct_play: bool,
+    #[serde(default)]
+    pub supports_direct_stream: bool,
+    #[serde(default)]
+    pub supports_transcoding: bool,
+    #[serde(default)]
+    pub transcoding_url: Option<String>,
+    #[serde(default)]
+    pub transcoding_sub_protocol: Option<String>,
+    #[serde(default)]
+    pub transcoding_container: Option<String>,
+}
+
+/// Response body for `POST /Items/{id}/PlaybackInfo`. Carries every
+/// playable media source for the item plus the `PlaySessionId` the
+/// caller must echo back on subsequent `/Sessions/Playing` reports so
+/// the server can correlate them.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct PlaybackInfoResponse {
+    #[serde(default)]
+    pub media_sources: Vec<MediaSourceInfo>,
+    #[serde(default)]
+    pub play_session_id: Option<String>,
+    #[serde(default)]
+    pub error_code: Option<String>,
+}
+
+// ============================================================================
+// Playback start report — sent to `POST /Sessions/Playing` on track load so
+// Jellyfin shows "Now playing on macOS" for this device.
+// ============================================================================
+
+/// The body for `POST /Sessions/Playing`. Mirrors Jellyfin's
+/// `PlaybackStartInfo`, which is itself a subset of `PlaybackProgressInfo`
+/// — everything optional is skipped when `None` to keep the wire payload
+/// small.
+///
+/// `position_ticks` / `playback_start_time_ticks` are in Jellyfin's 100-ns
+/// tick units (`seconds * 10_000_000`).
+///
+/// `play_method` is one of `"DirectPlay"`, `"DirectStream"`, `"Transcode"`
+/// — left as a raw string so callers forward whatever the `/PlaybackInfo`
+/// response implied without a round-trip through a local enum.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct PlaybackStartInfo {
+    pub item_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_stream_index: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub play_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub play_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position_ticks: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub playback_start_time_ticks: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_level: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub playlist_index: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub playlist_length: Option<i32>,
+    pub can_seek: bool,
+    pub is_paused: bool,
+    pub is_muted: bool,
+}
+
 /// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
 /// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -2103,6 +2103,742 @@ async fn add_to_playlist_requires_authenticated_session() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// report_playback_started — POST /Sessions/Playing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn report_playback_started_posts_pascal_case_body() {
+    use crate::models::PlaybackStartInfo;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Playing"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .report_playback_started(PlaybackStartInfo {
+            item_id: "track-xyz".into(),
+            media_source_id: Some("src-1".into()),
+            play_session_id: Some("play-session-abc".into()),
+            play_method: Some("DirectPlay".into()),
+            position_ticks: Some(0),
+            can_seek: true,
+            is_paused: false,
+            is_muted: false,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Sessions/Playing")
+        .expect("expected POST to /Sessions/Playing");
+    let body: serde_json::Value = serde_json::from_slice(&post.body).expect("json body");
+
+    // Required fields must be PascalCase.
+    assert_eq!(
+        body.get("ItemId").and_then(|v| v.as_str()),
+        Some("track-xyz"),
+        "body: {body}"
+    );
+    assert_eq!(
+        body.get("MediaSourceId").and_then(|v| v.as_str()),
+        Some("src-1")
+    );
+    assert_eq!(
+        body.get("PlaySessionId").and_then(|v| v.as_str()),
+        Some("play-session-abc")
+    );
+    assert_eq!(
+        body.get("PlayMethod").and_then(|v| v.as_str()),
+        Some("DirectPlay")
+    );
+    assert_eq!(body.get("CanSeek").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(body.get("IsPaused").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(body.get("IsMuted").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(body.get("PositionTicks").and_then(|v| v.as_i64()), Some(0));
+
+    // None-valued optional fields must be elided from the payload.
+    assert!(
+        !body.as_object().unwrap().contains_key("SessionId"),
+        "unset optional should not appear: {body}"
+    );
+    assert!(
+        !body.as_object().unwrap().contains_key("VolumeLevel"),
+        "unset optional should not appear: {body}"
+    );
+
+    // No snake_case leakage from serde.
+    assert!(
+        body.as_object().unwrap().keys().all(|k| !k.contains('_')),
+        "expected PascalCase keys only: {:?}",
+        body.as_object().unwrap().keys().collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn report_playback_started_requires_authenticated_session() {
+    use crate::models::PlaybackStartInfo;
+
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .report_playback_started(PlaybackStartInfo {
+            item_id: "anything".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// post_capabilities — POST /Sessions/Capabilities/Full
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn post_capabilities_posts_full_client_capabilities_dto() {
+    use crate::models::{ClientCapabilities, DeviceProfile};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Capabilities/Full"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let caps = ClientCapabilities {
+        playable_media_types: vec!["Audio".into()],
+        supported_commands: vec!["VolumeUp".into(), "Pause".into()],
+        supports_media_control: true,
+        supports_persistent_identifier: true,
+        device_profile: DeviceProfile::default_macos_profile(),
+        app_store_url: None,
+        icon_url: Some("https://example.com/icon.png".into()),
+    };
+    client.post_capabilities(caps).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Sessions/Capabilities/Full")
+        .expect("expected POST to /Sessions/Capabilities/Full");
+    let body: serde_json::Value = serde_json::from_slice(&post.body).expect("json body");
+
+    assert_eq!(
+        body.get("PlayableMediaTypes").and_then(|v| v.as_array()),
+        Some(&vec![serde_json::Value::String("Audio".into())])
+    );
+    assert_eq!(
+        body.get("SupportsMediaControl").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        body.get("IconUrl").and_then(|v| v.as_str()),
+        Some("https://example.com/icon.png")
+    );
+    // Device profile round-trips with PascalCase nested fields.
+    let profile = body
+        .get("DeviceProfile")
+        .and_then(|v| v.as_object())
+        .expect("DeviceProfile object");
+    assert!(profile.contains_key("MaxStreamingBitrate"));
+    assert!(profile.contains_key("DirectPlayProfiles"));
+    assert!(profile.contains_key("TranscodingProfiles"));
+    // None-valued optional AppStoreUrl should be elided.
+    assert!(
+        !body.as_object().unwrap().contains_key("AppStoreUrl"),
+        "unset optional should not appear: {body}"
+    );
+}
+
+#[tokio::test]
+async fn post_capabilities_requires_authenticated_session() {
+    use crate::models::{ClientCapabilities, DeviceProfile};
+
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .post_capabilities(ClientCapabilities {
+            playable_media_types: vec![],
+            supported_commands: vec![],
+            supports_media_control: false,
+            supports_persistent_identifier: false,
+            device_profile: DeviceProfile::default_macos_profile(),
+            app_store_url: None,
+            icon_url: None,
+        })
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// playback_info — POST /Items/{id}/PlaybackInfo
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn playback_info_posts_device_profile_and_parses_response() {
+    use crate::models::{DeviceProfile, PlaybackInfoOpts};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Items/track-xyz/PlaybackInfo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "MediaSources": [
+                {
+                    "Id": "src-1",
+                    "Path": "/music/song.flac",
+                    "Container": "flac",
+                    "Bitrate": 900000,
+                    "Size": 42_000_000i64,
+                    "RunTimeTicks": 1800000000i64,
+                    "SupportsDirectPlay": true,
+                    "SupportsDirectStream": true,
+                    "SupportsTranscoding": true,
+                    "TranscodingUrl": "/Audio/track-xyz/stream.mp3?PlaySessionId=abc",
+                    "TranscodingSubProtocol": "http",
+                    "TranscodingContainer": "mp3"
+                }
+            ],
+            "PlaySessionId": "play-session-abc"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let opts = PlaybackInfoOpts {
+        device_profile: Some(DeviceProfile::default_macos_profile()),
+        max_streaming_bitrate: Some(320_000),
+        ..Default::default()
+    };
+    let resp = client.playback_info("track-xyz", opts).await.unwrap();
+
+    assert_eq!(resp.play_session_id.as_deref(), Some("play-session-abc"));
+    assert_eq!(resp.media_sources.len(), 1);
+    let src = &resp.media_sources[0];
+    assert_eq!(src.id, "src-1");
+    assert_eq!(src.container.as_deref(), Some("flac"));
+    assert_eq!(src.bitrate, Some(900_000));
+    assert!(src.supports_direct_play);
+    assert_eq!(
+        src.transcoding_url.as_deref(),
+        Some("/Audio/track-xyz/stream.mp3?PlaySessionId=abc")
+    );
+
+    // Body fills in the live session's user id even when the caller
+    // leaves `user_id` unset.
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Items/track-xyz/PlaybackInfo")
+        .expect("expected POST to /Items/track-xyz/PlaybackInfo");
+    let body: serde_json::Value = serde_json::from_slice(&post.body).expect("json body");
+    assert_eq!(body.get("UserId").and_then(|v| v.as_str()), Some("u1"));
+    assert_eq!(
+        body.get("MaxStreamingBitrate").and_then(|v| v.as_u64()),
+        Some(320_000)
+    );
+    assert!(body.get("DeviceProfile").is_some());
+}
+
+#[tokio::test]
+async fn playback_info_requires_authenticated_session() {
+    use crate::models::PlaybackInfoOpts;
+
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .playback_info("anything", PlaybackInfoOpts::default())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Library resolution — /UserViews + ManualPlaylistsFolder
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn user_views_parses_and_returns_all_libraries() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/UserViews"))
+        .and(query_param("userId", "u1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "lib-music", "Name": "Music", "CollectionType": "music" },
+                { "Id": "lib-movies", "Name": "Movies", "CollectionType": "movies" },
+                { "Id": "lib-pl", "Name": "Playlists", "CollectionType": "playlists" }
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let views = client.user_views().await.unwrap();
+    assert_eq!(views.len(), 3);
+    assert_eq!(views[0].id, "lib-music");
+    assert_eq!(views[0].collection_type.as_deref(), Some("music"));
+    assert_eq!(views[2].collection_type.as_deref(), Some("playlists"));
+}
+
+#[tokio::test]
+async fn music_library_id_filters_and_caches() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/UserViews"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "lib-movies", "Name": "Movies", "CollectionType": "movies" },
+                { "Id": "lib-music", "Name": "Music", "CollectionType": "music" }
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let first = client.music_library_id().await.unwrap();
+    assert_eq!(first, "lib-music");
+
+    // Second call must come from the cache, not a fresh HTTP hit — if the
+    // cache regresses this count would be 2.
+    let second = client.music_library_id().await.unwrap();
+    assert_eq!(second, "lib-music");
+    let get_count = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/UserViews")
+        .count();
+    assert_eq!(
+        get_count, 1,
+        "music_library_id must cache /UserViews response"
+    );
+}
+
+#[tokio::test]
+async fn music_library_id_returns_404_when_no_music_view() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/UserViews"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "lib-movies", "Name": "Movies", "CollectionType": "movies" }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.music_library_id().await.unwrap_err();
+    match err {
+        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
+        other => panic!("expected Server 404, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn playlist_library_id_finds_manual_playlists_folder() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("userId", "u1"))
+        .and(query_param("includeItemTypes", "ManualPlaylistsFolder"))
+        .and(query_param("excludeItemTypes", "CollectionFolder"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "lib-pl", "Name": "Playlists", "CollectionType": "playlists" }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let id = client.playlist_library_id().await.unwrap();
+    assert_eq!(id, "lib-pl");
+
+    // Second call is served from the cache.
+    let again = client.playlist_library_id().await.unwrap();
+    assert_eq!(again, "lib-pl");
+    let get_count = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/Items")
+        .count();
+    assert_eq!(
+        get_count, 1,
+        "playlist_library_id must cache its resolution"
+    );
+}
+
+#[tokio::test]
+async fn library_resolution_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.user_views().await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated on user_views, got {err:?}"
+    );
+    let err = client.music_library_id().await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated on music_library_id, got {err:?}"
+    );
+    let err = client.playlist_library_id().await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated on playlist_library_id, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn set_session_invalidates_library_cache() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/UserViews"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "lib-music", "Name": "Music", "CollectionType": "music" }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client.music_library_id().await.unwrap();
+    // Re-auth against the same mock: cache must be dropped so the new
+    // session triggers a fresh /UserViews lookup.
+    client.set_session("t2".into(), "u2".into());
+    let _ = client.music_library_id().await.unwrap();
+
+    let get_count = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/UserViews")
+        .count();
+    assert_eq!(
+        get_count, 2,
+        "set_session must invalidate cached library ids"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// remove_from_playlist — DELETE /Playlists/{id}/Items?entryIds=...
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn remove_from_playlist_sends_entry_ids_query_and_expects_204() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/Playlists/pl-1/Items"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .remove_from_playlist("pl-1", &["entry-1".into(), "entry-2".into()])
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let del = requests
+        .iter()
+        .find(|r| r.method.as_str() == "DELETE" && r.url.path() == "/Playlists/pl-1/Items")
+        .expect("expected DELETE to /Playlists/pl-1/Items");
+    let entry_ids = del
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "entryIds")
+        .map(|(_, v)| v.into_owned())
+        .expect("expected entryIds query param");
+    assert_eq!(entry_ids, "entry-1,entry-2");
+}
+
+#[tokio::test]
+async fn remove_from_playlist_is_noop_on_empty_entry_ids() {
+    // No DELETE mock is registered — an accidental network hit would
+    // surface as an unmatched-route error rather than silently succeed.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.remove_from_playlist("pl-1", &[]).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE" && r.url.path().starts_with("/Playlists/")),
+        "empty entry_ids must short-circuit before any HTTP request"
+    );
+}
+
+#[tokio::test]
+async fn remove_from_playlist_propagates_server_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/Playlists/pl-1/Items"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client
+        .remove_from_playlist("pl-1", &["entry-1".into()])
+        .await
+        .unwrap_err();
+    match err {
+        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 403),
+        other => panic!("expected Server 403, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn remove_from_playlist_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .remove_from_playlist("pl-1", &["entry-1".into()])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DeviceProfile serde
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_macos_profile_serializes_to_pascal_case() {
+    use crate::models::DeviceProfile;
+
+    let profile = DeviceProfile::default_macos_profile();
+    let v = serde_json::to_value(&profile).unwrap();
+    let obj = v.as_object().expect("object profile");
+
+    // Top-level PascalCase keys Jellyfin expects.
+    for key in [
+        "Name",
+        "MaxStreamingBitrate",
+        "MaxStaticBitrate",
+        "MusicStreamingTranscodingBitrate",
+        "DirectPlayProfiles",
+        "TranscodingProfiles",
+    ] {
+        assert!(obj.contains_key(key), "missing top-level key {key}: {v}");
+    }
+    assert!(
+        obj.keys().all(|k| !k.contains('_')),
+        "expected PascalCase only, got {:?}",
+        obj.keys().collect::<Vec<_>>()
+    );
+
+    // Direct-play entries cover the AVFoundation set: flac/alac/mp3/aac/opus/ogg/wav.
+    let direct = obj
+        .get("DirectPlayProfiles")
+        .and_then(|v| v.as_array())
+        .unwrap();
+    let containers: std::collections::HashSet<&str> = direct
+        .iter()
+        .filter_map(|e| e.get("Container").and_then(|v| v.as_str()))
+        .collect();
+    for c in ["flac", "alac", "mp3", "aac", "opus", "ogg", "wav"] {
+        assert!(
+            containers.contains(c),
+            "direct-play must include {c}: {containers:?}"
+        );
+    }
+    // Entries opt into AudioCodec only when the container is ambiguous
+    // (e.g. m4a that can hold either ALAC or AAC). Entries without a codec
+    // should simply elide the key, not emit `"AudioCodec": null`.
+    for entry in direct {
+        let entry_obj = entry.as_object().unwrap();
+        assert_eq!(
+            entry_obj.get("Type").and_then(|v| v.as_str()),
+            Some("Audio")
+        );
+        if let Some(codec) = entry_obj.get("AudioCodec") {
+            assert!(codec.is_string(), "AudioCodec must be a string: {entry}");
+        }
+    }
+
+    // Transcoding fallback is MP3 @ 320 over HTTP.
+    let transcodes = obj
+        .get("TranscodingProfiles")
+        .and_then(|v| v.as_array())
+        .unwrap();
+    assert_eq!(transcodes.len(), 1, "expected one transcoding fallback");
+    let t = transcodes[0].as_object().unwrap();
+    assert_eq!(t.get("Container").and_then(|v| v.as_str()), Some("mp3"));
+    assert_eq!(t.get("AudioCodec").and_then(|v| v.as_str()), Some("mp3"));
+    assert_eq!(t.get("Protocol").and_then(|v| v.as_str()), Some("http"));
+
+    // Bitrate caps — the 320 transcode ceiling and ~100 Mbps direct-play
+    // cap the default profile advertises.
+    assert_eq!(
+        obj.get("MaxStreamingBitrate").and_then(|v| v.as_u64()),
+        Some(320_000)
+    );
+    assert_eq!(
+        obj.get("MusicStreamingTranscodingBitrate")
+            .and_then(|v| v.as_u64()),
+        Some(320_000)
+    );
+    assert_eq!(
+        obj.get("MaxStaticBitrate").and_then(|v| v.as_u64()),
+        Some(100_000_000)
+    );
+}
+
+#[test]
+fn default_macos_profile_round_trips_through_serde() {
+    use crate::models::DeviceProfile;
+
+    let profile = DeviceProfile::default_macos_profile();
+    let json = serde_json::to_string(&profile).expect("serialize");
+    let back: DeviceProfile = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.name, profile.name);
+    assert_eq!(back.max_streaming_bitrate, profile.max_streaming_bitrate);
+    assert_eq!(
+        back.direct_play_profiles.len(),
+        profile.direct_play_profiles.len()
+    );
+    assert_eq!(
+        back.transcoding_profiles.len(),
+        profile.transcoding_profiles.len()
+    );
+}
+
 #[test]
 fn stream_url_contains_api_key() {
     let mut client =


### PR DESCRIPTION
## Summary

Adds the P0 set of Jellyfin API endpoints the macOS player needs before it can route streams through Jellyfin's official negotiation flow instead of the best-effort universal stream URL.

- `post_capabilities(ClientCapabilities)` — registers this session as a "Play on macOS" target.
- `playback_info(item_id, PlaybackInfoOpts) -> PlaybackInfoResponse` — the canonical pre-stream hop; returns direct-play flags, `PlaySessionId`, and `TranscodingUrl`.
- `report_playback_started(PlaybackStartInfo)` — fires once per track load so Jellyfin Web shows "Now Playing on macOS".
- `user_views() -> [Library]`, `music_library_id()`, `playlist_library_id()` — cached library resolution (invalidated on `set_session`).
- `remove_from_playlist(playlist_id, entry_ids)` — `DELETE /Playlists/{id}/Items?entryIds=...`.
- `DeviceProfile::default_macos_profile()` — advertises FLAC/ALAC/MP3/AAC/Opus/OGG/WAV direct-play with an MP3 320 transcode fallback.

All wire types serialize PascalCase to match Jellyfin, UniFFI-exposed through `JellifyCore`, and covered by wiremock round-trips plus serde assertions.

## Test plan

- [ ] `cargo test --workspace` — new suite covers each endpoint's PascalCase body shape, auth-guard short-circuit, cache hits on library resolution, cache invalidation on re-auth, and empty-input short-circuit for `remove_from_playlist`.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [ ] `cargo fmt --check` — clean.
- [ ] macOS worker regenerates UniFFI Swift bindings on top of this PR.

Closes #128, #138, #142, #157, #169, #174