### PR TITLE
core+macos: retry/backoff, silent re-auth, stall recovery

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2,12 +2,40 @@ use crate::error::{JellifyError, Result};
 use crate::models::*;
 use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
-use reqwest::{Client as HttpClient, Response};
+use reqwest::{Client as HttpClient, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
 use url::Url;
 
 const CLIENT_NAME: &str = "Jellify Desktop";
 const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Maximum number of HTTP attempts per logical request, inclusive of the
+/// initial try. With the backoff ladder below this caps a single request at
+/// ~3.5s of added latency in the worst case.
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Exponential backoff schedule between retries, in milliseconds. The entry
+/// at index `N` is the delay *before* attempt `N+1`. `±15%` jitter is
+/// applied on top of each base delay at send time. Tuned to be fast enough
+/// to mask a transient blip on home Wi-Fi without making the UI feel
+/// stuck on a legit server outage.
+const BACKOFF_BASE_MS: [u64; 3] = [200, 400, 800];
+
+/// Upper bound on the delay granted by a server-side `Retry-After` header.
+/// Any value larger than this is clamped — we'd rather surface the error to
+/// the user than hang for the duration the server suggested.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(5);
+
+/// Pluggable silent re-auth callback. Invoked by [`JellyfinClient`]'s 401
+/// interceptor; see [`JellyfinClient::set_refresh_callback`].
+///
+/// Implementations return the new access token on success, or a concrete
+/// [`JellifyError`] on failure. A `None` return means "credentials are
+/// still valid but the keyring has no fresher token" — callers treat that
+/// the same as a failure and surface [`JellifyError::AuthExpired`].
+pub type RefreshTokenFn = dyn Fn() -> Result<Option<String>> + Send + Sync;
 
 /// Per-client memoization of the library-resolution lookups behind
 /// [`JellyfinClient::music_library_id`] and
@@ -27,9 +55,16 @@ pub struct JellyfinClient {
     base_url: Url,
     device_id: String,
     device_name: String,
-    token: Option<String>,
+    /// Current access token. Stored behind a `Mutex` so the 401 interceptor
+    /// can swap in a freshly-fetched token under `&self` without fighting
+    /// the rest of the client's borrow graph.
+    token: Mutex<Option<String>>,
     user_id: Option<String>,
     library_cache: Mutex<LibraryCache>,
+    /// Optional silent re-auth hook invoked on the first 401 per request.
+    /// Wired by [`crate::JellifyCore`] at login / resume time; tests may
+    /// leave it unset to exercise the "no refresh available" fallback.
+    refresh_cb: Mutex<Option<Arc<RefreshTokenFn>>>,
 }
 
 impl JellyfinClient {
@@ -49,9 +84,10 @@ impl JellyfinClient {
             base_url: url,
             device_id,
             device_name,
-            token: None,
+            token: Mutex::new(None),
             user_id: None,
             library_cache: Mutex::new(LibraryCache::default()),
+            refresh_cb: Mutex::new(None),
         })
     }
 
@@ -67,21 +103,33 @@ impl JellyfinClient {
         self.user_id.as_deref()
     }
 
