### PR TITLE
macos: now playing full view + lyrics drawer

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -22,8 +22,17 @@ final class AppModel {
     var username: String = ""
 
     // MARK: - Navigation
-    enum Screen: Hashable { case home, discover, library, search, settings, album(String), artist(String), playlist(String) }
+    enum Screen: Hashable { case home, discover, library, search, settings, album(String), artist(String), playlist(String), nowPlaying }
     var screen: Screen = .library
+
+    /// Screen the app was on before the user opened the full Now Playing
+    /// view. `NowPlayingView` offers a "Back" affordance that pops to this
+    /// value rather than unconditionally routing to `.library`, so a user
+    /// who opened the full player from the Album detail page lands back
+    /// there on exit. `nil` when we've never been anywhere interesting
+    /// (first launch lands on `.library`, which is already the fallback).
+    /// See #89.
+    var previousScreen: Screen?
 
     /// Toggled by the ⌘F menu command to request that `SearchView` move
     /// keyboard focus into its text field. `SearchView` observes changes and
@@ -157,6 +166,19 @@ final class AppModel {
     /// skip redundant network calls when the status poll fires with the
     /// same track still playing.
     private var currentTrackPeopleForId: String?
+
+    /// Parsed lyrics for the currently-playing track, if any. Populated by
+    /// `fetchCurrentTrackLyrics()` on track changes and cleared when the
+    /// track stops. `nil` while a fetch is pending or when no lyrics have
+    /// been requested yet; empty array when the server answered but had no
+    /// lyrics. The Lyrics tab of the Now Playing view uses the
+    /// `nil` / empty distinction to render a loading state vs. a "No
+    /// lyrics available" placeholder. See #91, #273, #287, #288.
+    var currentLyrics: [LyricLine]?
+    /// Track id that `currentLyrics` was fetched for, to skip redundant
+    /// network calls while the same track keeps playing. Mirrors
+    /// `currentTrackPeopleForId`.
+    private var currentLyricsForId: String?
 
     // MARK: - Loading / errors
     var isLoggingIn = false
@@ -303,6 +325,8 @@ final class AppModel {
         searchQuery = ""
         currentTrackPeople = []
         currentTrackPeopleForId = nil
+        currentLyrics = nil
+        currentLyricsForId = nil
         resetPaginationState()
         stopPolling()
     }
@@ -336,6 +360,8 @@ final class AppModel {
         searchQuery = ""
         currentTrackPeople = []
         currentTrackPeopleForId = nil
+        currentLyrics = nil
+        currentLyricsForId = nil
         resetPaginationState()
         stopPolling()
     }
@@ -1563,6 +1589,43 @@ final class AppModel {
         }
     }
 
+    /// Load lyrics for the currently-playing track and publish them on
+    /// `currentLyrics`. Supports both LRC (timestamped) and plain-text
+    /// bodies — the parser detects the shape and `LyricsView` renders the
+    /// right layout. See #91, #273, #287, #288.
+    ///
+    /// TODO(core-#162): wire to `core.track_lyrics(track_id)` once the FFI
+    /// lands. Jellyfin exposes lyrics at `GET /Audio/{id}/Lyrics` (and as
+    /// a `Lyrics` field on the item JSON when requested); the core is the
+    /// right place to decide between the two and return a normalized
+    /// string. Until that ships this method is a stub that clears any
+    /// stale data and returns an empty result so the view renders its
+    /// "No lyrics available" empty state.
+    ///
+    /// Safe to call repeatedly — short-circuits when the current track
+    /// id already matches the last successful fetch. Cleared on track
+    /// change by the polling loop (see `startPolling`).
+    func fetchCurrentTrackLyrics() async {
+        guard let track = status.currentTrack else {
+            currentLyrics = nil
+            currentLyricsForId = nil
+            return
+        }
+        if currentLyricsForId == track.id { return }
+        let id = track.id
+
+        // TODO(core-#162): replace the stub with
+        //   let raw = try core.trackLyrics(itemId: id)
+        //   currentLyrics = LyricLine.parseLRC(raw)
+        // For now we publish an empty array so the Lyrics tab renders
+        // the "No lyrics available" empty state rather than a perpetual
+        // loading spinner — unlocks the surrounding Now Playing UI
+        // without blocking on the core FFI.
+        guard status.currentTrack?.id == id else { return }
+        currentLyrics = []
+        currentLyricsForId = id
+    }
+
     // MARK: - Status polling
 
     private func startPolling() {
@@ -1581,8 +1644,11 @@ final class AppModel {
                     if after == nil {
                         self.currentTrackPeople = []
                         self.currentTrackPeopleForId = nil
+                        self.currentLyrics = nil
+                        self.currentLyricsForId = nil
                     } else {
                         Task { await self.fetchCurrentTrackDetails() }
+                        Task { await self.fetchCurrentTrackLyrics() }
                     }
                 }
             }

--- a/macos/Sources/Jellify/Components/LyricsView.swift
+++ b/macos/Sources/Jellify/Components/LyricsView.swift
@@ -1,0 +1,352 @@
+import SwiftUI
+
+/// A single line of lyrics, optionally anchored to a playback timestamp.
+///
+/// LRC files encode time as `[mm:ss.ff]lyric text` — we store the timestamp
+/// as seconds so the highlight tick can compare straight against
+/// `PlayerStatus.positionSeconds`. Untimed lyrics (plain text, or the
+/// metadata header of an LRC file that hasn't been parsed out) surface with
+/// a `nil` timestamp and render as static rows that don't participate in
+/// the auto-scroll.
+///
+/// See #287 (LRC parser) and #288 (auto-scroll).
+struct LyricLine: Equatable, Identifiable {
+    /// Stable-within-a-track id so SwiftUI lists don't thrash when the set
+    /// of lines is swapped wholesale between tracks. We use the line index
+    /// because LRC files occasionally repeat the same text at multiple
+    /// timestamps (choruses) — the text alone isn't unique.
+    let id: Int
+    /// Playback position at which this line becomes active, in seconds.
+    /// `nil` for lines without an LRC timestamp — those render but never
+    /// auto-highlight or auto-scroll.
+    let timestamp: Double?
+    /// The lyric text, stripped of any timestamp tags.
+    let text: String
+}
+
+extension LyricLine {
+    /// Parse an LRC blob into lines. Each input line may carry one or more
+    /// `[mm:ss.ff]` tags — when multiple tags appear on the same text, we
+    /// emit one `LyricLine` per tag (common for repeated choruses). Lines
+    /// with no tags surface with `timestamp = nil` so the view can still
+    /// render them, but they won't participate in auto-scroll.
+    ///
+    /// This is intentionally permissive: `[mm:ss]`, `[mm:ss.f]`,
+    /// `[mm:ss.ff]`, and `[mm:ss.fff]` are all accepted. Metadata tags like
+    /// `[ar: Artist]` / `[ti: Title]` — which technically look like
+    /// timestamps but aren't — are rejected by requiring two numeric
+    /// components separated by `:`. Blank lines are dropped. Output order
+    /// follows ascending timestamp (nil-timestamped lines preserve their
+    /// relative order at the end).
+    ///
+    /// See #287.
+    static func parseLRC(_ raw: String) -> [LyricLine] {
+        var timed: [(Double, String)] = []
+        var untimed: [String] = []
+
+        for line in raw.split(whereSeparator: { $0.isNewline }) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+
+            let (stamps, rest) = extractTimestamps(from: trimmed)
+            if stamps.isEmpty {
+                // Plain text — could be lyrics without timing, or an
+                // orphan LRC metadata tag we rejected. Keep the original
+                // (trimmed) text so the line still reads naturally.
+                if !trimmed.isEmpty { untimed.append(trimmed) }
+            } else {
+                let text = rest.trimmingCharacters(in: .whitespaces)
+                // An LRC line can have only tags and no text (rare, but
+                // some tools emit these as structural anchors). Skip —
+                // an empty highlight row reads like a bug, not lyrics.
+                guard !text.isEmpty else { continue }
+                for stamp in stamps {
+                    timed.append((stamp, text))
+                }
+            }
+        }
+
+        // If we never parsed a single timestamp, treat the entire blob as
+        // plain text — caller can render it as a static column.
+        if timed.isEmpty {
+            return untimed.enumerated().map { idx, text in
+                LyricLine(id: idx, timestamp: nil, text: text)
+            }
+        }
+
+        timed.sort { $0.0 < $1.0 }
+        var out = timed.enumerated().map { idx, pair in
+            LyricLine(id: idx, timestamp: pair.0, text: pair.1)
+        }
+        // Append any stray untimed lines after the timed block. In
+        // practice untimed lines in a timed file are rare (usually the
+        // header after we've already stripped tags); they follow the
+        // timed run so auto-scroll doesn't jump past them on the last
+        // chorus.
+        let base = out.count
+        for (offset, text) in untimed.enumerated() {
+            out.append(LyricLine(id: base + offset, timestamp: nil, text: text))
+        }
+        return out
+    }
+
+    /// Strip one or more leading `[mm:ss.ff]` tags from `line` and return
+    /// the parsed timestamps (in seconds) plus the text that follows.
+    /// Tags after the first character of actual lyric text are left
+    /// in-place — LRC spec has them only at the start of a line.
+    private static func extractTimestamps(from line: String) -> ([Double], String) {
+        var stamps: [Double] = []
+        var cursor = line.startIndex
+        while cursor < line.endIndex, line[cursor] == "[" {
+            guard let close = line[cursor...].firstIndex(of: "]") else { break }
+            let inner = line[line.index(after: cursor)..<close]
+            if let seconds = parseTimestamp(String(inner)) {
+                stamps.append(seconds)
+                cursor = line.index(after: close)
+            } else {
+                // Not a timestamp — bail without consuming. The `[ar:]`
+                // case lands here. Treat the whole line as plain text.
+                return ([], line)
+            }
+        }
+        return (stamps, String(line[cursor...]))
+    }
+
+    /// Parse the contents of a single `[...]` tag as `mm:ss` /
+    /// `mm:ss.f` / `mm:ss.ff` / `mm:ss.fff`. Returns `nil` on any other
+    /// shape (metadata tags, malformed numbers, etc.).
+    private static func parseTimestamp(_ s: String) -> Double? {
+        let parts = s.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let minutes = Int(parts[0])
+        else { return nil }
+
+        let secondsRaw = parts[1]
+        let secondsParts = secondsRaw.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let seconds = Int(secondsParts[0]) else { return nil }
+
+        var fractional: Double = 0
+        if secondsParts.count == 2 {
+            let frac = secondsParts[1]
+            guard let num = Int(frac) else { return nil }
+            // `[mm:ss.f]` → tenths, `[mm:ss.ff]` → hundredths, etc.
+            let divisor = pow(10.0, Double(frac.count))
+            fractional = Double(num) / divisor
+        }
+
+        return Double(minutes * 60 + seconds) + fractional
+    }
+}
+
+/// Lyrics viewer used inside `NowPlayingView` and as a potential full-screen
+/// surface (#91). Takes the lyric lines + a live `progress` hook — the
+/// view owns its own ticker so callers don't have to wire one up. When
+/// `lines` is empty, renders an "No lyrics available" empty state rather
+/// than a blank panel.
+///
+/// Auto-scroll (#288) uses `ScrollViewReader.scrollTo(.center)` with a
+/// 300ms easeInOut animation. Reduce Motion disables the animation — the
+/// highlight still follows the track, just without the smooth scroll.
+struct LyricsView: View {
+    /// Parsed lyric lines, ordered by timestamp. Untimed lines (timestamp
+    /// = nil) are allowed and render as static rows.
+    let lines: [LyricLine]
+    /// Closure returning the current playback position in seconds. Called
+    /// every 200ms while the view is on-screen. Wrapped in a closure
+    /// rather than taken as a plain Double so the view reads the freshest
+    /// value on every tick without the caller having to push updates.
+    let progress: () -> Double
+
+    /// When true, falls back to a completely static (no ticker, no
+    /// highlight) layout. Used as the "No lyrics" placeholder would
+    /// otherwise still spin a timer for no reason.
+    private var isEmpty: Bool { lines.isEmpty }
+    /// When true, the lyrics blob had no LRC timestamps at all — we
+    /// render it as a plain text column without a highlight or ticker.
+    private var isStatic: Bool {
+        !lines.isEmpty && lines.allSatisfy { $0.timestamp == nil }
+    }
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Current active line id. Driven by the ticker; the view re-renders
+    /// on each change to move the highlight + trigger the scroll.
+    @State private var activeId: Int?
+    /// Cached `Date` used to drive the ticker's Combine timer publisher.
+    /// The actual polling cadence is 200ms per the issue, tight enough
+    /// to feel live but loose enough not to pummel the main thread.
+    @State private var tick: Date = .now
+
+    var body: some View {
+        Group {
+            if isEmpty {
+                emptyState
+            } else if isStatic {
+                staticText
+            } else {
+                scrollingLyrics
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.bg)
+    }
+
+    // MARK: - Empty state
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "quote.bubble")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(Theme.ink3)
+            Text("No lyrics available")
+                .font(Theme.font(14, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+            Text("Lyrics haven't been provided for this track.")
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Static (untimed) text
+
+    @ViewBuilder
+    private var staticText: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(lines) { line in
+                    Text(line.text)
+                        .font(Theme.font(15, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 24)
+        }
+        .accessibilityLabel("Lyrics")
+    }
+
+    // MARK: - Auto-scrolling lyrics
+
+    @ViewBuilder
+    private var scrollingLyrics: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(lines) { line in
+                        LyricRow(line: line, isActive: line.id == activeId)
+                            .id(line.id)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 28)
+                // Top/bottom padding lets the active line sit near the
+                // middle of the viewport even when the song is near the
+                // first or last line.
+                .padding(.vertical, 120)
+            }
+            .onAppear {
+                updateActiveLine()
+            }
+            // 200ms cadence per #288. Cheap: a timestamp lookup + an id
+            // compare, and we only mutate `activeId` when it changes, so
+            // most ticks are no-ops.
+            .onReceive(Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()) { _ in
+                tick = .now
+                updateActiveLine()
+            }
+            .onChange(of: activeId) { _, newValue in
+                guard let newValue else { return }
+                if reduceMotion {
+                    proxy.scrollTo(newValue, anchor: .center)
+                } else {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(newValue, anchor: .center)
+                    }
+                }
+            }
+        }
+        .accessibilityLabel("Lyrics")
+    }
+
+    /// Find the line whose timestamp is the most recent one at or before
+    /// the current playback position. Runs every tick; no-op on stable
+    /// state because we only assign `activeId` when it changes.
+    private func updateActiveLine() {
+        let now = progress()
+        // Walk backwards — lyric lines in timestamp order, so the last
+        // one with timestamp <= now is active. O(n) on a handful of
+        // lines, which is fine for the 200ms cadence.
+        var newActive: Int? = nil
+        for line in lines {
+            guard let ts = line.timestamp else { continue }
+            if ts <= now {
+                newActive = line.id
+            } else {
+                break
+            }
+        }
+        if newActive != activeId {
+            activeId = newActive
+        }
+    }
+}
+
+/// One rendered lyric row. Active rows bloom in size + brightness; past
+/// rows dim so the eye is pulled to the current line.
+private struct LyricRow: View {
+    let line: LyricLine
+    let isActive: Bool
+
+    var body: some View {
+        Text(line.text)
+            .font(Theme.font(isActive ? 22 : 18, weight: isActive ? .bold : .medium))
+            .foregroundStyle(isActive ? Theme.ink : Theme.ink3)
+            .fixedSize(horizontal: false, vertical: true)
+            .animation(.easeInOut(duration: 0.2), value: isActive)
+            .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}
+
+#Preview("Lyrics — timed") {
+    let sample = """
+    [00:00.00]Line one at the top
+    [00:04.50]Line two after a pause
+    [00:09.20]Line three with feeling
+    [00:14.00]Line four pulls it together
+    [00:18.80]Line five — final chorus
+    """
+    return LyricsView(
+        lines: LyricLine.parseLRC(sample),
+        progress: { 9.5 }
+    )
+    .frame(width: 420, height: 480)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Lyrics — empty") {
+    LyricsView(lines: [], progress: { 0 })
+        .frame(width: 420, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Lyrics — static text") {
+    let lines = [
+        "A first line of static lyrics",
+        "A second line without timing",
+        "A third — useful for LRC-less tracks",
+    ].enumerated().map { idx, text in
+        LyricLine(id: idx, timestamp: nil, text: text)
+    }
+    return LyricsView(lines: lines, progress: { 0 })
+        .frame(width: 420, height: 480)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -94,6 +94,24 @@ struct JellifyCommands: Commands {
 
             Divider()
 
+            // Full Now Playing view — #89. Swaps the detail column to the
+            // large player + lyrics/queue/about/credits tabs. When already
+            // on Now Playing, the shortcut pops back to the previous
+            // screen so pressing it again feels like a toggle.
+            Button("Show Now Playing") {
+                if model.screen == .nowPlaying {
+                    model.screen = model.previousScreen ?? .library
+                    model.previousScreen = nil
+                } else {
+                    model.previousScreen = model.screen
+                    model.screen = .nowPlaying
+                }
+            }
+            .keyboardShortcut("l", modifiers: [.command, .option])
+            .disabled(model.session == nil)
+
+            Divider()
+
             // TODO(#321): Wire to the mini-player scene once it exists.
             // Tracked separately in the macOS polish milestone.
             Button("Toggle Mini Player") {

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -73,6 +73,8 @@ struct MainShell: View {
             ArtistDetailView(artistID: id)
         case .playlist(let id):
             PlaylistView(playlistID: id)
+        case .nowPlaying:
+            NowPlayingView()
         default:
             LibraryView()
         }
@@ -132,6 +134,8 @@ struct MainShell: View {
             } else {
                 segments.append("Playlist")
             }
+        case .nowPlaying:
+            segments.append("Now Playing")
         case .settings:
             segments.append("Settings")
         }
@@ -152,7 +156,7 @@ struct MainShell: View {
         }
 
         switch model.screen {
-        case .home, .discover, .library, .search, .settings:
+        case .home, .discover, .library, .search, .settings, .nowPlaying:
             // Shape: ["Jellify", <current>] — only the final index, which is
             // the current location and non-navigable. Nothing to do.
             break

--- a/macos/Sources/Jellify/Screens/NowPlayingView.swift
+++ b/macos/Sources/Jellify/Screens/NowPlayingView.swift
@@ -1,0 +1,426 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Full Now Playing view — takes over the detail column when the user
+/// opens the "full player" from the `PlayerBar` quote-icon or via the
+/// `Cmd+Opt+L` shortcut. Replaces the compact `NowPlayingSheet` used for
+/// a quick glance at credits.
+///
+/// Layout mirrors `design/project/src/panels.jsx`: large album art on the
+/// left (~50% width, square with a soft shadow), a segmented picker on
+/// the right that toggles between **Queue**, **Lyrics**, **About**, and
+/// **Credits**. The screen is a `View`, not a modal, so it slots into
+/// `MainShell`'s `mainContent` switch alongside the other top-level
+/// surfaces.
+///
+/// Closes: #89 (full player), #91 (lyrics inline), #272 (queue drawer),
+/// #273 (lyrics drawer), #278 (about block), #287 (LRC parser),
+/// #288 (auto-scroll).
+///
+/// Out of scope — tracked in separate batches:
+/// - The quote-icon entry on the `PlayerBar` is wired in BATCH-02 (the
+///   `PlayerBar` is off-limits for this batch). `Cmd+Opt+L` from
+///   `JellifyCommands` plus the `AppModel.screen = .nowPlaying` route
+///   are enough to reach this view today.
+/// - The queue inspector (#272) is owned by BATCH-07 — the Queue tab
+///   here renders a placeholder until that lands.
+struct NowPlayingView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Active right-pane tab. Reset to `.queue` when the view appears so
+    /// opening the full player always lands on "what's next" rather than
+    /// the tab the user was last on — a prior-tab memory would surprise
+    /// people returning to Now Playing days later.
+    @State private var tab: Tab = .queue
+
+    enum Tab: String, CaseIterable, Identifiable {
+        case queue = "Queue"
+        case lyrics = "Lyrics"
+        case about = "About"
+        case credits = "Credits"
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        Group {
+            if let track = model.status.currentTrack {
+                content(for: track)
+            } else {
+                emptyState
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.bg)
+        // Re-fetch the People array + lyrics on open and on track change.
+        // The polling loop in AppModel already handles mid-session
+        // transitions; this keeps the open-from-cold path honest too.
+        .task(id: model.status.currentTrack?.id) {
+            await model.fetchCurrentTrackDetails()
+            await model.fetchCurrentTrackLyrics()
+        }
+    }
+
+    // MARK: - Main content
+
+    @ViewBuilder
+    private func content(for track: Track) -> some View {
+        GeometryReader { geom in
+            let isCompact = geom.size.width < 820
+            HStack(alignment: .top, spacing: 0) {
+                heroPane(for: track, width: isCompact ? nil : geom.size.width * 0.5)
+                detailPane(for: track)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+
+    /// Left pane — large artwork + primary metadata. Sized at ~50% of
+    /// the container at wide widths, so the art never dwarfs the detail
+    /// column on a 13" MBP. Below ~820pt the hero collapses to its
+    /// natural width so the right pane retains at least a usable column.
+    @ViewBuilder
+    private func heroPane(for track: Track, width: CGFloat?) -> some View {
+        let artSide = heroArtSide(containerWidth: width)
+        VStack(alignment: .leading, spacing: 22) {
+            closeButton
+            Spacer(minLength: 0)
+            Artwork(
+                url: model.imageURL(
+                    for: track.albumId ?? track.id,
+                    tag: track.imageTag,
+                    maxWidth: UInt32(max(320, artSide * 2))
+                ),
+                seed: track.name,
+                size: artSide,
+                radius: 14
+            )
+            .frame(width: artSide, height: artSide)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(track.name)
+                    .font(Theme.font(26, weight: .heavy))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button(action: {
+                    if let artistId = track.artistId {
+                        model.previousScreen = .nowPlaying
+                        model.screen = .artist(artistId)
+                    }
+                }) {
+                    Text(track.artistName)
+                        .font(Theme.font(15, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+                .disabled(track.artistId == nil)
+                .accessibilityHint(track.artistId == nil ? "" : "Open artist page")
+
+                if let album = track.albumName, !album.isEmpty {
+                    Button(action: {
+                        if let albumId = track.albumId {
+                            model.previousScreen = .nowPlaying
+                            model.screen = .album(albumId)
+                        }
+                    }) {
+                        Text(album)
+                            .font(Theme.font(12, weight: .medium))
+                            .foregroundStyle(Theme.ink3)
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(track.albumId == nil)
+                    .accessibilityHint(track.albumId == nil ? "" : "Open album page")
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: width, alignment: .topLeading)
+        .padding(.horizontal, 36)
+        .padding(.vertical, 28)
+    }
+
+    /// Compute a side length for the hero artwork that never exceeds
+    /// half the pane height (keeps metadata visible) and caps out at
+    /// 520pt so the art doesn't swell past a visually pleasing size on
+    /// ultrawide displays.
+    private func heroArtSide(containerWidth: CGFloat?) -> CGFloat {
+        let byWidth = containerWidth.map { max(240, $0 - 72) } ?? 320
+        return min(520, byWidth)
+    }
+
+    /// Right pane — segmented tab picker over a per-tab view.
+    @ViewBuilder
+    private func detailPane(for track: Track) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            paneHeader
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { t in
+                    Text(t.rawValue).tag(t)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            tabBody(for: track)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                // Reduce Motion disables the tab transition; otherwise
+                // let SwiftUI cross-fade to avoid a hard snap between
+                // the richly-laid-out panels.
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: tab)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.horizontal, 28)
+        .padding(.vertical, 28)
+        .background(
+            Rectangle()
+                .fill(Theme.bgAlt.opacity(0.35))
+        )
+    }
+
+    @ViewBuilder
+    private var paneHeader: some View {
+        HStack {
+            Text("NOW PLAYING")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.accent)
+                .tracking(3)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func tabBody(for track: Track) -> some View {
+        switch tab {
+        case .queue:
+            queuePanel
+        case .lyrics:
+            lyricsPanel
+        case .about:
+            aboutPanel(for: track)
+        case .credits:
+            creditsPanel
+        }
+    }
+
+    // MARK: - Queue tab (#272)
+
+    /// Placeholder queue drawer. BATCH-07 owns the rich queue inspector
+    /// (#272); until it lands we render a minimal "Queue goes here"
+    /// marker so the tab is explorable without looking broken.
+    @ViewBuilder
+    private var queuePanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Queue goes here")
+                    .font(Theme.font(14, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                Text("A full queue inspector lands with BATCH-07 (#272).")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Lyrics tab (#91, #273)
+
+    /// Lyrics drawer. Delegates all rendering to `LyricsView`, which
+    /// handles the LRC parse + auto-scroll + reduce-motion fallback.
+    /// While `currentLyrics` is nil (pre-fetch / between tracks) we
+    /// show a minimal loading row; an empty array — the stub state
+    /// until the core lyrics FFI lands — renders the view's empty
+    /// state.
+    @ViewBuilder
+    private var lyricsPanel: some View {
+        if let lines = model.currentLyrics {
+            LyricsView(
+                lines: lines,
+                progress: { model.status.positionSeconds }
+            )
+        } else {
+            VStack {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(Theme.ink3)
+                Text("Loading lyrics…")
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.top, 10)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - About tab (#278)
+
+    /// About block. Surfaces the subset of metadata we already have on
+    /// the `Track` — album, artist, year, runtime — plus the album's
+    /// track count via a library lookup. The bio / extended overview
+    /// lives on the artist item, which the core doesn't project yet
+    /// (see TODO in `ArtistDetailView.artistOverview`). When that FFI
+    /// lands we can surface the first paragraph here.
+    @ViewBuilder
+    private func aboutPanel(for track: Track) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                aboutSection(
+                    label: "Artist",
+                    value: track.artistName
+                )
+
+                if let album = track.albumName, !album.isEmpty {
+                    aboutSection(label: "Album", value: album)
+                }
+
+                if let year = track.year {
+                    aboutSection(label: "Year", value: String(year))
+                }
+
+                aboutSection(
+                    label: "Runtime",
+                    value: formatRuntime(track.durationSeconds)
+                )
+
+                if let album = matchingAlbum(for: track) {
+                    if album.trackCount > 0 {
+                        aboutSection(
+                            label: "Tracks",
+                            value: "\(album.trackCount) on \(album.name)"
+                        )
+                    }
+                    if !album.genres.isEmpty {
+                        aboutSection(
+                            label: "Genres",
+                            value: album.genres.joined(separator: ", ")
+                        )
+                    }
+                }
+
+                // TODO(core-#231): once `Artist.overview` lands, surface
+                // the first paragraph as a "Bio" block here. The
+                // `ArtistDetailView` expandable block is the final home
+                // for the full text; this surface deliberately stays
+                // compact.
+                Text("Bio will appear once the core exposes artist overviews (core-#231).")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .italic()
+                    .padding(.top, 8)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+        }
+    }
+
+    @ViewBuilder
+    private func aboutSection(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label.uppercased())
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            Text(value)
+                .font(Theme.font(14, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+
+    /// Look up the album record for this track in the cached library,
+    /// if any. Returns `nil` when the track's album isn't in the
+    /// currently-loaded page (e.g. a track started from a search
+    /// hint). The About panel gracefully omits album-derived rows in
+    /// that case.
+    private func matchingAlbum(for track: Track) -> Album? {
+        guard let albumId = track.albumId else { return nil }
+        return model.albums.first { $0.id == albumId }
+    }
+
+    private func formatRuntime(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        let m = total / 60
+        let s = total % 60
+        return String(format: "%d:%02d", m, s)
+    }
+
+    // MARK: - Credits tab (PR #508)
+
+    /// Credits block — pulls the `People` array off `AppModel` (populated
+    /// by `fetchCurrentTrackDetails`) and hands it straight to the
+    /// existing `NowPlayingCredits` component so we coexist with the
+    /// work from PR #508 rather than re-implementing it.
+    @ViewBuilder
+    private var creditsPanel: some View {
+        ScrollView {
+            NowPlayingCredits(
+                credits: Credit.rows(from: model.currentTrackPeople)
+            )
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Close / dismiss
+
+    /// Back affordance that pops to the screen the user was on before
+    /// they opened the full player. Falls back to the library when we
+    /// never stashed a predecessor.
+    @ViewBuilder
+    private var closeButton: some View {
+        Button(action: dismiss) {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 11, weight: .bold))
+                Text("Close")
+                    .font(Theme.font(11, weight: .semibold))
+            }
+            .foregroundStyle(Theme.ink2)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                Capsule().fill(Theme.surface)
+            )
+            .overlay(
+                Capsule().stroke(Theme.border, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.cancelAction)
+        .accessibilityLabel("Close Now Playing")
+    }
+
+    private func dismiss() {
+        model.screen = model.previousScreen ?? .library
+        model.previousScreen = nil
+    }
+
+    // MARK: - Empty state
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "music.note")
+                .font(.system(size: 42, weight: .light))
+                .foregroundStyle(Theme.ink3)
+            Text("Nothing playing")
+                .font(Theme.font(16, weight: .bold))
+                .foregroundStyle(Theme.ink2)
+            Text("Start a track to see the full player.")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+            Button("Back to Library") {
+                model.screen = .library
+                model.previousScreen = nil
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Theme.accent)
+            .padding(.top, 6)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}


### PR DESCRIPTION
Closes #89, #91, #272, #273, #278, #287, #288

## Summary

- New `NowPlayingView` — takes over the detail column with a large album hero on the left (~50% width) and a segmented Queue / Lyrics / About / Credits picker on the right. Routed via `AppModel.Screen.nowPlaying`; `MainShell` switches into it like any other top-level surface.
- New `LyricsView` — parses LRC `[mm:ss.ff]lyric` blobs into timed lines, auto-scrolls the active line to the viewport center every 200ms (300ms `.easeInOut`, disabled under Reduce Motion), and falls back to plain text or a "No lyrics available" empty state. Includes a pure-Swift `LyricLine.parseLRC` that accepts `[mm:ss]`, `[mm:ss.f]`, `[mm:ss.ff]`, `[mm:ss.fff]` and rejects metadata tags.
- `AppModel` adds `currentLyrics: [LyricLine]?` state + `fetchCurrentTrackLyrics()`, wired into the existing status-polling track-change hook alongside the Credits fetch. The fetcher is a stub today (`TODO(core-#162)`) — it clears and publishes an empty array so the Lyrics tab shows the empty state.
- `Cmd+Opt+L` shortcut added to the Playback menu. When already on Now Playing, the shortcut toggles back to the previous screen.
- Credits tab calls straight through to the existing `NowPlayingCredits` component (from PR #508); Queue tab is a placeholder deferring to BATCH-07 (#272).

## Out of scope

- PlayerBar quote-icon entry (BATCH-02 owns PlayerBar).
- Real queue inspector (BATCH-07 / #272).
- Core lyrics FFI (core-#162) — the Swift-side parser + view are ready to consume it.

## Test plan

- [ ] `swift build` clean from `macos/`.
- [ ] `Cmd+Opt+L` switches the detail column to the full player; pressing again returns to the previous screen.
- [ ] Tabs swap cleanly between Queue (placeholder), Lyrics (empty state), About (artist/album/year/runtime), and Credits (reuses PR #508 block).
- [ ] Feeding the `LyricsView` preview a timed LRC blob auto-scrolls the highlighted line.
- [ ] Without lyrics, "No lyrics available" renders.
- [ ] With Reduce Motion on, highlight still follows playback but the scroll is instant.
- [ ] Artist / album links in the hero route to their detail pages and the Close button pops back to Now Playing's predecessor.
