### PR TITLE
macos: shared empty states + loading skeletons + error toasts

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -182,6 +182,19 @@ final class AppModel {
     /// tracked separately in #440 — this flag only powers the prompt.
     var authExpired: Bool = false
 
+    /// Toggled `true` for a brief window when a track fails to stream, so the
+    /// `PlayerBar` can flash a 10% danger tint as a peripheral-vision cue.
+    /// `StreamErrorToast` is the foreground surface; this flag is the
+    /// subtle accompanying signal (see issue #302).
+    ///
+    /// The toast + flash pair is published here so the reliability wiring
+    /// (`BATCH-21`) can flip it without reaching into view code. `PlayerBar`
+    /// observes the flag via the usual `@Environment(AppModel.self)` channel;
+    /// callers that raise an error should flip this on, then flip it off
+    /// after ~2s (the flash duration). No animation is driven from here — the
+    /// consumer owns the tween.
+    var streamErrorFlash: Bool = false
+
     init() throws {
         let core = try JellifyCore(
             config: CoreConfig(dataDir: "", deviceName: "Jellify macOS")

--- a/macos/Sources/Jellify/Components/EmptyStateView.swift
+++ b/macos/Sources/Jellify/Components/EmptyStateView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+/// Generic, centered empty-state primitive used across the app.
+///
+/// A single component so every "nothing here yet" surface lands with the same
+/// visual weight: a pill-backed SF Symbol illustration, `ink` headline, `ink2`
+/// body copy, and up to two CTAs (primary + secondary). Screens should prefer
+/// the static factory presets on this type — `firstRunNoLibrary`, `noFavorites`,
+/// `noDownloads`, `emptyPlaylist` — so the copy and affordances stay in sync
+/// across Library, Home, Playlists, and Downloads.
+///
+/// This replaces the per-screen one-offs (`EmptyLibraryState`, etc.) going
+/// forward; those will be migrated in the next batch when the screens switch
+/// over. See issues #99, #100, #297, #298, #299.
+///
+/// Design tokens: `surface2` pill around the illustration, `border` stroke,
+/// `ink` headline, `ink2` body copy. Primary CTA is an amethyst pill to match
+/// the player's primary button; secondary CTA is a borderless text button.
+struct EmptyStateView: View {
+    /// SF Symbol name for the illustration glyph.
+    let symbol: String
+    /// Short title — "No music yet", "Empty playlist", etc.
+    let headline: LocalizedStringKey
+    /// Optional descriptive copy below the headline. Use `nil` for surfaces
+    /// that are self-explanatory from the headline alone (e.g. "No favorites
+    /// yet").
+    ///
+    /// Named `bodyText` rather than `body` to avoid shadowing `View.body`.
+    let bodyText: LocalizedStringKey?
+    /// Primary action, rendered as an amethyst pill button. Tuple is
+    /// `(label, handler)`.
+    let primaryCTA: (LocalizedStringKey, () -> Void)?
+    /// Secondary action, rendered below the primary as a borderless text
+    /// button. Tuple is `(label, handler)`.
+    let secondaryCTA: (LocalizedStringKey, () -> Void)?
+
+    /// Matches the task spec: `init(symbol:headline:body:primaryCTA:secondaryCTA:)`.
+    /// Internally stored as `bodyText` so the SwiftUI `body` requirement isn't
+    /// shadowed.
+    init(
+        symbol: String,
+        headline: LocalizedStringKey,
+        body: LocalizedStringKey? = nil,
+        primaryCTA: (LocalizedStringKey, () -> Void)? = nil,
+        secondaryCTA: (LocalizedStringKey, () -> Void)? = nil
+    ) {
+        self.symbol = symbol
+        self.headline = headline
+        self.bodyText = body
+        self.primaryCTA = primaryCTA
+        self.secondaryCTA = secondaryCTA
+    }
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: symbol)
+                .font(.system(size: 44, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+                .frame(width: 112, height: 112)
+                .background(Circle().fill(Theme.surface2))
+                .overlay(Circle().stroke(Theme.border, lineWidth: 1))
+                .accessibilityHidden(true)
+
+            VStack(spacing: 6) {
+                Text(headline)
+                    .font(Theme.font(22, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+                    .multilineTextAlignment(.center)
+
+                if let bodyText {
+                    Text(bodyText)
+                        .font(Theme.font(13, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 420)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            if primaryCTA != nil || secondaryCTA != nil {
+                VStack(spacing: 10) {
+                    if let primaryCTA {
+                        Button(action: primaryCTA.1) {
+                            Text(primaryCTA.0)
+                                .font(Theme.font(13, weight: .bold))
+                                .foregroundStyle(Theme.ink)
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 10)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 22)
+                                        .fill(Theme.primary.opacity(0.2))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 22)
+                                        .stroke(Theme.primary, lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    if let secondaryCTA {
+                        Button(action: secondaryCTA.1) {
+                            Text(secondaryCTA.0)
+                                .font(Theme.font(12, weight: .semibold))
+                                .foregroundStyle(Theme.ink2)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 56)
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Factory presets
+//
+// Each preset pins copy + glyph for a specific canonical empty state. Screens
+// should reach for these first — they exist so the visual language stays
+// consistent across surfaces and so copy changes land in one place. Callers
+// provide the handlers (navigation, refresh, etc.) since this module doesn't
+// own routing.
+
+extension EmptyStateView {
+    /// First-run state for a freshly-logged-in user whose server has no music
+    /// library configured. Matches issue #99. The primary CTA is intended to
+    /// bounce the user into the Jellyfin web admin where libraries are
+    /// configured; `onChangeLibrary` is wired by the caller.
+    static func firstRunNoLibrary(
+        onChangeLibrary: @escaping () -> Void
+    ) -> EmptyStateView {
+        EmptyStateView(
+            symbol: "turntable.circle",
+            headline: "No music yet",
+            body: "Your Jellyfin server doesn't have a music library configured yet. Add one on the server, then come back and refresh.",
+            primaryCTA: ("Change Library", onChangeLibrary)
+        )
+    }
+
+    /// Favorites tab / playlist empty state. Issue #297.
+    static func noFavorites() -> EmptyStateView {
+        EmptyStateView(
+            symbol: "heart",
+            headline: "No favorites yet",
+            body: "Heart a track, album, or artist and it'll show up here."
+        )
+    }
+
+    /// Downloads / Offline tab empty state. Issue #298. The download UX
+    /// itself is tracked separately (#441) — this is just the empty surface
+    /// that tells the user how to get something here.
+    static func noDownloads() -> EmptyStateView {
+        EmptyStateView(
+            symbol: "arrow.down.circle",
+            headline: "Nothing offline yet",
+            body: "Downloaded tracks will appear here and stay playable without a network connection."
+        )
+    }
+
+    /// Empty playlist state. Issue #299. Caller provides the "Add tracks"
+    /// handler when a playlist supports edits; pass `nil` to render the
+    /// read-only variant (e.g. for a smart playlist).
+    static func emptyPlaylist(
+        onAddTracks: (() -> Void)? = nil
+    ) -> EmptyStateView {
+        EmptyStateView(
+            symbol: "music.note.list",
+            headline: "Empty playlist",
+            body: "This playlist doesn't have any tracks yet.",
+            primaryCTA: onAddTracks.map { ("Add Tracks", $0) }
+        )
+    }
+}
+
+#Preview("First run — no library") {
+    EmptyStateView.firstRunNoLibrary(onChangeLibrary: {})
+        .frame(width: 720, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("No favorites") {
+    EmptyStateView.noFavorites()
+        .frame(width: 720, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("No downloads") {
+    EmptyStateView.noDownloads()
+        .frame(width: 720, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Empty playlist — editable") {
+    EmptyStateView.emptyPlaylist(onAddTracks: {})
+        .frame(width: 720, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Empty playlist — read-only") {
+    EmptyStateView.emptyPlaylist()
+        .frame(width: 720, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Custom with primary + secondary") {
+    EmptyStateView(
+        symbol: "sparkles",
+        headline: "Nothing to show",
+        body: "Try refreshing, or head back to the library.",
+        primaryCTA: ("Refresh", {}),
+        secondaryCTA: ("Go to Library", {})
+    )
+    .frame(width: 720, height: 480)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Components/LoadingSkeleton.swift
+++ b/macos/Sources/Jellify/Components/LoadingSkeleton.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+/// Skeleton placeholders for in-flight library/track/artist fetches.
+///
+/// Issue #100 / #102. Three canonical shapes — `albumTile`, `artistTile`,
+/// `trackRow` — match the real components they stand in for so first-paint
+/// layout stays stable when data arrives. A 200ms linear-gradient shimmer
+/// sweeps the base rectangle; `@Environment(\.accessibilityReduceMotion)` is
+/// honored — the shimmer is replaced with a static fill when the system
+/// preference is on.
+///
+/// ## Usage note — crossfade to real content
+///
+/// When the caller swaps the skeleton for real content, wrap the swap in a
+/// 120ms crossfade so the transition doesn't feel like a jump-cut:
+///
+/// ```swift
+/// Group {
+///     if isLoading {
+///         LoadingSkeleton(shape: .albumTile)
+///     } else {
+///         AlbumCard(album: album)
+///     }
+/// }
+/// .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isLoading)
+/// ```
+///
+/// The 120ms duration matches the hover-reveal timing used elsewhere in the
+/// app (`AlbumCard`, `TrackListRow`) so all "state change" motion feels
+/// coherent. Respect `reduceMotion` at the call site as shown above — passing
+/// `nil` to `.animation` disables the crossfade entirely for that preference.
+struct LoadingSkeleton: View {
+    /// Predefined sizes matching the real components the skeleton stands in
+    /// for. Keep these synced with the components below:
+    /// - `albumTile`  → `AlbumCard` square artwork (180pt)
+    /// - `artistTile` → `ArtistCard` artwork rendered as a circle (140pt)
+    /// - `trackRow`   → `TrackListRow` / `TrackRow` (full width × 56pt)
+    enum Shape {
+        case albumTile
+        case artistTile
+        case trackRow
+    }
+
+    let shape: Shape
+
+    init(shape: Shape) {
+        self.shape = shape
+    }
+
+    var body: some View {
+        switch shape {
+        case .albumTile:
+            ShimmerRect(cornerRadius: 8)
+                .frame(width: 180, height: 180)
+        case .artistTile:
+            ShimmerCircle()
+                .frame(width: 140, height: 140)
+        case .trackRow:
+            ShimmerRect(cornerRadius: 6)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+        }
+    }
+}
+
+// MARK: - Shimmer primitives
+//
+// Both primitives share the same shimmer recipe: a base `surface2` fill with a
+// brighter diagonal gradient band sweeping from leading to trailing over
+// 200ms. The band is clipped to the container shape so the artist skeleton
+// shimmers as a circle and the tile/row skeletons shimmer within rounded
+// rectangles. `reduceMotion` short-circuits the sweep to a static fill.
+
+/// Rounded-rectangle shimmer base. Used for album tiles and track rows.
+private struct ShimmerRect: View {
+    let cornerRadius: CGFloat
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(Theme.surface2)
+            .overlay {
+                if !reduceMotion {
+                    ShimmerBand()
+                        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+                }
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+/// Circular shimmer base. Used for artist tiles.
+private struct ShimmerCircle: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Circle()
+            .fill(Theme.surface2)
+            .overlay {
+                if !reduceMotion {
+                    ShimmerBand()
+                        .clipShape(Circle())
+                }
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+/// Diagonal gradient band that sweeps across its parent every 200ms.
+///
+/// Drawn as a stretched `LinearGradient` that we translate along the x-axis
+/// from `-width` to `+width` on a 0.2s linear loop. The gradient fades
+/// symmetrically so the highlight reads as a single pass rather than a
+/// flashing edge. The band is sized 2× parent width so the highlight fully
+/// exits the frame before the animation wraps.
+private struct ShimmerBand: View {
+    @State private var phase: CGFloat = -1
+
+    var body: some View {
+        GeometryReader { geom in
+            let width = geom.size.width
+            let band = width * 2
+            LinearGradient(
+                stops: [
+                    .init(color: .clear, location: 0.0),
+                    .init(color: Color.white.opacity(0.08), location: 0.45),
+                    .init(color: Color.white.opacity(0.16), location: 0.5),
+                    .init(color: Color.white.opacity(0.08), location: 0.55),
+                    .init(color: .clear, location: 1.0),
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: band, height: geom.size.height)
+            .offset(x: phase * width)
+            .onAppear {
+                withAnimation(.linear(duration: 0.2).repeatForever(autoreverses: false)) {
+                    phase = 1.5
+                }
+            }
+        }
+    }
+}
+
+#Preview("Album tile skeleton") {
+    LoadingSkeleton(shape: .albumTile)
+        .padding(24)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Artist tile skeleton") {
+    LoadingSkeleton(shape: .artistTile)
+        .padding(24)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Track row skeleton") {
+    LoadingSkeleton(shape: .trackRow)
+        .padding(.horizontal, 24)
+        .frame(width: 640)
+        .padding(.vertical, 24)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Mixed — library first paint") {
+    VStack(spacing: 24) {
+        HStack(spacing: 16) {
+            LoadingSkeleton(shape: .albumTile)
+            LoadingSkeleton(shape: .albumTile)
+            LoadingSkeleton(shape: .albumTile)
+        }
+        HStack(spacing: 16) {
+            LoadingSkeleton(shape: .artistTile)
+            LoadingSkeleton(shape: .artistTile)
+            LoadingSkeleton(shape: .artistTile)
+        }
+        VStack(spacing: 8) {
+            LoadingSkeleton(shape: .trackRow)
+            LoadingSkeleton(shape: .trackRow)
+            LoadingSkeleton(shape: .trackRow)
+        }
+    }
+    .padding(32)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Components/OfflineBanner.swift
+++ b/macos/Sources/Jellify/Components/OfflineBanner.swift
@@ -6,10 +6,32 @@ import SwiftUI
 /// border, and a `Retry` action that re-evaluates network state and refetches
 /// the library via `AppModel`. The banner hides automatically when
 /// connectivity returns (debounced by `NetworkMonitor`).
+///
+/// ## Variants
+///
+/// - **Default** — `OfflineBanner(onRetry:)` renders the generic offline
+///   message: "You're offline. Playing from downloaded tracks only."
+/// - **Named server** — `OfflineBanner(host:onRetry:)` renders the
+///   issue-#101 copy: "Can't reach {host}. Trying again…" with the same
+///   Retry action. Use this when the caller knows the configured server
+///   host and wants to thread that into the copy.
 struct OfflineBanner: View {
+    /// Optional server host/URL surfaced in the copy. When `nil`, falls
+    /// back to the generic offline message.
+    let host: String?
     let onRetry: () -> Void
 
-    private let message = "You're offline. Playing from downloaded tracks only."
+    init(host: String? = nil, onRetry: @escaping () -> Void) {
+        self.host = host
+        self.onRetry = onRetry
+    }
+
+    private var message: String {
+        if let host, !host.isEmpty {
+            return "Can't reach \(host). Trying again\u{2026}"
+        }
+        return "You're offline. Playing from downloaded tracks only."
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -59,8 +81,16 @@ struct OfflineBanner: View {
     }
 }
 
-#Preview("Offline banner") {
+#Preview("Offline banner — generic") {
     OfflineBanner(onRetry: {})
+        .frame(width: 720)
+        .padding()
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Offline banner — named server (#101)") {
+    OfflineBanner(host: "jellyfin.example.com", onRetry: {})
         .frame(width: 720)
         .padding()
         .background(Theme.bg)

--- a/macos/Sources/Jellify/Components/ServerUnreachableBanner.swift
+++ b/macos/Sources/Jellify/Components/ServerUnreachableBanner.swift
@@ -11,10 +11,32 @@ import SwiftUI
 /// left border, and a `Retry` action that refetches the library via
 /// `AppModel`. Hides automatically when a subsequent fetch succeeds
 /// (`ServerReachability.noteSuccess`).
+///
+/// ## Variants
+///
+/// - **Default** — `ServerUnreachableBanner(onRetry:)` renders the generic
+///   copy ("Can't reach your server.") for backwards compatibility with the
+///   existing call site in `MainShell`.
+/// - **Named server** — `ServerUnreachableBanner(host:onRetry:)` threads
+///   the configured host (optionally `host:port`) into the copy, matching
+///   issue #101's "Can't reach {server}. Trying again…" design.
 struct ServerUnreachableBanner: View {
+    /// Host (or `host:port`) displayed in the copy. `nil` falls back to the
+    /// generic "your server" wording.
+    let host: String?
     let onRetry: () -> Void
 
-    private let message = "Can't reach your server."
+    init(host: String? = nil, onRetry: @escaping () -> Void) {
+        self.host = host
+        self.onRetry = onRetry
+    }
+
+    private var message: String {
+        if let host, !host.isEmpty {
+            return "Can't reach \(host). Trying again\u{2026}"
+        }
+        return "Can't reach your server."
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -64,8 +86,16 @@ struct ServerUnreachableBanner: View {
     }
 }
 
-#Preview("Server unreachable banner") {
+#Preview("Server unreachable — generic") {
     ServerUnreachableBanner(onRetry: {})
+        .frame(width: 720)
+        .padding()
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Server unreachable — named host") {
+    ServerUnreachableBanner(host: "jellyfin.example.com:8096", onRetry: {})
         .frame(width: 720)
         .padding()
         .background(Theme.bg)

--- a/macos/Sources/Jellify/Components/StreamErrorToast.swift
+++ b/macos/Sources/Jellify/Components/StreamErrorToast.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Foreground toast shown when a track fails to stream and playback has
+/// decided to skip it. The user gets a clear, non-silent acknowledgement —
+/// the toast does *not* dismiss itself by auto-advancing; a `Retry` button
+/// re-attempts the failed track and a `Go to track` button routes to the
+/// track's surface so the user can investigate manually.
+///
+/// Issue #302. The accompanying low-intensity cue (a 10% danger tint flash on
+/// the `PlayerBar`) is driven by `AppModel.streamErrorFlash` — this component
+/// doesn't touch `PlayerBar` directly; that's owned by the reliability
+/// wiring batch (`BATCH-21`). The caller raises both the toast and the flag
+/// together, and lowers the flag after the flash window.
+///
+/// Design tokens: `danger` text/accent, `bgAlt` surface with a `danger` left
+/// border, `ink` primary button, borderless secondary. Sized to sit at the
+/// bottom of the content column, above the `PlayerBar`.
+struct StreamErrorToast: View {
+    /// Track name shown in the copy. Kept plain `String` (not
+    /// `LocalizedStringKey`) because it's user data, not a UI string.
+    let trackName: String
+    /// Called when the user taps `Retry`. Typically re-issues the stream
+    /// request via the audio engine.
+    let onRetry: () -> Void
+    /// Called when the user taps `Go to track`. Typically routes to the
+    /// parent album detail or the track's artist page via `AppModel.screen`.
+    let onGoToTrack: () -> Void
+    /// Called when the user dismisses the toast without acting. Optional —
+    /// if `nil`, the toast renders without a close affordance and the caller
+    /// is expected to dismiss it on its own timer.
+    let onDismiss: (() -> Void)?
+
+    init(
+        trackName: String,
+        onRetry: @escaping () -> Void,
+        onGoToTrack: @escaping () -> Void,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.trackName = trackName
+        self.onRetry = onRetry
+        self.onGoToTrack = onGoToTrack
+        self.onDismiss = onDismiss
+    }
+
+    private var message: String {
+        "\u{201C}\(trackName)\u{201D} couldn't play. Skipping."
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.danger)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 12)
+
+            Button(action: onRetry) {
+                Text("Retry")
+                    .font(Theme.font(12, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Theme.danger.opacity(0.25))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Theme.danger, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Retry playing \(trackName)")
+
+            Button(action: onGoToTrack) {
+                Text("Go to track")
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Go to \(trackName)")
+
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Theme.ink3)
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.bgAlt)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Theme.danger)
+                .frame(width: 3)
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Theme.border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: Color.black.opacity(0.35), radius: 12, y: 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+        .accessibilityAddTraits(.isStaticText)
+    }
+}
+
+#Preview("Stream error toast") {
+    StreamErrorToast(
+        trackName: "Paranoid Android",
+        onRetry: {},
+        onGoToTrack: {},
+        onDismiss: {}
+    )
+    .frame(width: 640)
+    .padding(24)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Stream error toast — long title, no dismiss") {
+    StreamErrorToast(
+        trackName: "A Really Long Track Title That Probably Wraps",
+        onRetry: {},
+        onGoToTrack: {},
+        onDismiss: nil
+    )
+    .frame(width: 480)
+    .padding(24)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
Closes #99, #100, #101, #102, #297, #298, #299, #302