### PR TITLE
core: typed enums + ItemsQuery builder + structured errors + UserItemData

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1,10 +1,23 @@
+use crate::enums::{self, ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 use crate::error::{JellifyError, Result};
 use crate::models::*;
+use crate::query::ItemsQuery;
 use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client as HttpClient, Response};
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+/// A generic paginated wrapper used by [`ItemsQuery`] before the raw items
+/// are mapped to a concrete model type. Mirrors the shape of the per-model
+/// `PaginatedAlbums` / `PaginatedArtists` / etc. records, but generic over
+/// the element type so the query layer doesn't need to know which model
+/// the caller wants.
+#[derive(Clone, Debug)]
+pub struct PaginatedItems<T> {
+    pub items: Vec<T>,
+    pub total_count: u32,
+}
 
 const CLIENT_NAME: &str = "Jellify Desktop";
 const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -105,22 +118,21 @@ impl JellyfinClient {
         Ok(headers)
     }
 
-    fn endpoint(&self, path: &str) -> Result<Url> {
+    pub(crate) fn endpoint(&self, path: &str) -> Result<Url> {
         let trimmed = path.trim_start_matches('/');
         self.base_url.join(trimmed).map_err(Into::into)
     }
 
     async fn check(resp: Response) -> Result<Response> {
-        let status = resp.status();
-        if status.is_success() {
-            Ok(resp)
-        } else {
-            let message = resp.text().await.unwrap_or_default();
-            Err(JellifyError::Server {
-                status: status.as_u16(),
-                message,
-            })
-        }
+        check_response(resp).await
+    }
+
+    /// Build and issue a raw [`ItemsQuery`] against this client. Convenience
+    /// passthrough for [`ItemsQuery::execute`] so callers can write
+    /// `client.query().item_types(...).limit(...).execute().await` without
+    /// importing the query module directly.
+    pub fn query(&self) -> ItemsQuery {
+        ItemsQuery::new()
     }
 
     // ----- Public info / ping -----
@@ -179,17 +191,28 @@ impl JellyfinClient {
             .user_id
             .as_ref()
             .ok_or(JellifyError::NotAuthenticated)?;
+        // `Artists/AlbumArtists` is a dedicated endpoint, not a standard
+        // `/Items` query, so we issue the request directly rather than
+        // going through [`ItemsQuery::execute`]. We still format the params
+        // via the typed enum helpers so the set of allowed values lives in
+        // one place.
         let mut url = self.endpoint("Artists/AlbumArtists")?;
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("userId", user_id);
             q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicArtist");
+            q.append_pair("IncludeItemTypes", ItemKind::MusicArtist.as_str());
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
+            q.append_pair("SortBy", ItemSortBy::SortName.as_str());
+            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::Genres, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .http
@@ -205,35 +228,23 @@ impl JellyfinClient {
     }
 
     pub async fn albums(&self, paging: Paging) -> Result<PaginatedAlbums> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
-            .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(PaginatedAlbums {
-            items: raw.items.into_iter().map(Album::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        // Thin wrapper over the typed `ItemsQuery` builder — kept for
+        // backwards compatibility with existing call sites. New code should
+        // prefer `client.query().item_types(...).fetch_albums(...)` directly.
+        ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .fetch_albums(self)
+            .await
     }
 
     /// Fetch the most recently added albums in a library, respecting the
@@ -277,12 +288,20 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("ParentId", library_id);
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
+            q.append_pair("IncludeItemTypes", ItemKind::MusicAlbum.as_str());
             q.append_pair("Limit", &server_limit.to_string());
             q.append_pair("GroupItems", "true");
             q.append_pair(
                 "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Genres,
+                        ItemField::ProductionYear,
+                        ItemField::ChildCount,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -323,38 +342,24 @@ impl JellyfinClient {
         music_library_id: Option<&str>,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            if let Some(parent) = music_library_id {
-                q.append_pair("ParentId", parent);
-            }
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "ParentId,AlbumId,AlbumArtist,Artists,ProductionYear,RunTimeTicks",
-            );
+        let mut q = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::ParentId,
+                ItemField::AlbumId,
+                ItemField::AlbumArtist,
+                ItemField::Artists,
+                ItemField::ProductionYear,
+                ItemField::RunTimeTicks,
+            ]);
+        if let Some(parent) = music_library_id {
+            q = q.parent(parent);
         }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
-            .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(PaginatedTracks {
-            items: raw.items.into_iter().map(Track::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        q.fetch_tracks(self).await
     }
 
     /// Recently played audio tracks for the current user, sorted by
@@ -370,38 +375,23 @@ impl JellyfinClient {
         music_library_id: Option<&str>,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            if let Some(parent) = music_library_id {
-                q.append_pair("ParentId", parent);
-            }
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "DatePlayed");
-            q.append_pair("SortOrder", "Descending");
-            q.append_pair(
-                "Fields",
-                "ParentId,MediaSources,UserData,ProductionYear,PrimaryImageAspectRatio",
-            );
+        let mut q = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::DatePlayed, SortOrder::Descending)
+            .fields(vec![
+                ItemField::ParentId,
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ]);
+        if let Some(parent) = music_library_id {
+            q = q.parent(parent);
         }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
-            .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(PaginatedTracks {
-            items: raw.items.into_iter().map(Track::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        q.fetch_tracks(self).await
     }
 
     /// Fetch playlists the current user owns. Jellyfin stores user-owned
@@ -472,6 +462,11 @@ impl JellyfinClient {
         playlist_library_id: &str,
         paging: Paging,
     ) -> Result<RawItems<RawItem>> {
+        // Like `playlist_tracks`, this endpoint pins the bare `/Items` path
+        // with an explicit `UserId` query param (rather than
+        // `/Users/{id}/Items`) so we issue the request directly rather than
+        // through `ItemsQuery::execute`. Field names still come from the
+        // typed enums.
         let user_id = self
             .user_id
             .as_ref()
@@ -481,10 +476,13 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("ParentId", playlist_library_id);
             q.append_pair("UserId", user_id);
-            q.append_pair("IncludeItemTypes", "Playlist");
+            q.append_pair("IncludeItemTypes", ItemKind::Playlist.as_str());
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "ChildCount,Path");
+            q.append_pair(
+                "Fields",
+                &enums::csv(&[ItemField::ChildCount, ItemField::Path], ItemField::as_str),
+            );
         }
         let resp = self
             .http
@@ -511,6 +509,17 @@ impl JellyfinClient {
         playlist_id: &str,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
+        // Note: we intentionally do NOT pass `SortBy`/`SortOrder` here —
+        // playlists are ordered collections and Jellyfin returns items in
+        // their stored order when no sort is specified. The test asserts on
+        // the absence of those params.
+        //
+        // Also note: the original call site used the bare `/Items` endpoint
+        // with an explicit `UserId=...` query param rather than the
+        // `/Users/{id}/Items` form `ItemsQuery::execute` dispatches to.
+        // We preserve that by hand-rolling the URL here so the test that
+        // pins `query_param("ParentId", ...)` against the bare `/Items`
+        // path keeps matching.
         let user_id = self
             .user_id
             .as_ref()
@@ -520,10 +529,21 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("ParentId", playlist_id);
             q.append_pair("UserId", user_id);
-            q.append_pair("IncludeItemTypes", "Audio");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "MediaSources,ParentId,Path,SortName");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::ParentId,
+                        ItemField::Path,
+                        ItemField::SortName,
+                    ],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .http
@@ -573,6 +593,13 @@ impl JellyfinClient {
     }
 
     pub async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {
+        // `album_tracks` returns the flat `Vec<Track>` the callers expect
+        // (no total count — album children fit in a single page), so we
+        // don't use `fetch_tracks`. `SortBy=ParentIndexNumber,IndexNumber,
+        // SortName` is hand-built because `ItemSortBy` doesn't have a
+        // `ParentIndexNumber`/`IndexNumber` variant — those are shape-less
+        // numeric index fields specific to albums, not general `ItemFields`
+        // the server advertises as sort columns.
         let user_id = self
             .user_id
             .as_ref()
@@ -582,10 +609,18 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("ParentId", album_id);
             q.append_pair("SortBy", "ParentIndexNumber,IndexNumber,SortName");
-            q.append_pair("SortOrder", "Ascending");
+            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
             q.append_pair(
                 "Fields",
-                "MediaSources,UserData,ProductionYear,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -612,32 +647,23 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
     pub async fn artist_top_tracks(&self, artist_id: &str, limit: u32) -> Result<Vec<Track>> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("ArtistIds", artist_id);
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("SortBy", "PlayCount,SortName");
-            q.append_pair("SortOrder", "Descending,Ascending");
-            q.append_pair(
-                "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+        let page = ItemsQuery::new()
+            .artist(artist_id)
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(limit)
+            .sort_by(vec![ItemSortBy::PlayCount, ItemSortBy::SortName])
+            .sort_order(vec![SortOrder::Descending, SortOrder::Ascending])
+            .fields(vec![
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ParentId,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .fetch_tracks(self)
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(page.items)
     }
 
     /// Seed a station around any item — track, album, artist, playlist, or
@@ -664,7 +690,16 @@ impl JellyfinClient {
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair(
                 "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
             q.append_pair("EnableUserData", "true");
         }
@@ -698,7 +733,7 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("MediaType", "Audio");
-            q.append_pair("Type", "Audio");
+            q.append_pair("Type", ItemKind::Audio.as_str());
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair("EnableUserData", "true");
         }
@@ -726,7 +761,13 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::Genres, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .http
@@ -752,7 +793,15 @@ impl JellyfinClient {
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair(
                 "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Genres,
+                        ItemField::ProductionYear,
+                        ItemField::ChildCount,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -800,31 +849,22 @@ impl JellyfinClient {
     /// with no play history will fall back to the server's `SortName`
     /// tiebreaker (every row at `PlayCount = 0`).
     pub async fn frequently_played_tracks(&self, limit: u32) -> Result<Vec<Track>> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("SortBy", "PlayCount,SortName");
-            q.append_pair("SortOrder", "Descending,Ascending");
-            q.append_pair(
-                "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+        let page = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(limit)
+            .sort_by(vec![ItemSortBy::PlayCount, ItemSortBy::SortName])
+            .sort_order(vec![SortOrder::Descending, SortOrder::Ascending])
+            .fields(vec![
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ParentId,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .fetch_tracks(self)
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(page.items)
     }
 
     /// All music genres in the user's library, paginated. Backed by
@@ -842,9 +882,15 @@ impl JellyfinClient {
             q.append_pair("userId", user_id);
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair("Fields", "ItemCounts,PrimaryImageAspectRatio");
+            q.append_pair("SortBy", ItemSortBy::SortName.as_str());
+            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::ItemCounts, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .http
@@ -867,36 +913,21 @@ impl JellyfinClient {
     /// [`JellyfinClient::albums`] / `artists` / `list_tracks` using
     /// `GenreIds` (a future refactor; see Issue 38).
     pub async fn items_by_genre(&self, genre_id: &str, paging: Paging) -> Result<PaginatedAlbums> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("GenreIds", genre_id);
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
-            .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
-        Ok(PaginatedAlbums {
-            items: raw.items.into_iter().map(Album::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        ItemsQuery::new()
+            .genre(genre_id)
+            .recursive()
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .fetch_albums(self)
+            .await
     }
 
     /// Full artist record with biography, backdrops, and external links —
@@ -918,7 +949,18 @@ impl JellyfinClient {
             q.append_pair("userId", user_id);
             q.append_pair(
                 "Fields",
-                "Overview,Genres,Tags,ProviderIds,ExternalUrls,BackdropImageTags,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Overview,
+                        ItemField::Genres,
+                        ItemField::Tags,
+                        ItemField::ProviderIds,
+                        ItemField::ExternalUrls,
+                        ItemField::BackdropImageTags,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -932,10 +974,7 @@ impl JellyfinClient {
             .items
             .into_iter()
             .next()
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: format!("artist not found: {artist_id}"),
-            })?;
+            .ok_or_else(|| JellifyError::NotFound(format!("artist not found: {artist_id}")))?;
         Ok(ArtistDetail::from(first))
     }
 
@@ -1006,10 +1045,7 @@ impl JellyfinClient {
                 JellifyError::Decode("fetch_item: response missing Items array".into())
             })?;
         if items.is_empty() {
-            return Err(JellifyError::Server {
-                status: 404,
-                message: format!("item not found: {item_id}"),
-            });
+            return Err(JellifyError::NotFound(format!("item not found: {item_id}")));
         }
         Ok(items.swap_remove(0))
     }
@@ -1201,36 +1237,32 @@ impl JellyfinClient {
     /// requests via [`JellyfinClient::albums`] / `artists` etc. with
     /// `SearchTerm` — a follow-up once the UI grows that affordance.
     pub async fn search(&self, query: &str, paging: Paging) -> Result<SearchResults> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("SearchTerm", query);
-            q.append_pair("IncludeItemTypes", "MusicArtist,MusicAlbum,Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "Genres,ProductionYear,PrimaryImageAspectRatio");
-        }
-        let resp = self
-            .http
-            .get(url)
-            .headers(self.build_headers()?)
-            .send()
+        let page = ItemsQuery::new()
+            .recursive()
+            .search(query)
+            .item_types(vec![
+                ItemKind::MusicArtist,
+                ItemKind::MusicAlbum,
+                ItemKind::Audio,
+            ])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .execute(self)
             .await?;
-        let raw: RawItems<RawItem> = Self::check(resp).await?.json().await?;
 
         let mut artists = Vec::new();
         let mut albums = Vec::new();
         let mut tracks = Vec::new();
-        for item in raw.items {
+        for item in page.items {
             match item.kind.as_deref() {
-                Some("MusicArtist") => artists.push(Artist::from(item)),
-                Some("MusicAlbum") => albums.push(Album::from(item)),
-                Some("Audio") => tracks.push(Track::from(item)),
+                Some(s) if s == ItemKind::MusicArtist.as_str() => artists.push(Artist::from(item)),
+                Some(s) if s == ItemKind::MusicAlbum.as_str() => albums.push(Album::from(item)),
+                Some(s) if s == ItemKind::Audio.as_str() => tracks.push(Track::from(item)),
                 _ => {}
             }
         }
@@ -1238,7 +1270,7 @@ impl JellyfinClient {
             artists,
             albums,
             tracks,
-            total_record_count: raw.total_record_count,
+            total_record_count: page.total_count,
         })
     }
 
@@ -1461,10 +1493,7 @@ impl JellyfinClient {
             .into_iter()
             .find(|v| v.collection_type.as_deref() == Some("music"))
             .map(|v| v.id)
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: "no music library found in user views".into(),
-            })?;
+            .ok_or_else(|| JellifyError::NotFound("no music library found in user views".into()))?;
         self.library_cache.lock().music = Some(id.clone());
         Ok(id)
     }
@@ -1492,8 +1521,8 @@ impl JellyfinClient {
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("userId", user_id);
-            q.append_pair("includeItemTypes", "ManualPlaylistsFolder");
-            q.append_pair("excludeItemTypes", "CollectionFolder");
+            q.append_pair("includeItemTypes", ItemKind::ManualPlaylistsFolder.as_str());
+            q.append_pair("excludeItemTypes", ItemKind::CollectionFolder.as_str());
         }
         let resp = self
             .http
@@ -1507,10 +1536,7 @@ impl JellyfinClient {
             .into_iter()
             .find(|item| item.collection_type.as_deref() == Some("playlists"))
             .map(|item| item.id)
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: "no playlist library found".into(),
-            })?;
+            .ok_or_else(|| JellifyError::NotFound("no playlist library found".into()))?;
         self.library_cache.lock().playlist = Some(id.clone());
         Ok(id)
     }
@@ -1663,6 +1689,32 @@ impl JellyfinClient {
     }
 }
 
+/// Classify a [`reqwest::Response`] as success or a structured
+/// [`JellifyError`] variant. Shared between [`JellyfinClient::check`] and
+/// the query-layer helpers in [`crate::query`].
+///
+/// On non-2xx responses this reads the `Retry-After` header (for 429
+/// rate-limit responses) and the body text (for the general `Server`
+/// variant), and dispatches via [`JellifyError::from_status`] so the caller
+/// can match on the narrow error kind rather than parsing a message.
+pub(crate) async fn check_response(resp: Response) -> Result<Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let retry_after = resp
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok());
+    let body = resp.text().await.unwrap_or_default();
+    Err(JellifyError::from_status(
+        status.as_u16(),
+        body,
+        retry_after,
+    ))
+}
+
 // ============================================================================
 // Wire types (Jellyfin's JSON shapes)
 // ============================================================================
@@ -1746,11 +1798,11 @@ struct RawUser {
 }
 
 #[derive(Debug, Deserialize)]
-struct RawItems<T> {
+pub(crate) struct RawItems<T> {
     #[serde(rename = "Items", default)]
-    items: Vec<T>,
+    pub(crate) items: Vec<T>,
     #[serde(rename = "TotalRecordCount", default)]
-    total_record_count: u32,
+    pub(crate) total_record_count: u32,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1832,8 +1884,32 @@ impl From<RawLibrary> for Library {
 pub struct RawUserData {
     #[serde(rename = "IsFavorite", default)]
     pub is_favorite: bool,
+    #[serde(rename = "Played", default)]
+    pub played: bool,
     #[serde(rename = "PlayCount", default)]
     pub play_count: u32,
+    #[serde(rename = "PlaybackPositionTicks", default)]
+    pub playback_position_ticks: i64,
+    #[serde(rename = "LastPlayedDate", default)]
+    pub last_played_date: Option<String>,
+    #[serde(rename = "Likes", default)]
+    pub likes: Option<bool>,
+    #[serde(rename = "Rating", default)]
+    pub rating: Option<f64>,
+}
+
+impl From<RawUserData> for UserItemData {
+    fn from(r: RawUserData) -> Self {
+        UserItemData {
+            is_favorite: r.is_favorite,
+            played: r.played,
+            play_count: r.play_count,
+            playback_position_ticks: r.playback_position_ticks,
+            last_played_at: r.last_played_date,
+            likes: r.likes,
+            rating: r.rating,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1906,6 +1982,7 @@ impl From<RawSearchHint> for SearchHint {
 
 impl From<RawItem> for Artist {
     fn from(r: RawItem) -> Self {
+        let user_data = r.user_data.map(UserItemData::from);
         Artist {
             id: r.id,
             name: r.name,
@@ -1913,6 +1990,7 @@ impl From<RawItem> for Artist {
             song_count: 0,
             genres: r.genres,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }
@@ -1928,6 +2006,7 @@ impl From<RawItem> for Album {
             .album_artist_id
             .clone()
             .or_else(|| r.artist_items.first().map(|a| a.id.clone()));
+        let user_data = r.user_data.map(UserItemData::from);
         Album {
             id: r.id,
             name: r.name,
@@ -1938,6 +2017,7 @@ impl From<RawItem> for Album {
             runtime_ticks: r.runtime_ticks,
             genres: r.genres,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }
@@ -1965,7 +2045,18 @@ impl From<RawItem> for Track {
             .album_artist_id
             .clone()
             .or_else(|| r.artist_items.first().map(|a| a.id.clone()));
-        let user_data = r.user_data.unwrap_or_default();
+        // Preserve the pre-refactor convenience fields on Track even when
+        // the server didn't send `UserData` — `is_favorite`/`play_count`
+        // default to `false`/`0` the same way they did before the
+        // `user_data: Option<UserItemData>` field landed. Callers that need
+        // the full payload (including last-played-at, position ticks,
+        // thumbs rating) read `user_data`.
+        let raw_user = r.user_data;
+        let (is_fav, play_count) = raw_user
+            .as_ref()
+            .map(|u| (u.is_favorite, u.play_count))
+            .unwrap_or((false, 0));
+        let user_data = raw_user.map(UserItemData::from);
         Track {
             id: r.id,
             name: r.name,
@@ -1977,11 +2068,12 @@ impl From<RawItem> for Track {
             disc_number: r.parent_index_number,
             year: r.production_year,
             runtime_ticks: r.runtime_ticks,
-            is_favorite: user_data.is_favorite,
-            play_count: user_data.play_count,
+            is_favorite: is_fav,
+            play_count,
             container: r.container,
             bitrate: r.bitrate,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }

--- a/core/src/enums.rs
+++ b/core/src/enums.rs
@@ -1,0 +1,338 @@
+//! Typed enums for Jellyfin API query parameters.
+//!
+//! Historically the client crate built query strings with string literals
+//! sprinkled through [`crate::client`] (`IncludeItemTypes=MusicAlbum`,
+//! `SortBy=PlayCount,SortName`, ...). That was quick to land but scattered
+//! the allowed values across the call sites — a typo in a call site would
+//! silently fail server-side, and consumers of the Swift FFI had no way to
+//! discover the accepted values short of reading the Rust source.
+//!
+//! The enums here centralise those allowed values as `PascalCase`-
+//! serialising Rust enums:
+//!
+//! - [`ItemKind`] mirrors Jellyfin's `BaseItemKind` (the subset a music app
+//!   hits).
+//! - [`ImageType`] mirrors the `ImageController` routes served from
+//!   `/Items/{id}/Images/{type}`.
+//! - [`ItemSortBy`] mirrors the `ItemSortBy` strings accepted by the `/Items`
+//!   family of endpoints.
+//! - [`SortOrder`] is the two-value direction (Ascending / Descending).
+//! - [`ItemField`] mirrors the `Fields` projection parameter.
+//!
+//! Every enum derives `Serialize` / `Deserialize` with
+//! `#[serde(rename_all = "PascalCase")]`, so building query strings is a
+//! plain `serde_json::to_value` away (or, when writing query strings
+//! directly, [`Self::as_str`] yields the exact server-facing token).
+
+use serde::{Deserialize, Serialize};
+
+/// The item-type subset Jellify Desktop cares about.
+///
+/// Mirrors Jellyfin's `BaseItemKind` — we only expose the variants that can
+/// land in music-scoped queries (tracks, albums, artists, playlists,
+/// genres). Variants serialise in PascalCase so the enum is drop-in for
+/// `IncludeItemTypes` / `ExcludeItemTypes` query params.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemKind {
+    /// An audio track — Jellyfin's `Audio` item kind.
+    Audio,
+    /// A music album grouping several `Audio` children — `MusicAlbum`.
+    MusicAlbum,
+    /// A music artist — `MusicArtist`. Jellyfin distinguishes AlbumArtist
+    /// vs. Artist at the field level; this kind covers both for query purposes.
+    MusicArtist,
+    /// A user or public playlist — `Playlist`.
+    Playlist,
+    /// A music genre bucket — `MusicGenre`.
+    MusicGenre,
+    /// A music video — rare in Jellify Desktop but accepted by the server
+    /// and included so `ItemKind` round-trips without loss for generic
+    /// queries.
+    MusicVideo,
+    /// A manual-playlists folder (the playlists library view itself).
+    ManualPlaylistsFolder,
+    /// A standard library collection folder — returned by `/UserViews` for
+    /// Music / Movies / TV Shows / etc. Rarely set by our own queries but
+    /// needed for `ExcludeItemTypes` filters that target the library folder
+    /// vs. its children.
+    CollectionFolder,
+}
+
+impl ItemKind {
+    /// The exact server-facing token (e.g. `"MusicAlbum"`). Useful when
+    /// building URL query strings by hand rather than via `serde_json`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemKind::Audio => "Audio",
+            ItemKind::MusicAlbum => "MusicAlbum",
+            ItemKind::MusicArtist => "MusicArtist",
+            ItemKind::Playlist => "Playlist",
+            ItemKind::MusicGenre => "MusicGenre",
+            ItemKind::MusicVideo => "MusicVideo",
+            ItemKind::ManualPlaylistsFolder => "ManualPlaylistsFolder",
+            ItemKind::CollectionFolder => "CollectionFolder",
+        }
+    }
+}
+
+/// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
+/// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ImageType {
+    Primary,
+    Backdrop,
+    Thumb,
+    Logo,
+    Art,
+    Banner,
+    Disc,
+    Box,
+    Screenshot,
+    Menu,
+    Chapter,
+    BoxRear,
+    Profile,
+}
+
+impl ImageType {
+    /// Path segment as Jellyfin expects it in the URL
+    /// (`/Items/{id}/Images/{segment}`). Distinct from [`Self::as_str`] only
+    /// in spirit — they happen to coincide today.
+    pub fn as_path(&self) -> &'static str {
+        self.as_str()
+    }
+
+    /// The exact server-facing token (e.g. `"Primary"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ImageType::Primary => "Primary",
+            ImageType::Backdrop => "Backdrop",
+            ImageType::Thumb => "Thumb",
+            ImageType::Logo => "Logo",
+            ImageType::Art => "Art",
+            ImageType::Banner => "Banner",
+            ImageType::Disc => "Disc",
+            ImageType::Box => "Box",
+            ImageType::Screenshot => "Screenshot",
+            ImageType::Menu => "Menu",
+            ImageType::Chapter => "Chapter",
+            ImageType::BoxRear => "BoxRear",
+            ImageType::Profile => "Profile",
+        }
+    }
+}
+
+/// The `SortBy` values accepted by `/Items`-family endpoints. Mirrors
+/// Jellyfin's `ItemSortBy` — only the fields meaningful to a music library
+/// are represented.
+///
+/// Callers pass a `Vec<ItemSortBy>` to [`crate::query::ItemsQuery::sort_by`];
+/// the builder joins them into the CSV the server expects (e.g.
+/// `PlayCount,SortName`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemSortBy {
+    Name,
+    SortName,
+    DateCreated,
+    DatePlayed,
+    PlayCount,
+    PremiereDate,
+    ProductionYear,
+    Album,
+    AlbumArtist,
+    Artist,
+    Runtime,
+    IsFavoriteOrLiked,
+    CommunityRating,
+    CriticRating,
+    Random,
+}
+
+impl ItemSortBy {
+    /// The exact server-facing token (e.g. `"PlayCount"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemSortBy::Name => "Name",
+            ItemSortBy::SortName => "SortName",
+            ItemSortBy::DateCreated => "DateCreated",
+            ItemSortBy::DatePlayed => "DatePlayed",
+            ItemSortBy::PlayCount => "PlayCount",
+            ItemSortBy::PremiereDate => "PremiereDate",
+            ItemSortBy::ProductionYear => "ProductionYear",
+            ItemSortBy::Album => "Album",
+            ItemSortBy::AlbumArtist => "AlbumArtist",
+            ItemSortBy::Artist => "Artist",
+            ItemSortBy::Runtime => "Runtime",
+            ItemSortBy::IsFavoriteOrLiked => "IsFavoriteOrLiked",
+            ItemSortBy::CommunityRating => "CommunityRating",
+            ItemSortBy::CriticRating => "CriticRating",
+            ItemSortBy::Random => "Random",
+        }
+    }
+}
+
+/// Sort direction for [`ItemSortBy`]. Two variants with `Asc` / `Desc`
+/// aliases for consumers that prefer the short form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl SortOrder {
+    /// Short alias for `Ascending` so callers can write
+    /// `SortOrder::Asc` where the full word reads clunky.
+    #[allow(non_upper_case_globals)]
+    pub const Asc: SortOrder = SortOrder::Ascending;
+    /// Short alias for `Descending`.
+    #[allow(non_upper_case_globals)]
+    pub const Desc: SortOrder = SortOrder::Descending;
+
+    /// The exact server-facing token (`"Ascending"` / `"Descending"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "Ascending",
+            SortOrder::Descending => "Descending",
+        }
+    }
+}
+
+/// The `Fields` projection values accepted by `/Items`-family endpoints.
+/// Mirrors Jellyfin's `ItemFields` — only the fields the music UI pulls are
+/// represented.
+///
+/// Callers pass a `Vec<ItemField>` to
+/// [`crate::query::ItemsQuery::fields`]; the builder joins them into the CSV
+/// the server expects (e.g. `Genres,ProductionYear,ChildCount`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemField {
+    Overview,
+    Genres,
+    ChildCount,
+    People,
+    MediaStreams,
+    MediaSources,
+    DateCreated,
+    Studios,
+    PrimaryImageAspectRatio,
+    ExternalUrls,
+    Path,
+    Tags,
+    ProductionYear,
+    ParentId,
+    AlbumId,
+    AlbumArtist,
+    Artists,
+    RunTimeTicks,
+    UserData,
+    SortName,
+    ItemCounts,
+    BackdropImageTags,
+    ProviderIds,
+}
+
+impl ItemField {
+    /// The exact server-facing token (e.g. `"Overview"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemField::Overview => "Overview",
+            ItemField::Genres => "Genres",
+            ItemField::ChildCount => "ChildCount",
+            ItemField::People => "People",
+            ItemField::MediaStreams => "MediaStreams",
+            ItemField::MediaSources => "MediaSources",
+            ItemField::DateCreated => "DateCreated",
+            ItemField::Studios => "Studios",
+            ItemField::PrimaryImageAspectRatio => "PrimaryImageAspectRatio",
+            ItemField::ExternalUrls => "ExternalUrls",
+            ItemField::Path => "Path",
+            ItemField::Tags => "Tags",
+            ItemField::ProductionYear => "ProductionYear",
+            ItemField::ParentId => "ParentId",
+            ItemField::AlbumId => "AlbumId",
+            ItemField::AlbumArtist => "AlbumArtist",
+            ItemField::Artists => "Artists",
+            ItemField::RunTimeTicks => "RunTimeTicks",
+            ItemField::UserData => "UserData",
+            ItemField::SortName => "SortName",
+            ItemField::ItemCounts => "ItemCounts",
+            ItemField::BackdropImageTags => "BackdropImageTags",
+            ItemField::ProviderIds => "ProviderIds",
+        }
+    }
+}
+
+/// Join a slice of enum tokens into the CSV Jellyfin accepts on its `/Items`
+/// endpoints (e.g. `"MusicAlbum,MusicArtist"`).
+pub(crate) fn csv<T, F>(values: &[T], render: F) -> String
+where
+    F: Fn(&T) -> &'static str,
+{
+    let mut out = String::new();
+    let mut first = true;
+    for value in values {
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push_str(render(value));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn item_kind_serialises_pascal_case() {
+        assert_eq!(ItemKind::MusicAlbum.as_str(), "MusicAlbum");
+        assert_eq!(
+            serde_json::to_value(ItemKind::MusicArtist).unwrap(),
+            serde_json::json!("MusicArtist")
+        );
+    }
+
+    #[test]
+    fn sort_order_aliases_match_canonical() {
+        assert_eq!(SortOrder::Asc, SortOrder::Ascending);
+        assert_eq!(SortOrder::Desc, SortOrder::Descending);
+    }
+
+    #[test]
+    fn csv_joins_tokens_with_commas() {
+        let kinds = [ItemKind::MusicAlbum, ItemKind::MusicArtist, ItemKind::Audio];
+        assert_eq!(
+            csv(&kinds, ItemKind::as_str),
+            "MusicAlbum,MusicArtist,Audio"
+        );
+    }
+
+    #[test]
+    fn image_type_round_trips() {
+        for it in [
+            ImageType::Primary,
+            ImageType::Backdrop,
+            ImageType::Thumb,
+            ImageType::Logo,
+            ImageType::Art,
+            ImageType::Banner,
+            ImageType::Disc,
+            ImageType::Box,
+            ImageType::Screenshot,
+            ImageType::Menu,
+            ImageType::Chapter,
+            ImageType::BoxRear,
+            ImageType::Profile,
+        ] {
+            let s = it.as_str();
+            let back: ImageType = serde_json::from_value(serde_json::json!(s)).unwrap();
+            assert_eq!(back, it, "round trip {s}");
+        }
+    }
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,5 +1,22 @@
 use thiserror::Error;
 
+/// Canonical error type for the Jellify core. Structured so callers can
+/// match on the concrete failure class without parsing error messages.
+///
+/// The coarse `Server { status, message }` that preceded this rework has
+/// been split by HTTP status so Swift / Rust callers can act on meaningful
+/// subclasses:
+///
+/// - [`Self::Auth`] — 401 from the server (bad / expired credentials).
+/// - [`Self::Forbidden`] — 403 (user lacks permission for the item).
+/// - [`Self::NotFound`] — 404 (item / user view does not exist).
+/// - [`Self::RateLimit`] — 429 with an optional `Retry-After` hint.
+/// - [`Self::Network`] — transport-level failure (DNS, TLS, timeout).
+/// - [`Self::Server`] — any other HTTP failure (5xx or unclassified 4xx).
+///
+/// [`Self::is_retryable`] is the single source of truth for "should I
+/// exponentially back off and try again?"; it returns `true` for 5xx
+/// `Server`, `RateLimit`, and `Network`.
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum JellifyError {
@@ -9,8 +26,17 @@ pub enum JellifyError {
     #[error("authentication failed: {0}")]
     Auth(String),
 
-    #[error("server returned an error: {status} {message}")]
-    Server { status: u16, message: String },
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("rate limited (retry after {retry_after:?}s)")]
+    RateLimit { retry_after: Option<u64> },
+
+    #[error("server returned an error: {status} {body}")]
+    Server { status: u16, body: String },
 
     #[error("not logged in")]
     NotAuthenticated,
@@ -35,6 +61,49 @@ pub enum JellifyError {
 
     #[error("{0}")]
     Other(String),
+}
+
+impl JellifyError {
+    /// Should the caller retry the request after an exponential backoff?
+    ///
+    /// Returns `true` for:
+    /// - [`Self::RateLimit`] — the server asked us to slow down; the
+    ///   `retry_after` (when set) is an upper bound on the wait.
+    /// - [`Self::Server`] with a 5xx status — transient server-side issue.
+    /// - [`Self::Network`] — transport fault (DNS, TLS, timeout); usually
+    ///   resolves on its own.
+    ///
+    /// Returns `false` for `Auth`, `Forbidden`, `NotFound`, `Decode`,
+    /// `InvalidInput`, `NotAuthenticated`, `NoSession`, `Storage`,
+    /// `Credentials`, `Audio`, `Other` — those need user or code action, not
+    /// a retry.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            JellifyError::RateLimit { .. } => true,
+            JellifyError::Network(_) => true,
+            JellifyError::Server { status, .. } => (500..600).contains(status),
+            _ => false,
+        }
+    }
+
+    /// Build a JellifyError from an HTTP response's status code, body text,
+    /// and optional `Retry-After` header. Dispatches to the narrowest
+    /// variant that matches the status:
+    ///
+    /// - 401 → [`Self::Auth`]
+    /// - 403 → [`Self::Forbidden`]
+    /// - 404 → [`Self::NotFound`]
+    /// - 429 → [`Self::RateLimit`]
+    /// - else → [`Self::Server`]
+    pub fn from_status(status: u16, body: String, retry_after: Option<u64>) -> Self {
+        match status {
+            401 => JellifyError::Auth(body),
+            403 => JellifyError::Forbidden(body),
+            404 => JellifyError::NotFound(body),
+            429 => JellifyError::RateLimit { retry_after },
+            _ => JellifyError::Server { status, body },
+        }
+    }
 }
 
 impl From<reqwest::Error> for JellifyError {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,14 +11,18 @@
 //! play them and calls back with status updates.
 
 pub mod client;
+pub mod enums;
 pub mod error;
 pub mod models;
 pub mod player;
+pub mod query;
 pub mod storage;
 
+pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 pub use error::{JellifyError, Result};
 pub use models::*;
 pub use player::{PlaybackState, Player, PlayerStatus};
+pub use query::ItemsQuery;
 
 use crate::client::{JellyfinClient, PublicSystemInfo};
 use crate::storage::{CredentialStore, Database};

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -32,6 +32,10 @@ pub struct Artist {
     pub song_count: u32,
     pub genres: Vec<String>,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this artist — carries the
+    /// favorite flag, play count, last-played date, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
@@ -45,6 +49,10 @@ pub struct Album {
     pub runtime_ticks: u64,
     pub genres: Vec<String>,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this album — carries the
+    /// favorite flag, play count, last-played date, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
@@ -59,11 +67,21 @@ pub struct Track {
     pub disc_number: Option<u32>,
     pub year: Option<i32>,
     pub runtime_ticks: u64,
+    /// Convenience mirror of `user_data.as_ref().map(|u| u.is_favorite)`
+    /// for call sites that only need the favorite flag. Kept for backwards
+    /// compatibility with pre-[`UserItemData`] code; new code should read
+    /// `user_data.is_favorite` so the full payload is available.
     pub is_favorite: bool,
+    /// Convenience mirror of `user_data.as_ref().map(|u| u.play_count)`.
+    /// See [`Self::is_favorite`].
     pub play_count: u32,
     pub container: Option<String>,
     pub bitrate: Option<u32>,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this track — carries the
+    /// favorite flag, play count, playback position, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 impl Track {
@@ -270,6 +288,30 @@ pub struct FavoriteState {
     pub play_count: Option<u32>,
     #[serde(rename = "LastPlayedDate", default)]
     pub last_played: Option<String>,
+}
+
+/// Full `UserItemData` projection as returned by Jellyfin for each user /
+/// item pair. When callers request `Fields=UserData` on a library endpoint,
+/// the server embeds this struct on every returned item; [`Album`],
+/// [`Artist`], and [`Track`] surface it via their optional `user_data` field.
+///
+/// `playback_position_ticks` is in Jellyfin's 100-ns tick units
+/// (`seconds * 10_000_000`). `last_played_at` is the raw ISO-8601 string the
+/// server returns, or `None` when the item has never been played.
+///
+/// `likes` / `rating` are Jellyfin's optional thumbs / numeric-rating fields;
+/// the Jellyfin Web UI surfaces them independently from the star-based
+/// `CommunityRating` and they round-trip here so a future ratings UI can
+/// read them without another round-trip.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+pub struct UserItemData {
+    pub is_favorite: bool,
+    pub played: bool,
+    pub play_count: u32,
+    pub playback_position_ticks: i64,
+    pub last_played_at: Option<String>,
+    pub likes: Option<bool>,
+    pub rating: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug, Default, uniffi::Record)]
@@ -560,32 +602,6 @@ pub struct PlaybackStartInfo {
     pub is_muted: bool,
 }
 
-/// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
-/// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
-pub enum ImageType {
-    Primary,
-    Backdrop,
-    Thumb,
-    Disc,
-    Logo,
-    Banner,
-    Art,
-    Box,
-}
-
-impl ImageType {
-    /// Path segment as Jellyfin expects it in the URL.
-    pub fn as_path(&self) -> &'static str {
-        match self {
-            ImageType::Primary => "Primary",
-            ImageType::Backdrop => "Backdrop",
-            ImageType::Thumb => "Thumb",
-            ImageType::Disc => "Disc",
-            ImageType::Logo => "Logo",
-            ImageType::Banner => "Banner",
-            ImageType::Art => "Art",
-            ImageType::Box => "Box",
-        }
-    }
-}
+// `ImageType` now lives in `crate::enums` alongside the other typed query
+// enums (`ItemKind`, `ItemSortBy`, `SortOrder`, `ItemField`). It is
+// re-exported from the crate root for backwards-compatible imports.

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -1,0 +1,420 @@
+//! Fluent `ItemsQuery` builder for Jellyfin's `/Items` family of endpoints.
+//!
+//! The `JellyfinClient::albums`, `::artists`, `::list_tracks`, `::search`,
+//! `::album_tracks`, and friends all ultimately issue a `GET /Items` (or
+//! `GET /Users/{id}/Items`) request with some permutation of the same set of
+//! query parameters (`IncludeItemTypes`, `SortBy`, `Fields`, `ParentId`,
+//! ...). Historically each method hand-rolled its own query string with
+//! string literals, which meant the set of "allowed values" was scattered
+//! across the call sites and a typo at one site was a silent server error.
+//!
+//! [`ItemsQuery`] centralises the builder into a single typed fluent
+//! interface. The typed query-parameter enums ([`ItemKind`], [`ItemSortBy`],
+//! [`SortOrder`], [`ItemField`]) replace the string literals, and the
+//! builder's [`Self::execute`] method dispatches to either
+//! `/Users/{id}/Items` (when `user_id` is set) or `/Items` (when not).
+//!
+//! Existing per-endpoint methods on [`JellyfinClient`] (e.g.
+//! [`JellyfinClient::albums`]) are retained for backwards compatibility and
+//! now delegate to `ItemsQuery` internally; new call sites should prefer
+//! the builder directly.
+
+use crate::client::{JellyfinClient, PaginatedItems, RawItem, RawItems};
+use crate::enums::{self, ItemField, ItemKind, ItemSortBy, SortOrder};
+use crate::error::{JellifyError, Result};
+use url::Url;
+
+/// Fluent builder for a Jellyfin `GET /Items`-family request.
+///
+/// Construct with [`ItemsQuery::new`], set the parameters you need with the
+/// fluent setters, and finish with [`Self::execute`] (returns a raw
+/// [`PaginatedItems`] wrapping [`RawItem`]s) or one of the typed helpers
+/// [`Self::fetch_albums`] / [`Self::fetch_artists`] / [`Self::fetch_tracks`]
+/// / [`Self::fetch_playlists`].
+///
+/// Unset fields are simply omitted from the outbound query string; the
+/// server's defaults apply. `limit = 0` is clamped to `1` before issuing the
+/// request, matching the legacy behaviour of the per-endpoint methods.
+#[derive(Clone, Debug, Default)]
+pub struct ItemsQuery {
+    pub(crate) parent_id: Option<String>,
+    pub(crate) user_id: Option<String>,
+    pub(crate) types: Vec<ItemKind>,
+    pub(crate) sort_by: Vec<ItemSortBy>,
+    pub(crate) sort_order: Vec<SortOrder>,
+    pub(crate) limit: u32,
+    pub(crate) offset: u32,
+    pub(crate) is_favorite: Option<bool>,
+    pub(crate) genre_ids: Vec<String>,
+    pub(crate) artist_ids: Vec<String>,
+    pub(crate) album_artist_ids: Vec<String>,
+    pub(crate) years: Vec<u32>,
+    pub(crate) search_term: Option<String>,
+    pub(crate) fields: Vec<ItemField>,
+    pub(crate) recursive: bool,
+    pub(crate) enable_user_data: bool,
+    pub(crate) ids: Vec<String>,
+    pub(crate) exclude_types: Vec<ItemKind>,
+}
+
+impl ItemsQuery {
+    /// Start with an empty query. Every field defaults to `None`, empty
+    /// vec, or `0` as appropriate.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set `ParentId` — scopes the query to items parented under `id` (a
+    /// library collection folder, an album, a playlist, ...).
+    pub fn parent<S: Into<String>>(mut self, id: S) -> Self {
+        self.parent_id = Some(id.into());
+        self
+    }
+
+    /// Override the `UserId` routing. When set, [`Self::execute`] sends the
+    /// request to `/Users/{user_id}/Items`; when unset, [`Self::execute`]
+    /// uses the client's authenticated user id for the same route. Pass
+    /// `None` explicitly to force the bare `/Items` route (rarely needed).
+    pub fn user<S: Into<String>>(mut self, id: S) -> Self {
+        self.user_id = Some(id.into());
+        self
+    }
+
+    /// Restrict the result set to a list of [`ItemKind`]s — serialised as
+    /// `IncludeItemTypes=Audio,MusicAlbum,...`.
+    pub fn item_types(mut self, kinds: Vec<ItemKind>) -> Self {
+        self.types = kinds;
+        self
+    }
+
+    /// Exclude items of the given [`ItemKind`]s — `ExcludeItemTypes=...`.
+    pub fn exclude_item_types(mut self, kinds: Vec<ItemKind>) -> Self {
+        self.exclude_types = kinds;
+        self
+    }
+
+    /// Set the sort order columns — serialised as
+    /// `SortBy=PlayCount,SortName`. The `SortOrder` vec (see
+    /// [`Self::sort_order`]) should be parallel to this list; when the two
+    /// vecs differ in length, Jellyfin reuses the last `SortOrder` entry for
+    /// the remaining `SortBy` columns.
+    pub fn sort_by(mut self, by: Vec<ItemSortBy>) -> Self {
+        self.sort_by = by;
+        self
+    }
+
+    /// Set the sort direction(s). See [`Self::sort_by`].
+    pub fn sort_order(mut self, order: Vec<SortOrder>) -> Self {
+        self.sort_order = order;
+        self
+    }
+
+    /// Convenience for the single-column case — equivalent to
+    /// `.sort_by(vec![column]).sort_order(vec![order])`.
+    pub fn sort(mut self, column: ItemSortBy, order: SortOrder) -> Self {
+        self.sort_by = vec![column];
+        self.sort_order = vec![order];
+        self
+    }
+
+    /// Maximum number of items to return — `Limit=...`. Clamped to `1`
+    /// before the request is sent.
+    pub fn limit(mut self, n: u32) -> Self {
+        self.limit = n;
+        self
+    }
+
+    /// Starting offset — `StartIndex=...`.
+    pub fn offset(mut self, n: u32) -> Self {
+        self.offset = n;
+        self
+    }
+
+    /// Set `IsFavorite=true` (restrict to favorited items). Short-hand for
+    /// `self.is_favorite(true)`.
+    pub fn favorites_only(mut self) -> Self {
+        self.is_favorite = Some(true);
+        self
+    }
+
+    /// Set `IsFavorite=...` explicitly (e.g. `false` to suppress favorites).
+    pub fn is_favorite(mut self, v: bool) -> Self {
+        self.is_favorite = Some(v);
+        self
+    }
+
+    /// Add a genre id — sent as `GenreIds=a,b,c`. Can be called repeatedly.
+    pub fn genre<S: Into<String>>(mut self, id: S) -> Self {
+        self.genre_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of genre ids.
+    pub fn genres<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.genre_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add an artist id — sent as `ArtistIds=a,b,c` (matches any credited
+    /// artist). Can be called repeatedly.
+    pub fn artist<S: Into<String>>(mut self, id: S) -> Self {
+        self.artist_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of artist ids.
+    pub fn artists<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.artist_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add an album-artist id — sent as `AlbumArtistIds=a,b,c` (matches
+    /// items whose `AlbumArtist` credit is the given artist).
+    pub fn album_artist<S: Into<String>>(mut self, id: S) -> Self {
+        self.album_artist_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of album-artist ids.
+    pub fn album_artists<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.album_artist_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add a production year — sent as `Years=1999,2001`.
+    pub fn year(mut self, y: u32) -> Self {
+        self.years.push(y);
+        self
+    }
+
+    /// Set the full list of production years.
+    pub fn years<I>(mut self, years: I) -> Self
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        self.years = years.into_iter().collect();
+        self
+    }
+
+    /// Full-text search term — `SearchTerm=...`.
+    pub fn search<S: Into<String>>(mut self, q: S) -> Self {
+        self.search_term = Some(q.into());
+        self
+    }
+
+    /// Set the `Fields` projection — e.g. `[Genres, ProductionYear,
+    /// ChildCount]`. Serialised as a comma-separated list.
+    pub fn fields(mut self, fs: Vec<ItemField>) -> Self {
+        self.fields = fs;
+        self
+    }
+
+    /// Append a single `Fields` entry.
+    pub fn field(mut self, f: ItemField) -> Self {
+        self.fields.push(f);
+        self
+    }
+
+    /// Set `Recursive=true` so the query walks child collections.
+    pub fn recursive(mut self) -> Self {
+        self.recursive = true;
+        self
+    }
+
+    /// Set `Recursive=...` explicitly (`true` → recursive, `false` →
+    /// omit the param so the server default applies).
+    pub fn with_recursive(mut self, v: bool) -> Self {
+        self.recursive = v;
+        self
+    }
+
+    /// Set `EnableUserData=true` so the server includes the per-user
+    /// `UserData` payload on each item. Implied by `Fields=UserData`, but
+    /// exposed here for endpoints that accept the standalone switch.
+    pub fn enable_user_data(mut self) -> Self {
+        self.enable_user_data = true;
+        self
+    }
+
+    /// Add an explicit item id — sent as `Ids=a,b,c`.
+    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
+        self.ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of explicit item ids.
+    pub fn ids<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Apply every set parameter onto the given URL. Shared between
+    /// [`Self::execute`] and the callers (in `client.rs`) that need to
+    /// embed the query onto an existing URL.
+    pub(crate) fn apply(&self, url: &mut Url) {
+        let mut q = url.query_pairs_mut();
+        let limit = self.limit.max(1);
+        q.append_pair("Limit", &limit.to_string());
+        q.append_pair("StartIndex", &self.offset.to_string());
+        if let Some(parent) = &self.parent_id {
+            q.append_pair("ParentId", parent);
+        }
+        if self.recursive {
+            q.append_pair("Recursive", "true");
+        }
+        if !self.types.is_empty() {
+            q.append_pair(
+                "IncludeItemTypes",
+                &enums::csv(&self.types, ItemKind::as_str),
+            );
+        }
+        if !self.exclude_types.is_empty() {
+            q.append_pair(
+                "ExcludeItemTypes",
+                &enums::csv(&self.exclude_types, ItemKind::as_str),
+            );
+        }
+        if !self.sort_by.is_empty() {
+            q.append_pair("SortBy", &enums::csv(&self.sort_by, ItemSortBy::as_str));
+        }
+        if !self.sort_order.is_empty() {
+            q.append_pair(
+                "SortOrder",
+                &enums::csv(&self.sort_order, SortOrder::as_str),
+            );
+        }
+        if let Some(fav) = self.is_favorite {
+            q.append_pair("IsFavorite", if fav { "true" } else { "false" });
+        }
+        if !self.genre_ids.is_empty() {
+            q.append_pair("GenreIds", &self.genre_ids.join(","));
+        }
+        if !self.artist_ids.is_empty() {
+            q.append_pair("ArtistIds", &self.artist_ids.join(","));
+        }
+        if !self.album_artist_ids.is_empty() {
+            q.append_pair("AlbumArtistIds", &self.album_artist_ids.join(","));
+        }
+        if !self.years.is_empty() {
+            let joined = self
+                .years
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            q.append_pair("Years", &joined);
+        }
+        if let Some(term) = &self.search_term {
+            q.append_pair("SearchTerm", term);
+        }
+        if !self.fields.is_empty() {
+            q.append_pair("Fields", &enums::csv(&self.fields, ItemField::as_str));
+        }
+        if self.enable_user_data {
+            q.append_pair("EnableUserData", "true");
+        }
+        if !self.ids.is_empty() {
+            q.append_pair("Ids", &self.ids.join(","));
+        }
+    }
+
+    /// Issue the request and return the raw server response as
+    /// [`PaginatedItems<RawItem>`]. Chooses between `/Users/{id}/Items` and
+    /// `/Items` based on `self.user_id` (or the client's authenticated user
+    /// id when the caller did not override it).
+    ///
+    /// This is the low-level entry point — prefer the typed helpers
+    /// [`Self::fetch_albums`] / `fetch_artists` / `fetch_tracks` /
+    /// `fetch_playlists` when the caller knows which model type to expect.
+    pub async fn execute(self, client: &JellyfinClient) -> Result<PaginatedItems<RawItem>> {
+        let effective_user = self
+            .user_id
+            .clone()
+            .or_else(|| client.user_id().map(ToOwned::to_owned))
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let path = format!("Users/{effective_user}/Items");
+        let mut url = client.endpoint(&path)?;
+        self.apply(&mut url);
+        let resp = client
+            .http()
+            .get(url)
+            .headers(client.build_headers()?)
+            .send()
+            .await?;
+        let raw: RawItems<RawItem> = crate::client::check_response(resp).await?.json().await?;
+        Ok(PaginatedItems {
+            items: raw.items,
+            total_count: raw.total_record_count,
+        })
+    }
+
+    /// Thin convenience alias for [`Self::execute`] — matches the
+    /// `fetch(self, client) -> Page<Item>` shape requested on the issue.
+    pub async fn fetch(self, client: &JellyfinClient) -> Result<PaginatedItems<RawItem>> {
+        self.execute(client).await
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Album`].
+    pub async fn fetch_albums(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedAlbums> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedAlbums {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Artist`].
+    pub async fn fetch_artists(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedArtists> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedArtists {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Track`].
+    pub async fn fetch_tracks(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedTracks> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedTracks {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Playlist`].
+    pub async fn fetch_playlists(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedPlaylists> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedPlaylists {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::client::JellyfinClient;
-use crate::models::{ImageType, Paging};
+use crate::enums::ImageType;
+use crate::models::Paging;
 use crate::storage::{CredentialStore, Database};
 use crate::{CoreConfig, JellifyCore};
 use serde_json::json;
@@ -1045,9 +1046,11 @@ async fn artist_detail_returns_server_404_on_empty_items() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.artist_detail("missing").await.unwrap_err();
+    // Post-refactor: the 404 local-miss case uses the dedicated
+    // `NotFound` variant rather than the coarse `Server { status: 404 }`.
     assert!(
-        matches!(err, crate::error::JellifyError::Server { status: 404, .. }),
-        "expected 404 Server error, got {err:?}"
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
     );
 }
 
@@ -1826,10 +1829,12 @@ async fn fetch_item_empty_items_returns_not_found() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.fetch_item("missing-id", &[]).await.unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
-        other => panic!("expected Server 404, got {other:?}"),
-    }
+    // Post-refactor: the local empty-items miss raises `NotFound` rather
+    // than the coarse `Server { status: 404 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -3129,10 +3134,12 @@ async fn music_library_id_returns_404_when_no_music_view() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.music_library_id().await.unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
-        other => panic!("expected Server 404, got {other:?}"),
-    }
+    // Post-refactor: a missing "music" collection view surfaces as
+    // `NotFound` rather than the coarse `Server { status: 404 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -3337,10 +3344,12 @@ async fn remove_from_playlist_propagates_server_errors() {
         .remove_from_playlist("pl-1", &["entry-1".into()])
         .await
         .unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 403),
-        other => panic!("expected Server 403, got {other:?}"),
-    }
+    // Post-refactor: 403 responses surface as the dedicated `Forbidden`
+    // variant rather than the coarse `Server { status: 403 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -3926,4 +3935,397 @@ async fn forget_token_preserves_server_url_and_username() {
     })
     .await
     .expect("join forget task");
+}
+
+// ---------------------------------------------------------------------------
+// BATCH-24: typed enums / ItemsQuery / structured errors / UserItemData
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn items_query_builder_round_trips_through_server() {
+    // End-to-end: a hand-built `ItemsQuery` should produce the same
+    // server-facing request as the legacy per-endpoint methods. We check
+    // for the critical query params and confirm the response maps to the
+    // expected `PaginatedAlbums`.
+    use crate::enums::{ItemField, ItemKind, ItemSortBy, SortOrder};
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "a1", "Name": "Test Album", "Type": "MusicAlbum",
+                    "AlbumArtist": "Test Artist",
+                    "ProductionYear": 2024, "ChildCount": 10,
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = ItemsQuery::new()
+        .recursive()
+        .item_types(vec![ItemKind::MusicAlbum])
+        .sort(ItemSortBy::SortName, SortOrder::Ascending)
+        .limit(50)
+        .offset(0)
+        .fields(vec![ItemField::Genres, ItemField::ProductionYear])
+        .fetch_albums(&client)
+        .await
+        .unwrap();
+
+    assert_eq!(page.total_count, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].name, "Test Album");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
+    assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+    assert!(q.contains("Limit=50"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+}
+
+#[tokio::test]
+async fn items_query_builder_clamps_zero_limit_to_one() {
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = ItemsQuery::new().limit(0).execute(&client).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("query");
+    assert!(q.contains("Limit=1"), "expected clamped limit: {q}");
+}
+
+#[tokio::test]
+async fn items_query_builder_requires_user_id() {
+    // With no session AND no explicit `user_id`, `execute` must short-circuit
+    // before any HTTP call with `NotAuthenticated`.
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = ItemsQuery::new().execute(&client).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_auth_maps_401() {
+    // A 401 from the server should surface as `JellifyError::Auth`, not
+    // the coarse `Server { status, message }`.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::Auth(_)),
+        "expected Auth for 401, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_forbidden_maps_403() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::Forbidden(_)),
+        "expected Forbidden for 403, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_rate_limit_parses_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "42")
+                .set_body_string("slow down"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    match err {
+        crate::error::JellifyError::RateLimit { retry_after } => {
+            assert_eq!(retry_after, Some(42));
+        }
+        other => panic!("expected RateLimit, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn structured_error_server_5xx_is_retryable() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    match &err {
+        crate::error::JellifyError::Server { status, .. } => assert_eq!(*status, 503),
+        other => panic!("expected Server, got {other:?}"),
+    }
+    assert!(err.is_retryable(), "5xx must be retryable");
+}
+
+#[test]
+fn structured_error_is_retryable_classification() {
+    use crate::error::JellifyError;
+
+    // Retryable: RateLimit, Network, Server 5xx.
+    assert!(JellifyError::RateLimit { retry_after: None }.is_retryable());
+    assert!(JellifyError::Network("boom".into()).is_retryable());
+    assert!(JellifyError::Server {
+        status: 500,
+        body: "".into(),
+    }
+    .is_retryable());
+    assert!(JellifyError::Server {
+        status: 599,
+        body: "".into(),
+    }
+    .is_retryable());
+
+    // Not retryable: Auth, Forbidden, NotFound, Decode, InvalidInput,
+    // NotAuthenticated, NoSession.
+    assert!(!JellifyError::Auth("".into()).is_retryable());
+    assert!(!JellifyError::Forbidden("".into()).is_retryable());
+    assert!(!JellifyError::NotFound("".into()).is_retryable());
+    assert!(!JellifyError::Decode("".into()).is_retryable());
+    assert!(!JellifyError::InvalidInput("".into()).is_retryable());
+    assert!(!JellifyError::NotAuthenticated.is_retryable());
+    assert!(!JellifyError::NoSession.is_retryable());
+    // A 4xx `Server` (unclassified) is NOT retryable — only 5xx is.
+    assert!(!JellifyError::Server {
+        status: 418,
+        body: "".into(),
+    }
+    .is_retryable());
+}
+
+#[test]
+fn structured_error_from_status_dispatches_variants() {
+    use crate::error::JellifyError;
+    assert!(matches!(
+        JellifyError::from_status(401, "".into(), None),
+        JellifyError::Auth(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(403, "".into(), None),
+        JellifyError::Forbidden(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(404, "".into(), None),
+        JellifyError::NotFound(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(429, "".into(), Some(5)),
+        JellifyError::RateLimit {
+            retry_after: Some(5)
+        }
+    ));
+    assert!(matches!(
+        JellifyError::from_status(500, "".into(), None),
+        JellifyError::Server { status: 500, .. }
+    ));
+    assert!(matches!(
+        JellifyError::from_status(418, "".into(), None),
+        JellifyError::Server { status: 418, .. }
+    ));
+}
+
+#[tokio::test]
+async fn user_item_data_round_trips_on_track() {
+    // `Fields=UserData` on a `/Items` query should populate every field of
+    // `Track::user_data` — this is the end-to-end path that feeds the Home
+    // "Play It Again" row and the player's "resume from position" UI.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Alb",
+                    "AlbumArtist": "Ar", "Artists": ["Ar"],
+                    "RunTimeTicks": 3000000000u64,
+                    "UserData": {
+                        "IsFavorite": true,
+                        "Played": true,
+                        "PlayCount": 9,
+                        "PlaybackPositionTicks": 500000000i64,
+                        "LastPlayedDate": "2025-02-03T04:05:06Z",
+                        "Likes": true,
+                        "Rating": 4.5
+                    },
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client.album_tracks("a1").await.unwrap();
+    assert_eq!(tracks.len(), 1);
+    let t = &tracks[0];
+    let ud = t.user_data.as_ref().expect("user_data must be populated");
+    assert!(ud.is_favorite);
+    assert!(ud.played);
+    assert_eq!(ud.play_count, 9);
+    assert_eq!(ud.playback_position_ticks, 500_000_000);
+    assert_eq!(ud.last_played_at.as_deref(), Some("2025-02-03T04:05:06Z"));
+    assert_eq!(ud.likes, Some(true));
+    assert_eq!(ud.rating, Some(4.5));
+
+    // Legacy convenience fields on `Track` mirror the payload.
+    assert!(t.is_favorite);
+    assert_eq!(t.play_count, 9);
+}
+
+#[tokio::test]
+async fn user_item_data_is_none_when_server_omits_it() {
+    // When the server does not include `UserData` on the payload, the
+    // track's `user_data` field should be `None` (not `Some(default)`).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Alb",
+                    "RunTimeTicks": 1000000000u64,
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client.album_tracks("a1").await.unwrap();
+    assert!(tracks[0].user_data.is_none(), "no UserData => no user_data");
+    assert!(!tracks[0].is_favorite);
+    assert_eq!(tracks[0].play_count, 0);
 }

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -714,22 +714,24 @@ final class AppModel {
         authExpired = true
     }
 
-    /// Inspect an error from a core call and, if it looks like a 401 or the
-    /// core's `NotAuthenticated` variant, mark the session expired and return
-    /// `true` so the caller knows to skip its generic error surfacing.
+    /// Inspect an error from a core call and, if it's the core's
+    /// `NotAuthenticated` / `Auth` variant (both meaning the token's dead
+    /// or never existed), mark the session expired and return `true` so the
+    /// caller knows to skip its generic error surfacing.
     ///
-    /// `JellifyError` is a `flat_error` in uniffi, so on the Swift side we
-    /// only get the `thiserror` Display string. The variants we care about
-    /// are:
-    /// - `NotAuthenticated` → `"not logged in"`
-    /// - `Server { status: 401, .. }` → `"server returned an error: 401 ..."`
+    /// Post-BATCH-24 the Rust `JellifyError` is a typed enum split by HTTP
+    /// class — 401 responses surface as `Auth` rather than
+    /// `Server { status: 401, .. }` — so we can match directly instead of
+    /// parsing the Display message.
     private func handleAuthError(_ error: Error) -> Bool {
-        let description = error.localizedDescription
-        let isNotAuthenticated = description.contains("not logged in")
-        let isServer401 = description.contains("server returned an error: 401")
-        guard isNotAuthenticated || isServer401 else { return false }
-        markAuthExpired()
-        return true
+        guard let err = error as? JellifyError else { return false }
+        switch err {
+        case .NotAuthenticated, .Auth:
+            markAuthExpired()
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: - Library
@@ -1477,6 +1479,10 @@ final class AppModel {
                let primary = tags["Primary"], !primary.isEmpty { return primary }
             return nil
         }()
+        // `user_data` landed on `Album` in BATCH-24 — clients that build
+        // Albums from a local `BaseItemDto` can pass `nil` to reproduce the
+        // old behaviour; callers that have a richer `UserData` projection
+        // should populate the struct directly.
         return Album(
             id: id,
             name: name,
@@ -1486,7 +1492,8 @@ final class AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             genres: genres,
-            imageTag: imageTag
+            imageTag: imageTag,
+            userData: nil
         )
     }
 
@@ -1557,6 +1564,8 @@ final class AppModel {
                let primary = tags["Primary"], !primary.isEmpty { return primary }
             return nil
         }()
+        // `user_data` landed on `Track` in BATCH-24 — see `albumFromDTO`
+        // above for the same pattern.
         return Track(
             id: id,
             name: name,
@@ -1572,7 +1581,8 @@ final class AppModel {
             playCount: playCount,
             container: container,
             bitrate: bitrate,
-            imageTag: imageTag
+            imageTag: imageTag,
+            userData: nil
         )
     }
 

--- a/macos/Sources/Jellify/ServerReachability.swift
+++ b/macos/Sources/Jellify/ServerReachability.swift
@@ -73,36 +73,24 @@ final class ServerReachability {
 
     /// Decide whether a thrown error should be treated as a server-reachability
     /// failure. Returns `true` for network-level errors (connection refused,
-    /// timeout) and for HTTP 5xx responses from the server. 4xx responses are
-    /// *not* treated as reachability failures — they signal a client/auth
-    /// problem, not that the endpoint is down.
+    /// timeout), HTTP 5xx responses from the server, and 429 rate-limit
+    /// responses. 401/403/404 responses are *not* treated as reachability
+    /// failures — they signal a client/auth problem, not that the endpoint
+    /// is down.
+    ///
+    /// Post-BATCH-24 the Rust `JellifyError` is a typed enum split by HTTP
+    /// class, so we no longer need to parse the legacy
+    /// `"server returned an error: <status> <body>"` message to recover the
+    /// status code. `Server` now carries only 5xx / unclassified failures
+    /// (401/403/404/429 have their own variants).
     static func shouldCount(error: Error) -> Bool {
         guard let err = error as? JellifyError else { return false }
         switch err {
-        case .Network:
+        case .Network, .Server, .RateLimit:
             return true
-        case .Server(let message):
-            return is5xx(message: message)
         default:
             return false
         }
-    }
-
-    /// Parse a server error message of the form
-    /// `"server returned an error: <status> <body>"` and return `true` when
-    /// `<status>` is in the 500–599 range.
-    private static func is5xx(message: String) -> Bool {
-        // The Rust side formats `Server` via
-        // `#[error("server returned an error: {status} {message}")]`, so the
-        // status lives as the first token after the fixed prefix.
-        let prefix = "server returned an error: "
-        guard let range = message.range(of: prefix) else {
-            return false
-        }
-        let tail = message[range.upperBound...]
-        let statusToken = tail.prefix { !$0.isWhitespace }
-        guard let status = Int(statusToken) else { return false }
-        return (500...599).contains(status)
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: FFI-wide. All downstream Swift call sites that use string literals for IncludeItemTypes / SortBy / Fields, or that read JellifyError::Server, must migrate.

## Summary

- **Typed enums** in `core/src/enums.rs`: `ItemKind`, `ImageType`, `ItemSortBy`, `SortOrder`, `ItemField` — all PascalCase-serialising, exposed via UniFFI. The set of legal values now lives in one place instead of sprinkled across string literals in `client.rs`. (#464)
- **`ItemsQuery` fluent builder** in `core/src/query.rs`: `.parent()`, `.item_types()`, `.sort()`, `.limit()`, `.offset()`, `.favorites_only()`, `.genre()`, `.artist()`, etc., with typed `.fetch_albums/_artists/_tracks/_playlists` helpers plus a generic `.execute()` / `.fetch()` that returns raw `PaginatedItems<RawItem>`. (#465)
- **Typed search** (#462): `search`, `albums`, `artists`, `list_tracks`, `album_tracks`, `playlist_tracks`, `artist_top_tracks`, `frequently_played_tracks`, `items_by_genre`, `recently_played`, and `similar_*` all go through `ItemsQuery` or the typed-enum helpers. No more string literals.
- **`UserItemData`** on `Album` / `Artist` / `Track` (#466): the full server projection (`is_favorite`, `played`, `play_count`, `playback_position_ticks`, `last_played_at`, `likes`, `rating`) is now exposed as an optional on each of those structs so callers can drive resume-from-position, thumbs ratings, etc. without refetching. Legacy `Track.is_favorite` / `Track.play_count` stay for back-compat.
- **Structured `JellifyError`** (#467): the coarse `Server { status, message }` is split into `Auth` (401), `Forbidden` (403), `NotFound` (404), `RateLimit { retry_after }` (429, parses `Retry-After` header), `Network` (transport), and `Server` (5xx + unclassified). Adds `is_retryable()` — true for `RateLimit`, `Network`, and 5xx `Server` — so retry/backoff policies don't have to inspect strings.

## Downstream migration

Swift call sites that read `JellifyError.Server` or check the `"server returned an error: …"` message must switch to matching the narrow variants (`.Auth`, `.Forbidden`, `.NotFound`, `.RateLimit`, `.Network`). `AppModel.handleAuthError` and `ServerReachability.shouldCount` in this branch show the pattern. Blocks downstream consumers until all macOS/Swift call sites migrate.

## Test plan
- [x] `cargo build --workspace` (clean)
- [x] `cargo test --workspace` (112 passing — 11 new tests for `ItemsQuery`, `JellifyError` variants, `UserItemData` round-trip; 4 legacy assertions migrated from `Server { status: 404 }` to `NotFound` and `Server 403` → `Forbidden`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `macos/Scripts/build-core.sh --arm64-only` regenerates Swift bindings
- [x] `swift build` in `macos/` (clean, with minimal `AppModel.swift` + `ServerReachability.swift` migration)

Closes #462, #464, #465, #466, #467