-    pub fn token(&self) -> Option<&str> {
-        self.token.as_deref()
+    pub fn token(&self) -> Option<String> {
+        self.token.lock().clone()
     }
 
     pub fn set_session(&mut self, token: String, user_id: String) {
-        self.token = Some(token);
+        *self.token.lock() = Some(token);
         self.user_id = Some(user_id);
         // Library ids are tied to `(server, user)`, so re-auth must drop
         // the memoized lookups before the new session resumes traffic.
         *self.library_cache.lock() = LibraryCache::default();
     }
 
+    /// Register a silent re-auth callback invoked on 401 responses.
+    ///
+    /// The callback is called at most once per logical request — if it
+    /// surfaces a new token the request is retried with it, otherwise the
+    /// client returns [`JellifyError::AuthExpired`] so the UI can drive the
+    /// re-auth sheet. Wired by [`crate::JellifyCore`] at login/resume so the
+    /// callback can re-read the OS credential store without the client
+    /// having to know about the [`crate::storage::Database`].
+    pub fn set_refresh_callback(&self, cb: Arc<RefreshTokenFn>) {
+        *self.refresh_cb.lock() = Some(cb);
+    }
+
     fn auth_header(&self) -> String {
-        let token_part = self
-            .token
+        let token_guard = self.token.lock();
+        let token_part = token_guard
             .as_deref()
             .map(|t| format!(", Token=\"{t}\""))
             .unwrap_or_default();
@@ -110,6 +158,17 @@ impl JellyfinClient {
         self.base_url.join(trimmed).map_err(Into::into)
     }
 
+    /// Bail out with [`JellifyError::NotAuthenticated`] when no access token
+    /// is present. Mirrors the old inline `self.token.as_ref().ok_or(...)?`
+    /// idiom now that the field lives behind a `Mutex`.
+    fn require_token(&self) -> Result<()> {
+        if self.token.lock().is_some() {
+            Ok(())
+        } else {
+            Err(JellifyError::NotAuthenticated)
+        }
+    }
+
     async fn check(resp: Response) -> Result<Response> {
         let status = resp.status();
         if status.is_success() {
@@ -123,12 +182,217 @@ impl JellyfinClient {
         }
     }
 
+    /// Is the HTTP status worth retrying?
+    ///
+    /// Retriable:
+    ///   * `408 Request Timeout` — the server gave up before we did.
+    ///   * `429 Too Many Requests` — caller will honour `Retry-After`.
+    ///   * `5xx` except `501 Not Implemented`, which is a semantic "we
+    ///     don't do that" and will never succeed on retry.
+    fn is_retriable_status(status: StatusCode) -> bool {
+        if status == StatusCode::REQUEST_TIMEOUT || status == StatusCode::TOO_MANY_REQUESTS {
+            return true;
+        }
+        if status.is_server_error() && status != StatusCode::NOT_IMPLEMENTED {
+            return true;
+        }
+        false
+    }
+
+    /// Is the transport-layer error worth retrying?
+    ///
+    /// Heuristic: we retry on timeouts, connect-phase failures (resolve,
+    /// refused, reset), and reqwest's built-in `is_request()` which covers
+    /// things like early TLS handshake failures. Body-decode errors after a
+    /// `2xx` are non-retriable — the server already committed to the
+    /// response.
+    fn is_retriable_transport_error(err: &reqwest::Error) -> bool {
+        if err.is_timeout() || err.is_connect() {
+            return true;
+        }
+        if err.is_request() {
+            // `is_request()` covers a grab-bag of early failures including
+            // failed TLS negotiation and cancelled sends — all worth a
+            // second chance.
+            return true;
+        }
+        false
+    }
+
+    /// Parse a `Retry-After` header as a delay. Accepts both the integer
+    /// seconds form and the HTTP-date form (best effort — falls back to
+    /// `None` on parse failure rather than fighting the server). Clamped by
+    /// [`RETRY_AFTER_CAP`].
+    fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+        let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+        if let Ok(secs) = value.parse::<u64>() {
+            return Some(Duration::from_secs(secs).min(RETRY_AFTER_CAP));
+        }
+        // Jellyfin doesn't emit HTTP-date-form Retry-After, so we don't pull
+        // in an `httpdate` crate just for this — callers that run into such
+        // a header fall back to the exponential backoff schedule below.
+        None
+    }
+
+    /// Backoff for attempt `n` (1-indexed: attempt 1 is the first *retry*,
+    /// i.e. the backoff *after* the initial send failed). Applies ±15%
+    /// symmetric jitter seeded from the system clock.
+    fn backoff_for(attempt: u32) -> Duration {
+        let idx = (attempt.saturating_sub(1) as usize).min(BACKOFF_BASE_MS.len() - 1);
+        let base = BACKOFF_BASE_MS[idx] as f64;
+        // Cheap `±15%` jitter: the high bits of the system clock's
+        // subsecond nanos are plenty random for breaking up synchronized
+        // retries. Pulling in `rand` for this would be overkill.
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        // Map nanos [0, 1e9) onto jitter factor [0.85, 1.15].
+        let jitter = 0.85 + (seed as f64 / 1_000_000_000.0) * 0.30;
+        Duration::from_millis((base * jitter).round() as u64)
+    }
+
+    /// Issue a request with retry + backoff + silent re-auth, returning the
+    /// raw [`Response`] for callers that need status inspection (e.g.
+    /// `lyrics()` turning `404` into `Ok(None)`, or the favorite endpoints
+    /// falling back from the preferred path to a legacy path on `404/405`).
+    ///
+    /// The caller passes a closure that returns a fresh
+    /// [`RequestBuilder`] per attempt. Rebuilding (rather than cloning) is
+    /// important for two reasons:
+    ///   1. The `Authorization` header must reflect the *current* token,
+    ///      not the one that was in place before a 401 refresh.
+    ///   2. `RequestBuilder::try_clone` returns `None` for streaming bodies
+    ///      — for uniformity we always rebuild, even when the body is a
+    ///      cheap JSON blob we could have cloned.
+    ///
+    /// Retry rules live in [`Self::is_retriable_status`] /
+    /// [`Self::is_retriable_transport_error`]; backoff ladder lives in
+    /// [`BACKOFF_BASE_MS`]. `401` is handled specially: if a refresh
+    /// callback is wired and returns a new token, the request is retried
+    /// once; otherwise this returns [`JellifyError::AuthExpired`].
+    async fn send_with_retry_raw<F>(&self, mut build: F) -> Result<Response>
+    where
+        F: FnMut() -> Result<RequestBuilder>,
+    {
+        let mut attempt: u32 = 0;
+        let mut reauth_attempted = false;
+        loop {
+            attempt += 1;
+            let builder = build()?;
+            let outcome = builder.send().await;
+
+            match outcome {
+                Ok(resp) => {
+                    let status = resp.status();
+
+                    // Silent re-auth on the first 401. If we've already
+                    // tried a refresh on this request, don't loop — the
+                    // credentials are truly stale and the UI needs to
+                    // prompt.
+                    if status == StatusCode::UNAUTHORIZED && !reauth_attempted {
+                        reauth_attempted = true;
+                        match self.try_refresh_token() {
+                            Ok(true) => {
+                                tracing::warn!(
+                                    "jellyfin 401 — refreshed token from keyring, retrying"
+                                );
+                                continue;
+                            }
+                            Ok(false) => return Err(JellifyError::AuthExpired),
+                            Err(e) => {
+                                tracing::warn!(error = %e, "token refresh failed");
+                                return Err(JellifyError::AuthExpired);
+                            }
+                        }
+                    }
+
+                    if Self::is_retriable_status(status) && attempt < MAX_ATTEMPTS {
+                        let delay = Self::parse_retry_after(resp.headers())
+                            .unwrap_or_else(|| Self::backoff_for(attempt));
+                        tracing::warn!(
+                            attempt,
+                            status = status.as_u16(),
+                            delay_ms = delay.as_millis() as u64,
+                            "jellyfin request retriable, backing off"
+                        );
+                        drop(resp);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+
+                    return Ok(resp);
+                }
+                Err(err) => {
+                    if Self::is_retriable_transport_error(&err) && attempt < MAX_ATTEMPTS {
+                        let delay = Self::backoff_for(attempt);
+                        tracing::warn!(
+                            attempt,
+                            error = %err,
+                            delay_ms = delay.as_millis() as u64,
+                            "jellyfin transport error, backing off"
+                        );
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(JellifyError::Network(err.to_string()));
+                }
+            }
+        }
+    }
+
+    /// Convenience wrapper that runs [`Self::send_with_retry_raw`] and
+    /// additionally runs the response through [`Self::check`] — the path
+    /// almost every caller takes. Use [`Self::send_with_retry_raw`] when a
+    /// caller needs to inspect non-success status codes (e.g. 404 → Ok(None))
+    /// or dispatch to a fallback endpoint.
+    async fn send_with_retry<F>(&self, build: F) -> Result<Response>
+    where
+        F: FnMut() -> Result<RequestBuilder>,
+    {
+        let resp = self.send_with_retry_raw(build).await?;
+        Self::check(resp).await
+    }
+
+    /// Silent re-auth hook. Invokes the registered [`RefreshTokenFn`] (if
+    /// any) and, on success, swaps the client's in-memory token so the
+    /// next attempt picks it up via [`Self::auth_header`].
+    ///
+    /// Returns `Ok(true)` when a usable new token was installed,
+    /// `Ok(false)` when either no callback is wired or the callback
+    /// returned `None`, and `Err(_)` when the callback itself errored.
+    fn try_refresh_token(&self) -> Result<bool> {
+        let cb = match self.refresh_cb.lock().clone() {
+            Some(cb) => cb,
+            None => return Ok(false),
+        };
+        match cb()? {
+            Some(new_token) => {
+                // Only swap if the new token actually differs — otherwise
+                // the keyring handed back the same stale token and another
+                // retry would just loop.
+                let changed = {
+                    let mut guard = self.token.lock();
+                    let differs = guard.as_deref() != Some(new_token.as_str());
+                    if differs {
+                        *guard = Some(new_token);
+                    }
+                    differs
+                };
+                Ok(changed)
+            }
+            None => Ok(false),
+        }
+    }
+
     // ----- Public info / ping -----
 
     pub async fn public_info(&self) -> Result<PublicSystemInfo> {
         let url = self.endpoint("System/Info/Public")?;
-        let resp = self.http.get(url).send().await?;
-        Self::check(resp).await?.json().await.map_err(Into::into)
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone())))
+            .await?;
+        resp.json().await.map_err(Into::into)
     }
 
     // ----- Auth -----
@@ -144,15 +408,16 @@ impl JellyfinClient {
             pw: password.to_string(),
         };
         let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
+            .send_with_retry(|| {
+                Ok(self
+                    .http
+                    .post(url.clone())
+                    .headers(self.build_headers()?)
+                    .json(&body))
+            })
             .await?;
-        let resp = Self::check(resp).await?;
         let auth: AuthResult = resp.json().await?;
-        self.token = Some(auth.access_token.clone());
+        *self.token.lock() = Some(auth.access_token.clone());
         self.user_id = Some(auth.user.id.clone());
         Ok(Session {
             server: Server {
@@ -192,12 +457,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedArtists {
             items: raw.items.into_iter().map(Artist::from).collect(),
             total_count: raw.total_record_count,
@@ -224,12 +486,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedAlbums {
             items: raw.items.into_iter().map(Album::from).collect(),
             total_count: raw.total_record_count,
@@ -286,12 +545,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let items: Vec<RawItem> = Self::check(resp).await?.json().await?;
+        let items: Vec<RawItem> = resp.json().await?;
         let total_count = items.len() as u32;
         let sliced: Vec<Album> = items
             .into_iter()
@@ -345,12 +601,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedTracks {
             items: raw.items.into_iter().map(Track::from).collect(),
             total_count: raw.total_record_count,
@@ -392,12 +645,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedTracks {
             items: raw.items.into_iter().map(Track::from).collect(),
             total_count: raw.total_record_count,
@@ -487,12 +737,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "ChildCount,Path");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw)
     }
 
@@ -526,12 +773,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "MediaSources,ParentId,Path,SortName");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedTracks {
             items: raw.items.into_iter().map(Track::from).collect(),
             total_count: raw.total_record_count,
@@ -562,13 +806,8 @@ impl JellyfinClient {
             q.append_pair("Ids", &item_ids.join(","));
             q.append_pair("UserId", user_id);
         }
-        let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .send()
+        self.send_with_retry(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
             .await?;
-        Self::check(resp).await?;
         Ok(())
     }
 
@@ -589,12 +828,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
@@ -631,12 +867,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
@@ -669,12 +902,9 @@ impl JellyfinClient {
             q.append_pair("EnableUserData", "true");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
@@ -703,12 +933,9 @@ impl JellyfinClient {
             q.append_pair("EnableUserData", "true");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
@@ -729,12 +956,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Artist::from).collect())
     }
 
@@ -756,12 +980,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Album::from).collect())
     }
 
@@ -781,12 +1002,9 @@ impl JellyfinClient {
             q.append_pair("Limit", &limit.max(1).to_string());
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(ItemRef::from).collect())
     }
 
