### PR TITLE
ci: bump e2e jellyfin image to 10.11.8

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
       # --health-cmd and let Scripts/e2e-setup-jellyfin.sh block on the
       # server's public info endpoint from the host side instead.
       jellyfin:
-        image: jellyfin/jellyfin:10.10.3
+        image: jellyfin/jellyfin:10.11.8
         ports:
           - 8096:8096
     steps:
@@ -101,7 +101,7 @@ jobs:
           docker run -d --name jellyfin \
             -p 8096:8096 \
             -e JELLYFIN_PublishedServerUrl=http://localhost:8096 \
-            jellyfin/jellyfin:10.10.3
+            jellyfin/jellyfin:10.11.8
       - name: Complete Jellyfin first-run wizard
         run: ./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 "$JELLIFY_E2E_USER" "$JELLIFY_E2E_PASS"
       - name: Build xcframework


### PR DESCRIPTION
10.10.3 was pinned when #528 landed and is now ~18 months stale —
10.11 has been the stable minor since October 2025 and 10.11.8 is
the current patch (April 5).

This is a one-line bump before we decide whether to keep chasing the
`UserManager.Users.First()` 500s on `POST /Startup/User` or gate the
job to scheduled-only. If 10.11 fixes the containerized startup-wizard
bootstrap, the retry loop just completes and we're green.

## Test plan

- [ ] E2E rust-core job completes the first-run wizard and runs
      `cargo test --test e2e_live` against a live 10.11.8 server.
- [ ] If it still 500s, follow-up switches to scheduled-only + files
      a Jellyfin issue with the container logs.