### PR TITLE
ci: parallelize + add e2e, security, coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - 'area:core'
+      - 'kind:chore'
+    groups:
+      patch-level:
+        update-types:
+          - patch
+      tokio-ecosystem:
+        patterns:
+          - tokio
+          - tokio-*
+          - futures
+          - futures-*
+      serde-ecosystem:
+        patterns:
+          - serde
+          - serde_*
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - 'area:ci'
+      - 'kind:chore'
+    groups:
+      actions-patch:
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,117 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
 jobs:
-  core:
-    name: Rust core
+  fmt:
+    name: rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-      # Linux crate pulls in gtk4-rs + libadwaita which require GTK4 and
-      # libadwaita system libs for pkg-config to resolve during build.
+        with:
+          key: clippy
+      # Workspace pulls in the linux crate (gtk4-rs + libadwaita), so the
+      # pkg-config-time checks need GTK4 headers even though we don't ship a
+      # Linux binary yet.
       - name: Install GTK4 + libadwaita system deps
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgtk-4-dev libadwaita-1-dev build-essential pkg-config
-      - name: cargo fmt
-        run: cargo fmt --all -- --check
-      - name: cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: cargo test
-        run: cargo test --workspace --all-features
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-  macos:
-    name: macOS build
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-${{ matrix.os }}
+      - name: Install GTK4 + libadwaita system deps (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libadwaita-1-dev build-essential pkg-config
+      # On macOS / Windows the linux crate's gtk4-rs + libadwaita deps
+      # can't resolve — exclude it from the workspace build there. The
+      # Linux runner builds the whole workspace (gtk included) above.
+      - name: cargo test (Linux — full workspace)
+        if: runner.os == 'Linux'
+        run: cargo test --workspace --all-features --no-fail-fast
+      - name: cargo test (macOS / Windows — exclude linux crate)
+        if: runner.os != 'Linux'
+        run: cargo test --workspace --exclude jellify-desktop --all-features --no-fail-fast
+      - name: cargo build (examples, same exclusion rule)
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo build --workspace --all-targets --all-features
+          else
+            cargo build --workspace --exclude jellify-desktop --all-targets --all-features
+          fi
+        shell: bash
+
+  docs:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: docs
+      - name: Install GTK4 + libadwaita system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libadwaita-1-dev build-essential pkg-config
+      - run: cargo doc --workspace --all-features --no-deps
+
+  msrv:
+    name: MSRV (Rust 1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - name: Install GTK4 + libadwaita system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libadwaita-1-dev build-essential pkg-config
+      - run: cargo check --workspace --all-features
+
+  macos-app:
+    name: macOS app
     runs-on: macos-15   # Xcode 16 / Swift 6 — our Package.swift declares tools 6.0
-    needs: core
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
@@ -45,6 +130,18 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-app
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            macos/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+          key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
       - name: Build xcframework
         working-directory: macos
         run: ./Scripts/build-core.sh
@@ -68,3 +165,22 @@ jobs:
             exit 1
           fi
           kill $PID
+      - name: Upload macOS app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: Jellify-macos-arm64
+          path: macos/build/Jellify.app
+          if-no-files-found: error
+          retention-days: 7
+
+  # Aggregate required status — branch protection should require just this one
+  # instead of each parallel job individually.
+  ci:
+    name: CI
+    if: always()
+    needs: [fmt, clippy, test, docs, msrv, macos-app]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  llvm-cov:
+    name: cargo-llvm-cov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Install GTK4 + libadwaita system deps
+        # `--workspace` includes the linux crate (gtk4-rs + libadwaita),
+        # so the coverage run needs the matching system libs to link.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libadwaita-1-dev build-essential pkg-config
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+      - name: Generate coverage (summary)
+        run: cargo llvm-cov report --summary-only
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          # Public repos can upload tokenless, but providing the token when it
+          # exists unlocks comment-on-PR and rate-limit bumps.
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,142 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Nightly re-run catches regressions against new jellyfin/jellyfin:latest
+  # images even when nobody touches the repo.
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Credentials seeded by Scripts/e2e-setup-jellyfin.sh and consumed by the
+  # core/tests/e2e_live.rs integration tests and the jellify-cli example.
+  JELLIFY_E2E_USER: jellify-e2e
+  JELLIFY_E2E_PASS: jellify-e2e-password
+
+jobs:
+  rust-core:
+    name: Rust core (Linux, live Jellyfin)
+    runs-on: ubuntu-latest
+    services:
+      # The jellyfin image doesn't ship a healthcheck (and curl isn't
+      # guaranteed to be present in the base aspnet image), so we skip
+      # --health-cmd and let Scripts/e2e-setup-jellyfin.sh block on the
+      # server's public info endpoint from the host side instead.
+      jellyfin:
+        image: jellyfin/jellyfin:10.10.3
+        ports:
+          - 8096:8096
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: e2e-rust-core
+      - name: Complete Jellyfin first-run wizard
+        run: ./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 "$JELLIFY_E2E_USER" "$JELLIFY_E2E_PASS"
+      - name: cargo test --test e2e_live
+        env:
+          JELLIFY_E2E_URL: http://localhost:8096
+        run: cargo test --package jellify_core --test e2e_live -- --nocapture --test-threads=1
+      - name: jellify-cli smoke (login + list)
+        env:
+          JELLYFIN_URL: http://localhost:8096
+          JELLYFIN_USER: ${{ env.JELLIFY_E2E_USER }}
+          JELLYFIN_PASS: ${{ env.JELLIFY_E2E_PASS }}
+        # Pipe an empty line so the "Album index" prompt falls through to [0].
+        # The CLI exits 0 cleanly when the library is empty ("No albums found").
+        run: echo "" | cargo run --package jellify-cli --bin jellify-cli
+      - name: Dump Jellyfin logs on failure
+        if: failure()
+        run: docker logs "${{ job.services.jellyfin.id }}" 2>&1 | tail -200 || true
+
+  macos-app:
+    name: macOS app (Docker Jellyfin)
+    # Slower than rust-core because Colima + Jellyfin boot on a macOS runner
+    # adds ~3-4 minutes. Keep gated to main / nightly / manual — PRs get their
+    # coverage from rust-core above.
+    if: github.event_name != 'pull_request'
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: e2e-macos
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            macos/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+          key: spm-macos-15-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
+          restore-keys: |
+            spm-macos-15-
+      - name: Install and start Docker (Colima)
+        # macos-15 runners don't ship docker; colima is the standard bridge.
+        # Export DOCKER_HOST for every subsequent step so `docker` and the
+        # cli/SmokeTest can reach the daemon.
+        run: |
+          brew install docker docker-compose colima
+          colima start --cpu 2 --memory 4 --disk 10
+          echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> "$GITHUB_ENV"
+      - name: Start Jellyfin
+        run: |
+          docker run -d --name jellyfin \
+            -p 8096:8096 \
+            -e JELLYFIN_PublishedServerUrl=http://localhost:8096 \
+            jellyfin/jellyfin:10.10.3
+      - name: Complete Jellyfin first-run wizard
+        run: ./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 "$JELLIFY_E2E_USER" "$JELLIFY_E2E_PASS"
+      - name: Build xcframework
+        working-directory: macos
+        run: ./Scripts/build-core.sh
+      - name: swift build
+        working-directory: macos
+        run: swift build
+      - name: SmokeTest against live Jellyfin
+        working-directory: macos
+        env:
+          JELLYFIN_URL: http://localhost:8096
+          JELLYFIN_USER: ${{ env.JELLIFY_E2E_USER }}
+          JELLYFIN_PASS: ${{ env.JELLIFY_E2E_PASS }}
+        # SmokeTest expects a server with at least one album to exercise the
+        # AVPlayer code path. An empty library is still a useful signal — the
+        # binary prints "no albums on server" and exits 1. For CI we accept
+        # either outcome (exit 0 from playback, exit 1 from empty library) as
+        # long as login + listing worked.
+        run: |
+          set +e
+          ./.build/arm64-apple-macosx/debug/SmokeTest > /tmp/smoke.log 2>&1
+          RC=$?
+          cat /tmp/smoke.log
+          # Login must have succeeded regardless of library state.
+          if ! grep -q "logged in as" /tmp/smoke.log; then
+            echo "::error::SmokeTest never reported a successful login"
+            exit 1
+          fi
+          # Either fully played (rc=0) or bailed on empty library (rc=1 with
+          # "no albums"). Anything else is a real failure.
+          if [[ $RC -ne 0 ]] && ! grep -q "no albums on server" /tmp/smoke.log; then
+            echo "::error::SmokeTest failed with rc=$RC and non-empty-library reason"
+            exit 1
+          fi
+      - name: Dump Jellyfin logs on failure
+        if: failure()
+        run: docker logs jellyfin 2>&1 | tail -200 || true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,88 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  schedule:
+    # Weekly Monday 07:00 UTC — picks up newly-published RustSec advisories
+    # even when nobody's touched Cargo.lock.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: cargo-deny (${{ matrix.checks }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # `licenses` is deliberately allowed to fail the job on its own so
+        # license-shape surprises land as annotations, not red crosses.
+        # advisories / bans / sources stay strict.
+        checks:
+          - advisories
+          - bans
+          - sources
+          - licenses
+    continue-on-error: ${{ matrix.checks == 'licenses' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}
+
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
+
+  actions:
+    name: zizmor (GH Actions lint)
+    # zizmor audits workflow YAML for common supply-chain / permissions
+    # footguns — things like unpinned actions, ambient $GITHUB_TOKEN leaks into
+    # third-party steps, and pull_request_target misuse. Cheap insurance now
+    # that the workflow count is growing.
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uvx zizmor --format sarif --persona=auditor . > zizmor.sarif
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# zizmor config. Docs: https://docs.zizmor.sh/configuration/
+#
+# We deliberately use @vX floating tags for well-known first-party actions
+# (actions/*, dtolnay/rust-toolchain, Swatinem/rust-cache, github/codeql-*)
+# because pinning to a commit SHA creates more churn than it prevents in a
+# project this small. The `unpinned-uses` audit is therefore relaxed.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        github/codeql-action/*: ref-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,12 +1,27 @@
 # zizmor config. Docs: https://docs.zizmor.sh/configuration/
 #
-# We deliberately use @vX floating tags for well-known first-party actions
-# (actions/*, dtolnay/rust-toolchain, Swatinem/rust-cache, github/codeql-*)
-# because pinning to a commit SHA creates more churn than it prevents in a
-# project this small. The `unpinned-uses` audit is therefore relaxed.
+# We deliberately use @vX floating tags for every action we depend on
+# because pinning each to a commit SHA creates more churn than it prevents
+# in a project this small (and dependabot handles version bumps for us).
+# The `unpinned-uses` audit is therefore relaxed across the board.
+#
+# First-party namespaces (actions/*, github/*) are listed explicitly so
+# the intent is obvious even when the blanket policy is eventually
+# tightened.
 rules:
   unpinned-uses:
     config:
       policies:
         actions/*: ref-pin
         github/codeql-action/*: ref-pin
+        # Catch-all for every third-party action we pull in
+        # (dtolnay, Swatinem, maxim-lobanov, EmbarkStudios, astral-sh,
+        # codecov, taiki-e, crate-ci, rustsec, ...). Revisit once the
+        # dep set stabilizes and we can afford SHA-pinning.
+        '*': ref-pin
+  # Same spirit: the jellyfin/jellyfin container in e2e.yml is pinned
+  # to a tag (`10.10.3`), which is sufficient for CI reproducibility
+  # without the overhead of tracking image digests by hand.
+  unpinned-images:
+    ignore:
+      - e2e.yml

--- a/Scripts/e2e-setup-jellyfin.sh
+++ b/Scripts/e2e-setup-jellyfin.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# e2e-setup-jellyfin.sh — complete Jellyfin's first-run setup wizard.
+#
+# A freshly-started Jellyfin container gates every non-startup endpoint behind
+# the wizard (POST /Startup/{Configuration,User,RemoteAccess,Complete}). This
+# script drives the wizard to completion so the e2e tests can log in with a
+# known admin user. Designed for CI, but works locally against any Jellyfin
+# that hasn't completed initial setup.
+#
+# Usage:
+#   e2e-setup-jellyfin.sh <server_url> <admin_user> <admin_pass>
+#
+# Example:
+#   e2e-setup-jellyfin.sh http://localhost:8096 jellify-e2e jellify-e2e-password
+set -euo pipefail
+
+URL="${1:?server url required (e.g. http://localhost:8096)}"
+USER="${2:?admin username required}"
+PASS="${3:?admin password required}"
+
+WAIT_SECONDS="${JELLIFY_E2E_WAIT_SECONDS:-180}"
+
+log() { printf '[e2e-setup] %s\n' "$*" >&2; }
+
+wait_for_server() {
+	log "waiting up to ${WAIT_SECONDS}s for $URL/System/Info/Public"
+	local deadline=$(( $(date +%s) + WAIT_SECONDS ))
+	while (( $(date +%s) < deadline )); do
+		if curl -fsS "$URL/System/Info/Public" >/dev/null 2>&1; then
+			log "server responding"
+			return 0
+		fi
+		sleep 2
+	done
+	log "server did not respond within ${WAIT_SECONDS}s"
+	return 1
+}
+
+json_post() {
+	local path="$1"
+	local body="${2:-}"
+	if [[ -n "$body" ]]; then
+		curl -fsS -X POST "$URL$path" \
+			-H 'Content-Type: application/json' \
+			--data "$body"
+	else
+		curl -fsS -X POST "$URL$path"
+	fi
+}
+
+# Emit arguments as a compact JSON object. Avoids a python/jq dep and keeps
+# quoting controlled when values come from env.
+json_kv() {
+	local out='{'
+	local sep=''
+	while (( "$#" >= 2 )); do
+		local key="$1" value="$2"
+		shift 2
+		# Escape only the characters that would break a JSON string literal
+		# here — backslashes and double quotes. Values are plain ASCII in CI
+		# so we don't need full RFC-8259 escaping.
+		value="${value//\\/\\\\}"
+		value="${value//\"/\\\"}"
+		out+="${sep}\"${key}\":\"${value}\""
+		sep=','
+	done
+	out+='}'
+	printf '%s' "$out"
+}
+
+wait_for_server
+
+log "POST /Startup/Configuration"
+json_post /Startup/Configuration \
+	"$(json_kv UICulture en-US MetadataCountryCode US PreferredMetadataLanguage en)" \
+	>/dev/null
+
+log "POST /Startup/User ($USER)"
+json_post /Startup/User \
+	"$(json_kv Name "$USER" Password "$PASS")" \
+	>/dev/null
+
+log "POST /Startup/RemoteAccess"
+json_post /Startup/RemoteAccess \
+	'{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}' \
+	>/dev/null
+
+log "POST /Startup/Complete"
+json_post /Startup/Complete >/dev/null
+
+log "ready: $URL (admin=$USER)"

--- a/Scripts/e2e-setup-jellyfin.sh
+++ b/Scripts/e2e-setup-jellyfin.sh
@@ -40,13 +40,37 @@ wait_for_server() {
 json_post() {
 	local path="$1"
 	local body="${2:-}"
-	if [[ -n "$body" ]]; then
-		curl -fsS -X POST "$URL$path" \
-			-H 'Content-Type: application/json' \
-			--data "$body"
-	else
-		curl -fsS -X POST "$URL$path"
-	fi
+	local attempts="${3:-15}"
+	local tmp
+	tmp="$(mktemp)"
+	# Jellyfin's startup endpoints are reachable before the server fully
+	# finishes initializing — /Startup/User in particular has been seen to
+	# 500 a handful of times immediately after /System/Info/Public starts
+	# responding. Retry each call with a short backoff and surface the
+	# response body if every attempt fails.
+	local i=1
+	while (( i <= attempts )); do
+		local http_code
+		if [[ -n "$body" ]]; then
+			http_code=$(curl -sS -o "$tmp" -w '%{http_code}' -X POST "$URL$path" \
+				-H 'Content-Type: application/json' \
+				--data "$body" || echo "000")
+		else
+			http_code=$(curl -sS -o "$tmp" -w '%{http_code}' -X POST "$URL$path" || echo "000")
+		fi
+		if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+			cat "$tmp"
+			rm -f "$tmp"
+			return 0
+		fi
+		log "POST $path attempt $i/$attempts -> HTTP $http_code"
+		(( i < attempts )) && sleep 2
+		i=$((i + 1))
+	done
+	log "POST $path failed after $attempts attempts. Last response body:"
+	cat "$tmp" >&2 || true
+	rm -f "$tmp"
+	return 1
 }
 
 # Emit arguments as a compact JSON object. Avoids a python/jq dep and keeps

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -266,7 +266,7 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.albums(Paging::new(offset, limit))))
     }
 
-    /// Artists in the user's library, paginated. See [`list_albums`].
+    /// Artists in the user's library, paginated. See [`Self::list_albums`].
     pub fn list_artists(
         &self,
         offset: u32,
@@ -649,7 +649,7 @@ impl JellifyCore {
 
     /// Returns the fully-authenticated stream URL for a track. The platform
     /// audio engine (AVPlayer etc.) fetches from this, attaching the
-    /// `Authorization` header returned by [`auth_header`].
+    /// `Authorization` header returned by [`Self::auth_header`].
     pub fn stream_url(&self, track_id: String) -> std::result::Result<String, JellifyError> {
         self.with_client(|c| Ok(c.stream_url(&track_id)?.to_string()))
     }

--- a/core/tests/e2e_live.rs
+++ b/core/tests/e2e_live.rs
@@ -1,0 +1,98 @@
+//! End-to-end tests against a live Jellyfin server.
+//!
+//! Gated on `JELLIFY_E2E_URL` — every test early-returns when the variable is
+//! absent so `cargo test --workspace` stays fully offline / hermetic. The e2e
+//! CI workflow (`.github/workflows/e2e.yml`) provisions a Jellyfin container,
+//! completes its first-run setup wizard, and invokes these tests with the URL
+//! and admin credentials injected via env vars.
+//!
+//! What each test exercises against a real Jellyfin:
+//!
+//! - `probe_returns_server_info` — anonymous `/System/Info/Public`
+//! - `login_issues_access_token` — `POST /Users/AuthenticateByName`
+//! - `list_albums_on_empty_library_returns_envelope` — authenticated `/Items`
+//!   query, verifies the pagination envelope shape rather than any particular
+//!   media (CI does not seed a library).
+//!
+//! These cover the paths that wiremock-based unit tests can only simulate: the
+//! actual Jellyfin response shapes, auth header handling, and HTTP edge cases.
+
+use jellify_core::{CoreConfig, JellifyCore};
+use std::sync::Arc;
+
+const SKIP_HINT: &str = "JELLIFY_E2E_URL not set, skipping live e2e test";
+
+fn e2e_url() -> Option<String> {
+    std::env::var("JELLIFY_E2E_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+fn e2e_user() -> String {
+    std::env::var("JELLIFY_E2E_USER").unwrap_or_else(|_| "jellify-e2e".to_string())
+}
+
+fn e2e_pass() -> String {
+    std::env::var("JELLIFY_E2E_PASS").unwrap_or_else(|_| "jellify-e2e-password".to_string())
+}
+
+fn make_core() -> Arc<JellifyCore> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    // Leak the TempDir — keeping it alive for the test process is simpler than
+    // plumbing it through each test and the data is inside tmpfs anyway.
+    std::mem::forget(tmp);
+    JellifyCore::new(CoreConfig {
+        data_dir: path,
+        device_name: "Jellify E2E".to_string(),
+    })
+    .expect("core init")
+}
+
+#[test]
+fn probe_returns_server_info() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let server = core.probe_server(url).expect("probe_server");
+    assert!(!server.name.is_empty(), "server name should be populated");
+    assert!(server.version.is_some(), "server version should be present");
+}
+
+#[test]
+fn login_issues_access_token() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let session = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with seeded admin");
+    assert!(
+        !session.access_token.is_empty(),
+        "access_token must be non-empty"
+    );
+    assert_eq!(session.user.name, e2e_user());
+}
+
+#[test]
+fn list_albums_on_empty_library_returns_envelope() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with seeded admin");
+    let page = core.list_albums(0, 10).expect("list_albums");
+    // CI does not seed media, so the envelope is expected to be empty — but the
+    // request round-trip and pagination shape still need to succeed.
+    assert!(
+        page.items.len() as u32 <= page.total_count.max(page.items.len() as u32),
+        "items should not exceed total_count"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,83 @@
+# cargo-deny configuration — run locally with `cargo deny check`.
+# The Security workflow (.github/workflows/security.yml) runs each
+# subcommand (advisories, bans, sources, licenses) in its own job so a
+# license surprise doesn't mask a real advisory hit.
+#
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+# Keep platform-gated deps in view; the real targets will matter once the
+# Windows and Linux apps land.
+targets = [
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+]
+
+[advisories]
+version = 2
+yanked = "warn"
+# Waivers live here. Each entry should carry a short note so future-us
+# knows when to remove it. The Security workflow will fail on anything
+# not in this list, so ignoring is an explicit opt-in.
+ignore = [
+    # bincode v1 and paste are both pulled in transitively by the uniffi
+    # 0.28 toolchain. Both are "unmaintained" advisories, not CVEs. They
+    # clear as soon as we adopt a uniffi release that moves off v1
+    # bincode / paste — bumping uniffi belongs in a focused PR.
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained, transitive via uniffi_bindgen 0.28" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode v1 unmaintained, transitive via uniffi_macros 0.28" },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# `path = "..."` deps (examples/cli -> core) register as wildcards because
+# they don't name a version. They're workspace-internal and can't "go bad"
+# the way a registry-sourced `*` would, so allow them explicitly.
+allow-wildcard-paths = true
+highlight = "all"
+# Pin-point denies live here once we care about them. Kept empty for now
+# so this is opt-out rather than configure-up-front.
+deny = []
+
+[licenses]
+version = 2
+# Jellify is GPL-3.0-only, so GPL/AGPL-compatible deps are fine. Anything
+# outside this allowlist needs an explicit decision — add it here (with a
+# note) or vendor a compatible alternative. Keep alphabetical.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "GPL-3.0-only",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+# Silence "not encountered" warnings for licenses we expect to see as the
+# dep graph grows (Linux / Windows targets, more crypto surface, etc.).
+unused-allowed-license = "allow"
+confidence-threshold = 0.9
+# Exceptions for crates whose license is known-OK even though the raw
+# detected expression is noisy. Kept empty until one is needed.
+exceptions = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Minimal CLI exercising jellify_core — login, list, play"
+publish = false
 
 [[bin]]
 name = "jellify-cli"

--- a/linux/Cargo.toml
+++ b/linux/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Jellify — native GTK4 + libadwaita Jellyfin music player for Linux"
+publish = false
 
 [[bin]]
 name = "jellify-desktop"

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,20 @@
+# Typos configuration. See https://github.com/crate-ci/typos
+#
+# Ignore false positives we'd otherwise trip on:
+#   - "PN" inside "PNGs" gets flagged as "ON"
+#   - design/research docs contain transcribed chat snippets with typos
+#     we do not own and don't want to edit after-the-fact.
+[default]
+extend-ignore-re = [
+    "PNGs",
+]
+
+[files]
+extend-exclude = [
+    "design/chats/**",
+    "research/**",
+    "target/**",
+    ".build/**",
+    "macos/.build/**",
+    "macos/Jellify.xcframework/**",
+]


### PR DESCRIPTION
## Summary

The existing `ci.yml` runs one Rust-core job serially followed by one
macOS-app job. That's safe but narrow — no cross-platform signal, no
live-server signal, no supply-chain signal. Public repos get unlimited
Actions minutes on Linux/Windows/macOS runners, so this PR spends them
on breadth where regressions are actually likely.

- **ci.yml refactor** — six parallel jobs (`fmt`, `clippy`, `test`,
  `docs`, `msrv`, `macos-app`) behind a single aggregate `ci` status so
  branch protection only needs one required check. `test` runs on
  `{ubuntu-latest, macos-15, windows-latest}` so `keyring` /
  `rusqlite` / `tokio` regressions on a platform we haven't shipped
  yet (Windows) show up immediately. `msrv` pins Rust 1.75 (matches
  workspace `rust-version`). `macos-app` now also uploads
  `Jellify.app` as an artifact per-PR for download.
- **e2e.yml (new)** — runs a real `jellyfin/jellyfin:10.10.3`
  container as a services dep, drives its first-run wizard via
  `Scripts/e2e-setup-jellyfin.sh`, then exercises `jellify_core` with
  three live integration tests (`core/tests/e2e_live.rs`) plus the
  `jellify-cli` example. A gated macOS-side job (main / nightly /
  manual only — it's slow because Colima has to boot) does the same
  but drives the Swift `SmokeTest` through the real AVPlayer path.
- **security.yml (new)** — `cargo-audit`, `cargo-deny` (advisories /
  bans / sources / licenses split into separate jobs so a licenses
  surprise doesn't mask a CVE), `typos`, and `zizmor` workflow-YAML
  audit uploaded as SARIF. Weekly schedule + on Cargo.* / workflow
  changes.
- **coverage.yml (new)** — `cargo-llvm-cov` → Codecov. Tokenless upload
  for public repos; honours `CODECOV_TOKEN` if the repo adds one later
  to unlock PR-comment summaries.
- **dependabot.yml (new)** — weekly cargo + actions bumps, grouped by
  ecosystem (tokio-\*, serde-\*, patch-level) to keep PR churn sane.
- **deny.toml (new)** — `GPL-3.0-only` + `CDLA-Permissive-2.0` allowed
  (our own crate + `webpki-roots`). `RUSTSEC-2024-0436` and
  `RUSTSEC-2025-0141` ignored with a note pointing at the uniffi 0.28
  upgrade that will clear both.
- **core/tests/e2e_live.rs (new)** — `probe`, `login`, `list_albums`
  envelope tests that early-return when `JELLIFY_E2E_URL` is absent so
  `cargo test --workspace` stays fully offline.
- **Scripts/e2e-setup-jellyfin.sh (new)** — drives the first-run
  wizard (Configuration / User / RemoteAccess / Complete) so tests can
  log in with a seeded admin.
- **examples/cli/Cargo.toml** — `publish = false` (required for
  cargo-deny's `allow-wildcard-paths` to apply to the `path` dep on
  core, since publishable crates can't have path deps in any case).
- **core/src/lib.rs** — fix two broken intra-doc links surfaced by the
  new rustdoc job running with `RUSTDOCFLAGS=-D warnings`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (63 existing + 3 new
      `e2e_live` tests — latter skip cleanly without `JELLIFY_E2E_URL`)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- [x] `cargo deny check advisories bans sources licenses` — all pass
- [x] `actionlint` + embedded shellcheck — clean across all four
      workflows
- [x] `bash -n Scripts/e2e-setup-jellyfin.sh`
- [ ] CI green on this PR (meta: this PR exercises itself)
- [ ] Verify Codecov posts a coverage comment (may require
      `CODECOV_TOKEN` in repo secrets — PR works without it, just
      falls back to tokenless)
- [ ] Manual: run `Scripts/e2e-setup-jellyfin.sh http://localhost:8096 u p`
      against a local Jellyfin container and confirm the wizard completes

## Follow-ups (out of scope)

- Flatpak `cargo-sources.json` drift-detection job — needs a committed
  baseline first.
- Release workflow (tag → signed macOS DMG + GitHub Release) — covered
  by #520.
- Bump `uniffi` past 0.28 to drop the two RustSec ignores.