@@ -818,12 +1036,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
@@ -847,12 +1062,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "ItemCounts,PrimaryImageAspectRatio");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawGenre> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawGenre> = resp.json().await?;
         Ok(PaginatedGenres {
             items: raw.items.into_iter().map(Genre::from).collect(),
             total_count: raw.total_record_count,
@@ -887,12 +1099,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
         Ok(PaginatedAlbums {
             items: raw.items.into_iter().map(Album::from).collect(),
             total_count: raw.total_record_count,
@@ -922,12 +1131,9 @@ impl JellyfinClient {
             );
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawArtistDetail> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawArtistDetail> = resp.json().await?;
         let first = raw
             .items
             .into_iter()
@@ -950,15 +1156,12 @@ impl JellyfinClient {
     /// Jellyfin's 100-ns tick units so UIs can compare directly against
     /// the audio engine's playback position.
     pub async fn lyrics(&self, track_id: &str) -> Result<Option<Lyrics>> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
         let url = self.endpoint(&format!("Audio/{track_id}/Lyrics"))?;
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry_raw(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        if resp.status() == StatusCode::NOT_FOUND {
             return Ok(None);
         }
         let raw: RawLyrics = Self::check(resp).await?.json().await?;
@@ -993,12 +1196,9 @@ impl JellyfinClient {
             q.append_pair("userId", user_id);
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let mut body: serde_json::Value = Self::check(resp).await?.json().await?;
+        let mut body: serde_json::Value = resp.json().await?;
         let items = body
             .get_mut("Items")
             .and_then(|v| v.as_array_mut())
@@ -1028,14 +1228,11 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
     pub async fn set_favorite(&self, item_id: &str) -> Result<FavoriteState> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
 
         let url = self.endpoint(&format!("UserFavoriteItems/{item_id}"))?;
         let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry_raw(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
             .await?;
 
         if resp.status().is_success() {
@@ -1044,22 +1241,20 @@ impl JellyfinClient {
 
         if matches!(
             resp.status(),
-            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
         ) {
             if let Some(user_id) = self.user_id.as_ref() {
                 let legacy_url =
                     self.endpoint(&format!("Users/{user_id}/FavoriteItems/{item_id}"))?;
                 let legacy_resp = self
-                    .http
-                    .post(legacy_url)
-                    .headers(self.build_headers()?)
-                    .send()
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .post(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
                     .await?;
-                return Self::check(legacy_resp)
-                    .await?
-                    .json()
-                    .await
-                    .map_err(Into::into);
+                return legacy_resp.json().await.map_err(Into::into);
             }
         }
 
@@ -1080,14 +1275,13 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
     pub async fn unset_favorite(&self, item_id: &str) -> Result<FavoriteState> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
 
         let url = self.endpoint(&format!("UserFavoriteItems/{item_id}"))?;
         let resp = self
-            .http
-            .delete(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry_raw(|| {
+                Ok(self.http.delete(url.clone()).headers(self.build_headers()?))
+            })
             .await?;
 
         if resp.status().is_success() {
@@ -1096,22 +1290,20 @@ impl JellyfinClient {
 
         if matches!(
             resp.status(),
-            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
         ) {
             if let Some(user_id) = self.user_id.as_ref() {
                 let legacy_url =
                     self.endpoint(&format!("Users/{user_id}/FavoriteItems/{item_id}"))?;
                 let legacy_resp = self
-                    .http
-                    .delete(legacy_url)
-                    .headers(self.build_headers()?)
-                    .send()
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .delete(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
                     .await?;
-                return Self::check(legacy_resp)
-                    .await?
-                    .json()
-                    .await
-                    .map_err(Into::into);
+                return legacy_resp.json().await.map_err(Into::into);
             }
         }
 
@@ -1142,13 +1334,15 @@ impl JellyfinClient {
             media_type: "Audio".to_string(),
         };
         let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
+            .send_with_retry(|| {
+                Ok(self
+                    .http
+                    .post(url.clone())
+                    .headers(self.build_headers()?)
+                    .json(&body))
+            })
             .await?;
-        let result: CreatePlaylistResult = Self::check(resp).await?.json().await?;
+        let result: CreatePlaylistResult = resp.json().await?;
         Ok(result.id)
     }
 
@@ -1169,7 +1363,7 @@ impl JellyfinClient {
         position_ticks: i64,
         is_paused: bool,
     ) -> Result<()> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
 
         let url = self.endpoint("Sessions/Playing/Progress")?;
         let body = PlaybackProgressBody {
@@ -1177,14 +1371,14 @@ impl JellyfinClient {
             position_ticks,
             is_paused,
         };
-        let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
-            .await?;
-        Self::check(resp).await?;
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&body))
+        })
+        .await?;
         Ok(())
     }
 
@@ -1216,12 +1410,9 @@ impl JellyfinClient {
             q.append_pair("Fields", "Genres,ProductionYear,PrimaryImageAspectRatio");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
 
         let mut artists = Vec::new();
         let mut albums = Vec::new();
@@ -1277,12 +1468,9 @@ impl JellyfinClient {
             q.append_pair("startIndex", &paging.offset.to_string());
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawSearchHintResults = Self::check(resp).await?.json().await?;
+        let raw: RawSearchHintResults = resp.json().await?;
         Ok(SearchHintResults {
             search_hints: raw.search_hints.into_iter().map(SearchHint::from).collect(),
             total_record_count: raw.total_record_count,
@@ -1305,20 +1493,20 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
     pub async fn report_playback_stopped(&self, item_id: &str, position_ticks: i64) -> Result<()> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
         let url = self.endpoint("Sessions/Playing/Stopped")?;
         let body = PlaybackStoppedBody {
             item_id: item_id.to_string(),
             position_ticks,
         };
-        let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
-            .await?;
-        Self::check(resp).await?;
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&body))
+        })
+        .await?;
         Ok(())
     }
 
@@ -1337,16 +1525,16 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
     pub async fn report_playback_started(&self, info: PlaybackStartInfo) -> Result<()> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
         let url = self.endpoint("Sessions/Playing")?;
-        let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&info)
-            .send()
-            .await?;
-        Self::check(resp).await?;
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&info))
+        })
+        .await?;
         Ok(())
     }
 
@@ -1362,16 +1550,16 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
     pub async fn post_capabilities(&self, caps: ClientCapabilities) -> Result<()> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
         let url = self.endpoint("Sessions/Capabilities/Full")?;
-        let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&caps)
-            .send()
-            .await?;
-        Self::check(resp).await?;
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&caps)) // ClientCapabilities is Clone so the body can be rebuilt each attempt via serde
+        })
+        .await?;
         Ok(())
     }
 
