### PR TITLE
macos: Nuke artwork + virtualized grid + size-hinted URLs

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -12,6 +12,12 @@ let package = Package(
         .library(name: "JellifyCore", targets: ["JellifyCore"]),
         .library(name: "JellifyAudio", targets: ["JellifyAudio"]),
     ],
+    dependencies: [
+        // Nuke powers artwork loading (disk cache, request coalescing, background
+        // decoding, decode-time downscaling). Replaces SwiftUI.AsyncImage which had
+        // no caching and decoded at source resolution — #426 / #427.
+        .package(url: "https://github.com/kean/Nuke.git", from: "13.0.0"),
+    ],
     targets: [
         .binaryTarget(
             name: "JellifyCoreFFI",
@@ -35,7 +41,12 @@ let package = Package(
         ),
         .executableTarget(
             name: "Jellify",
-            dependencies: ["JellifyCore", "JellifyAudio"],
+            dependencies: [
+                "JellifyCore",
+                "JellifyAudio",
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "NukeUI", package: "Nuke"),
+            ],
             path: "Sources/Jellify",
             resources: [
                 .process("Resources")

--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -10,11 +10,27 @@ import SwiftUI
 /// `AppModel.playAll(artist:)`, which is a logging stub today pending
 /// `artist_tracks` FFI (#156 / #465). The visual affordance matches the
 /// album card so users have a consistent hover model across the grid.
+///
+/// Hover state is lifted to the parent (`LibraryView`) through the
+/// `.libraryHoverID` environment, so a 5k-artist grid doesn't accumulate
+/// per-cell `@State`. When the env isn't active (stand-alone embedding),
+/// cells fall back to local state so hover keeps working. See #428.
 struct ArtistCard: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.libraryHoverID) private var hoverTracker
     let artist: Artist
-    @State private var isHovering = false
+    /// Fallback hover flag; inert on the library path.
+    @State private var localHovering = false
+
+    /// True when the shared hover tracker reports this cell as hovered —
+    /// or when we're on the fallback path and the cursor is over the cell.
+    private var isHovering: Bool {
+        if hoverTracker.isActive {
+            return hoverTracker.id.wrappedValue == artist.id
+        }
+        return localHovering
+    }
 
     var body: some View {
         Button {
@@ -26,7 +42,11 @@ struct ArtistCard: View {
                         url: model.imageURL(for: artist.id, tag: artist.imageTag, maxWidth: 400),
                         seed: artist.name,
                         size: 180,
-                        radius: 8
+                        radius: 8,
+                        // 180pt square at 2x = 360px, 3x = 540px. 540 gives
+                        // us Retina-5K headroom without decoding the full
+                        // server image. See #427.
+                        targetPixelSize: CGSize(width: 540, height: 540)
                     )
                     .frame(maxWidth: .infinity)
                     .aspectRatio(1, contentMode: .fit)
@@ -64,7 +84,17 @@ struct ArtistCard: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
+        .onHover { hovering in
+            if hoverTracker.isActive {
+                if hovering {
+                    hoverTracker.id.wrappedValue = artist.id
+                } else if hoverTracker.id.wrappedValue == artist.id {
+                    hoverTracker.id.wrappedValue = nil
+                }
+            } else {
+                localHovering = hovering
+            }
+        }
         .contextMenu { ArtistContextMenu(artist: artist) }
     }
 

--- a/macos/Sources/Jellify/Components/Artwork.swift
+++ b/macos/Sources/Jellify/Components/Artwork.swift
@@ -1,27 +1,85 @@
 import SwiftUI
+import Nuke
+import NukeUI
 
 /// Displays an artwork image if the Jellyfin `image_tag` is available, otherwise
 /// renders a deterministic gradient placeholder matching the design's Artwork.jsx.
+///
+/// Backed by Nuke's `LazyImage` so we get:
+///   - Disk + memory cache (Nuke.DataCache + ImageCache.shared)
+///   - Request coalescing (two cells asking for the same URL fetch once)
+///   - Background decoding (`isDecompressionEnabled` on macOS)
+///   - Decode-time downscaling via `ImageProcessors.Resize(size:unit:.pixels)`
+///   - Memory-pressure eviction (ImageCache is NSCache-backed)
+///
+/// The `targetPixelSize` tells Nuke what pixel dimensions to decode at —
+/// large library grids decode at ~360×360 even if the server ships a 1024px
+/// image, so we don't blow memory on a 5k-album grid. Callers that don't pass
+/// a pixel size get a sensible default derived from `size` at 2x scale.
+///
+/// Issue: #426 (Nuke replaces AsyncImage), #427 (size-hinted URLs + decode
+/// downscale). `Artwork` is used by album, artist, playlist, track-row, and
+/// now-playing surfaces — the default shape is backward-compatible so those
+/// screens don't need to change in this batch (see BATCH-20 scope).
 struct Artwork: View {
     let url: URL?
     let seed: String
     var size: CGFloat = 120
     var radius: CGFloat = 8
     var overlayLabel: String?
+    /// Target decode size in pixels. Nuke downscales during decode to avoid
+    /// holding a 1024×1024 CGImage in memory when the cell renders at 180pt.
+    /// Defaults to `size * 2` to match typical Retina displays — the 3x
+    /// headroom is handled by the `maxWidth` on the URL + disk cache.
+    var targetPixelSize: CGSize?
+
+    /// Shared image pipeline for the whole app. Initialised lazily so the
+    /// disk cache sets itself up once on first artwork render, then registered
+    /// as `ImagePipeline.shared` so any call that doesn't pipe through
+    /// `Artwork` (e.g. the SmokeTest target, future prefetcher) picks up the
+    /// same cache + decoding config.
+    ///
+    /// `isDecompressionEnabled = true` overrides the macOS default (off) so
+    /// decoding happens on Nuke's dedicated queue rather than on the main
+    /// thread when `Image` commits to the layer.
+    static let pipeline: ImagePipeline = {
+        var config = ImagePipeline.Configuration.withDataCache(
+            name: "com.jellify.macos.artwork",
+            sizeLimit: 256 * 1024 * 1024 // 256 MB on-disk, larger than 150MB
+                                         // default so a full library grid
+                                         // stays warm across relaunches.
+        )
+        config.isDecompressionEnabled = true
+        // Task coalescing + rate limiter are on by default; spelling them out
+        // here so the config's intent reads at a glance.
+        config.isTaskCoalescingEnabled = true
+        config.isRateLimiterEnabled = true
+        let pipeline = ImagePipeline(configuration: config)
+        ImagePipeline.shared = pipeline
+        return pipeline
+    }()
+
+    /// Effective pixel size used to build the decode processor. Uses the
+    /// caller's hint when present; otherwise derives from display `size` at
+    /// 2x (the common Retina case on Apple Silicon MacBooks).
+    private var effectivePixelSize: CGSize {
+        if let targetPixelSize { return targetPixelSize }
+        return CGSize(width: size * 2, height: size * 2)
+    }
 
     var body: some View {
         ZStack {
             if let url = url {
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .success(let image):
+                LazyImage(request: imageRequest(for: url)) { state in
+                    if let image = state.image {
                         image.resizable().scaledToFill()
-                    case .failure, .empty:
+                    } else if state.error != nil {
                         placeholder
-                    @unknown default:
+                    } else {
                         placeholder
                     }
                 }
+                .pipeline(Artwork.pipeline)
             } else {
                 placeholder
             }
@@ -29,6 +87,22 @@ struct Artwork: View {
         .frame(width: size, height: size)
         .clipShape(RoundedRectangle(cornerRadius: radius))
         .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
+    }
+
+    /// Build the Nuke request with a resize processor that downscales at
+    /// decode. `.pixels` unit means we hand Nuke the literal pixel target so
+    /// it doesn't double-multiply by screen scale.
+    private func imageRequest(for url: URL) -> ImageRequest {
+        let processors: [any ImageProcessing] = [
+            ImageProcessors.Resize(
+                size: effectivePixelSize,
+                unit: .pixels,
+                contentMode: .aspectFill,
+                crop: false,
+                upscale: false
+            )
+        ]
+        return ImageRequest(url: url, processors: processors)
     }
 
     private var placeholder: some View {

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -1,6 +1,36 @@
 import SwiftUI
 @preconcurrency import JellifyCore
 
+/// Shared hover state for the Library grid. A single optional item ID lives
+/// on the `LibraryView` root and gets read by every `AlbumCard` / `ArtistCard`,
+/// so cells in the 5k+ library grid don't each carry their own
+/// `@State var isHovering`. See #428.
+///
+/// `AlbumCard` is also rendered by `SearchView` without a container tracker —
+/// the env default carries `isActive = false`, and cells fall back to a local
+/// `@State` on that path so hover affordance keeps working outside the
+/// library. The library path (`isActive = true`) uses the shared ID
+/// exclusively and the cell's local state stays inert.
+struct LibraryHoverBinding {
+    var id: Binding<String?>
+    /// `true` when a container lifted hover tracking up; cells on this path
+    /// read/write the shared ID and ignore their local fallback state.
+    var isActive: Bool
+
+    static let inactive = LibraryHoverBinding(id: .constant(nil), isActive: false)
+}
+
+private struct LibraryHoverIDKey: EnvironmentKey {
+    static let defaultValue = LibraryHoverBinding.inactive
+}
+
+extension EnvironmentValues {
+    var libraryHoverID: LibraryHoverBinding {
+        get { self[LibraryHoverIDKey.self] }
+        set { self[LibraryHoverIDKey.self] = newValue }
+    }
+}
+
 /// Library tab options. The active tab filters what the library grid shows
 /// and drives the count subline. See `Chip` / `ChipRow` in
 /// `Components/Chips.swift` and spec issue #212.
@@ -33,6 +63,10 @@ struct LibraryView: View {
     @Environment(AppModel.self) private var model
     @AppStorage("libraryViewMode") private var viewMode: LibraryViewMode = .grid
     @State private var selectedTab: LibraryTab = .albums
+    /// Single shared hover ID for the grid. Published via
+    /// `.libraryHoverID` env so every cell reads from (and writes to) the same
+    /// binding — avoids N `@State`s on a 5k-item grid. See #428.
+    @State private var hoverID: String?
 
     private let columns = [GridItem(.adaptive(minimum: 180, maximum: 220), spacing: 18)]
 
@@ -56,6 +90,10 @@ struct LibraryView: View {
             .padding(.bottom, 32)
         }
         .background(backgroundWash)
+        .environment(
+            \.libraryHoverID,
+            LibraryHoverBinding(id: $hoverID, isActive: true)
+        )
     }
 
     /// Jellyfin's web UI lives at `/web/` on the server host. Falls back to
@@ -430,11 +468,31 @@ struct LibraryViewToggle: View {
     }
 }
 
+/// Square grid tile used in the Library Albums tab. When a container has
+/// lifted hover tracking (Library), hover state reads the single shared
+/// `libraryHoverID` binding instead of a per-cell `@State` — that's the
+/// key to keeping a 5k-item grid lightweight (see #428). When `AlbumCard`
+/// renders outside the library (e.g. search results), `isActive` is false
+/// and the cell falls back to a local `@State` so hover affordance is
+/// preserved on those surfaces.
 struct AlbumCard: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.libraryHoverID) private var hoverTracker
     let album: Album
-    @State private var isHovering = false
+    /// Fallback hover flag for non-library hosts. Stays `false` forever when
+    /// `hoverTracker.isActive` is true (library path), so it doesn't drive
+    /// any view invalidations in the 5k-grid case.
+    @State private var localHovering = false
+
+    /// True when the container's shared hover tracker points at this album —
+    /// or when we're on the fallback path and the cursor is over the cell.
+    private var isHovering: Bool {
+        if hoverTracker.isActive {
+            return hoverTracker.id.wrappedValue == album.id
+        }
+        return localHovering
+    }
 
     var body: some View {
         Button {
@@ -446,7 +504,11 @@ struct AlbumCard: View {
                         url: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 400),
                         seed: album.name,
                         size: 180,
-                        radius: 8
+                        radius: 8,
+                        // 180pt @ 3x = 540px — enough headroom for a 5K
+                        // external display without decoding source (often
+                        // 1024px+ from Jellyfin). See #427.
+                        targetPixelSize: CGSize(width: 540, height: 540)
                     )
                     .frame(maxWidth: .infinity)
                     .aspectRatio(1, contentMode: .fit)
@@ -491,7 +553,17 @@ struct AlbumCard: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
+        .onHover { hovering in
+            if hoverTracker.isActive {
+                if hovering {
+                    hoverTracker.id.wrappedValue = album.id
+                } else if hoverTracker.id.wrappedValue == album.id {
+                    hoverTracker.id.wrappedValue = nil
+                }
+            } else {
+                localHovering = hovering
+            }
+        }
         .contextMenu { AlbumContextMenu(album: album) }
     }
 }


### PR DESCRIPTION
Closes #426, #427, #428

## What

### #426 — Replace AsyncImage with Nuke
`SwiftUI.AsyncImage` had no caching, no coalescing, no background decoding, and
re-downloaded on every re-render. `Artwork` now renders through Nuke's
`LazyImage`:

- **Disk cache** — `ImagePipeline.Configuration.withDataCache` (256 MB limit,
  150 MB default bumped up so a full library stays warm across relaunches).
- **Request coalescing** — `isTaskCoalescingEnabled = true`. Two cells asking
  for the same URL fetch + decode once.
- **Background decoding** — `isDecompressionEnabled = true` overrides the
  macOS default (off), moving decode off the main thread.
- **Memory-pressure eviction** — default `ImageCache.shared` is NSCache-backed
  and evicts under pressure automatically. `defaultCostLimit` is 15% of
  physical memory, capped at 768 MB.
- The pipeline is also assigned to `ImagePipeline.shared` so any future callsite
  (prefetcher, SmokeTest) picks up the same config.

### #427 — Size-hinted URLs + decode downscaling
- New `targetPixelSize: CGSize?` parameter on `Artwork`. `AlbumCard` and
  `ArtistCard` pass `CGSize(width: 540, height: 540)` for the 180pt grid cells
  (180 @ 3x = 540; 2x Retina falls out at 360px well below the ceiling, and
  5K external display gets the headroom).
- The URL-level `maxWidth` hint (which tells Jellyfin to ship a pre-sized
  image) was already wired through `AppModel.imageURL(for:tag:maxWidth:)` — no
  work needed there.
- `ImageProcessors.Resize(size:unit:.pixels, contentMode:.aspectFill)` runs on
  Nuke's decode queue, so the CGImage held in the memory cache matches the
  display size. A 5k-album grid previously could have held 5k × 1024×1024
  RGBA bitmaps (~20 GB worst case in theory, though memory pressure culled
  them in practice); it now holds at most ~5k × 540×540 ≈ 5.8 GB, and memory
  eviction brings that down further.

### #428 — Virtualize library grid
- Lifted hover state out of per-cell `@State var isHovering` on `AlbumCard`
  and `ArtistCard`. The container (`LibraryView`) now owns a single
  `@State var hoverID: String?` and publishes it through
  `LibraryHoverBinding` on the `libraryHoverID` environment key.
- Cells derive `isHovering` by comparing the shared ID to their own item ID,
  so a hover change only invalidates the two cells whose equality flipped —
  not all 5k.
- `AlbumCard` keeps a `@State var localHovering` for the SearchView path
  (where the env tracker isn't active). On the library path that state stays
  `false` and never fires updates. This preserves hover affordance on
  SearchView without regressing library-grid perf.
- `LazyVGrid` inside `ScrollView` kept as-is. The existing
  `.onAppear { triggerLoadMoreXIfNeeded(...) }` calls are guarded pagination
  threshold checks (O(1), cheap per cell; the model dedupes the underlying
  page fetch), not per-cell data fetches, so they stay.

## Files

- `macos/Package.swift` — adds Nuke 13.0.2 (SPM) + `Nuke` / `NukeUI` products
  to the `Jellify` executable target.
- `macos/Sources/Jellify/Components/Artwork.swift` — Nuke-backed `LazyImage`
  with a shared pipeline and `targetPixelSize` decode hint.
- `macos/Sources/Jellify/Components/ArtistCard.swift` — reads `libraryHoverID`
  env, passes `targetPixelSize: 540×540`.
- `macos/Sources/Jellify/Screens/LibraryView.swift` — defines
  `LibraryHoverBinding` + env key, publishes it on the root, updates
  `AlbumCard` to match.

## Verified statically

- `swift build` clean from `macos/` (only pre-existing
  `object file ... built for newer macOS version` warnings from the prebuilt
  Rust static lib; unrelated to this change).
- Nuke + NukeUI build into `.build/.../Modules/`.
- Incremental build touching just the three Swift files recompiles cleanly
  against Nuke's public API.
- Scroll-perf validation with a live 5k+ library requires a running Jellyfin
  server with that dataset, which isn't available in this sandbox. The
  architectural wins (decode downscaling, deduplication, lifted hover state)
  are structural rather than measurement-dependent.