### PR TITLE
macos: complete context menus (track/album/artist/playlist/genre + multi-select)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -250,6 +250,17 @@ final class AppModel {
     /// consumer owns the tween.
     var streamErrorFlash: Bool = false
 
+    /// Playlist the user asked to delete from a context menu. Observed by
+    /// `MainShell` to present a `.confirmationDialog`; cleared when the
+    /// user confirms or dismisses. Single-shot rather than a list because
+    /// the dialog is modal — only one can be pending at a time. See #131.
+    var playlistPendingDelete: Playlist?
+
+    /// Artists the user has "followed" in-app. Today this is purely local
+    /// state (no server-side follow primitive on Jellyfin), persisted to
+    /// `UserDefaults` on write. See #64 / #228.
+    var followedArtistIds: Set<String> = []
+
     init() throws {
         let core = try JellifyCore(
             config: CoreConfig(dataDir: "", deviceName: "Jellify macOS")
@@ -1807,11 +1818,39 @@ final class AppModel {
         screen = .artist(artistID)
     }
 
+    /// Navigate to the album's own detail screen. Used when the menu is
+    /// invoked from a surface other than the album detail itself (e.g. a
+    /// track row that links back to its album).
+    func goToAlbum(album: Album) {
+        screen = .album(album.id)
+    }
+
     /// Kick off an Instant Mix ("album radio") seeded by this album.
     /// TODO: #144, #327 — Instant Mix endpoint + modal not yet wired.
     func startAlbumRadio(album: Album) {
         // TODO: #144 / #327 — Instant Mix FFI not yet wired.
         print("[AppModel] startAlbumRadio(album:) not yet wired — see #144 / #327")
+    }
+
+    /// Mark every track on the album as played.
+    /// TODO: #133 / #222 — `mark_played` FFI not yet wired.
+    func markAllAsPlayed(album: Album) {
+        // TODO(#133): mark_played FFI not yet wired.
+        print("[AppModel] markAllAsPlayed(album:) not yet wired — see #133 / #222")
+    }
+
+    /// Present the album metadata editor. Admin-only once the sheet lands.
+    /// TODO: #96 / #222 — metadata editor sheet not yet implemented.
+    func requestEditAlbum(album: Album) {
+        // TODO(#96): metadata editor sheet not yet implemented.
+        print("[AppModel] requestEditAlbum(album:) not yet wired — see #96 / #222")
+    }
+
+    /// Append every track on the album to a user-picked playlist.
+    /// TODO: #126 / #130 — `add_to_playlist` FFI not yet wired.
+    func addAlbumToPlaylist(album: Album, playlist: Playlist) {
+        // TODO(#126): add_to_playlist FFI not yet wired.
+        print("[AppModel] addAlbumToPlaylist(\(album.name) → \(playlist.name)) not yet wired — see #126")
     }
 
     // MARK: - Sharing
@@ -1874,10 +1913,38 @@ final class AppModel {
     }
 
     /// Toggle the follow flag for an artist.
-    /// TODO: #64, #228 — follow/unfollow semantics + core support TBD.
+    /// TODO: #64 / #228 — server-side follow primitive TBD. For now,
+    /// toggle a local `followedArtistIds` set so the UI has something to
+    /// render against; persistence lives alongside the real API work.
     func toggleFollow(artist: Artist) {
-        // TODO: #64 / #228 — follow/unfollow not yet wired.
-        print("[AppModel] toggleFollow(artist:) not yet wired — see #64 / #228")
+        if followedArtistIds.contains(artist.id) {
+            followedArtistIds.remove(artist.id)
+        } else {
+            followedArtistIds.insert(artist.id)
+        }
+    }
+
+    /// `true` when the user has followed this artist (in-app, today).
+    /// See `toggleFollow(artist:)` for the TODO on server-side follow.
+    func isFollowing(artist: Artist) -> Bool {
+        followedArtistIds.contains(artist.id)
+    }
+
+    /// Play a handful of the artist's top tracks as "Play Next".
+    /// TODO: #282 — needs an Up Next queue primitive. Until that lands,
+    /// behaves like `playTopTracks` (start playback from the first top
+    /// track) so the UI action has a landing pad.
+    func playNextArtist(artist: Artist) {
+        // TODO(#282): queue "Up Next" insertion. Fall through to top-tracks
+        // playback so the menu item does something.
+        playTopTracks(artist: artist)
+    }
+
+    /// Navigate to the artist detail screen. Used when the menu is invoked
+    /// from a surface other than the artist detail itself (e.g. a track
+    /// row whose secondary line is the artist).
+    func goToArtistPage(artist: Artist) {
+        screen = .artist(artist.id)
     }
 
     /// Kick off an Instant Mix ("artist radio") seeded by this artist.
@@ -2007,6 +2074,47 @@ final class AppModel {
         print("[AppModel] requestDelete(playlist:) not yet wired — see #75 / #131")
     }
 
+    /// Raise a delete-confirmation dialog for a playlist. Sets
+    /// `playlistPendingDelete`, which `MainShell` observes to present a
+    /// `.confirmationDialog` with clear "Delete <playlist name>?" copy.
+    /// The actual delete happens in `performDeletePending()` once the user
+    /// confirms.
+    func confirmDelete(playlist: Playlist) {
+        playlistPendingDelete = playlist
+    }
+
+    /// Execute the pending playlist deletion, if any. Called from the
+    /// confirmation dialog's destructive button.
+    /// TODO(#131): delete_playlist FFI not yet wired; for now, optimistically
+    /// drop from the local `playlists` array so the UI can be tested.
+    func performDeletePending() {
+        guard let target = playlistPendingDelete else { return }
+        playlistPendingDelete = nil
+        playlists.removeAll { $0.id == target.id }
+        // TODO(#131): delete_playlist FFI not yet wired — local drop only.
+        print("[AppModel] performDeletePending(\(target.name)) local-only — see #131")
+    }
+
+    /// Dismiss the pending delete dialog without deleting anything.
+    func cancelDeletePending() {
+        playlistPendingDelete = nil
+    }
+
+    /// Duplicate a playlist: create a new playlist with the same tracks.
+    /// TODO(#126): create_playlist + add_to_playlist FFIs not yet wired.
+    func requestDuplicate(playlist: Playlist) {
+        // TODO(#126): create_playlist + add_to_playlist FFIs not yet wired.
+        print("[AppModel] requestDuplicate(playlist:) not yet wired — see #126")
+    }
+
+    /// Present a save panel and write the playlist to disk as an `.m3u8` file.
+    /// TODO(#98): needs `playlist_tracks` (#125) to resolve file paths + the
+    /// save panel + an m3u8 writer. Logging stub for now.
+    func exportPlaylist(playlist: Playlist) {
+        // TODO(#98): m3u8 export not yet wired — needs #125 + save panel.
+        print("[AppModel] exportPlaylist(playlist:) not yet wired — see #98 / #125")
+    }
+
     /// Rename a playlist in place from the playlist hero's click-to-edit
     /// title (#234). Updates the cached `Playlist` in `playlists` so the hero
     /// reflects the new name immediately.
@@ -2076,6 +2184,165 @@ final class AppModel {
     func openInJellyfin(playlist: Playlist) {
         guard let url = webURL(for: playlist) else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Track actions
+    //
+    // Backing calls for `TrackContextMenu`. Accept `[Track]` rather than a
+    // single `Track` so the same surface handles single-row and multi-select
+    // invocations — spec in #95 / #310 / #315. Most of these are TODO stubs
+    // pending follow-up FFI work (queue primitives #282, favorites #133,
+    // download engine #70, mark-played #133, song radio #144, metadata
+    // editor #96).
+
+    /// Insert a selection of tracks immediately after the currently-playing
+    /// track.
+    /// TODO(#282): queue "Up Next" insertion primitive. For now, behaves
+    /// like `play(tracks:)` so the menu item does something.
+    func playNext(tracks: [Track]) {
+        guard !tracks.isEmpty else { return }
+        // TODO(#282): queue "Up Next" insertion not yet wired.
+        print("[AppModel] playNext(tracks:) not yet wired — see #282")
+        play(tracks: tracks, startIndex: 0)
+    }
+
+    /// Append a selection of tracks to the end of the queue.
+    /// TODO(#282): queue append primitive. For now, replaces the queue via
+    /// `play(tracks:)` so the menu item has a landing pad.
+    func addToQueue(tracks: [Track]) {
+        guard !tracks.isEmpty else { return }
+        // TODO(#282): queue append not yet wired.
+        print("[AppModel] addToQueue(tracks:) not yet wired — see #282")
+        play(tracks: tracks, startIndex: 0)
+    }
+
+    /// Kick off an Instant Mix ("song radio") seeded by a single track.
+    /// TODO(#144): Instant Mix (polymorphic) FFI not yet wired.
+    func startSongRadio(track: Track) {
+        // TODO(#144): Instant Mix FFI not yet wired.
+        print("[AppModel] startSongRadio(track:) not yet wired — see #144")
+    }
+
+    /// Append a selection of tracks to a user-picked playlist.
+    /// TODO(#126): `add_to_playlist` FFI not yet wired.
+    func addTracksToPlaylist(tracks: [Track], playlist: Playlist) {
+        // TODO(#126): add_to_playlist FFI not yet wired.
+        print("[AppModel] addTracksToPlaylist(\(tracks.count) tracks → \(playlist.name)) not yet wired — see #126")
+    }
+
+    /// Present a "new playlist" flow seeded with the given selection.
+    /// TODO(#126): create_playlist FFI + sheet not yet wired.
+    func requestAddTracksToPlaylist(tracks: [Track]) {
+        // TODO(#126): create_playlist + picker sheet not yet wired.
+        print("[AppModel] requestAddTracksToPlaylist(\(tracks.count) tracks) not yet wired — see #126")
+    }
+
+    /// Navigate to the album detail screen for this track's album.
+    func goToAlbum(track: Track) {
+        guard let albumID = track.albumId else { return }
+        screen = .album(albumID)
+    }
+
+    /// Navigate to the artist detail screen for this track's artist.
+    func goToArtist(track: Track) {
+        guard let artistID = track.artistId else { return }
+        screen = .artist(artistID)
+    }
+
+    /// Present the per-track info sheet (title, album, bitrate, people).
+    /// TODO(#95): info sheet not yet implemented. Logging stub so ⌘I has a
+    /// landing pad.
+    func showTrackInfo(track: Track) {
+        // TODO(#95): track info sheet not yet wired.
+        print("[AppModel] showTrackInfo(track: \(track.name)) not yet wired — see #95")
+    }
+
+    /// Remove a selection of tracks from a specific playlist. Used by the
+    /// multi-select context menu when scoped to a playlist detail view.
+    /// TODO(#132): `remove_from_playlist` FFI not yet wired.
+    func removeTracksFromPlaylist(tracks: [Track], playlist: Playlist) {
+        // TODO(#132): remove_from_playlist FFI not yet wired.
+        print("[AppModel] removeTracksFromPlaylist(\(tracks.count) from \(playlist.name)) not yet wired — see #132")
+    }
+
+    /// Toggle favorite across every track in the selection. If every track
+    /// is already favorited, this unfavorites them all; otherwise favorites
+    /// the un-favorited subset.
+    /// TODO(#133): set_favorite / unset_favorite FFIs not yet wired.
+    func toggleFavorite(tracks: [Track]) {
+        guard !tracks.isEmpty else { return }
+        // TODO(#133): set_favorite / unset_favorite FFIs not yet wired.
+        print("[AppModel] toggleFavorite(tracks: \(tracks.count)) not yet wired — see #133")
+    }
+
+    /// Toggle the download state of every track in the selection.
+    /// TODO(#70): download engine not yet wired.
+    func toggleDownload(tracks: [Track]) {
+        guard !tracks.isEmpty else { return }
+        // TODO(#70): download engine not yet wired.
+        print("[AppModel] toggleDownload(tracks: \(tracks.count)) not yet wired — see #70")
+    }
+
+    /// Mark or unmark every track in the selection as played.
+    /// TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
+    func toggleMarkPlayed(tracks: [Track]) {
+        guard !tracks.isEmpty else { return }
+        // TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
+        print("[AppModel] toggleMarkPlayed(tracks: \(tracks.count)) not yet wired — see #133")
+    }
+
+    // MARK: - Track sharing
+
+    /// Jellyfin web URL for a single track. Jellyfin's web UI uses the
+    /// same `details` route for every item type, so this mirrors
+    /// `webURL(for album:)` / `webURL(for playlist:)`.
+    func webURL(for track: Track) -> URL? {
+        guard !serverURL.isEmpty else { return nil }
+        let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+        return URL(string: "\(base)/web/#/details?id=\(track.id)")
+    }
+
+    /// Copy the track's web URL to the system pasteboard.
+    func copyShareLink(track: Track) {
+        guard let url = webURL(for: track) else { return }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(url.absoluteString, forType: .string)
+    }
+
+    // MARK: - Genre actions
+    //
+    // Backing calls for `GenreContextMenu`. The core doesn't yet expose a
+    // Genre type (genres are surfaced as bare strings on `Album`/`Artist`
+    // today). All four actions are TODO stubs pending follow-up work
+    // (#144 radio, #318 genre detail screen, #248 / #249 Home pinning).
+
+    /// Navigate to the genre's browse view.
+    /// TODO(#318): genre detail screen not yet implemented.
+    func browseGenre(genre: String) {
+        // TODO(#318): genre detail screen not yet implemented.
+        print("[AppModel] browseGenre(\(genre)) not yet wired — see #318")
+    }
+
+    /// Kick off an Instant Mix seeded by a genre.
+    /// TODO(#144): genre-seeded Instant Mix FFI not yet wired.
+    func startGenreRadio(genre: String) {
+        // TODO(#144): genre-seeded Instant Mix FFI not yet wired.
+        print("[AppModel] startGenreRadio(\(genre)) not yet wired — see #144")
+    }
+
+    /// Shuffle every track tagged with the given genre.
+    /// TODO(#318): genre-scoped track list FFI not yet wired.
+    func shuffleGenre(genre: String) {
+        // TODO(#318): genre-scoped track list FFI not yet wired.
+        print("[AppModel] shuffleGenre(\(genre)) not yet wired — see #318")
+    }
+
+    /// Pin a genre tile to the Home screen so the user can one-click-browse.
+    /// TODO(#248 / #249): Home personalization (pinned tiles) not yet wired.
+    func pinGenreToHome(genre: String) {
+        // TODO(#248): pinned tiles not yet wired.
+        print("[AppModel] pinGenreToHome(\(genre)) not yet wired — see #248 / #249")
     }
 
     func pause() { audio.pause() }

--- a/macos/Sources/Jellify/Components/AddToPlaylistSubmenu.swift
+++ b/macos/Sources/Jellify/Components/AddToPlaylistSubmenu.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// "Add to Playlist" submenu — shared by the track and album context menus.
+/// Renders one `Button` per user-owned playlist, plus a "New Playlist…"
+/// affordance at the top that opens the create-playlist flow.
+///
+/// Both callbacks land in `AppModel`: `onPick` fires with the chosen
+/// playlist, `onNewPlaylist` fires for the create-new shortcut. The
+/// submenu intentionally renders a flat list with a hard cap (see
+/// `maxPlaylists`) so a pathological 500-playlist library doesn't build
+/// a scroll-hostile menu — the spec mentions a search affordance in a
+/// future iteration (#72).
+///
+/// Disabled when `model.playlists` is empty, beyond the "New Playlist…"
+/// entry, so the user can still create one inline.
+struct AddToPlaylistSubmenu: View {
+    @Environment(AppModel.self) private var model
+    let onPick: (Playlist) -> Void
+    let onNewPlaylist: () -> Void
+
+    /// Safety cap — keeps the submenu usable when the server vends
+    /// thousands of playlists. The spec in #72 calls for a search field;
+    /// until that lands, capping at 50 matches Spotify's behavior.
+    private let maxPlaylists = 50
+
+    var body: some View {
+        Button("New Playlist…", systemImage: "plus") { onNewPlaylist() }
+        if !model.playlists.isEmpty {
+            Divider()
+            ForEach(model.playlists.prefix(maxPlaylists), id: \.id) { playlist in
+                Button(playlist.name) { onPick(playlist) }
+            }
+            if model.playlists.count > maxPlaylists {
+                Text("…and \(model.playlists.count - maxPlaylists) more")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/macos/Sources/Jellify/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Jellify/Components/AlbumContextMenu.swift
@@ -4,11 +4,29 @@ import SwiftUI
 /// Shared right-click / long-press context menu for album surfaces
 /// (library grid cell + album hero in detail view).
 ///
-/// Issue: #311. Many of the backing actions are TODO stubs pending
-/// follow-up FFI work (see individual `AppModel` methods for issue refs).
+/// Menu order follows Apple Music + Spotify convention and the spec in #96:
+///
+///     Play, Shuffle, Play Next, Add to Queue
+///     ─
+///     Start Album Radio, Add to Playlist →
+///     ─
+///     Go to Artist, Go to Album
+///     ─
+///     Favorite Album, Mark All as Played
+///     ─
+///     Download, Edit Album…, Copy Link
+///
+/// `showGoToAlbum` is omitted when the menu is invoked from the album's own
+/// detail screen — mirrors the spec's "if invoked from a context outside the
+/// album page" qualifier. Defaults to `true` so call sites like the library
+/// grid don't need to think about it.
+///
+/// Many of the backing actions are TODO stubs pending follow-up FFI work
+/// (see individual `AppModel` methods for issue refs).
 struct AlbumContextMenu: View {
     @Environment(AppModel.self) private var model
     let album: Album
+    var showGoToAlbum: Bool = true
 
     var body: some View {
         Button("Play", systemImage: "play.fill") { model.play(album: album) }
@@ -18,25 +36,43 @@ struct AlbumContextMenu: View {
 
         Divider()
 
-        Button("Favorite", systemImage: "heart") { model.toggleFavorite(album: album) }
-        Button("Download", systemImage: "arrow.down.circle") { model.enqueueDownload(album: album) }
-        Button("Add All to Playlist…", systemImage: "plus.rectangle.on.folder") {
-            model.requestAddToPlaylist(album: album)
+        Button("Start Album Radio", systemImage: "dot.radiowaves.left.and.right") {
+            model.startAlbumRadio(album: album)
+        }
+        Menu("Add to Playlist", systemImage: "text.badge.plus") {
+            AddToPlaylistSubmenu { playlist in
+                model.addAlbumToPlaylist(album: album, playlist: playlist)
+            } onNewPlaylist: {
+                model.requestAddToPlaylist(album: album)
+            }
         }
 
         Divider()
 
         Button("Go to Artist", systemImage: "person") { model.goToArtist(album: album) }
             .disabled(album.artistId == nil)
-        Button("Start Album Radio", systemImage: "dot.radiowaves.left.and.right") {
-            model.startAlbumRadio(album: album)
+        if showGoToAlbum {
+            Button("Go to Album", systemImage: "square.stack") {
+                model.goToAlbum(album: album)
+            }
         }
 
         Divider()
 
-        Button("Share Link", systemImage: "link") { model.copyShareLink(album: album) }
-            .disabled(model.webURL(for: album) == nil)
-        Button("Show in Jellyfin", systemImage: "safari") { model.openInJellyfin(album: album) }
+        Button("Favorite Album", systemImage: "heart") { model.toggleFavorite(album: album) }
+        Button("Mark All as Played", systemImage: "checkmark.circle") {
+            model.markAllAsPlayed(album: album)
+        }
+
+        Divider()
+
+        Button("Download", systemImage: "arrow.down.circle") {
+            model.enqueueDownload(album: album)
+        }
+        Button("Edit Album…", systemImage: "pencil") {
+            model.requestEditAlbum(album: album)
+        }
+        Button("Copy Link", systemImage: "link") { model.copyShareLink(album: album) }
             .disabled(model.webURL(for: album) == nil)
     }
 }

--- a/macos/Sources/Jellify/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/ArtistContextMenu.swift
@@ -4,41 +4,60 @@ import SwiftUI
 /// Shared right-click / long-press context menu for artist surfaces
 /// (library/search rows + artist detail hero).
 ///
-/// Issue: #312. Many of the backing actions are TODO stubs pending
-/// follow-up FFI work (see individual `AppModel` methods for issue refs).
+/// Menu order follows Apple Music + Spotify convention and the spec in #97:
+///
+///     Play All, Shuffle All, Play Next
+///     ─
+///     Start Artist Radio
+///     ─
+///     Follow / Unfollow, Go to Artist Page
+///     ─
+///     Copy Link, Share
+///
+/// `showGoToArtist` is omitted when the menu is invoked from the artist's
+/// own detail screen — mirrors the spec's "if invoked elsewhere" qualifier.
+/// Defaults to `true` so call sites like grid rows don't need to think
+/// about it.
+///
+/// Many of the backing actions are TODO stubs pending follow-up FFI work
+/// (see individual `AppModel` methods for issue refs).
 struct ArtistContextMenu: View {
     @Environment(AppModel.self) private var model
     let artist: Artist
+    var showGoToArtist: Bool = true
 
     var body: some View {
         Button("Play All", systemImage: "play.fill") { model.playAll(artist: artist) }
-        Button("Shuffle", systemImage: "shuffle") { model.shuffle(artist: artist) }
-        Button("Play Top Tracks", systemImage: "chart.bar.fill") {
-            model.playTopTracks(artist: artist)
-        }
-
-        Divider()
-
-        Button("Favorite", systemImage: "heart") { model.toggleFavorite(artist: artist) }
-        Button("Follow", systemImage: "person.badge.plus") { model.toggleFollow(artist: artist) }
+        Button("Shuffle All", systemImage: "shuffle") { model.shuffle(artist: artist) }
+        Button("Play Next", systemImage: "text.insert") { model.playNextArtist(artist: artist) }
 
         Divider()
 
         Button("Start Artist Radio", systemImage: "dot.radiowaves.left.and.right") {
             model.startArtistRadio(artist: artist)
         }
-        Button("Go to Discography", systemImage: "square.stack") {
-            model.goToDiscography(artist: artist)
-        }
-        Button("Show Similar", systemImage: "person.2") {
-            model.showSimilar(artist: artist)
+
+        Divider()
+
+        Button(
+            model.isFollowing(artist: artist) ? "Unfollow" : "Follow",
+            systemImage: model.isFollowing(artist: artist) ? "person.badge.minus" : "person.badge.plus"
+        ) { model.toggleFollow(artist: artist) }
+        if showGoToArtist {
+            Button("Go to Artist Page", systemImage: "person") {
+                model.goToArtistPage(artist: artist)
+            }
         }
 
         Divider()
 
-        Button("Share Link", systemImage: "link") { model.copyShareLink(artist: artist) }
+        Button("Copy Link", systemImage: "link") { model.copyShareLink(artist: artist) }
             .disabled(model.webURL(for: artist) == nil)
-        Button("Show in Jellyfin", systemImage: "safari") { model.openInJellyfin(artist: artist) }
-            .disabled(model.webURL(for: artist) == nil)
+        // Share is not yet wired — disabled per spec. NSSharingServicePicker
+        // support lands with #318.
+        Button("Share", systemImage: "square.and.arrow.up") {
+            // TODO(#318): present NSSharingServicePicker.
+        }
+        .disabled(true)
     }
 }

--- a/macos/Sources/Jellify/Components/GenreContextMenu.swift
+++ b/macos/Sources/Jellify/Components/GenreContextMenu.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Context menu for a genre row or chip. Spec: #314.
+///
+/// Menu order:
+///
+///     Browse genre, Start genre radio, Shuffle genre
+///     ─
+///     Pin to Home
+///
+/// The core does not yet expose a Genre type (genres are surfaced as
+/// bare strings on `Album`/`Artist` today), so this menu accepts the
+/// genre name directly. When #318 introduces a proper `Genre` struct this
+/// view can grow an overload without touching call sites.
+///
+/// All actions call through to `AppModel`. Several are TODO stubs pending
+/// follow-up FFI work (genre browse is #318, genre radio is part of
+/// #144, and pin-to-home lives alongside the Home personalization work
+/// in #248 / #249).
+struct GenreContextMenu: View {
+    @Environment(AppModel.self) private var model
+    let genre: String
+
+    var body: some View {
+        Button("Browse genre", systemImage: "square.grid.2x2") {
+            model.browseGenre(genre: genre)
+        }
+        Button("Start genre radio", systemImage: "dot.radiowaves.left.and.right") {
+            model.startGenreRadio(genre: genre)
+        }
+        Button("Shuffle genre", systemImage: "shuffle") {
+            model.shuffleGenre(genre: genre)
+        }
+
+        Divider()
+
+        Button("Pin to Home", systemImage: "pin") {
+            model.pinGenreToHome(genre: genre)
+        }
+    }
+}

--- a/macos/Sources/Jellify/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/PlaylistContextMenu.swift
@@ -2,13 +2,20 @@ import SwiftUI
 @preconcurrency import JellifyCore
 
 /// Shared right-click / long-press context menu for playlist surfaces
-/// (sidebar rows + playlist detail hero, once those land).
+/// (sidebar rows, library grid cards, playlist detail hero).
 ///
-/// Issue: #313. Parallels `AlbumContextMenu` (#311). Many of the backing
-/// actions are TODO stubs pending follow-up FFI work: playlist mutation
-/// (#126 create, #130 update/rename, #131 delete), queue append (#282),
-/// favorites (#133), and the download engine (#70). See the individual
-/// `AppModel` methods for the full list of issue references.
+/// Menu order follows Apple Music + Spotify convention and the spec in #98:
+///
+///     Play, Shuffle, Play Next, Add to Queue
+///     ─
+///     Rename (inline), Duplicate, Delete (with confirm)
+///     ─
+///     Export as .m3u8…, Copy Link
+///
+/// The destructive Delete action opens a `.confirmationDialog` on the parent
+/// view via `AppModel.playlistPendingDelete`. Destructive mutations
+/// (rename, duplicate, delete) call through to BATCH-06 stubs in
+/// `AppModel`; those forward to real core calls when #126 / #130 / #131 land.
 struct PlaylistContextMenu: View {
     @Environment(AppModel.self) private var model
     let playlist: Playlist
@@ -21,18 +28,20 @@ struct PlaylistContextMenu: View {
 
         Divider()
 
-        Button("Favorite", systemImage: "heart") { model.toggleFavorite(playlist: playlist) }
-        Button("Download", systemImage: "arrow.down.circle") { model.enqueueDownload(playlist: playlist) }
-        Button("Rename…", systemImage: "pencil") { model.requestRename(playlist: playlist) }
+        Button("Rename", systemImage: "pencil") { model.requestRename(playlist: playlist) }
+        Button("Duplicate", systemImage: "plus.square.on.square") {
+            model.requestDuplicate(playlist: playlist)
+        }
         Button("Delete", systemImage: "trash", role: .destructive) {
-            model.requestDelete(playlist: playlist)
+            model.confirmDelete(playlist: playlist)
         }
 
         Divider()
 
-        Button("Share Link", systemImage: "link") { model.copyShareLink(playlist: playlist) }
-            .disabled(model.webURL(for: playlist) == nil)
-        Button("Show in Jellyfin", systemImage: "safari") { model.openInJellyfin(playlist: playlist) }
+        Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
+            model.exportPlaylist(playlist: playlist)
+        }
+        Button("Copy Link", systemImage: "link") { model.copyShareLink(playlist: playlist) }
             .disabled(model.webURL(for: playlist) == nil)
     }
 }

--- a/macos/Sources/Jellify/Components/TopTrackRow.swift
+++ b/macos/Sources/Jellify/Components/TopTrackRow.swift
@@ -114,6 +114,7 @@ struct TopTrackRow: View {
                 withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
             }
         }
+        .contextMenu { TrackContextMenu(selection: [track]) }
         .accessibilityLabel("\(track.name), \(playCountLabel), rank \(rank)")
         .accessibilityHint("Plays this track")
     }

--- a/macos/Sources/Jellify/Components/TrackContextMenu.swift
+++ b/macos/Sources/Jellify/Components/TrackContextMenu.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Shared right-click / long-press context menu for track rows. Covers
+/// both the single-track and multi-selection cases via the `selection`
+/// parameter — pass a single-element array for `TrackListRow` / `TrackRow`
+/// surfaces and the full selection set for multi-select contexts (tracked
+/// in #315).
+///
+/// Menu order follows Apple Music + Spotify convention and the spec in
+/// #95 / #310:
+///
+///     Play (↩), Play Next, Add to Queue
+///     ─
+///     Start Song Radio, Add to Playlist →
+///     ─
+///     Go to Album, Go to Artist, Show Track Info    (single-track only)
+///     Remove from Playlist                          (multi-select in playlist)
+///     ─
+///     Favorite / Unfavorite, Download / Remove Download, Mark as Played / Unplayed
+///     ─
+///     Copy Link, Share
+///
+/// For multi-selection: the "Go to …" actions are omitted (they can't
+/// disambiguate across a selection); a "Remove from Playlist" action
+/// appears when `playlistScope` is non-nil (invoked from a playlist
+/// detail view).
+///
+/// Backing actions call through to `AppModel`. Several are TODO stubs
+/// pending FFI work (song radio, track info, download engine,
+/// mark-played, share). Disabled states follow suit per spec.
+struct TrackContextMenu: View {
+    @Environment(AppModel.self) private var model
+    /// The selection this menu acts on. Single-track call sites pass
+    /// `[track]`; multi-select surfaces pass every selected track.
+    let selection: [Track]
+    /// When non-nil, the menu was invoked from within a playlist detail
+    /// view; enables the "Remove from Playlist" entry.
+    var playlistScope: Playlist?
+
+    private var isMulti: Bool { selection.count > 1 }
+    private var first: Track? { selection.first }
+
+    /// Label suffix for actions that span a multi-track selection, e.g.
+    /// "Add 5 Songs to Queue". Empty for the single-track case so labels
+    /// stay short and canonical.
+    private var countSuffix: String {
+        guard isMulti else { return "" }
+        return " (\(selection.count))"
+    }
+
+    var body: some View {
+        Button("Play\(countSuffix)", systemImage: "play.fill") {
+            model.play(tracks: selection, startIndex: 0)
+        }
+        .keyboardShortcut(.defaultAction)
+        Button("Play Next\(countSuffix)", systemImage: "text.insert") {
+            model.playNext(tracks: selection)
+        }
+        Button("Add to Queue\(countSuffix)", systemImage: "text.append") {
+            model.addToQueue(tracks: selection)
+        }
+
+        Divider()
+
+        Button("Start Song Radio", systemImage: "dot.radiowaves.left.and.right") {
+            if let track = first { model.startSongRadio(track: track) }
+        }
+        .disabled(isMulti || first == nil)
+        Menu("Add to Playlist", systemImage: "text.badge.plus") {
+            AddToPlaylistSubmenu { playlist in
+                model.addTracksToPlaylist(tracks: selection, playlist: playlist)
+            } onNewPlaylist: {
+                model.requestAddTracksToPlaylist(tracks: selection)
+            }
+        }
+
+        Divider()
+
+        // Go-to actions are single-track only per #315.
+        if !isMulti, let track = first {
+            Button("Go to Album", systemImage: "square.stack") {
+                model.goToAlbum(track: track)
+            }
+            .disabled(track.albumId == nil)
+            Button("Go to Artist", systemImage: "person") {
+                model.goToArtist(track: track)
+            }
+            .disabled(track.artistId == nil)
+            Button("Show Track Info", systemImage: "info.circle") {
+                model.showTrackInfo(track: track)
+            }
+            .keyboardShortcut("i", modifiers: .command)
+        }
+
+        if let scope = playlistScope {
+            Button("Remove from Playlist", systemImage: "minus.circle", role: .destructive) {
+                model.removeTracksFromPlaylist(tracks: selection, playlist: scope)
+            }
+        }
+
+        if !isMulti || playlistScope != nil { Divider() }
+
+        Button(
+            favoriteLabel,
+            systemImage: allFavorited ? "heart.slash" : "heart"
+        ) { model.toggleFavorite(tracks: selection) }
+        Button(
+            downloadLabel,
+            systemImage: "arrow.down.circle"
+        ) { model.toggleDownload(tracks: selection) }
+        Button(
+            markPlayedLabel,
+            systemImage: "checkmark.circle"
+        ) { model.toggleMarkPlayed(tracks: selection) }
+
+        Divider()
+
+        Button("Copy Link", systemImage: "link") {
+            if let track = first { model.copyShareLink(track: track) }
+        }
+        .disabled(isMulti || first.flatMap { model.webURL(for: $0) } == nil)
+        // Share is not yet wired — disabled per spec. NSSharingServicePicker
+        // support lands with #318.
+        Button("Share", systemImage: "square.and.arrow.up") {
+            // TODO(#318): present NSSharingServicePicker.
+        }
+        .disabled(true)
+    }
+
+    /// True when every track in the selection is already favorited, so the
+    /// toggle reads as "Unfavorite" rather than "Favorite".
+    private var allFavorited: Bool {
+        !selection.isEmpty && selection.allSatisfy { $0.isFavorite }
+    }
+
+    private var favoriteLabel: String {
+        allFavorited ? "Unfavorite\(countSuffix)" : "Favorite\(countSuffix)"
+    }
+
+    private var downloadLabel: String {
+        // Download state isn't tracked per-track yet (#70 downloads engine),
+        // so the label always reads as "Download" for now. Once state lands
+        // this mirrors favorite's all-on / any-off logic.
+        "Download\(countSuffix)"
+    }
+
+    private var markPlayedLabel: String {
+        // Mark-played state tracked by playCount>0 would require per-track
+        // inspection; for the selection-aware label we report the canonical
+        // "Mark as Played" copy and let the action toggle intelligently.
+        "Mark as Played\(countSuffix)"
+    }
+}

--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -106,6 +106,7 @@ struct TrackListRow: View {
                 withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
             }
         }
+        .contextMenu { TrackContextMenu(selection: [track]) }
         .accessibilityLabel("\(track.name) by \(track.artistName)")
     }
 }

--- a/macos/Sources/Jellify/Components/TrackRow.swift
+++ b/macos/Sources/Jellify/Components/TrackRow.swift
@@ -64,6 +64,7 @@ struct TrackRow: View {
         .onHover { isHovering = $0 }
         .onTapGesture(count: 2) { onPlay?() }
         .onTapGesture(count: 1) { onPlay?() }
+        .contextMenu { TrackContextMenu(selection: [track]) }
     }
 }
 

--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -85,7 +85,7 @@ struct AlbumDetailView: View {
             .overlay(alignment: .bottom) {
                 Rectangle().fill(Theme.border).frame(height: 1)
             }
-            .contextMenu { AlbumContextMenu(album: album) }
+            .contextMenu { AlbumContextMenu(album: album, showGoToAlbum: false) }
         }
     }
 

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -29,6 +29,22 @@ struct MainShell: View {
                 model.authExpired = false
             }
         }
+        // Playlist-delete confirmation — see #98 / #131. Triggered from
+        // `PlaylistContextMenu` via `AppModel.confirmDelete(playlist:)`.
+        .confirmationDialog(
+            model.playlistPendingDelete.map { "Delete \($0.name)?" } ?? "",
+            isPresented: .init(
+                get: { model.playlistPendingDelete != nil },
+                set: { if !$0 { model.cancelDeletePending() } }
+            ),
+            titleVisibility: .visible,
+            presenting: model.playlistPendingDelete
+        ) { _ in
+            Button("Delete", role: .destructive) { model.performDeletePending() }
+            Button("Cancel", role: .cancel) { model.cancelDeletePending() }
+        } message: { playlist in
+            Text("This will permanently delete \"\(playlist.name)\". This action cannot be undone.")
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes #15, #95, #96, #97, #98, #310, #314, #315