@@ -1408,13 +1596,15 @@ impl JellyfinClient {
         }
         let url = self.endpoint(&format!("Items/{item_id}/PlaybackInfo"))?;
         let resp = self
-            .http
-            .post(url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
+            .send_with_retry(|| {
+                Ok(self
+                    .http
+                    .post(url.clone())
+                    .headers(self.build_headers()?)
+                    .json(&body))
+            })
             .await?;
-        Self::check(resp).await?.json().await.map_err(Into::into)
+        resp.json().await.map_err(Into::into)
     }
 
     // ----- Library resolution -----
@@ -1436,12 +1626,9 @@ impl JellyfinClient {
         let mut url = self.endpoint("UserViews")?;
         url.query_pairs_mut().append_pair("userId", user_id);
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawLibrary> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawLibrary> = resp.json().await?;
         Ok(raw.items.into_iter().map(Library::from).collect())
     }
 
@@ -1496,12 +1683,9 @@ impl JellyfinClient {
             q.append_pair("excludeItemTypes", "CollectionFolder");
         }
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let raw: RawItems<RawLibrary> = Self::check(resp).await?.json().await?;
+        let raw: RawItems<RawLibrary> = resp.json().await?;
         let id = raw
             .items
             .into_iter()
@@ -1542,20 +1726,15 @@ impl JellyfinClient {
         playlist_id: &str,
         entry_ids: &[String],
     ) -> Result<()> {
-        self.token.as_ref().ok_or(JellifyError::NotAuthenticated)?;
+        self.require_token()?;
         if entry_ids.is_empty() {
             return Ok(());
         }
         let mut url = self.endpoint(&format!("Playlists/{playlist_id}/Items"))?;
         url.query_pairs_mut()
             .append_pair("entryIds", &entry_ids.join(","));
-        let resp = self
-            .http
-            .delete(url)
-            .headers(self.build_headers()?)
-            .send()
+        self.send_with_retry(|| Ok(self.http.delete(url.clone()).headers(self.build_headers()?)))
             .await?;
-        Self::check(resp).await?;
         Ok(())
     }
 
