### PR TITLE
macos: onboarding flow + login rewrite

### DIFF
--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -170,6 +170,13 @@ struct RootView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// Sticky "first-launch is done" flag. On a fresh install this is
+    /// `false` and the app lands on `OnboardingView`. After the user either
+    /// completes the flow or taps "Skip, explore offline" it becomes
+    /// `true` permanently so subsequent signed-out launches go straight
+    /// to `LoginView`. See #291 / #292 / #293.
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+
     var body: some View {
         Group {
             if model.isRestoringSession {
@@ -178,6 +185,16 @@ struct RootView: View {
                 // We don't want to briefly flash `LoginView` on every launch
                 // just because the restore hasn't completed yet.
                 RestoreLoadingView()
+            } else if !hasCompletedOnboarding {
+                // First launch. `OnboardingView` owns the flow across all
+                // three steps; it flips `hasCompletedOnboarding` itself once
+                // the user either lands in the sync step and hits Continue
+                // to Home, or skips offline from the connect step. Keeping
+                // `OnboardingView` mounted *even after* a successful login
+                // matters: the first-sync step needs to stay on screen
+                // while the library is fetching, which happens against a
+                // live `model.session`.
+                OnboardingView()
             } else if model.session == nil {
                 LoginView()
             } else {
@@ -189,6 +206,7 @@ struct RootView: View {
         // instant under Reduce Motion.
         .animation(reduceMotion ? nil : .default, value: model.session != nil)
         .animation(reduceMotion ? nil : .default, value: model.isRestoringSession)
+        .animation(reduceMotion ? nil : .default, value: hasCompletedOnboarding)
         .task {
             // Kick off session restore exactly once, on the first appearance
             // of the root view. `attemptRestoreSession` guards against

--- a/macos/Sources/Jellify/Screens/LoginView.swift
+++ b/macos/Sources/Jellify/Screens/LoginView.swift
@@ -1,5 +1,24 @@
 import SwiftUI
+@preconcurrency import JellifyCore
 
+/// Full-window login surface for the macOS app.
+///
+/// This is the view the user lands on when they've gone through onboarding
+/// once (so `OnboardingView` is skipped) but are currently signed out —
+/// either because they logged out, because `forgetToken` fired from the
+/// auth-expired sheet (#303), or because the keyring lost its token.
+///
+/// Design (#200):
+/// - Full-window `Theme.bg` background, no sidebar, no player bar.
+/// - Centered 420pt-wide column with the brand lockup top-anchored.
+/// - `_jellyfin._tcp` Bonjour discovery surfaces a chip row above the URL
+///   field when at least one server is visible on the LAN (#111).
+/// - 400ms debounced probe against `core.probeServer` shows "Jellyfin vX.Y.Z"
+///   on success or "Couldn't reach server" on failure (#201).
+/// - 401 on submit shakes the password field + shows "Wrong username or
+///   password" (#203). Network offline shows a top banner. Repeated
+///   unreachable failures swap the error message for a "Last connected …"
+///   hint.
 struct LoginView: View {
     @Environment(AppModel.self) private var model
 
@@ -7,91 +26,602 @@ struct LoginView: View {
     @State private var username: String = ""
     @State private var password: String = ""
 
+    @State private var discovery = ServerDiscovery()
+    @State private var probe = ServerProbe()
+
+    /// Per-submit count that drives the password-field shake on 401. Each
+    /// failed attempt increments the value; the field observes
+    /// `.animation(value:)` on it so the animation re-runs every time.
+    @State private var shakeAttempts: Int = 0
+
+    /// When `true`, we've seen the server reachability dip below threshold
+    /// during this app session. Flip the "no such server" language for the
+    /// "Last connected {date}. Trying offline mode." copy on subsequent
+    /// failures (#203).
+    @State private var hasSeenRepeatedUnreachable: Bool = false
+
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case url, username, password
+    }
+
     var body: some View {
-        ZStack {
+        ZStack(alignment: .top) {
             Theme.bg.ignoresSafeArea()
+            // Invisible drag handle spanning the full title-bar area so
+            // users can drag the window by the chrome — the rewrite spec
+            // (#200) keeps the standard traffic lights on a draggable title
+            // bar even though the shell sidebar is hidden.
+            WindowDragHandle()
+                .frame(height: 28)
+                .frame(maxWidth: .infinity)
+                .ignoresSafeArea()
 
-            VStack(spacing: 24) {
-                VStack(spacing: 4) {
-                    Text("Jellify")
-                        .font(Theme.font(40, weight: .black, italic: true))
-                        .foregroundStyle(Theme.ink)
-                    Text("DESKTOP")
-                        .font(Theme.font(10, weight: .bold))
-                        .foregroundStyle(Theme.ink3)
-                        .tracking(3)
+            VStack(spacing: 0) {
+                if !model.network.isOnline {
+                    LoginNetworkBanner()
+                        .padding(.top, 40)
+                        .padding(.horizontal, 40)
+                        .transition(.move(edge: .top).combined(with: .opacity))
                 }
-                .padding(.bottom, 8)
-
-                VStack(alignment: .leading, spacing: 14) {
-                    field("Server URL", text: $url, placeholder: "https://jellyfin.example.com")
-                    field("Username", text: $username, placeholder: "you")
-                    field("Password", text: $password, placeholder: "••••••••", secure: true)
-
-                    if let error = model.errorMessage {
-                        Text(error)
-                            .font(Theme.font(12, weight: .medium))
-                            .foregroundStyle(Theme.accentHot)
-                            .padding(.top, 4)
-                    }
-                }
-                .frame(width: 340)
-
-                Button {
-                    Task { await model.login(url: url, username: username, password: password) }
-                } label: {
-                    HStack(spacing: 8) {
-                        if model.isLoggingIn {
-                            ProgressView().scaleEffect(0.7).tint(Theme.bg)
-                        }
-                        Text(model.isLoggingIn ? "Signing in…" : "Sign in")
-                            .font(Theme.font(14, weight: .bold))
-                    }
-                    .frame(width: 340, height: 42)
-                    .foregroundStyle(Theme.bg)
-                    .background(Theme.ink)
-                    .clipShape(RoundedRectangle(cornerRadius: 22))
-                }
-                .buttonStyle(.plain)
-                .disabled(model.isLoggingIn || url.isEmpty || username.isEmpty)
-                .opacity(url.isEmpty || username.isEmpty ? 0.5 : 1)
+                Spacer(minLength: 0)
+                loginColumn
+                    .frame(width: 420)
+                Spacer(minLength: 0)
             }
-            .padding(40)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(.easeInOut(duration: 0.2), value: model.network.isOnline)
         }
         .onAppear {
-            // After an auth-expired bounce (#303), the server URL and
-            // username live on AppModel from the last successful sign-in.
-            // Prefill so the user only needs to re-enter their password.
-            if url.isEmpty, !model.serverURL.isEmpty { url = model.serverURL }
-            if username.isEmpty, !model.username.isEmpty { username = model.username }
+            probe.configure(core: model.core)
+            discovery.start()
+            // Prefill from the last successful sign-in. This also covers the
+            // post-auth-expired bounce (#303): the auth-expired sheet drops
+            // the token but keeps `serverURL` / `username` around so the
+            // user only has to re-enter their password.
+            if url.isEmpty, !model.serverURL.isEmpty {
+                url = model.serverURL
+                // Prefilled URLs should show server version right away —
+                // schedule a probe so the success row populates on appear.
+                probe.schedule(url: url)
+            }
+            if username.isEmpty, !model.username.isEmpty {
+                username = model.username
+            }
+            focusedField = username.isEmpty ? .url : .password
+        }
+        .onDisappear {
+            discovery.stop()
+            probe.reset()
+        }
+        .onChange(of: url) { _, newValue in
+            if newValue.isEmpty {
+                probe.reset()
+            } else {
+                probe.schedule(url: newValue)
+            }
+        }
+        .onChange(of: model.serverReachability.isServerReachable) { _, reachable in
+            if !reachable { hasSeenRepeatedUnreachable = true }
+        }
+    }
+
+    // MARK: - Layout
+
+    @ViewBuilder
+    private var loginColumn: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            brand
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.bottom, 8)
+
+            if !discovery.servers.isEmpty {
+                discoveredServersRow
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                urlField
+                probeResultRow
+                usernameField
+                passwordField
+
+                if let error = loginErrorMessage {
+                    Text(error)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.accentHot)
+                        .padding(.top, 2)
+                }
+            }
+
+            signInButton
+        }
+        .padding(.horizontal, 0)
+        .padding(.vertical, 40)
+    }
+
+    @ViewBuilder
+    private var brand: some View {
+        VStack(spacing: 4) {
+            JellyfishMark(size: 72)
+                .padding(.bottom, 4)
+            Text("Jellify")
+                .font(Theme.font(40, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("DESKTOP")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(3)
         }
     }
 
     @ViewBuilder
-    private func field(_ label: String, text: Binding<String>, placeholder: String, secure: Bool = false) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label.uppercased())
+    private var discoveredServersRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("FOUND ON THIS NETWORK")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            Group {
-                if secure {
-                    SecureField(placeholder, text: text)
-                } else {
-                    TextField(placeholder, text: text)
+            LoginFlowLayout(spacing: 6) {
+                ForEach(discovery.servers) { server in
+                    Button {
+                        url = server.url.isEmpty ? server.name : server.url
+                        probe.schedule(url: url)
+                        focusedField = .username
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "wifi")
+                                .font(.system(size: 10, weight: .bold))
+                            Text(server.name)
+                                .font(Theme.font(12, weight: .semibold))
+                                .lineLimit(1)
+                        }
+                        .foregroundStyle(Theme.ink)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Theme.surface)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Use discovered server \(server.name)")
                 }
             }
-            .textFieldStyle(.plain)
-            .font(Theme.font(14, weight: .medium))
-            .foregroundStyle(Theme.ink)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(Theme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Theme.border, lineWidth: 1)
-            )
         }
+    }
+
+    @ViewBuilder
+    private var urlField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("SERVER URL")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            TextField("https://jellyfin.example.com", text: $url)
+                .textFieldStyle(.plain)
+                .font(Theme.font(14, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+                .focused($focusedField, equals: .url)
+                .submitLabel(.next)
+                .onSubmit { focusedField = .username }
+                .accessibilityLabel("Server URL")
+        }
+    }
+
+    @ViewBuilder
+    private var probeResultRow: some View {
+        // Reserve space so the field layout doesn't jump when the row
+        // appears/disappears. Empty text still counts as a 1-line frame.
+        Group {
+            switch probe.state {
+            case .idle:
+                Text(" ")
+                    .font(Theme.font(12, weight: .medium))
+            case .checking:
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.mini)
+                    Text("Checking…")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.teal)
+                }
+            case .ok(let version, let name):
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Theme.teal)
+                    Text(probeOkLabel(version: version, name: name))
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.teal)
+                }
+            case .failed(let message):
+                Text(message)
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.accentHot)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .animation(.easeInOut(duration: 0.15), value: probeStateKey)
+    }
+
+    @ViewBuilder
+    private var usernameField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("USERNAME")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            TextField("you", text: $username)
+                .textFieldStyle(.plain)
+                .font(Theme.font(14, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+                .focused($focusedField, equals: .username)
+                .submitLabel(.next)
+                .onSubmit { focusedField = .password }
+                .accessibilityLabel("Username")
+        }
+    }
+
+    @ViewBuilder
+    private var passwordField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("PASSWORD")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            SecureField("••••••••", text: $password)
+                .textFieldStyle(.plain)
+                .font(Theme.font(14, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(passwordBorderColor, lineWidth: 1)
+                )
+                .focused($focusedField, equals: .password)
+                .submitLabel(.go)
+                .onSubmit(submit)
+                .modifier(ShakeEffect(animatableData: CGFloat(shakeAttempts)))
+                .animation(.interpolatingSpring(stiffness: 800, damping: 10), value: shakeAttempts)
+                .accessibilityLabel("Password")
+        }
+    }
+
+    @ViewBuilder
+    private var signInButton: some View {
+        Button(action: submit) {
+            HStack(spacing: 8) {
+                if model.isLoggingIn {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(Theme.ink)
+                }
+                Text(model.isLoggingIn ? "Signing in…" : "Sign in")
+                    .font(Theme.font(14, weight: .bold))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 44)
+            .foregroundStyle(Theme.ink)
+            .background(Theme.accent)
+            .clipShape(RoundedRectangle(cornerRadius: 22))
+            .shadow(color: Theme.accent.opacity(0.35), radius: 18, x: 0, y: 10)
+        }
+        .buttonStyle(.plain)
+        .disabled(model.isLoggingIn || !canSubmit)
+        .opacity(canSubmit ? 1 : 0.5)
+        .keyboardShortcut(.defaultAction)
+        .accessibilityLabel("Sign in")
+    }
+
+    // MARK: - Actions
+
+    private func submit() {
+        guard canSubmit, !model.isLoggingIn else { return }
+        let previousError = model.errorMessage
+        Task {
+            await model.login(url: url, username: username, password: password)
+            // `AppModel.login` stuffs `"Login failed: <localized>"` into
+            // `errorMessage` on failure. Treat a 401 specially so we can
+            // shake the password field.
+            if let err = model.errorMessage, err != previousError {
+                if err.contains("401") {
+                    shakeAttempts += 1
+                    // Overwrite the raw server error with a friendlier copy
+                    // so the row under the fields reads cleanly.
+                    model.errorMessage = "Wrong username or password"
+                }
+            }
+        }
+    }
+
+    // MARK: - Derived state
+
+    private var canSubmit: Bool {
+        !url.trimmingCharacters(in: .whitespaces).isEmpty
+            && !username.trimmingCharacters(in: .whitespaces).isEmpty
+            && !password.isEmpty
+    }
+
+    private var loginErrorMessage: String? {
+        if !model.network.isOnline {
+            // The banner at the top already covers offline; skip the inline
+            // row so we don't double up.
+            return nil
+        }
+        if hasSeenRepeatedUnreachable && !model.serverReachability.isServerReachable {
+            if let relative = LastConnectedStore.relativeLastConnected() {
+                return "Last connected \(relative). Trying offline mode."
+            }
+            return "Trying offline mode."
+        }
+        return model.errorMessage
+    }
+
+    private var passwordBorderColor: Color {
+        if let err = model.errorMessage, err == "Wrong username or password" {
+            return Theme.accentHot
+        }
+        return Theme.border
+    }
+
+    /// Collapses the probe state into a small value so `.animation(value:)`
+    /// fires only on meaningful transitions (not every `ok` with an equal
+    /// version).
+    private var probeStateKey: Int {
+        switch probe.state {
+        case .idle: return 0
+        case .checking: return 1
+        case .ok: return 2
+        case .failed: return 3
+        }
+    }
+
+    private func probeOkLabel(version: String, name: String) -> String {
+        let versionLabel = "Jellyfin \(version)"
+        if !name.isEmpty, name != "Jellyfin" {
+            return "\(versionLabel) · \(name)"
+        }
+        return versionLabel
+    }
+}
+
+// MARK: - Helpers
+
+/// Small NSView wrapper that lets the user drag the window by the invisible
+/// bar we place at the top of `LoginView`. The standard macOS behaviour
+/// requires the title bar chrome; hiding the sidebar leaves the top 28pt
+/// region as the only drag surface.
+struct WindowDragHandle: NSViewRepresentable {
+    func makeNSView(context: Context) -> DragView { DragView() }
+    func updateNSView(_ view: DragView, context: Context) {}
+
+    final class DragView: NSView {
+        override var mouseDownCanMoveWindow: Bool { true }
+    }
+}
+
+/// Repeating horizontal shake applied to the password field on 401. Uses
+/// `animatableData` so SwiftUI can interpolate between the discrete
+/// attempt-count values.
+struct ShakeEffect: GeometryEffect {
+    var animatableData: CGFloat = 0
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        let amplitude: CGFloat = 6
+        // Three oscillations across the animation duration gives a visible
+        // but brief shake; clamp the phase to the fractional part so the
+        // effect starts/ends at zero.
+        let phase = animatableData.truncatingRemainder(dividingBy: 1.0)
+        let translationX = amplitude * sin(phase * .pi * 6)
+        return ProjectionTransform(CGAffineTransform(translationX: translationX, y: 0))
+    }
+}
+
+/// Inline banner shown above the login column when the system reports no
+/// network. Narrower and less persistent than the in-app `OfflineBanner`
+/// used inside `MainShell` — login has no sidebar to anchor against.
+struct LoginNetworkBanner: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.danger)
+            Text("No network. Check your connection.")
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.danger.opacity(0.12))
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Theme.danger).frame(width: 3)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// Stylised jellyfish brand mark. Pure SwiftUI (no asset catalog required)
+/// so `macos/` ships the same binary on any machine. Rendered as a glowing
+/// dome with trailing tendrils; the forms are abstract enough to read at
+/// both onboarding (120pt) and login (72pt) sizes.
+struct JellyfishMark: View {
+    let size: CGFloat
+
+    var body: some View {
+        Canvas { ctx, canvasSize in
+            let w = canvasSize.width
+            let h = canvasSize.height
+            let center = CGPoint(x: w / 2, y: h * 0.40)
+            let domeRadius = w * 0.32
+
+            // Soft outer glow.
+            let glowRadius = domeRadius * 1.4
+            let glowRect = CGRect(
+                x: center.x - glowRadius,
+                y: center.y - glowRadius,
+                width: glowRadius * 2,
+                height: glowRadius * 2
+            )
+            ctx.fill(
+                Path(ellipseIn: glowRect),
+                with: .color(Theme.primary.opacity(0.18))
+            )
+
+            // Inner glow.
+            let innerGlowRect = CGRect(
+                x: center.x - domeRadius * 1.1,
+                y: center.y - domeRadius * 1.1,
+                width: domeRadius * 2.2,
+                height: domeRadius * 2.2
+            )
+            ctx.fill(
+                Path(ellipseIn: innerGlowRect),
+                with: .color(Theme.accent.opacity(0.25))
+            )
+
+            // Dome.
+            let domeRect = CGRect(
+                x: center.x - domeRadius,
+                y: center.y - domeRadius * 0.95,
+                width: domeRadius * 2,
+                height: domeRadius * 1.5
+            )
+            let dome = Path { p in
+                p.addArc(
+                    center: center,
+                    radius: domeRadius,
+                    startAngle: .degrees(200),
+                    endAngle: .degrees(340),
+                    clockwise: false
+                )
+                p.addLine(to: CGPoint(x: center.x + domeRadius * 0.95, y: center.y + domeRadius * 0.12))
+                p.addQuadCurve(
+                    to: CGPoint(x: center.x - domeRadius * 0.95, y: center.y + domeRadius * 0.12),
+                    control: CGPoint(x: center.x, y: center.y + domeRadius * 0.55)
+                )
+                p.closeSubpath()
+            }
+            ctx.fill(
+                dome,
+                with: .linearGradient(
+                    Gradient(colors: [Theme.primary, Theme.accent]),
+                    startPoint: CGPoint(x: domeRect.minX, y: domeRect.minY),
+                    endPoint: CGPoint(x: domeRect.maxX, y: domeRect.maxY)
+                )
+            )
+
+            // Tendrils — four wavy tails below the dome.
+            let tendrilCount = 4
+            let tendrilSpacing = (domeRadius * 1.6) / CGFloat(tendrilCount - 1)
+            let tendrilTop = center.y + domeRadius * 0.1
+            let tendrilBottom = center.y + domeRadius * 1.7
+            for i in 0..<tendrilCount {
+                let x = center.x - domeRadius * 0.8 + CGFloat(i) * tendrilSpacing
+                let amp: CGFloat = domeRadius * 0.12 * (i.isMultiple(of: 2) ? 1 : -1)
+                let path = Path { p in
+                    p.move(to: CGPoint(x: x, y: tendrilTop))
+                    p.addCurve(
+                        to: CGPoint(x: x, y: tendrilBottom),
+                        control1: CGPoint(x: x + amp, y: tendrilTop + (tendrilBottom - tendrilTop) * 0.33),
+                        control2: CGPoint(x: x - amp, y: tendrilTop + (tendrilBottom - tendrilTop) * 0.66)
+                    )
+                }
+                ctx.stroke(
+                    path,
+                    with: .linearGradient(
+                        Gradient(colors: [Theme.accent, Theme.primary.opacity(0.4)]),
+                        startPoint: CGPoint(x: x, y: tendrilTop),
+                        endPoint: CGPoint(x: x, y: tendrilBottom)
+                    ),
+                    style: StrokeStyle(lineWidth: domeRadius * 0.10, lineCap: .round)
+                )
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+}
+
+/// Simple wrap-to-next-line layout for the discovered-servers chip row.
+/// SwiftUI's stock `HStack` would clip on narrow columns; this lays each
+/// child out in reading order and wraps when the running width exceeds the
+/// available width. Named `LoginFlowLayout` to avoid collision with the
+/// private `FlowLayout` in `AlbumDetailView.swift`.
+struct LoginFlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? .infinity
+        let rows = layout(subviews: subviews, width: width)
+        guard !rows.isEmpty else { return .zero }
+        let totalHeight = rows.reduce(0) { $0 + $1.height } + spacing * CGFloat(max(rows.count - 1, 0))
+        let fallbackWidth = rows.map(\.width).max() ?? 0
+        return CGSize(
+            width: width.isFinite ? width : fallbackWidth,
+            height: totalHeight
+        )
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = layout(subviews: subviews, width: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for item in row.items {
+                let size = item.sizeThatFits(.unspecified)
+                item.place(at: CGPoint(x: x, y: y), proposal: .unspecified)
+                x += size.width + spacing
+            }
+            y += row.height + spacing
+        }
+    }
+
+    private struct Row {
+        var items: [LayoutSubview] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func layout(subviews: Subviews, width: CGFloat) -> [Row] {
+        var rows: [Row] = [Row()]
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            var row = rows.removeLast()
+            let projected = row.items.isEmpty ? size.width : row.width + spacing + size.width
+            if projected > width, !row.items.isEmpty {
+                rows.append(row)
+                row = Row()
+            }
+            if row.items.isEmpty {
+                row.items = [subview]
+                row.width = size.width
+            } else {
+                row.items.append(subview)
+                row.width += spacing + size.width
+            }
+            row.height = max(row.height, size.height)
+            rows.append(row)
+        }
+        return rows
     }
 }

--- a/macos/Sources/Jellify/Screens/OnboardingView.swift
+++ b/macos/Sources/Jellify/Screens/OnboardingView.swift
@@ -1,0 +1,663 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Three-step first-launch onboarding flow.
+///
+/// 1. **Welcome** (#291) — brand mark, tagline, Get Started CTA.
+/// 2. **Connect Server** (#292) — same fields as login with extended helper
+///    copy and a "Skip, explore offline" escape link.
+/// 3. **First Sync** (#293) — animated progress through artists → albums →
+///    tracks → artwork with a live counter; "Continue to Home" unlocks when
+///    the library crosses an 80% threshold.
+///
+/// The flow exits by either completing a successful login (the last step
+/// flips `hasCompletedOnboarding` once the initial library sync crosses
+/// threshold and bounces the user into `MainShell`) or by tapping the
+/// "Skip, explore offline" link on the connect step (same flag flip, lands
+/// on `LoginView` which becomes the signed-out surface).
+struct OnboardingView: View {
+    @Environment(AppModel.self) private var model
+
+    /// Persisted flag. Set to `true` once the user either completes the
+    /// flow or skips from the connect step. `RootView` reads this via
+    /// `@AppStorage` to decide between showing `OnboardingView` (first
+    /// launch) or `LoginView` (signed out but already onboarded).
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+
+    @State private var step: Step = .welcome
+
+    /// Form state is lifted up here so back/forward between Welcome and
+    /// Connect preserves what the user typed.
+    @State private var url: String = ""
+    @State private var username: String = ""
+    @State private var password: String = ""
+
+    @State private var probe = ServerProbe()
+    @State private var discovery = ServerDiscovery()
+
+    enum Step: Hashable { case welcome, connect, sync }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Theme.bg.ignoresSafeArea()
+            WindowDragHandle()
+                .frame(height: 28)
+                .frame(maxWidth: .infinity)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                content
+                    .frame(width: 460)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            probe.configure(core: model.core)
+        }
+        .animation(.easeInOut(duration: 0.25), value: step)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch step {
+        case .welcome:
+            WelcomeStep(
+                onGetStarted: { step = .connect },
+                onExistingAccount: {
+                    // "I already have an account" skips the hero pitch but
+                    // keeps the connect step — the copy there is still
+                    // useful for returning users who haven't set up this
+                    // machine before.
+                    step = .connect
+                }
+            )
+            .transition(.opacity)
+        case .connect:
+            ConnectStep(
+                url: $url,
+                username: $username,
+                password: $password,
+                probe: probe,
+                discovery: discovery,
+                onBack: { step = .welcome },
+                onContinue: {
+                    // Successful login flips to the sync step; the view
+                    // uses `model.session` as its cue to render progress.
+                    step = .sync
+                },
+                onSkipOffline: {
+                    // Skip-explore-offline: mark the user as onboarded so
+                    // subsequent launches land on LoginView and let them
+                    // poke around the (empty) shell immediately.
+                    hasCompletedOnboarding = true
+                }
+            )
+            .transition(.move(edge: .trailing).combined(with: .opacity))
+        case .sync:
+            FirstSyncStep(
+                onContinue: {
+                    hasCompletedOnboarding = true
+                }
+            )
+            .transition(.move(edge: .trailing).combined(with: .opacity))
+        }
+    }
+}
+
+// MARK: - Welcome step
+
+private struct WelcomeStep: View {
+    let onGetStarted: () -> Void
+    let onExistingAccount: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            JellyfishMark(size: 120)
+                .padding(.bottom, 8)
+
+            Text("Welcome to Jellify")
+                .font(Theme.font(48, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+                .multilineTextAlignment(.center)
+
+            Text("Your music, your server, your rules.")
+                .font(Theme.font(16, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 14) {
+                Button(action: onGetStarted) {
+                    Text("Get started")
+                        .font(Theme.font(14, weight: .bold))
+                        .frame(width: 280, height: 44)
+                        .foregroundStyle(Theme.ink)
+                        .background(Theme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: 22))
+                        .shadow(color: Theme.accent.opacity(0.35), radius: 18, x: 0, y: 10)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityLabel("Get started")
+
+                Button(action: onExistingAccount) {
+                    Text("I already have an account →")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.primary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("I already have an account")
+            }
+            .padding(.top, 16)
+        }
+        .padding(.vertical, 40)
+    }
+}
+
+// MARK: - Connect step
+
+private struct ConnectStep: View {
+    @Environment(AppModel.self) private var model
+
+    @Binding var url: String
+    @Binding var username: String
+    @Binding var password: String
+    let probe: ServerProbe
+    let discovery: ServerDiscovery
+
+    let onBack: () -> Void
+    let onContinue: () -> Void
+    let onSkipOffline: () -> Void
+
+    @FocusState private var focusedField: Field?
+    @State private var shakeAttempts: Int = 0
+
+    private enum Field: Hashable { case url, username, password }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack {
+                BackButton(action: onBack)
+                Spacer()
+                ProgressDots(current: 2, of: 3)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Connect your server")
+                    .font(Theme.font(28, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+                Text("Your Jellyfin URL is the address you use to reach it from a browser.")
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if !discovery.servers.isEmpty {
+                DiscoveredServersChipRow(
+                    servers: discovery.servers,
+                    onPick: { server in
+                        url = server.url.isEmpty ? server.name : server.url
+                        probe.schedule(url: url)
+                        focusedField = .username
+                    }
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                labeledField(
+                    label: "SERVER URL",
+                    placeholder: "https://jellyfin.example.com",
+                    text: $url,
+                    focus: .url,
+                    onSubmit: { focusedField = .username }
+                )
+                ProbeResultRow(state: probe.state)
+
+                labeledField(
+                    label: "USERNAME",
+                    placeholder: "you",
+                    text: $username,
+                    focus: .username,
+                    onSubmit: { focusedField = .password }
+                )
+
+                labeledSecureField(
+                    label: "PASSWORD",
+                    placeholder: "••••••••",
+                    text: $password,
+                    shake: shakeAttempts,
+                    onSubmit: submit
+                )
+
+                if let err = visibleError {
+                    Text(err)
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.accentHot)
+                }
+            }
+
+            Button(action: submit) {
+                HStack(spacing: 8) {
+                    if model.isLoggingIn {
+                        ProgressView().scaleEffect(0.7).tint(Theme.ink)
+                    }
+                    Text(model.isLoggingIn ? "Connecting…" : "Continue")
+                        .font(Theme.font(14, weight: .bold))
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .foregroundStyle(Theme.ink)
+                .background(Theme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: 22))
+                .shadow(color: Theme.accent.opacity(0.35), radius: 18, x: 0, y: 10)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSubmit || model.isLoggingIn)
+            .opacity(canSubmit ? 1 : 0.5)
+            .keyboardShortcut(.defaultAction)
+
+            Button(action: onSkipOffline) {
+                Text("Skip, explore offline →")
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.vertical, 40)
+        .onAppear {
+            discovery.start()
+            focusedField = url.isEmpty ? .url : .username
+        }
+        .onDisappear {
+            discovery.stop()
+        }
+        .onChange(of: url) { _, newValue in
+            if newValue.isEmpty {
+                probe.reset()
+            } else {
+                probe.schedule(url: newValue)
+            }
+        }
+        .onChange(of: model.session != nil) { _, signedIn in
+            if signedIn { onContinue() }
+        }
+    }
+
+    private var canSubmit: Bool {
+        !url.trimmingCharacters(in: .whitespaces).isEmpty
+            && !username.trimmingCharacters(in: .whitespaces).isEmpty
+            && !password.isEmpty
+    }
+
+    private var visibleError: String? {
+        guard let err = model.errorMessage else { return nil }
+        if err.contains("401") {
+            return "Wrong username or password"
+        }
+        return err
+    }
+
+    private func submit() {
+        guard canSubmit, !model.isLoggingIn else { return }
+        let previous = model.errorMessage
+        Task {
+            await model.login(url: url, username: username, password: password)
+            if let err = model.errorMessage, err != previous, err.contains("401") {
+                shakeAttempts += 1
+                model.errorMessage = "Wrong username or password"
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func labeledField(
+        label: String,
+        placeholder: String,
+        text: Binding<String>,
+        focus: Field,
+        onSubmit: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(Theme.font(14, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+                .focused($focusedField, equals: focus)
+                .submitLabel(.next)
+                .onSubmit(onSubmit)
+        }
+    }
+
+    @ViewBuilder
+    private func labeledSecureField(
+        label: String,
+        placeholder: String,
+        text: Binding<String>,
+        shake: Int,
+        onSubmit: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            SecureField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(Theme.font(14, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+                .focused($focusedField, equals: .password)
+                .submitLabel(.go)
+                .onSubmit(onSubmit)
+                .modifier(ShakeEffect(animatableData: CGFloat(shake)))
+                .animation(.interpolatingSpring(stiffness: 800, damping: 10), value: shake)
+        }
+    }
+}
+
+// MARK: - First sync step
+
+private struct FirstSyncStep: View {
+    @Environment(AppModel.self) private var model
+    let onContinue: () -> Void
+
+    /// Nominal 0…1 progress derived from which library lists have started
+    /// populating. `refreshLibrary` fans out artist / album / track calls in
+    /// parallel, so this animates through the phases in order even when the
+    /// server answers fast.
+    @State private var animatedProgress: Double = 0.0
+
+    /// Current animated phase. Drives the "Loading artists… / albums… /
+    /// tracks… / artwork…" copy line.
+    @State private var phase: SyncPhase = .artists
+
+    enum SyncPhase: Int, CaseIterable {
+        case artists, albums, tracks, artwork
+
+        var label: String {
+            switch self {
+            case .artists: return "Loading artists…"
+            case .albums: return "Loading albums…"
+            case .tracks: return "Loading tracks…"
+            case .artwork: return "Fetching artwork…"
+            }
+        }
+    }
+
+    /// Progress crosses 0.8 = CTA unlocks. Matches the spec: "Continue to
+    /// Home button activates when sync crosses 80%." Once activated, the
+    /// computed library-percent or the animation whichever is further keeps
+    /// the bar in sync while the user is deciding.
+    private var isReady: Bool {
+        displayProgress >= 0.8
+    }
+
+    private var displayProgress: Double {
+        max(animatedProgress, librarySyncRatio)
+    }
+
+    /// Fraction of the library we actually have locally so far. This grows
+    /// as `refreshLibrary` populates `albums`, `artists`, and `tracks`
+    /// arrays on `AppModel`. When the server-reported totals are all zero
+    /// (e.g. on a brand-new server) we still let the animation tick so the
+    /// progress bar doesn't sit at 0.
+    private var librarySyncRatio: Double {
+        let known = Double(model.albums.count + model.artists.count + model.tracks.count)
+        let total = Double(Int(model.albumsTotal) + Int(model.artistsTotal) + Int(model.tracksTotal))
+        guard total > 0 else { return 0 }
+        return min(1.0, known / total)
+    }
+
+    var body: some View {
+        VStack(spacing: 28) {
+            HStack {
+                Spacer()
+                ProgressDots(current: 3, of: 3)
+            }
+
+            VStack(spacing: 8) {
+                JellyfishMark(size: 72)
+                Text("Loading your library")
+                    .font(Theme.font(28, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+            }
+
+            // Animated progress bar.
+            VStack(alignment: .leading, spacing: 10) {
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Theme.surface)
+                            .frame(height: 6)
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(LinearGradient(
+                                colors: [Theme.accent, Theme.primary],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            ))
+                            .frame(width: geo.size.width * displayProgress, height: 6)
+                    }
+                }
+                .frame(height: 6)
+
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.mini)
+                    Text(phase.label)
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.teal)
+                    Spacer()
+                    Text(counterLabel)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .monospacedDigit()
+                }
+            }
+
+            Button(action: onContinue) {
+                Text(isReady ? "Continue to Home" : "Syncing…")
+                    .font(Theme.font(14, weight: .bold))
+                    .frame(width: 280, height: 44)
+                    .foregroundStyle(Theme.ink)
+                    .background(isReady ? Theme.accent : Theme.surface2)
+                    .clipShape(RoundedRectangle(cornerRadius: 22))
+                    .shadow(
+                        color: Theme.accent.opacity(isReady ? 0.35 : 0),
+                        radius: 18, x: 0, y: 10
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!isReady)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Continue to Home")
+        }
+        .padding(.vertical, 40)
+        .onAppear {
+            startProgressAnimation()
+            // `ConnectStep.submit` calls `model.login`, which already kicks
+            // off `refreshLibrary`. If we got here via `onChange` of
+            // `model.session`, the library fetch is likely already in
+            // flight. No extra call needed — `librarySyncRatio` will tick
+            // up as the arrays populate.
+        }
+    }
+
+    /// Server-reported total across the three lists we care about. Same
+    /// signal as the counter row but rolled into a single display number
+    /// used in the CTA readiness check.
+    private var counterLabel: String {
+        // Prefer server totals when available — the counter reads as
+        // "4,208 tracks · 312 artists · 586 albums" per the spec. Falls
+        // back to local counts during the animation when the library
+        // totals haven't landed yet.
+        let tracks = max(Int(model.tracksTotal), model.tracks.count)
+        let artists = max(Int(model.artistsTotal), model.artists.count)
+        let albums = max(Int(model.albumsTotal), model.albums.count)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        let t = formatter.string(from: NSNumber(value: tracks)) ?? "\(tracks)"
+        let a = formatter.string(from: NSNumber(value: artists)) ?? "\(artists)"
+        let al = formatter.string(from: NSNumber(value: albums)) ?? "\(albums)"
+        return "\(t) tracks · \(a) artists · \(al) albums"
+    }
+
+    /// Drives `animatedProgress` and `phase` forward on a 250ms tick so
+    /// the bar doesn't sit still on a slow network. Caps at 0.85 so the
+    /// remaining 15% is reserved for the real library sync to push across
+    /// the finish line; if the real sync beats the animation (fast server,
+    /// small library) `displayProgress` jumps to `librarySyncRatio` and the
+    /// CTA unlocks immediately.
+    private func startProgressAnimation() {
+        Task { @MainActor in
+            let phases = SyncPhase.allCases
+            // Aim for a total animation of ~6s through the four phases if
+            // the server never answers; that's long enough that a typical
+            // library fetch wins and short enough that a pathological
+            // server doesn't frustrate the user.
+            let phaseDuration: Double = 1.5
+            for (i, next) in phases.enumerated() {
+                phase = next
+                let start = animatedProgress
+                let end = min(0.85, Double(i + 1) / Double(phases.count) * 0.85)
+                let steps = 15
+                for s in 0..<steps {
+                    try? await Task.sleep(nanoseconds: UInt64(phaseDuration / Double(steps) * 1_000_000_000))
+                    let t = Double(s + 1) / Double(steps)
+                    withAnimation(.linear(duration: 0.1)) {
+                        animatedProgress = start + (end - start) * t
+                    }
+                    if isReady { return }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Building blocks
+
+private struct ProgressDots: View {
+    let current: Int
+    let of: Int
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<of, id: \.self) { i in
+                Circle()
+                    .fill(i < current ? Theme.accent : Theme.border)
+                    .frame(width: 6, height: 6)
+            }
+        }
+    }
+}
+
+private struct BackButton: View {
+    let action: () -> Void
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 12, weight: .bold))
+                Text("Back")
+                    .font(Theme.font(12, weight: .semibold))
+            }
+            .foregroundStyle(Theme.ink3)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Back")
+    }
+}
+
+private struct ProbeResultRow: View {
+    let state: ServerProbeState
+    var body: some View {
+        Group {
+            switch state {
+            case .idle:
+                Text(" ").font(Theme.font(12, weight: .medium))
+            case .checking:
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.mini)
+                    Text("Checking…")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.teal)
+                }
+            case .ok(let version, let name):
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Theme.teal)
+                    Text(label(version: version, name: name))
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.teal)
+                }
+            case .failed(let message):
+                Text(message)
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.accentHot)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func label(version: String, name: String) -> String {
+        if !name.isEmpty, name != "Jellyfin" {
+            return "Jellyfin \(version) · \(name)"
+        }
+        return "Jellyfin \(version)"
+    }
+}
+
+private struct DiscoveredServersChipRow: View {
+    let servers: [DiscoveredServer]
+    let onPick: (DiscoveredServer) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("FOUND ON THIS NETWORK")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            LoginFlowLayout(spacing: 6) {
+                ForEach(servers) { server in
+                    Button {
+                        onPick(server)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "wifi")
+                                .font(.system(size: 10, weight: .bold))
+                            Text(server.name)
+                                .font(Theme.font(12, weight: .semibold))
+                                .lineLimit(1)
+                        }
+                        .foregroundStyle(Theme.ink)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Theme.surface)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/Jellify/ServerReachability.swift
+++ b/macos/Sources/Jellify/ServerReachability.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Observation
 @preconcurrency import JellifyCore
 
@@ -49,10 +50,13 @@ final class ServerReachability {
 
     /// Record a successful server interaction. Clears the failure window and
     /// restores reachability immediately — a single good response is strong
-    /// evidence the endpoint is healthy again.
+    /// evidence the endpoint is healthy again. Also stamps
+    /// `LastConnectedStore` so the login screen can fall back on a
+    /// "last connected {date}" hint after repeated failures (see #203).
     func noteSuccess() {
         recentFailures.removeAll(keepingCapacity: true)
         if !isServerReachable { isServerReachable = true }
+        LastConnectedStore.noteSuccess()
     }
 
     /// Reset to the optimistic state. Used by the Retry CTA so the banner
@@ -99,5 +103,268 @@ final class ServerReachability {
         let statusToken = tail.prefix { !$0.isWhitespace }
         guard let status = Int(statusToken) else { return false }
         return (500...599).contains(status)
+    }
+}
+
+// MARK: - Server discovery (Bonjour / mDNS)
+
+/// A Jellyfin server discovered on the local network via Bonjour (mDNS).
+///
+/// Populated from `_jellyfin._tcp` advertisements — each resolved service
+/// becomes one `DiscoveredServer` carrying a display name (the NetService
+/// name) and a URL built from the resolved host + port. Advertised services
+/// without a usable address are skipped, so consumers can render the array
+/// directly without extra filtering.
+struct DiscoveredServer: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let url: String
+}
+
+/// Browses the local network for Jellyfin servers advertising over Bonjour.
+///
+/// Jellyfin's self-hosting docs recommend advertising the server's HTTP
+/// endpoint under the `_jellyfin._tcp` service type; this browser subscribes
+/// to that type and publishes resolved results as `DiscoveredServer`s on the
+/// main actor. Results are cached for the session — `start()` is idempotent,
+/// and the browser stays live while the login/onboarding flow is on screen
+/// so late-arriving advertisements still appear.
+///
+/// Uses `NWBrowser` (Network.framework) instead of the older `NetService` API
+/// because `NWBrowser` delivers change sets on a dispatch queue and handles
+/// add/remove transitions explicitly — which keeps the published `servers`
+/// array stable even when the mDNS responder reflows (e.g. on Wi-Fi
+/// transitions).
+@Observable
+@MainActor
+final class ServerDiscovery {
+    /// All currently-visible Jellyfin servers on the LAN. Sorted by name for
+    /// a stable dropdown order. Empty until `start()` completes its first
+    /// browse result; consumers check `.isEmpty` to decide whether to render
+    /// the dropdown at all.
+    private(set) var servers: [DiscoveredServer] = []
+
+    private var browser: NWBrowser?
+    private let queue = DispatchQueue(label: "com.jellify.server-discovery")
+
+    /// Start browsing for `_jellyfin._tcp` advertisements. Idempotent — a
+    /// second call is a no-op when a browse is already in flight. Safe to
+    /// call from `.onAppear`; the view doesn't need to stash a handle.
+    func start() {
+        guard browser == nil else { return }
+        let params = NWParameters()
+        params.includePeerToPeer = false
+        let descriptor = NWBrowser.Descriptor.bonjour(type: "_jellyfin._tcp", domain: nil)
+        let browser = NWBrowser(for: descriptor, using: params)
+        self.browser = browser
+
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            Task { @MainActor in
+                self?.apply(results: results)
+            }
+        }
+        browser.start(queue: queue)
+    }
+
+    /// Stop the browser and clear the published list. Called from
+    /// `.onDisappear` so a login/onboarding session that outlives the view
+    /// doesn't keep the radio active.
+    func stop() {
+        browser?.cancel()
+        browser = nil
+        servers = []
+    }
+
+    private func apply(results: Set<NWBrowser.Result>) {
+        var collected: [DiscoveredServer] = []
+        for result in results {
+            let (name, seedURL) = extract(result: result)
+            guard !name.isEmpty else { continue }
+            collected.append(
+                DiscoveredServer(id: name, name: name, url: seedURL)
+            )
+        }
+        servers = collected
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Pull a friendly name + best-effort URL out of an `NWBrowser.Result`.
+    ///
+    /// Bonjour browses deliver `.service` endpoints until the consumer
+    /// resolves them by opening a connection. We skip the resolve step
+    /// (the login form immediately probes the URL with the core anyway)
+    /// and synthesise a `.local` URL using the service name plus the port
+    /// advertised in the TXT record if available, else Jellyfin's stock
+    /// 8096. Users can always edit the URL field before submit.
+    private func extract(result: NWBrowser.Result) -> (name: String, seedURL: String) {
+        let name: String
+        switch result.endpoint {
+        case .service(let serviceName, _, _, _):
+            name = serviceName
+        case .hostPort(let host, _):
+            name = hostString(from: host)
+        default:
+            name = ""
+        }
+        // TXT record may carry an explicit port; Jellyfin servers advertised
+        // via the standard `_jellyfin._tcp` service type default to 8096.
+        var port: UInt16 = 8096
+        if case let .bonjour(txt) = result.metadata {
+            if let advertised = txt.dictionary["port"], let p = UInt16(advertised) {
+                port = p
+            }
+        }
+        let scheme = (port == 443) ? "https" : "http"
+        let host = "\(name).local"
+        let seedURL = name.isEmpty ? "" : "\(scheme)://\(host):\(port)"
+        return (name, seedURL)
+    }
+
+    private func hostString(from host: NWEndpoint.Host) -> String {
+        switch host {
+        case .name(let s, _):
+            return s
+        case .ipv4(let addr):
+            return "\(addr)"
+        case .ipv6(let addr):
+            return "\(addr)"
+        @unknown default:
+            return ""
+        }
+    }
+}
+
+// MARK: - Server URL probe (inline validation)
+
+/// Outcome of a `ServerProbe` run. `.idle` is the initial state before the
+/// user has typed a URL that looks submittable; `.checking` drives the
+/// "Checking…" affordance; `.ok` carries the server version/name for the
+/// success row; `.failed` carries a user-facing message for the error row.
+enum ServerProbeState: Equatable {
+    case idle
+    case checking
+    case ok(version: String, name: String)
+    case failed(message: String)
+}
+
+/// Debounces server URL validation against `core.probeServer`.
+///
+/// The login and onboarding forms both want "start typing → wait ~400ms after
+/// the user stops → probe the server → surface version or error" behaviour.
+/// Rather than build that debounce inline in each view, this observable owns
+/// the cancellation loop and publishes a single `state` the view binds to.
+/// A single call to `schedule(url:)` cancels any in-flight probe and kicks
+/// off a fresh one after the debounce window.
+///
+/// The probe runs on a detached Task at `userInitiated`, so even a slow
+/// server doesn't block the main actor while typing.
+@Observable
+@MainActor
+final class ServerProbe {
+    /// Current state. `.idle` until `schedule` fires the first real probe.
+    private(set) var state: ServerProbeState = .idle
+
+    /// Debounce window after the last keystroke before hitting the server.
+    /// 400ms matches the issue spec — long enough to avoid probing on every
+    /// character of a paste, short enough that the user sees feedback within
+    /// ~1s of pausing.
+    private let debounceNanos: UInt64 = 400_000_000
+
+    private var task: Task<Void, Never>?
+    private weak var core: JellifyCore?
+
+    func configure(core: JellifyCore) {
+        self.core = core
+    }
+
+    /// Schedule a probe for the given URL. Cancels any pending probe.
+    /// When the URL doesn't look like a submittable address (no scheme or no
+    /// host yet), the state is reset to `.idle` instead of probing — that way
+    /// the "Checking…" row doesn't flash on the first few keystrokes.
+    func schedule(url: String) {
+        task?.cancel()
+        let trimmed = url.trimmingCharacters(in: .whitespaces)
+        guard ServerProbe.looksSubmittable(trimmed) else {
+            state = .idle
+            return
+        }
+        let core = self.core
+        task = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: self?.debounceNanos ?? 400_000_000)
+            if Task.isCancelled { return }
+            await MainActor.run { self?.state = .checking }
+            guard let core else {
+                await MainActor.run {
+                    self?.state = .failed(message: "Couldn't reach server")
+                }
+                return
+            }
+            do {
+                let server = try await Task.detached(priority: .userInitiated) {
+                    try core.probeServer(url: trimmed)
+                }.value
+                if Task.isCancelled { return }
+                let version = server.version ?? "unknown"
+                await MainActor.run {
+                    self?.state = .ok(version: version, name: server.name)
+                }
+            } catch {
+                if Task.isCancelled { return }
+                await MainActor.run {
+                    self?.state = .failed(message: "Couldn't reach server")
+                }
+            }
+        }
+    }
+
+    /// Clear the probe state. Called when the URL field is emptied so the
+    /// validation row disappears.
+    func reset() {
+        task?.cancel()
+        state = .idle
+    }
+
+    /// Return `true` when the URL has enough shape to bother probing. We
+    /// accept either an explicit `http(s)://host` or a bare `host[:port]`
+    /// since many Jellyfin users memorise an IP + port, not a full URL.
+    /// The core's `probeServer` normalises either shape internally.
+    static func looksSubmittable(_ url: String) -> Bool {
+        guard !url.isEmpty else { return false }
+        if let parsed = URL(string: url), let host = parsed.host, !host.isEmpty {
+            return true
+        }
+        // Bare "host" or "host:port" — treat a dot or colon followed by
+        // something as enough signal to probe.
+        return url.contains(".") || url.contains(":")
+    }
+}
+
+// MARK: - Last-connected tracking
+
+/// Tiny persisted store for "when did we last successfully reach the server?".
+///
+/// Drives the #203 "Last connected {date}. Trying offline mode." message on
+/// the login screen after repeated unreachable failures. Stored in
+/// `UserDefaults` because it's a UI hint, not a trust-sensitive fact — the
+/// core already owns auth/keychain state.
+enum LastConnectedStore {
+    private static let defaultsKey = "macos.lastSuccessfulServerContact"
+
+    static func noteSuccess(at date: Date = Date()) {
+        UserDefaults.standard.set(date, forKey: defaultsKey)
+    }
+
+    static var lastSuccess: Date? {
+        UserDefaults.standard.object(forKey: defaultsKey) as? Date
+    }
+
+    /// Relative, user-friendly phrase like "3 days ago". Returns `nil` when
+    /// we have no record — callers use that to decide whether to render the
+    /// offline-mode hint at all.
+    static func relativeLastConnected(now: Date = Date()) -> String? {
+        guard let last = lastSuccess else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: last, relativeTo: now)
     }
 }


