### PR TITLE
macos: home screen carousels (jump back in, recently played, recently added, quick picks, favorites)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -67,6 +67,38 @@ final class AppModel {
     /// follow-up on the core (no FFI exists yet; see `refreshForYou()` for
     /// the TODO).
     var forYou: [Track] = []
+    /// Last-played albums for the Home "Jump Back In" carousel (#51). Up to
+    /// 12 albums the user has played recently, sorted by `DatePlayed` desc.
+    /// Backed by a raw `/Items` fetch because the core's `ItemsQuery`
+    /// builder (BATCH-24) hasn't landed yet. See `refreshJumpBackIn`.
+    var jumpBackIn: [Album] = []
+    /// Recently-added albums for the Home "Recently Added" carousel (#54).
+    /// Up to 20 albums, sorted by `DateCreated` desc (server-side via
+    /// `/Users/{id}/Items/Latest`). Wired through the existing
+    /// `core.latestAlbums` FFI.
+    var recentlyAdded: [Album] = []
+    /// `DateCreated` for each album in `recentlyAdded`, keyed by album id.
+    /// Drives the "NEW" badge on tiles within the last 7 days. Parsed
+    /// alongside the album list in `refreshRecentlyAdded`.
+    var recentlyAddedDates: [String: Date] = [:]
+    /// "Quick Picks" — heavy-rotation albums over the last 30 days (#53).
+    /// Sorted by server-side `PlayCount` desc with a client-side
+    /// `DatePlayed > now - 30d` filter applied via Jellyfin's `MinDateLastSaved`.
+    /// Up to 12 albums.
+    var quickPicks: [Album] = []
+    /// Play count per album in `quickPicks`, keyed by album id. Shown as a
+    /// subtle "42 plays" badge on tile hover. Parsed out of the same `/Items`
+    /// response that drives `quickPicks`.
+    var quickPicksPlayCounts: [String: UInt32] = [:]
+    /// Favorite albums for the Home "Favorites" carousel (#55). The full
+    /// favorite set is fetched once per session and then shuffled down to
+    /// 12 visible tiles — re-shuffled on each `refreshFavoriteAlbums` call
+    /// so the carousel feels fresh on relaunch.
+    var favoriteAlbumsAll: [Album] = []
+    /// Currently-visible shuffled sample of `favoriteAlbumsAll`, capped at
+    /// 12. Re-derived every time the backing set is refreshed so the view
+    /// doesn't have to know about the shuffle.
+    var favoriteAlbumsVisible: [Album] = []
     var searchResults: SearchResults?
     var searchQuery: String = ""
 
@@ -299,6 +331,13 @@ final class AppModel {
         artistTopTracks = [:]
         recentlyPlayed = []
         forYou = []
+        jumpBackIn = []
+        recentlyAdded = []
+        recentlyAddedDates = [:]
+        quickPicks = []
+        quickPicksPlayCounts = [:]
+        favoriteAlbumsAll = []
+        favoriteAlbumsVisible = []
         searchResults = nil
         searchQuery = ""
         currentTrackPeople = []
@@ -332,6 +371,13 @@ final class AppModel {
         artistTopTracks = [:]
         recentlyPlayed = []
         forYou = []
+        jumpBackIn = []
+        recentlyAdded = []
+        recentlyAddedDates = [:]
+        quickPicks = []
+        quickPicksPlayCounts = [:]
+        favoriteAlbumsAll = []
+        favoriteAlbumsVisible = []
         searchResults = nil
         searchQuery = ""
         currentTrackPeople = []
@@ -432,6 +478,14 @@ final class AppModel {
         _ = await playlistsResult
         await refreshRecentlyPlayed()
         await refreshForYou()
+        // Home screen carousels (#49 / #51–#55). Kicked off after the main
+        // library so first paint isn't blocked on these secondary shelves.
+        // Each of these is best-effort — empty or errored rows just hide in
+        // the Home layout.
+        await refreshJumpBackIn()
+        await refreshRecentlyAdded()
+        await refreshQuickPicks()
+        await refreshFavoriteAlbums()
     }
 
     /// Fetch the next page of albums and append to `albums`. No-op when a
@@ -699,6 +753,526 @@ final class AppModel {
         // fetched. Capped at 20 so the carousel stays tight even if the core
         // later starts returning a longer list.
         self.forYou = Array(recentlyPlayed.prefix(20))
+    }
+
+    // MARK: - Home carousels (#49 / #51–#55)
+    //
+    // The Home carousels (#51 Jump Back In, #52 Recently Played, #53 Quick
+    // Picks, #54 Recently Added, #55 Favorites) each need an `/Items` query
+    // with a different `SortBy` / `Filters` combination. The core exposes
+    // `list_albums` / `latest_albums` / `recently_played` for the
+    // un-filtered variants, but the three new album-level shelves
+    // (Jump Back In, Quick Picks, Favorites) rely on filter knobs the
+    // core's current FFI doesn't expose. Rather than block Home on a new
+    // `items_query` builder (BATCH-24), we inline the raw HTTP call here
+    // via the session URL + `auth_header` and parse the subset of
+    // `BaseItemDto` we care about. Swap to the typed builder when it lands.
+    //
+    // TODO(core-#465): retire these raw fetches in favour of a typed
+    //   `core.items_query()` builder once it exists.
+
+    /// Refresh the "Jump Back In" carousel (#51). Fetches up to 12 albums
+    /// the user has played recently, sorted by `DatePlayed` descending and
+    /// filtered to `IsPlayed`. Silent on error — an empty shelf is a fine
+    /// first-time-user state.
+    func refreshJumpBackIn() async {
+        let albums = await fetchAlbumsViaItemsQuery(
+            sortBy: "DatePlayed",
+            filters: "IsPlayed",
+            limit: 12,
+            extraFields: [],
+            minDateLastSaved: nil
+        )
+        self.jumpBackIn = albums
+    }
+
+    /// Refresh the "Recently Added" carousel (#54). Uses the core's
+    /// `latest_albums` FFI, which is already backed by Jellyfin's
+    /// `/Users/{id}/Items/Latest` endpoint. Falls back to the empty
+    /// `library_id` convention already used elsewhere (see
+    /// `ensurePlaylistLibraryId`) until a real library resolver lands.
+    /// Also parses `DateCreated` off the server so the tile can surface a
+    /// "NEW" badge for albums created in the last 7 days.
+    func refreshRecentlyAdded() async {
+        // TODO(core-#465): the typed `latest_albums` FFI returns
+        //   `PaginatedAlbums` without the `DateCreated` field that drives
+        //   the NEW badge. Until the core surfaces that directly, fetch
+        //   the same shape via `/Users/{id}/Items/Latest` and pull both
+        //   the album list + per-item `DateCreated` out of one response.
+        let (albums, dates) = await fetchLatestAlbumsWithDates(limit: 20)
+        self.recentlyAdded = albums
+        self.recentlyAddedDates = dates
+    }
+
+    /// Refresh the "Quick Picks" carousel (#53). Heavy-rotation albums
+    /// over the last 30 days, sorted by `PlayCount` descending. The core
+    /// doesn't yet expose a `min_date_played` filter, so this is an
+    /// inlined `/Items` fetch. Also records per-album play counts so the
+    /// tile can surface a "42 plays" badge on hover.
+    func refreshQuickPicks() async {
+        // Jellyfin doesn't ship a "date played > X" filter, but the
+        // `MinDateLastSaved` parameter on /Items is a reasonable proxy —
+        // it gates on "last touched by the user", which for our purposes
+        // (filtering out stale top-played ancient history) lines up well.
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+        let thirtyDaysAgo = Date(timeIntervalSinceNow: -30 * 24 * 60 * 60)
+        let minDate = iso.string(from: thirtyDaysAgo)
+        let (albums, playCounts) = await fetchAlbumsWithPlayCounts(
+            sortBy: "PlayCount,SortName",
+            filters: "IsPlayed",
+            limit: 12,
+            minDateLastSaved: minDate
+        )
+        self.quickPicks = albums
+        self.quickPicksPlayCounts = playCounts
+    }
+
+    /// Refresh the "Favorites" carousel (#55). Fetches up to 50 favorite
+    /// albums, stores the full set, and picks a random 12 to surface
+    /// today. Re-shuffles whenever this is called — which happens on
+    /// login, on an explicit pull-to-refresh, or on app relaunch.
+    func refreshFavoriteAlbums() async {
+        let albums = await fetchAlbumsViaItemsQuery(
+            sortBy: "SortName",
+            filters: "IsFavorite",
+            limit: 50,
+            extraFields: [],
+            minDateLastSaved: nil
+        )
+        self.favoriteAlbumsAll = albums
+        self.favoriteAlbumsVisible = Array(albums.shuffled().prefix(12))
+        // Hydrate the per-id favorite map so album detail / tile hearts are
+        // correct from first paint without waiting for the user to toggle.
+        for album in albums {
+            favoriteById[album.id] = true
+        }
+    }
+
+    /// Re-shuffle `favoriteAlbumsVisible` from the already-fetched
+    /// `favoriteAlbumsAll`. Cheaper than a full refresh — used by the "see
+    /// all" / reshuffle affordance when we want a new set without hitting
+    /// the server.
+    func reshuffleFavoriteAlbumsVisible() {
+        self.favoriteAlbumsVisible = Array(favoriteAlbumsAll.shuffled().prefix(12))
+    }
+
+    /// Load every favorite track on the server and play them shuffled.
+    /// Powers the "Shuffle All Favorites" CTA on the Home favorites header
+    /// (#55). Fetches up to 500 favorite tracks in one shot — that's an
+    /// order of magnitude above the typical power-user favorite library
+    /// and more than enough to seed a shuffled listening session.
+    func shuffleAllFavorites() {
+        Task {
+            let tracks = await fetchFavoriteTracks(limit: 500)
+            guard !tracks.isEmpty else {
+                // Silent no-op if the user has nothing favorited yet — the
+                // empty state in the Favorites header explains how to
+                // start favoriting.
+                return
+            }
+            play(tracks: tracks.shuffled(), startIndex: 0)
+        }
+    }
+
+    /// Navigate to the full library scoped to favorites (#55 "See All").
+    /// The library view doesn't yet carry a "filter to favorites" chip
+    /// (tracked alongside the filter UI in a future library polish pass),
+    /// so this just routes the user to the library for now. The view
+    /// accepts additional filters once the chip row grows one.
+    func showAllFavorites() {
+        // TODO(library-filter): once the library chip row supports a
+        //   "Favorites" filter, route here with the filter pre-selected.
+        screen = .library
+    }
+
+    /// Shared helper: build a `GET /Items` request against the user's
+    /// library with the given `sortBy` / `filters`, parse the response,
+    /// and return a typed array of `Album`. Returns an empty array on
+    /// any failure (auth, network, parse) so callers can stay
+    /// conditionally-rendering shelves without an error-banner code path.
+    ///
+    /// TODO(core-#465): replace with a typed `core.items_query()` builder
+    ///   once that FFI exists. This function's surface lines up
+    ///   deliberately with the shape that builder will expose.
+    private func fetchAlbumsViaItemsQuery(
+        sortBy: String,
+        filters: String?,
+        limit: UInt32,
+        extraFields: [String],
+        minDateLastSaved: String?
+    ) async -> [Album] {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "MusicAlbum",
+            sortBy: sortBy,
+            sortOrder: "Descending",
+            filters: filters,
+            limit: limit,
+            extraFields: extraFields,
+            minDateLastSaved: minDateLastSaved,
+            parentId: nil
+        ) else { return [] }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return []
+            }
+            return Self.parseAlbumsFromItems(data: data)
+        } catch {
+            print("[AppModel] fetchAlbumsViaItemsQuery failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Like `fetchAlbumsViaItemsQuery` but also returns a map from album
+    /// id to the server-reported `UserData.PlayCount` so "N plays" can
+    /// render on the Quick Picks tile.
+    private func fetchAlbumsWithPlayCounts(
+        sortBy: String,
+        filters: String?,
+        limit: UInt32,
+        minDateLastSaved: String?
+    ) async -> ([Album], [String: UInt32]) {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "MusicAlbum",
+            sortBy: sortBy,
+            sortOrder: "Descending",
+            filters: filters,
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: minDateLastSaved,
+            parentId: nil
+        ) else { return ([], [:]) }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return ([], [:])
+            }
+            return Self.parseAlbumsWithPlayCounts(data: data)
+        } catch {
+            print("[AppModel] fetchAlbumsWithPlayCounts failed: \(error.localizedDescription)")
+            return ([], [:])
+        }
+    }
+
+    /// Fetch Recently Added via `/Users/{id}/Items/Latest`. Returns both
+    /// the album array and a per-album `DateCreated` map (used by the NEW
+    /// badge on `RecentlyAddedTile`).
+    private func fetchLatestAlbumsWithDates(limit: UInt32) async -> ([Album], [String: Date]) {
+        guard let session = session,
+              let baseURL = URL(string: session.server.url),
+              let authHeader = try? core.authHeader()
+        else { return ([], [:]) }
+        let userId = session.user.id
+        var comps = URLComponents(
+            url: baseURL.appendingPathComponent("Users/\(userId)/Items/Latest"),
+            resolvingAgainstBaseURL: false
+        )
+        comps?.queryItems = [
+            URLQueryItem(name: "IncludeItemTypes", value: "MusicAlbum"),
+            URLQueryItem(name: "Limit", value: String(limit)),
+            URLQueryItem(name: "GroupItems", value: "true"),
+            URLQueryItem(
+                name: "Fields",
+                value: "Genres,ProductionYear,DateCreated,ChildCount,PrimaryImageAspectRatio"
+            ),
+        ]
+        guard let url = comps?.url else { return ([], [:]) }
+        var request = URLRequest(url: url)
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return ([], [:])
+            }
+            // `/Items/Latest` returns a bare array, not the
+            // `{Items, TotalRecordCount}` wrapper — parse accordingly.
+            return Self.parseLatestAlbumsWithDates(data: data)
+        } catch {
+            print("[AppModel] fetchLatestAlbumsWithDates failed: \(error.localizedDescription)")
+            return ([], [:])
+        }
+    }
+
+    /// Fetch up to `limit` favorited audio tracks. Backs the
+    /// "Shuffle All Favorites" CTA on the Home Favorites header (#55).
+    private func fetchFavoriteTracks(limit: UInt32) async -> [Track] {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "Audio",
+            sortBy: "Random",
+            sortOrder: "Ascending",
+            filters: "IsFavorite",
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: nil,
+            parentId: nil
+        ) else { return [] }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return []
+            }
+            return Self.parseTracksFromItems(data: data)
+        } catch {
+            print("[AppModel] fetchFavoriteTracks failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Build an authenticated `GET /Items` request against the current
+    /// session's server. Returns `nil` when there is no session or the
+    /// core refuses to hand out an auth header. Keeps the URL
+    /// construction boilerplate in one place so each caller can just
+    /// specify the filter knobs it cares about.
+    private func buildItemsQuery(
+        includeItemTypes: String,
+        sortBy: String,
+        sortOrder: String,
+        filters: String?,
+        limit: UInt32,
+        extraFields: [String],
+        minDateLastSaved: String?,
+        parentId: String?
+    ) -> URLRequest? {
+        guard let session = session,
+              let baseURL = URL(string: session.server.url),
+              let authHeader = try? core.authHeader()
+        else { return nil }
+        let userId = session.user.id
+        var comps = URLComponents(
+            url: baseURL.appendingPathComponent("Users/\(userId)/Items"),
+            resolvingAgainstBaseURL: false
+        )
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "IncludeItemTypes", value: includeItemTypes),
+            URLQueryItem(name: "Recursive", value: "true"),
+            URLQueryItem(name: "SortBy", value: sortBy),
+            URLQueryItem(name: "SortOrder", value: sortOrder),
+            URLQueryItem(name: "Limit", value: String(limit)),
+            URLQueryItem(
+                name: "Fields",
+                value: (["Genres", "ProductionYear", "ChildCount", "PrimaryImageAspectRatio", "UserData"] + extraFields)
+                    .joined(separator: ",")
+            ),
+        ]
+        if let filters, !filters.isEmpty {
+            queryItems.append(URLQueryItem(name: "Filters", value: filters))
+        }
+        if let minDateLastSaved {
+            queryItems.append(URLQueryItem(name: "MinDateLastSaved", value: minDateLastSaved))
+        }
+        if let parentId, !parentId.isEmpty {
+            queryItems.append(URLQueryItem(name: "ParentId", value: parentId))
+        }
+        comps?.queryItems = queryItems
+        guard let url = comps?.url else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    /// Parse the `{ Items: [...], TotalRecordCount: ... }` envelope
+    /// Jellyfin returns for `/Users/{id}/Items` into our typed `Album`
+    /// array. Only the fields `Album` carries are extracted; everything
+    /// else is dropped. Returns `[]` on any parse failure.
+    private static func parseAlbumsFromItems(data: Data) -> [Album] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = root["Items"] as? [[String: Any]]
+        else { return [] }
+        return items.compactMap { Self.albumFromDTO($0) }
+    }
+
+    /// Like `parseAlbumsFromItems` but also extracts `UserData.PlayCount`
+    /// per item into the returned map.
+    private static func parseAlbumsWithPlayCounts(data: Data) -> ([Album], [String: UInt32]) {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = root["Items"] as? [[String: Any]]
+        else { return ([], [:]) }
+        var albums: [Album] = []
+        var plays: [String: UInt32] = [:]
+        for entry in items {
+            guard let album = Self.albumFromDTO(entry) else { continue }
+            albums.append(album)
+            if let userData = entry["UserData"] as? [String: Any],
+               let playCount = userData["PlayCount"] as? Int, playCount > 0 {
+                plays[album.id] = UInt32(playCount)
+            }
+        }
+        return (albums, plays)
+    }
+
+    /// Parse the bare `BaseItemDto[]` response from
+    /// `/Users/{id}/Items/Latest` into an album list + per-album
+    /// `DateCreated` map. The NEW badge on `RecentlyAddedTile` reads the
+    /// date map.
+    private static func parseLatestAlbumsWithDates(data: Data) -> ([Album], [String: Date]) {
+        guard let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return ([], [:]) }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var albums: [Album] = []
+        var dates: [String: Date] = [:]
+        for entry in items {
+            guard let album = Self.albumFromDTO(entry) else { continue }
+            albums.append(album)
+            if let raw = entry["DateCreated"] as? String {
+                if let d = iso.date(from: raw) {
+                    dates[album.id] = d
+                } else {
+                    iso.formatOptions = [.withInternetDateTime]
+                    if let d = iso.date(from: raw) {
+                        dates[album.id] = d
+                    }
+                    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                }
+            }
+        }
+        return (albums, dates)
+    }
+
+    /// Parse a Jellyfin `BaseItemDto` (from a `/Items` response) into the
+    /// typed `Album` the core produces. Returns `nil` when the minimum
+    /// required fields (`Id`, `Name`) aren't present so we don't render
+    /// blank tiles.
+    private static func albumFromDTO(_ entry: [String: Any]) -> Album? {
+        guard
+            let id = (entry["Id"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !id.isEmpty,
+            let name = (entry["Name"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !name.isEmpty
+        else { return nil }
+        let artistName = (entry["AlbumArtist"] as? String)
+            ?? (entry["Artists"] as? [String])?.first
+            ?? ""
+        let artistId: String? = {
+            if let id = entry["AlbumArtistId"] as? String, !id.isEmpty { return id }
+            if let items = entry["AlbumArtists"] as? [[String: Any]],
+               let first = items.first,
+               let id = first["Id"] as? String, !id.isEmpty { return id }
+            return nil
+        }()
+        let year: Int32? = {
+            if let y = entry["ProductionYear"] as? Int, y > 0 { return Int32(y) }
+            return nil
+        }()
+        let trackCount: UInt32 = {
+            if let c = entry["ChildCount"] as? Int, c >= 0 { return UInt32(c) }
+            return 0
+        }()
+        let runtimeTicks: UInt64 = {
+            if let t = entry["RunTimeTicks"] as? Int64, t >= 0 { return UInt64(t) }
+            if let t = entry["RunTimeTicks"] as? Int, t >= 0 { return UInt64(t) }
+            return 0
+        }()
+        let genres: [String] = (entry["Genres"] as? [String]) ?? []
+        let imageTag: String? = {
+            if let tags = entry["ImageTags"] as? [String: String],
+               let primary = tags["Primary"], !primary.isEmpty { return primary }
+            return nil
+        }()
+        return Album(
+            id: id,
+            name: name,
+            artistName: artistName,
+            artistId: artistId,
+            year: year,
+            trackCount: trackCount,
+            runtimeTicks: runtimeTicks,
+            genres: genres,
+            imageTag: imageTag
+        )
+    }
+
+    /// Parse the `{ Items: [...] }` envelope into typed `Track` values.
+    /// Mirrors `parseAlbumsFromItems` but targets audio tracks — used by
+    /// `fetchFavoriteTracks` for the Shuffle All Favorites CTA.
+    private static func parseTracksFromItems(data: Data) -> [Track] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = root["Items"] as? [[String: Any]]
+        else { return [] }
+        return items.compactMap { Self.trackFromDTO($0) }
+    }
+
+    /// Turn a `BaseItemDto` (audio track) into the typed `Track` record.
+    /// Returns `nil` on missing `Id`/`Name` so blank rows don't land in
+    /// the shuffle queue.
+    private static func trackFromDTO(_ entry: [String: Any]) -> Track? {
+        guard
+            let id = (entry["Id"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !id.isEmpty,
+            let name = (entry["Name"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !name.isEmpty
+        else { return nil }
+        let albumId = (entry["AlbumId"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let albumName = (entry["Album"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let artistName = (entry["AlbumArtist"] as? String)
+            ?? (entry["Artists"] as? [String])?.first
+            ?? ""
+        let artistId: String? = {
+            if let items = entry["ArtistItems"] as? [[String: Any]],
+               let first = items.first,
+               let id = first["Id"] as? String, !id.isEmpty { return id }
+            if let items = entry["AlbumArtists"] as? [[String: Any]],
+               let first = items.first,
+               let id = first["Id"] as? String, !id.isEmpty { return id }
+            return nil
+        }()
+        let indexNumber: UInt32? = {
+            if let n = entry["IndexNumber"] as? Int, n > 0 { return UInt32(n) }
+            return nil
+        }()
+        let discNumber: UInt32? = {
+            if let n = entry["ParentIndexNumber"] as? Int, n > 0 { return UInt32(n) }
+            return nil
+        }()
+        let year: Int32? = {
+            if let y = entry["ProductionYear"] as? Int, y > 0 { return Int32(y) }
+            return nil
+        }()
+        let runtimeTicks: UInt64 = {
+            if let t = entry["RunTimeTicks"] as? Int64, t >= 0 { return UInt64(t) }
+            if let t = entry["RunTimeTicks"] as? Int, t >= 0 { return UInt64(t) }
+            return 0
+        }()
+        let userData = entry["UserData"] as? [String: Any]
+        let isFavorite = (userData?["IsFavorite"] as? Bool) ?? false
+        let playCount: UInt32 = {
+            if let c = userData?["PlayCount"] as? Int, c > 0 { return UInt32(c) }
+            return 0
+        }()
+        let container = (entry["Container"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let bitrate: UInt32? = {
+            if let b = entry["Bitrate"] as? Int, b > 0 { return UInt32(b) }
+            return nil
+        }()
+        let imageTag: String? = {
+            if let tags = entry["ImageTags"] as? [String: String],
+               let primary = tags["Primary"], !primary.isEmpty { return primary }
+            return nil
+        }()
+        return Track(
+            id: id,
+            name: name,
+            albumId: albumId,
+            albumName: albumName,
+            artistName: artistName,
+            artistId: artistId,
+            indexNumber: indexNumber,
+            discNumber: discNumber,
+            year: year,
+            runtimeTicks: runtimeTicks,
+            isFavorite: isFavorite,
+            playCount: playCount,
+            container: container,
+            bitrate: bitrate,
+            imageTag: imageTag
+        )
     }
 
     func loadTracks(forAlbum albumID: String) async -> [Track] {

--- a/macos/Sources/Jellify/Components/HomeAlbumTile.swift
+++ b/macos/Sources/Jellify/Components/HomeAlbumTile.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// 180pt square album tile used in the Home screen's horizontal album
+/// carousels: Jump Back In (#51), Quick Picks (#53), Recently Added (#54),
+/// and Favorites (#55).
+///
+/// Clicking plays the album immediately; double-clicking opens the album
+/// detail screen. Right-click surfaces the shared `AlbumContextMenu` with
+/// Play / Shuffle / Play Next / Add to Queue / Go to Artist / radio
+/// actions. The floating play button lifts in on hover so the tile still
+/// reads as a single "open me" affordance in a dense row.
+///
+/// Intentionally distinct from the library's `AlbumCard` (which is tuned
+/// for a grid container that lifts hover state into a shared binding and
+/// uses `.adaptive` sizing). This tile is fixed-width and self-contained
+/// so it plays nicely in a `LazyHStack` carousel.
+///
+/// The `badge` closure is called during the artwork overlay phase — use
+/// it to stamp a "NEW" chip, a play-count chip, etc. on a specific tile
+/// variant without forking the whole component.
+struct HomeAlbumTile<Badge: View>: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let album: Album
+    /// Optional subtitle override — defaults to `artist · year`. Used by
+    /// variants that want a different subline (e.g. "Quick Picks" may
+    /// eventually want "Heavy rotation" as a genre chip).
+    var subtitle: String?
+    /// Accessibility hint suffix. Defaults to "Plays the album" — callers
+    /// that want a different hint (e.g. "Opens the album detail") override.
+    var hint: String = "Click to play, double-click to open"
+    @ViewBuilder let badge: () -> Badge
+
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            artwork
+            metadata
+        }
+        .frame(width: 180)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture(count: 2) {
+            model.screen = .album(album.id)
+        }
+        .onTapGesture(count: 1) {
+            model.play(album: album)
+        }
+        .contextMenu { AlbumContextMenu(album: album) }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(album.name) by \(album.artistName)")
+        .accessibilityHint(hint)
+    }
+
+    private var artwork: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Artwork(
+                url: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 400),
+                seed: album.name,
+                size: 180,
+                radius: 8,
+                targetPixelSize: CGSize(width: 540, height: 540)
+            )
+            .frame(width: 180, height: 180)
+            // Badge (NEW chip / play-count chip) anchored to the
+            // top-leading corner of the artwork itself — using `.overlay`
+            // rather than a sibling in the parent ZStack keeps the hit
+            // region scoped to the 180×180 tile and means the badge never
+            // forces the stack to expand past the artwork's bounds.
+            .overlay(alignment: .topLeading) {
+                badge()
+                    .padding(8)
+                    .allowsHitTesting(false)
+            }
+
+            Button {
+                model.play(album: album)
+            } label: {
+                Image(systemName: "play.fill")
+                    .foregroundStyle(.white)
+                    .font(.system(size: 16))
+                    .frame(width: 40, height: 40)
+                    .background(Circle().fill(Theme.primary))
+                    .shadow(color: Theme.primary.opacity(0.5), radius: 10, y: 4)
+            }
+            .buttonStyle(.plain)
+            .padding(8)
+            .opacity(isHovering ? 1 : 0)
+            .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+            .accessibilityLabel("Play \(album.name)")
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isHovering ? Theme.borderStrong : .clear,
+                    lineWidth: 1
+                )
+        )
+    }
+
+    private var metadata: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(album.name)
+                .font(Theme.font(13, weight: .bold))
+                .foregroundStyle(Theme.ink)
+                .lineLimit(1)
+            Text(subtitle ?? defaultSubtitle)
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+                .lineLimit(1)
+        }
+        .frame(width: 180, alignment: .leading)
+    }
+
+    private var defaultSubtitle: String {
+        if let year = album.year, year > 0 {
+            return "\(album.artistName) · \(year)"
+        }
+        return album.artistName
+    }
+}
+
+// Convenience: allow callers to skip the badge argument when they don't
+// need one (most of the time). Swift can't infer `EmptyView` through the
+// trailing-closure form, so this overload keeps the call sites clean.
+extension HomeAlbumTile where Badge == EmptyView {
+    init(album: Album, subtitle: String? = nil, hint: String = "Click to play, double-click to open") {
+        self.album = album
+        self.subtitle = subtitle
+        self.hint = hint
+        self.badge = { EmptyView() }
+    }
+}

--- a/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Compact horizontal track row used in the Home screen's "Recently
+/// Played" carousel (#52). Unlike `TrackRow` (which is tuned for album /
+/// playlist detail surfaces and starts with a row number), this variant
+/// leads with a 48pt artwork thumbnail and drops the numbering so it
+/// reads as a "tap to replay" suggestion, not a queue index.
+///
+/// Sized to fit a ~320pt card so 6 rows fit comfortably in the standard
+/// Home window width. Clicking plays the track; right-click opens a
+/// track-scoped context menu with Play / Go to Album / Go to Artist.
+struct RecentlyPlayedTrackRow: View {
+    @Environment(AppModel.self) private var model
+    let track: Track
+
+    @State private var isHovering = false
+
+    private var isActive: Bool {
+        model.status.currentTrack?.id == track.id
+    }
+
+    private var isPlaying: Bool {
+        isActive && model.status.state == .playing
+    }
+
+    var body: some View {
+        Button {
+            model.play(tracks: [track], startIndex: 0)
+        } label: {
+            HStack(spacing: 12) {
+                thumbnail
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(track.name)
+                        .font(Theme.font(13, weight: .bold))
+                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .lineLimit(1)
+                    Text(track.artistName)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                Text(track.durationFormatted)
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .frame(width: 320)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isHovering ? Theme.rowHover : .clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu {
+            Button("Play", systemImage: "play.fill") {
+                model.play(tracks: [track], startIndex: 0)
+            }
+            if let albumId = track.albumId, !albumId.isEmpty {
+                Button("Go to Album", systemImage: "square.stack") {
+                    model.screen = .album(albumId)
+                }
+            }
+            if let artistId = track.artistId, !artistId.isEmpty {
+                Button("Go to Artist", systemImage: "person") {
+                    model.screen = .artist(artistId)
+                }
+            }
+        }
+        .accessibilityLabel("\(track.name) by \(track.artistName)")
+        .accessibilityHint("Plays this track")
+    }
+
+    private var thumbnail: some View {
+        ZStack {
+            Artwork(
+                url: model.imageURL(
+                    for: track.albumId ?? track.id,
+                    tag: track.imageTag,
+                    maxWidth: 120
+                ),
+                seed: track.albumName ?? track.name,
+                size: 48,
+                radius: 4
+            )
+            .frame(width: 48, height: 48)
+
+            if isPlaying {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.black.opacity(0.45))
+                    .frame(width: 48, height: 48)
+                EqualizerIcon()
+                    .foregroundStyle(.white)
+            } else if isHovering {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.black.opacity(0.35))
+                    .frame(width: 48, height: 48)
+                Image(systemName: "play.fill")
+                    .foregroundStyle(.white)
+                    .font(.system(size: 14, weight: .bold))
+            }
+        }
+    }
+}

--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -6,11 +6,13 @@ import SwiftUI
 /// (Recently Played, Artists You Love, Jump Back In, Your Playlists,
 /// Recently Added). See `research/06-screen-specs.md`.
 ///
-/// The greeting header (#204), quick-tiles row (#205), Recently Played
-/// carousel (#206), Pinned Stations row (#253), and Artist Radio row (#254)
-/// are the first content blocks to land. The remaining carousels
-/// (#55 / #208 / #209 / #207) will slot into this scaffold in follow-up
-/// issues without needing a refactor.
+/// Shipped content blocks: greeting header (#204), quick-tiles row (#205),
+/// Recently Played tiles (#206), Pinned Stations row (#253), Artist Radio
+/// row (#254), Jump Back In (#51), Recently Played track rows (#52),
+/// Quick Picks (#53), Recently Added (#54), and Favorites (#55). The
+/// section stack is deliberately "dumb" — each section reads its own slice
+/// off `AppModel` and hides itself when empty, so a new shelf lands with
+/// zero coordination from the rest of the view.
 struct HomeView: View {
     @Environment(AppModel.self) private var model
 
@@ -25,6 +27,11 @@ struct HomeView: View {
                 header
                 quickTilesRow
                 recentlyPlayedSection
+                jumpBackInSection
+                recentlyPlayedTracksSection
+                recentlyAddedSection
+                quickPicksSection
+                favoritesSection
                 pinnedStationsRow
                 artistRadioRow
                 Spacer(minLength: 24)
@@ -376,6 +383,319 @@ struct HomeView: View {
         return Array(model.artists.prefix(limit))
     }
 
+    // MARK: - New carousels (#51 / #52 / #53 / #54 / #55)
+
+    /// "Jump Back In" — last-played albums (#51). Up to 12 tiles, 180pt
+    /// artwork. Hidden until data arrives so a brand-new user isn't left
+    /// staring at an empty shelf.
+    @ViewBuilder
+    private var jumpBackInSection: some View {
+        if !model.jumpBackIn.isEmpty {
+            carouselSection(
+                icon: "arrow.uturn.backward",
+                iconColor: Theme.primary,
+                title: "Jump Back In",
+                subtitle: "Pick up where you left off",
+                onSeeAll: { model.screen = .library }
+            ) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(model.jumpBackIn, id: \.id) { album in
+                        HomeAlbumTile(album: album)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// Track-level Recently Played (#52) — compact rows with a 48pt
+    /// thumbnail. Distinct from the existing tile-based `recentlyPlayed`
+    /// row above: this variant is denser and prioritises "tap to replay"
+    /// over "browse art". Hidden when there's no history.
+    ///
+    /// Jellyfin tracks `DatePlayed` via its playback-reporting pipeline,
+    /// which is always on for the stock server install. If a user has
+    /// disabled the playback-report plugin their history will stay empty —
+    /// we silently hide this shelf in that case (the Settings-side nudge
+    /// is tracked alongside the broader Preferences work).
+    @ViewBuilder
+    private var recentlyPlayedTracksSection: some View {
+        if !model.recentlyPlayed.isEmpty {
+            carouselSection(
+                icon: "clock.arrow.circlepath",
+                iconColor: Theme.accent,
+                title: "Recently Played",
+                subtitle: "Your latest listens, one click away",
+                onSeeAll: nil
+            ) {
+                LazyHStack(alignment: .top, spacing: 12) {
+                    ForEach(model.recentlyPlayed.prefix(20), id: \.id) { track in
+                        RecentlyPlayedTrackRow(track: track)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "Recently Added" — new arrivals in the library (#54). Backed by
+    /// `/Users/{id}/Items/Latest`, so the list is sorted by `DateCreated`
+    /// server-side. Items added within the last 7 days carry a "NEW"
+    /// badge in the tile's top-leading corner.
+    @ViewBuilder
+    private var recentlyAddedSection: some View {
+        if !model.recentlyAdded.isEmpty {
+            carouselSection(
+                icon: "sparkle",
+                iconColor: Theme.primary,
+                title: "Recently Added",
+                subtitle: "Fresh arrivals in your library",
+                onSeeAll: { model.screen = .library }
+            ) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(model.recentlyAdded, id: \.id) { album in
+                        HomeAlbumTile(album: album) {
+                            if let created = model.recentlyAddedDates[album.id],
+                               isWithinLastWeek(created) {
+                                NewBadge()
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "Quick Picks" — heavy-rotation albums over the last 30 days (#53).
+    /// Sorted server-side by `PlayCount` desc; each tile exposes a play
+    /// count on hover so the user sees *why* it picked these. Hidden until
+    /// the user has accumulated enough plays for the shelf to feel
+    /// non-random.
+    @ViewBuilder
+    private var quickPicksSection: some View {
+        if !model.quickPicks.isEmpty {
+            carouselSection(
+                icon: "flame.fill",
+                iconColor: Theme.accent,
+                title: "Quick Picks",
+                subtitle: "Your heavy rotation — last 30 days",
+                onSeeAll: nil
+            ) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(model.quickPicks, id: \.id) { album in
+                        HomeAlbumTile(album: album) {
+                            if let plays = model.quickPicksPlayCounts[album.id], plays > 0 {
+                                PlayCountBadge(plays: plays)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "Favorites" — shuffled random favorite albums, 12 visible (#55).
+    /// The header carries a "Shuffle All Favorites" CTA that pulls every
+    /// favorite track and starts playback shuffled. The row self-reshuffles
+    /// on each cold launch / refresh so it feels alive.
+    @ViewBuilder
+    private var favoritesSection: some View {
+        if model.favoriteAlbumsVisible.isEmpty {
+            favoritesEmptyState
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                favoritesSectionHeader
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(alignment: .top, spacing: 16) {
+                        ForEach(model.favoriteAlbumsVisible, id: \.id) { album in
+                            HomeAlbumTile(album: album)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    /// Favorites header — title + subtitle on the left, a primary
+    /// "Shuffle All Favorites" pill + ghost "Reshuffle row" on the right.
+    /// Pulled out because it diverges from the simpler `carouselSection`
+    /// scaffold (two CTAs instead of one "See All").
+    private var favoritesSectionHeader: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "heart.fill")
+                        .foregroundStyle(Theme.accentHot)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Favorites")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("A handful of the albums you love")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                Spacer(minLength: 12)
+                favoritesCTAs
+            }
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "heart.fill")
+                        .foregroundStyle(Theme.accentHot)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Favorites")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                }
+                favoritesCTAs
+            }
+        }
+    }
+
+    /// Right-hand CTA cluster for the Favorites header — "Shuffle All
+    /// Favorites" (primary accent pill) + "Reshuffle" (ghost). Extracted
+    /// so the narrow and wide layouts share one source of truth.
+    private var favoritesCTAs: some View {
+        HStack(spacing: 8) {
+            Button {
+                model.shuffleAllFavorites()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "shuffle")
+                        .font(.system(size: 12, weight: .bold))
+                    Text("Shuffle All Favorites")
+                        .font(Theme.font(12, weight: .bold))
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(Theme.accent))
+                .shadow(color: Theme.accent.opacity(0.3), radius: 8, y: 3)
+            }
+            .buttonStyle(.plain)
+            .help("Play every favorite track, shuffled")
+            .accessibilityLabel("Shuffle all favorites")
+
+            Button {
+                model.reshuffleFavoriteAlbumsVisible()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11, weight: .bold))
+                    Text("Reshuffle")
+                        .font(Theme.font(12, weight: .semibold))
+                }
+                .foregroundStyle(Theme.ink2)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Capsule().stroke(Theme.borderStrong, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .help("Pick a different handful of favorites")
+            .accessibilityLabel("Reshuffle the favorites row")
+        }
+    }
+
+    /// Empty-state card shown when the user hasn't favorited any albums
+    /// yet. Mirrors the shape of `PinnedStationsEmptyState` so the Home
+    /// layout has a consistent "tap this to fill the shelf" vocabulary.
+    private var favoritesEmptyState: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(Theme.surface2)
+                    .frame(width: 56, height: 56)
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(Theme.accentHot)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("No favorites yet")
+                    .font(Theme.font(15, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                Text("Tap the heart on any album or track to start building your favorites row.")
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 12)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Theme.surface.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Theme.border, lineWidth: 1)
+        )
+    }
+
+    /// Shared scaffold for the new carousels: icon + title + subtitle on
+    /// the left, optional "See All" ghost button on the right, and a
+    /// horizontally-scrolling content slot underneath. Keeps the five new
+    /// shelves visually consistent without a heavy component.
+    ///
+    /// `onSeeAll == nil` drops the button — useful for shelves where the
+    /// "full version" doesn't have a destination yet.
+    @ViewBuilder
+    private func carouselSection<Content: View>(
+        icon: String,
+        iconColor: Color,
+        title: String,
+        subtitle: String,
+        onSeeAll: (() -> Void)?,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: icon)
+                    .foregroundStyle(iconColor)
+                    .font(.system(size: 14, weight: .bold))
+                Text(title)
+                    .font(Theme.font(18, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                Text(subtitle)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                Spacer(minLength: 12)
+                if let onSeeAll {
+                    Button(action: onSeeAll) {
+                        HStack(spacing: 4) {
+                            Text("See All")
+                                .font(Theme.font(12, weight: .semibold))
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 10, weight: .bold))
+                        }
+                        .foregroundStyle(Theme.ink2)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule().stroke(Theme.border, lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open \(title) in full")
+                    .accessibilityLabel("See all \(title)")
+                }
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                content()
+            }
+        }
+    }
+
+    /// Returns `true` when the given date is within the last 7 days. Used
+    /// by `recentlyAddedSection` to decide whether to stamp the NEW badge
+    /// on a given tile.
+    private func isWithinLastWeek(_ date: Date) -> Bool {
+        let oneWeek: TimeInterval = 7 * 24 * 60 * 60
+        return Date().timeIntervalSince(date) < oneWeek
+    }
+
     private var backgroundWash: some View {
         LinearGradient(
             colors: [Theme.primary.opacity(0.15), .clear],
@@ -427,3 +747,45 @@ private struct HomeQuickTilePlaceholder: View {
 // `RecentlyPlayedTile` lives in `Components/RecentlyPlayedTile.swift` so it
 // can be reused from the Discover "For You" carousel (#249) without
 // duplication.
+
+/// "NEW" chip overlaid on `HomeAlbumTile` for items in the Recently Added
+/// row that were created within the last 7 days (#54). Small, hot-accent,
+/// top-leading — deliberately un-missable without crowding the artwork.
+private struct NewBadge: View {
+    var body: some View {
+        Text("NEW")
+            .font(Theme.font(9, weight: .black))
+            .foregroundStyle(.white)
+            .tracking(1.2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Theme.accentHot))
+            .shadow(color: Theme.accentHot.opacity(0.5), radius: 4, y: 1)
+            .accessibilityLabel("Newly added")
+    }
+}
+
+/// Subtle "42 plays" chip rendered in the top-leading corner of a
+/// `HomeAlbumTile` to explain why the Quick Picks row picked an album
+/// (#53). Dimmer than `NewBadge` because it's informational, not a call
+/// to action.
+private struct PlayCountBadge: View {
+    let plays: UInt32
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "play.circle.fill")
+                .font(.system(size: 9, weight: .bold))
+            Text(playsLabel)
+                .font(Theme.font(10, weight: .bold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(.black.opacity(0.55)))
+        .accessibilityLabel(playsLabel)
+    }
+
+    private var playsLabel: String {
+        plays == 1 ? "1 play" : "\(plays) plays"
+    }
+}


### PR DESCRIPTION
## Summary

- Adds five horizontally-scrolling carousels to the Home screen: Jump Back In, compact-row Recently Played (tracks), Recently Added, Quick Picks, and Favorites.
- Introduces `HomeAlbumTile` (a reusable 180pt album tile with an optional badge slot) and `RecentlyPlayedTrackRow` (compact 48pt-thumbnail track row). Shared `carouselSection` helper keeps the five new shelves visually consistent and each hides itself when empty.
- Adds the backing fetches on `AppModel`: `refreshJumpBackIn`, `refreshRecentlyAdded`, `refreshQuickPicks`, `refreshFavoriteAlbums`, plus a `shuffleAllFavorites()` CTA. Jump Back In / Quick Picks / Favorites inline raw `/Items` queries with `TODO(core-#465)` markers pending the typed `ItemsQuery` builder; Recently Added uses `/Users/{id}/Items/Latest` directly so it can surface `DateCreated` for the "NEW" badge (items within the last 7 days).

Closes #49, #51, #52, #53, #54, #55.

## Test plan

- [ ] `swift build` from `macos/` (clean).
- [ ] Log in against a Jellyfin server with listening history + favorites.
- [ ] Scroll the Home screen top-to-bottom; verify each new shelf renders above Pinned Stations / Artist Radio.
- [ ] Two-finger horizontal swipe scrolls each carousel.
- [ ] Click an album tile = play; double-click = open album detail. Right-click shows the shared album context menu.
- [ ] "Recently Played" track rows: single-click plays; right-click offers Play / Go to Album / Go to Artist.
- [ ] "Recently Added" tiles: a freshly-added album shows the "NEW" chip; older items don't.
- [ ] "Quick Picks" tile hover: play-count chip shows "N plays".
- [ ] "Favorites" header: "Shuffle All Favorites" starts playback across every favorited track; "Reshuffle" rotates the visible 12 without a refetch.
- [ ] "Favorites" empty state renders when the user has favorited nothing.
- [ ] "See All" buttons on Jump Back In / Recently Added route to Library.