@@ -1566,12 +1745,8 @@ impl JellyfinClient {
     pub async fn stream_bytes(&self, track_id: &str) -> Result<(Vec<u8>, Option<String>)> {
         let url = self.stream_url(track_id)?;
         let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
-        let resp = Self::check(resp).await?;
         let content_type = resp
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
@@ -1597,7 +1772,7 @@ impl JellyfinClient {
             q.append_pair("AudioCodec", "mp3,aac,flac,alac,pcm,vorbis,opus");
             q.append_pair("TranscodingContainer", "mp3");
             q.append_pair("TranscodingProtocol", "http");
-            if let Some(token) = &self.token {
+            if let Some(token) = self.token.lock().as_deref() {
                 q.append_pair("api_key", token);
             }
         }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -18,6 +18,13 @@ pub enum JellifyError {
     #[error("no active session — call login or restore first")]
     NoSession,
 
+    /// The current access token was rejected by the server (`401`) and a
+    /// silent re-read from the keyring did not surface a fresh one. Surfaced
+    /// so the UI can prompt the user to re-authenticate — see
+    /// [`crate::JellifyCore::forget_token`] for the pre-fill affordance.
+    #[error("authentication expired — please sign in again")]
+    AuthExpired,
+
     #[error("decode error: {0}")]
     Decode(String),
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,7 +39,11 @@ pub struct JellifyCore {
 
 struct Inner {
     client: Option<JellyfinClient>,
-    db: Database,
+    /// Wrapped in `Arc` so the HTTP client's 401 interceptor can close over
+    /// a standalone handle (see [`JellyfinClient::set_refresh_callback`])
+    /// without needing to re-lock `inner` — which it can't, since retry
+    /// callbacks fire while `with_client` already holds that lock.
+    db: Arc<Database>,
     device_id: String,
     device_name: String,
 }
@@ -60,7 +64,7 @@ impl JellifyCore {
             PathBuf::from(&config.data_dir)
         };
         let db_path = data_dir.join("jellify.db");
-        let db = Database::open(&db_path)?;
+        let db = Arc::new(Database::open(&db_path)?);
 
         let device_id = match db.get_setting("device_id")? {
             Some(id) => id,
@@ -113,9 +117,13 @@ impl JellifyCore {
         username: String,
         password: String,
     ) -> std::result::Result<models::Session, JellifyError> {
-        let (device_id, device_name) = {
+        let (device_id, device_name, db) = {
             let inner = self.inner.lock();
-            (inner.device_id.clone(), inner.device_name.clone())
+            (
+                inner.device_id.clone(),
+                inner.device_name.clone(),
+                inner.db.clone(),
+            )
         };
         let mut client = JellyfinClient::new(&url, device_id, device_name)?;
         let session = self
@@ -137,6 +145,7 @@ impl JellifyCore {
             }
             inner.db.set_setting("last_user_id", &session.user.id)?;
         }
+        Self::install_refresh_callback(&client, &db);
         self.inner.lock().client = Some(client);
         Ok(session)
     }
@@ -152,7 +161,7 @@ impl JellifyCore {
     /// block this call on network availability so users launching offline
     /// still see their cached library instantly.
     pub fn resume_session(&self) -> std::result::Result<Option<Session>, JellifyError> {
-        let (device_id, device_name, server_url, username, server_id, user_id) = {
+        let (device_id, device_name, db, server_url, username, server_id, user_id) = {
             let inner = self.inner.lock();
             let server_url = match inner.db.get_setting("last_server_url")? {
                 Some(v) => v,
@@ -173,6 +182,7 @@ impl JellifyCore {
             (
                 inner.device_id.clone(),
                 inner.device_name.clone(),
+                inner.db.clone(),
                 server_url,
                 username,
                 server_id,
@@ -187,6 +197,7 @@ impl JellifyCore {
 
         let mut client = JellyfinClient::new(&server_url, device_id, device_name)?;
         client.set_session(token.clone(), user_id.clone());
+        Self::install_refresh_callback(&client, &db);
         let resolved_url = client.base_url().to_string();
         self.inner.lock().client = Some(client);
 
@@ -832,6 +843,20 @@ impl JellifyCore {
         let inner = self.inner.lock();
         let client = inner.client.as_ref().ok_or(JellifyError::NoSession)?;
         f(client)
+    }
+
+    /// Wire the HTTP client's 401 interceptor so it can silently pull a
+    /// fresh token out of the OS credential store without round-tripping
+    /// through the UI.
+    ///
+    /// The callback only holds an `Arc` to [`Database`] — never to `Inner`
+    /// — because it fires from inside an in-flight request, and by that
+    /// point `with_client` is already holding the `parking_lot::Mutex` on
+    /// `Inner`. Re-locking it here would deadlock (parking_lot mutexes are
+    /// non-reentrant).
+    fn install_refresh_callback(client: &JellyfinClient, db: &Arc<Database>) {
+        let db = db.clone();
+        client.set_refresh_callback(Arc::new(move || storage::refresh_token_from_keyring(&db)));
     }
 }
 

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -175,3 +175,33 @@ impl CredentialStore {
         }
     }
 }
+
+/// Silent re-auth helper used by the HTTP client's 401 interceptor.
+///
+/// Re-reads `(last_server_id, last_username)` from `db`, then asks the OS
+/// credential store for the token that pair currently maps to. Returns the
+/// token string when one is present.
+///
+/// The design is a "pull latest from the keyring" pattern: when Jellyfin
+/// rejects a request with `401`, the in-memory token on the client may be
+/// stale relative to what's in the keychain (e.g. another Jellify instance
+/// refreshed it on this machine, or the user re-authenticated in a parallel
+/// window). Re-reading the keyring is the cheap first step — callers that
+/// want to force a full `POST /Users/AuthenticateByName` round trip drive
+/// that from the UI layer, where the password is still in scope.
+///
+/// Returns `Ok(None)` when the persisted identifiers are missing or the
+/// keyring has no entry for that `(server_id, username)` pair. Callers treat
+/// that the same as "user must re-authenticate" and typically raise
+/// [`crate::JellifyError::AuthExpired`].
+pub fn refresh_token_from_keyring(db: &Database) -> Result<Option<String>> {
+    let server_id = match db.get_setting("last_server_id")? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    let username = match db.get_setting("last_username")? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    CredentialStore::load_token(&server_id, &username)
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::client::JellyfinClient;
+use crate::error::JellifyError;
 use crate::models::{ImageType, Paging};
 use crate::storage::{CredentialStore, Database};
 use crate::{CoreConfig, JellifyCore};
@@ -3926,4 +3927,306 @@ async fn forget_token_preserves_server_url_and_username() {
     })
     .await
     .expect("join forget task");
+}
+
+// ============================================================================
+// Retry + backoff + silent re-auth (issues #438, #440)
+// ============================================================================
+//
+// These tests exercise the transport layer directly via `JellyfinClient` rather
+// than the UniFFI wrapper, because the harness needs to inject 5xx / 401 /
+// transient failures from wiremock. `MockServer::up_to_n_times` lets us chain
+// multiple `Mock`s against the same path — it consumes them in insertion
+// order, so the first two `respond_with` bodies land on the first two
+// attempts and the last one services the eventual success.
+
+/// `503` on the first two attempts, then `200`. The retry layer should
+/// swallow the early failures and return the eventual success payload —
+/// callers never see a `JellifyError::Server { 503, .. }`.
+#[tokio::test]
+async fn retry_recovers_from_transient_5xx() {
+    let server = MockServer::start().await;
+    // Mount three responses against `/System/Info/Public`: 503, 503, 200.
+    // `wiremock` consumes them in insertion order.
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ServerName": "After Retry",
+            "Version": "10.10.0",
+            "Id": "abc"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let info = client.public_info().await.expect("retry must recover");
+    assert_eq!(info.server_name.as_deref(), Some("After Retry"));
+
+    // The server saw 3 attempts total — 2 failures + the final success.
+    let requests = server.received_requests().await.unwrap();
+    let hits = requests
+        .iter()
+        .filter(|r| r.url.path() == "/System/Info/Public")
+        .count();
+    assert_eq!(hits, 3, "expected 3 attempts (2 retries); got {hits}");
+}
+
+/// `501 Not Implemented` is NOT retriable — it's a semantic rejection the
+/// server will keep returning. One attempt, one error.
+#[tokio::test]
+async fn retry_does_not_loop_on_501_not_implemented() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(501))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let err = client.public_info().await.unwrap_err();
+    match err {
+        JellifyError::Server { status, .. } => assert_eq!(status, 501),
+        other => panic!("expected Server {{ 501 }}, got {other:?}"),
+    }
+    let hits = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/System/Info/Public")
+        .count();
+    assert_eq!(hits, 1, "501 must not be retried");
+}
+
+/// Exhausting the retry budget (three 5xx in a row) surfaces the last
+/// server error as `JellifyError::Server`, not as `Network(_)`.
+#[tokio::test]
+async fn retry_surfaces_last_server_error_when_budget_exhausted() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(502))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let err = client.public_info().await.unwrap_err();
+    match err {
+        JellifyError::Server { status, .. } => assert_eq!(status, 502),
+        other => panic!("expected Server {{ 502 }}, got {other:?}"),
+    }
+    let hits = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/System/Info/Public")
+        .count();
+    // MAX_ATTEMPTS = 3 (initial + 2 retries).
+    assert_eq!(hits, 3, "expected 3 attempts total, got {hits}");
+}
+
+/// `401` with no refresh callback wired surfaces `AuthExpired` so the UI
+/// can drive the re-auth sheet. No retry beyond the single 401.
+#[tokio::test]
+async fn auth_401_without_callback_returns_auth_expired() {
+    let server = MockServer::start().await;
+    // Have to authenticate first so the library call runs with a token.
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client
+        .albums(Paging::new(0, 10))
+        .await
+        .expect_err("401 without refresh must fail");
+    assert!(
+        matches!(err, JellifyError::AuthExpired),
+        "expected AuthExpired, got {err:?}"
+    );
+}
+
+/// `401` with a wired callback that hands back a *new* token triggers a
+/// silent retry with the fresh token. Verifies both that the retry fires
+/// and that the subsequent request carries the refreshed bearer.
+#[tokio::test]
+async fn auth_401_with_callback_retries_with_new_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "old-token", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // First library hit: 401 (stale token).
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    // Second hit: 200 with a single album so the caller gets a real result.
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [{ "Id": "a1", "Name": "Album", "Type": "MusicAlbum" }],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+
+    // Hand back a *different* token on refresh — if the callback returned
+    // the same string the retry layer would bail with AuthExpired rather
+    // than loop.
+    client.set_refresh_callback(std::sync::Arc::new(|| Ok(Some("fresh-token".to_string()))));
+
+    let page = client
+        .albums(Paging::new(0, 10))
+        .await
+        .expect("refresh + retry should succeed");
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].id, "a1");
+
+    // Inspect the retry: second `GET /Users/u1/Items` must have carried the
+    // fresh token in its Authorization header.
+    let requests = server.received_requests().await.unwrap();
+    let gets: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/Users/u1/Items")
+        .collect();
+    assert_eq!(gets.len(), 2, "expected 2 GETs (initial + retry)");
+    let retry_auth = gets[1]
+        .headers
+        .get("authorization")
+        .expect("retry must carry Authorization");
+    let retry_auth_str = retry_auth.to_str().unwrap();
+    assert!(
+        retry_auth_str.contains("fresh-token"),
+        "retry should use new token, saw: {retry_auth_str}"
+    );
+}
+
+/// A refresh callback that returns `Ok(None)` (e.g. keyring wiped) surfaces
+/// `AuthExpired` — no retry, caller drives the re-auth sheet.
+#[tokio::test]
+async fn auth_401_with_callback_returning_none_surfaces_expired() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.set_refresh_callback(std::sync::Arc::new(|| Ok(None)));
+
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(matches!(err, JellifyError::AuthExpired));
+}
+
+/// When the callback hands back the *same* token the client already has,
+/// the retry layer treats it as a dead token — no pointless loop, just
+/// `AuthExpired`.
+#[tokio::test]
+async fn auth_401_with_same_token_does_not_loop() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "same-token", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.set_refresh_callback(std::sync::Arc::new(|| Ok(Some("same-token".to_string()))));
+
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(matches!(err, JellifyError::AuthExpired));
+
+    // Crucial: only the initial 401 hit, no loop.
+    let hits = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/Users/u1/Items")
+        .count();
+    assert_eq!(hits, 1, "expected exactly one GET — no retry loop");
+}
+
+/// `storage::refresh_token_from_keyring` is the bridge between the HTTP
+/// client's 401 interceptor and the OS credential store. Smoke-test the
+/// three scenarios the wrapping callback relies on: missing persisted
+/// ids (Ok(None)), ids-but-no-keychain-entry (Ok(None)), and a present
+/// keychain entry (Ok(Some)).
+#[test]
+fn refresh_token_from_keyring_returns_token_when_present() {
+    install_mock_keyring();
+    let db = Database::in_memory().expect("in-memory db");
+
+    // Missing ids → None.
+    let missing = crate::storage::refresh_token_from_keyring(&db).unwrap();
+    assert!(missing.is_none(), "no settings → None");
+
+    // Ids present but no keychain entry → None.
+    db.set_setting("last_server_id", "srv-refresh-test")
+        .unwrap();
+    db.set_setting("last_username", "refresh-user").unwrap();
+    // Make sure there's no stale entry from another test run.
+    CredentialStore::delete_token("srv-refresh-test", "refresh-user").unwrap();
+    let absent = crate::storage::refresh_token_from_keyring(&db).unwrap();
+    assert!(absent.is_none(), "no keychain entry → None");
+
+    // Save a token — now refresh should hand it back.
+    CredentialStore::save_token("srv-refresh-test", "refresh-user", "refreshed-token").unwrap();
+    let got = crate::storage::refresh_token_from_keyring(&db)
+        .unwrap()
+        .expect("token should be present");
+    assert_eq!(got, "refreshed-token");
 }

--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -13,6 +13,37 @@ import Foundation
 // and even on a cross-platform build it would just pollute this engine with
 // dead code.
 
+/// How long the engine will tolerate `AVPlayer` sitting in
+/// `.waitingToPlayAtSpecifiedRate` before treating it as a stall and
+/// kicking the stream.
+private let stallThreshold: TimeInterval = 5.0
+
+/// Maximum number of silent restart attempts before the engine surfaces a
+/// terminal failure to the owner. Two retries covers the "flaky Wi-Fi
+/// transient" case without turning a genuine outage into a busy-loop.
+private let maxAutoRetries: Int = 2
+
+/// Observer contract for transport failures surfaced by [`AudioEngine`].
+///
+/// The engine does not render UI — it only tells the owner that the stream
+/// stalled (retry in progress) or ultimately failed. See issue #439.
+///
+/// Every method is `@MainActor`-bound so implementors don't have to hop
+/// queues before touching SwiftUI state.
+@MainActor
+public protocol AudioEngineDelegate: AnyObject {
+    /// Called when the engine has been in
+    /// `.waitingToPlayAtSpecifiedRate` for longer than the stall threshold
+    /// and is about to restart the stream. The owner typically shows a
+    /// transient toast ("Stalled, retrying…").
+    func audioEngineDidStall()
+
+    /// Called when the engine has exhausted its auto-retry budget. The
+    /// owner should surface a terminal error with a tap-to-retry
+    /// affordance — the engine will NOT retry again on its own.
+    func audioEngineDidFail(_ message: String)
+}
+
 /// AVPlayer-backed audio engine. Reports transport state back to the Rust
 /// core so other parts of the app can observe it via `core.status()`.
 @MainActor
@@ -23,6 +54,22 @@ public final class AudioEngine: NSObject {
     private var endObserver: NSObjectProtocol?
     private var statusObservation: NSKeyValueObservation?
     private var rateObservation: NSKeyValueObservation?
+    private var timeControlObservation: NSKeyValueObservation?
+
+    /// The URL + auth header of the item currently loaded into the player.
+    /// Captured on `play(_:)` so we can rebuild a fresh `AVPlayerItem` when
+    /// recovering from a stall.
+    private var currentStreamURL: URL?
+    private var currentAuthHeader: String?
+
+    /// Pending stall-detection work item. Scheduled the moment
+    /// `timeControlStatus` flips to `.waitingToPlayAtSpecifiedRate`;
+    /// cancelled when playback resumes or the engine tears down.
+    private var stallWorkItem: DispatchWorkItem?
+
+    /// How many silent restart attempts we've made on the *current* stream.
+    /// Reset to 0 every time `play(_:)` loads a brand-new track.
+    private var stallRetryCount: Int = 0
 
     /// Called when AVPlayer reaches the end of the current item, so the
     /// owner (AppModel) can advance the queue.
@@ -33,6 +80,10 @@ public final class AudioEngine: NSObject {
     /// it of transport state transitions. See `MediaSession.swift` and
     /// issues #29 / #48.
     public weak var mediaSession: MediaSession?
+
+    /// Receives stall / terminal-failure notifications for issue #439.
+    /// Held weakly — the owner (`AppModel`) has the strong reference.
+    public weak var delegate: AudioEngineDelegate?
 
     public init(core: JellifyCore) {
         self.core = core
@@ -72,6 +123,15 @@ public final class AudioEngine: NSObject {
         newPlayer.automaticallyWaitsToMinimizeStalling = true
         self.player = newPlayer
 
+        // Remember the stream so `recoverFromStall` can rebuild a fresh
+        // `AVPlayerItem` without re-asking the core for a URL (which would
+        // cost an extra async hop on the main actor).
+        self.currentStreamURL = url
+        self.currentAuthHeader = authHeader
+        // Each new track gets a fresh budget for silent restart attempts —
+        // a genuine library-wide outage shouldn't poison the *next* song.
+        self.stallRetryCount = 0
+
         attachPlayerObservers(to: newPlayer, item: item)
 
         core.markTrackStarted(track: track)
@@ -100,10 +160,14 @@ public final class AudioEngine: NSObject {
     }
 
     public func stop() {
+        cancelStallWatchdog()
         player?.pause()
         player?.replaceCurrentItem(with: nil)
         removePlayerObservers()
         player = nil
+        currentStreamURL = nil
+        currentAuthHeader = nil
+        stallRetryCount = 0
         core.stop()
         mediaSession?.trackChanged(nil)
     }
@@ -164,6 +228,31 @@ public final class AudioEngine: NSObject {
                 self.mediaSession?.rateChanged(isPlaying: isPlaying)
             }
         }
+
+        // Stall detection (issue #439). `timeControlStatus` tells us why
+        // the player is or isn't moving:
+        //   * `.playing` — audio is flowing.
+        //   * `.paused` — user-initiated.
+        //   * `.waitingToPlayAtSpecifiedRate` — the buffer drained and the
+        //     network isn't catching up. AVPlayer already *wants* to play,
+        //     so a brief spell here is normal; anything past
+        //     `stallThreshold` is a real hang worth kicking.
+        timeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            let status = player.timeControlStatus
+            Task { @MainActor in
+                guard let self = self else { return }
+                switch status {
+                case .waitingToPlayAtSpecifiedRate:
+                    self.scheduleStallWatchdog()
+                case .playing, .paused:
+                    // Playback recovered (or user paused) — drop any pending
+                    // restart so we don't nuke a perfectly healthy stream.
+                    self.cancelStallWatchdog()
+                @unknown default:
+                    break
+                }
+            }
+        }
     }
 
     private func removePlayerObservers() {
@@ -179,6 +268,103 @@ public final class AudioEngine: NSObject {
         rateObservation = nil
         statusObservation?.invalidate()
         statusObservation = nil
+        timeControlObservation?.invalidate()
+        timeControlObservation = nil
+    }
+
+    // MARK: - Stall recovery (issue #439)
+
+    /// Queue a stall handler to fire after [`stallThreshold`]. If
+    /// playback resumes within the window the work item is cancelled in
+    /// [`cancelStallWatchdog`]; otherwise [`handleStallTimeout`] fires.
+    ///
+    /// Scheduling is idempotent — repeatedly calling this while the player
+    /// keeps flipping in and out of `.waitingToPlayAtSpecifiedRate` only
+    /// keeps one timer alive at a time.
+    private func scheduleStallWatchdog() {
+        stallWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                self?.handleStallTimeout()
+            }
+        }
+        stallWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + stallThreshold, execute: item)
+    }
+
+    private func cancelStallWatchdog() {
+        stallWorkItem?.cancel()
+        stallWorkItem = nil
+    }
+
+    /// Called from the watchdog when the player has been stuck in
+    /// `.waitingToPlayAtSpecifiedRate` for [`stallThreshold`].
+    ///
+    /// On the first two stalls of a given stream we notify the delegate
+    /// that a silent retry is in flight and rebuild the `AVPlayerItem`
+    /// against the same URL — that's enough to dislodge most transient
+    /// CDN / Wi-Fi blips. On the third stall we give up and surface a
+    /// terminal failure so the UI can offer tap-to-retry.
+    private func handleStallTimeout() {
+        // Guard against a stale timer firing after the user already
+        // stopped the engine or moved on to a different track.
+        guard let player = self.player, let url = self.currentStreamURL else {
+            return
+        }
+        // If playback resumed between the timer firing and us getting
+        // onto the main actor, bail — no retry needed.
+        if player.timeControlStatus != .waitingToPlayAtSpecifiedRate {
+            return
+        }
+
+        stallRetryCount += 1
+        if stallRetryCount > maxAutoRetries {
+            delegate?.audioEngineDidFail("Couldn't play, tap to retry.")
+            return
+        }
+
+        delegate?.audioEngineDidStall()
+        recoverFromStall(player: player, url: url)
+    }
+
+    /// Rebuild `AVPlayerItem` from the remembered URL + auth header and
+    /// swap it in via `replaceCurrentItem`. This restarts the HTTP fetch
+    /// without tearing the player down, so `rate` / `timeControlStatus`
+    /// observers remain wired and the UI doesn't flicker.
+    private func recoverFromStall(player: AVPlayer, url: URL) {
+        let options: [String: Any]
+        if let header = currentAuthHeader {
+            options = [
+                "AVURLAssetHTTPHeaderFieldsKey": ["Authorization": header]
+            ]
+        } else {
+            options = [:]
+        }
+        let asset = AVURLAsset(url: url, options: options)
+        let item = AVPlayerItem(asset: asset)
+
+        // `replaceCurrentItem` does NOT re-fire the end-of-item
+        // notification for the old item, so we need to re-register the
+        // end observer against the freshly-built `AVPlayerItem` or the
+        // queue will stop advancing after a stall recovery. Tearing down
+        // just the end observer (rather than everything) keeps
+        // `rateObservation` / `timeControlObservation` in place — both
+        // target the `AVPlayer`, not the item.
+        if let end = endObserver {
+            NotificationCenter.default.removeObserver(end)
+        }
+        endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            self.core.markState(state: .ended)
+            self.onTrackEnded?()
+        }
+
+        player.replaceCurrentItem(with: item)
+        player.play()
     }
 }
 