### PR DESCRIPTION
Closes #111, #200, #201, #203, #291, #292, #293

## Summary
- Three-step onboarding (Welcome → Connect Server → First Sync) shown on first launch; `@AppStorage("hasCompletedOnboarding")` gates it so subsequent signed-out launches go straight to LoginView.
- LoginView rewritten to the new full-window spec: `Theme.bg` background, draggable title bar, centered 420pt column, 120pt Canvas-drawn jellyfish brand mark (no asset catalog additions).
- Shared primitives in `ServerReachability.swift`: `ServerDiscovery` (NWBrowser over `_jellyfin._tcp`), `ServerProbe` (400ms debounced `core.probeServer(url:)` with idle/checking/ok/failed states), and `LastConnectedStore` (relative "last connected" hint after repeated unreachable failures).
- Inline validation shows "Jellyfin vX.Y.Z" on success or "Couldn't reach server" on failure within ~1s of typing. 401 shakes the password field and shows "Wrong username or password". Offline renders a top banner; repeated unreachable flips to "Last connected {date}. Trying offline mode."
- First Sync step animates through artists → albums → tracks → artwork with a live "N tracks · N artists · N albums" counter seeded from `AppModel` totals, unlocks Continue to Home at 80%.

## Test plan
- [x] `./macos/Scripts/build-core.sh && swift build` clean
- [x] `./macos/Scripts/make-bundle.sh` + 5s launch on fresh defaults (onboarding path) — stable
- [x] Second launch with `hasCompletedOnboarding=true` routes straight to LoginView — stable
- [ ] Manual: type an invalid URL → "Couldn't reach server" within ~1s of pausing
- [ ] Manual: type a valid URL → "Jellyfin 10.x.y · ServerName" within ~1s of pausing
- [ ] Manual: submit wrong password → password field shakes, error reads "Wrong username or password"
- [ ] Manual: advertise a second Jellyfin via `_jellyfin._tcp` on the LAN → chip appears above URL field, tap fills the URL
- [ ] Manual: disable Wi-Fi → "No network" banner above the login column
- [ ] Manual: complete onboarding end-to-end, verify First Sync counter updates and Continue to Home unlocks