### PR DESCRIPTION
Closes #438, #439, #440.

## Summary

- **#438 — HTTP retry + backoff.** `core::client::JellyfinClient` now routes every request through `send_with_retry`: exponential backoff at 200ms / 400ms / 800ms with ±15% jitter, 3 attempts max. Retriable = timeouts, 5xx (except 501), 429 (honours `Retry-After`, clamped to 5s), and connect-phase transport errors. Each retry is logged at `tracing::warn`.
- **#440 — Silent re-auth on 401.** A new `RefreshTokenFn` callback is wired by `JellifyCore::install_refresh_callback` at login / `resume_session` time. On 401 the client pulls a fresh token via `storage::refresh_token_from_keyring` (re-reads `last_server_id` + `last_username` from the DB, then the OS keyring), retries the request once with the new `Authorization` header, and surfaces `JellifyError::AuthExpired` when no fresher token is available.
- **#439 — AVPlayer stall recovery.** `AudioEngine` now observes `timeControlStatus`; a stall of more than 5s in `.waitingToPlayAtSpecifiedRate` notifies the new `AudioEngineDelegate.audioEngineDidStall()` and rebuilds the `AVPlayerItem` against the same URL via `replaceCurrentItem`. Two auto-retries before `audioEngineDidFail(\"Couldn't play, tap to retry.\")`.

## Notes

- `core/client.rs` has two retry entry points: `send_with_retry` for the common path (returns checked success response) and `send_with_retry_raw` for callers that need to inspect non-success status codes (lyrics → `Ok(None)` on 404, favorites endpoints falling back to legacy routes on 404/405).
- `JellyfinClient::token` moved from `Option<String>` to `Mutex<Option<String>>` so the 401 interceptor can swap in a fresh token under `&self`.
- `Inner::db` moved from `Database` to `Arc<Database>` so the refresh callback can close over a standalone handle — `with_client` already holds the `parking_lot::Mutex` on `Inner` when the callback fires, and those mutexes are non-reentrant.
- AudioEngine does NOT render UI on stall — it emits the delegate call so the PlayerBar toast wiring lands in a follow-up batch.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 105 passed (8 new tests for retry / 401 / `AuthExpired` / `refresh_token_from_keyring`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `swift build` from `macos/` — builds cleanly against the regenerated xcframework