### PR TITLE
macos: preferences — General, Server, Audio, Library, Downloads, About + top-level org

### DIFF
--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesAbout.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesAbout.swift
@@ -1,0 +1,196 @@
+import AppKit
+import SwiftUI
+
+/// About pane.
+///
+/// A one-glance summary of the app: title, version, copyright, and a link to
+/// the GitHub repo. Nothing here is interactive beyond the GitHub button —
+/// the values come from the app bundle so they stay accurate release-to-
+/// release without anyone having to remember to bump a string constant.
+///
+/// This is distinct from the system "About Jellify" sheet (the one that
+/// opens from the app-menu item); that sheet is owned by AppKit and shows
+/// the same version info in Apple's standard layout. The Preferences About
+/// pane exists so users who expect the info inside Settings (macOS System
+/// Settings has one, most third-party apps do too) don't have to go hunting
+/// through the app menu.
+///
+/// Spec: `research/03-ux-patterns.md` Issue 66 About bullet.
+struct PreferencesAbout: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            HStack(alignment: .top, spacing: 20) {
+                appIcon
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Jellify")
+                        .font(Theme.font(24, weight: .black, italic: true))
+                        .foregroundStyle(Theme.ink)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Version \(versionText)")
+                            .font(Theme.font(13, weight: .semibold))
+                            .foregroundStyle(Theme.ink)
+                            .monospacedDigit()
+                            .textSelection(.enabled)
+                        Text("Build \(buildText)")
+                            .font(Theme.font(11, weight: .medium))
+                            .foregroundStyle(Theme.ink3)
+                            .monospacedDigit()
+                            .textSelection(.enabled)
+                    }
+
+                    Text(copyrightText)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+
+                    Text("A native macOS music player for Jellyfin.")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Theme.border, lineWidth: 1)
+                    )
+            )
+
+            actions
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("About")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Version, copyright, and project links.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    /// A 64pt square rendered in the accent color with a stylised "J" —
+    /// matches the brand mark used on the login screen. Avoids pulling in
+    /// an asset dependency just for this pane.
+    private var appIcon: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 14)
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.primary, Theme.accent],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Text("J")
+                .font(Theme.font(36, weight: .black, italic: true))
+                .foregroundStyle(.white)
+        }
+        .frame(width: 64, height: 64)
+        .accessibilityHidden(true)
+    }
+
+    private var actions: some View {
+        HStack(spacing: 12) {
+            Button { openGitHub() } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.up.right.square")
+                    Text("View on GitHub")
+                }
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(Theme.surface2)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("View on GitHub")
+            .accessibilityHint("Opens the Jellify repository in your browser.")
+
+            Button { openIssues() } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.bubble")
+                    Text("Report an Issue")
+                }
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(Theme.surface2)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Report an issue")
+            .accessibilityHint("Opens the Jellify issue tracker in your browser.")
+        }
+    }
+
+    // MARK: - Bundle values
+
+    /// Marketing version (`CFBundleShortVersionString`). Falls back to a
+    /// dev-only placeholder when the bundle key is missing — e.g. when
+    /// running from Xcode against an unconfigured Info.plist.
+    private var versionText: String {
+        bundleString(for: "CFBundleShortVersionString") ?? "0.0.0 (dev)"
+    }
+
+    /// Build number (`CFBundleVersion`). Similar fallback reasoning.
+    private var buildText: String {
+        bundleString(for: "CFBundleVersion") ?? "—"
+    }
+
+    /// Copyright string (`NSHumanReadableCopyright`). When missing, render a
+    /// generic attribution for Skyler Althoff + Jellify contributors rather
+    /// than an empty row.
+    private var copyrightText: String {
+        bundleString(for: "NSHumanReadableCopyright")
+            ?? "Copyright © Skyler Althoff and Jellify contributors."
+    }
+
+    private func bundleString(for key: String) -> String? {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    // MARK: - Actions
+
+    private func openGitHub() {
+        guard let url = URL(string: "https://github.com/skalthoff/jellify-desktop") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func openIssues() {
+        guard let url = URL(string: "https://github.com/skalthoff/jellify-desktop/issues") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+#Preview {
+    PreferencesAbout()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesAudio.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesAudio.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// Audio quality preferences pane.
+///
+/// Deliberately overlaps with the Playback pane's quality pickers — both read
+/// from `playback.streamingQuality` and `playback.downloadQuality` so changes
+/// in one surface show up in the other. Audio is the "proper" home per the
+/// System Settings-style layout (#114); Playback keeps its copy because a
+/// user hunting for "streaming quality" will look under Playback first.
+///
+/// Also houses the **Transcoding preference** — a two-option toggle between
+/// Direct Play (the server decides, prefers passthrough) and Always Transcode
+/// (the server re-encodes even when a direct stream would work). This is the
+/// escape hatch for users hitting compatibility issues with a specific codec
+/// or container on their output device.
+///
+/// Preference keys (user-facing `@AppStorage`, shared with Playback):
+/// - `playback.streamingQuality`     — `PlaybackQuality`
+/// - `playback.downloadQuality`      — `PlaybackQuality`
+/// - `audio.transcodingPreference`   — `TranscodingPreference` (new)
+///
+/// Spec: `research/03-ux-patterns.md` Issue 69 and GitHub issue #117.
+struct PreferencesAudio: View {
+    @AppStorage("playback.streamingQuality") private var streamingQuality: PlaybackQuality = .automatic
+    @AppStorage("playback.downloadQuality") private var downloadQuality: PlaybackQuality = .lossless
+    @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
+
+    private var transcoding: Binding<TranscodingPreference> {
+        Binding(
+            get: { TranscodingPreference(rawValue: transcodingRaw) ?? .directPlay },
+            set: { transcodingRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Streaming Quality",
+                footnote: "Applied when playing over the network. Higher tiers use more bandwidth; Lossless and Original require your server (and your connection) to sustain them."
+            ) {
+                PreferenceRow(
+                    label: "Quality",
+                    help: streamingQuality.subtitle
+                ) {
+                    ExplicitQualityPicker(selection: $streamingQuality)
+                        .accessibilityLabel("Streaming quality")
+                }
+            }
+
+            PreferenceSection(
+                title: "Download Quality",
+                footnote: "Used when saving tracks for offline listening. Higher settings consume more disk space."
+            ) {
+                PreferenceRow(
+                    label: "Quality",
+                    help: downloadQuality.subtitle
+                ) {
+                    ExplicitQualityPicker(selection: $downloadQuality)
+                        .accessibilityLabel("Download quality")
+                }
+            }
+
+            PreferenceSection(
+                title: "Transcoding",
+                footnote: "Direct Play passes the original file through untouched when your device supports the codec — fastest and highest quality. Always Transcode forces the server to re-encode, which helps when a specific file won't play cleanly."
+            ) {
+                PreferenceRow(
+                    label: "Preference",
+                    help: transcoding.wrappedValue.subtitle
+                ) {
+                    Picker("", selection: transcoding) {
+                        ForEach(TranscodingPreference.allCases) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(width: 260)
+                    .accessibilityLabel("Transcoding preference")
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Audio")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Streaming and download quality, transcoding preference.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+}
+
+/// How to handle playback when a direct stream is available.
+///
+/// TODO(#117): feed this into the `PlaybackInfo` request — `directPlay` maps
+/// to sending a `DeviceProfile` that advertises the full set of decodable
+/// codecs/containers so the server returns a DirectStream URL when possible;
+/// `alwaysTranscode` strips the direct-play advertisements so every playback
+/// decision resolves to a transcoded session.
+enum TranscodingPreference: String, CaseIterable, Identifiable {
+    case directPlay
+    case alwaysTranscode
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .directPlay: return "Direct Play"
+        case .alwaysTranscode: return "Always Transcode"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .directPlay: return "Pass the file through when your device can decode it."
+        case .alwaysTranscode: return "Force the server to re-encode every stream."
+        }
+    }
+}
+
+/// Segmented quality picker that shows all five explicit tiers (no Auto).
+/// Matches the #117 spec exactly — the Playback pane's `QualityPicker` also
+/// shows `automatic` because historically that pane's copy read "Let Jellify
+/// pick." A separate picker here avoids touching that surface.
+private struct ExplicitQualityPicker: View {
+    @Binding var selection: PlaybackQuality
+
+    /// The five tiers the Audio pane cares about — Auto is deliberately
+    /// excluded because the spec asks for explicit choices. If the on-disk
+    /// value happens to be `.automatic` (legacy), the segmented control just
+    /// shows nothing selected; first tap commits to an explicit tier.
+    private static let tiers: [PlaybackQuality] = [.low, .normal, .high, .lossless, .original]
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(Self.tiers) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 420)
+    }
+}
+
+#Preview {
+    PreferencesAudio()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesDownloads.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesDownloads.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Downloads preferences pane.
+///
+/// Minimal shell today — two surfaces users look for first:
+///
+/// 1. **Download location** — read-only display of the path where offline
+///    copies will land. Today this resolves to
+///    `~/Library/Containers/.../Caches/Downloads` via
+///    `FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)`
+///    so the path reads as expected for a sandboxed app. Picking a custom
+///    location lands alongside the broader download manager work
+///    (`TODO(#570)`).
+///
+/// 2. **Storage budget slider** — caps total disk space used by offline
+///    downloads. 1 GB — 100 GB with a 500 MB step; the chosen value is
+///    persisted under `downloads.storageBudgetGb` so the download manager
+///    can enforce it once it lands.
+///
+/// Both surfaces are here now so users can see the feature exists and set
+/// their preference in advance — the download manager honours both when
+/// `core.download_track` / offline playback ships.
+///
+/// Spec: `research/03-ux-patterns.md` Issue 66 Downloads bullet.
+struct PreferencesDownloads: View {
+    @AppStorage("downloads.storageBudgetGb") private var storageBudgetGb: Double = 10
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Location",
+                footnote: "Offline copies live inside Jellify's cache folder so macOS can evict them under disk pressure. Choosing a custom location lives with the rest of the download manager work — TODO(#570)."
+            ) {
+                PreferenceRow(
+                    label: "Download location",
+                    help: "Cache directory inside Jellify's sandbox."
+                ) {
+                    Text(downloadLocationText)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: 420, alignment: .leading)
+                        .background(Theme.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Theme.border, lineWidth: 1)
+                        )
+                        .accessibilityLabel("Download location: \(downloadLocationText)")
+                }
+            }
+
+            PreferenceSection(
+                title: "Storage",
+                footnote: "Budget for offline downloads. When the cap is reached, the download manager stops queuing new tracks and asks you to free space. Oldest-played downloads evict first when auto-prune lands."
+            ) {
+                PreferenceRow(
+                    label: "Storage budget",
+                    help: budgetSubtitle
+                ) {
+                    HStack(spacing: 12) {
+                        Slider(value: $storageBudgetGb, in: 1...100, step: 1)
+                            .frame(width: 220)
+                            .accessibilityLabel("Storage budget")
+                            .accessibilityValue("\(Int(storageBudgetGb)) gigabytes")
+                        Text(budgetReadout)
+                            .font(Theme.font(12, weight: .semibold))
+                            .foregroundStyle(Theme.ink2)
+                            .monospacedDigit()
+                            .frame(width: 56, alignment: .trailing)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Downloads")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Offline location and storage budget.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    /// Path where offline tracks live. Resolves against the user's cache
+    /// directory so the value matches macOS's sandbox expectations. When the
+    /// resolver fails (extremely unusual) we show a dash rather than an
+    /// empty string so the row stays readable.
+    private var downloadLocationText: String {
+        let fm = FileManager.default
+        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return "—"
+        }
+        return caches.appendingPathComponent("Downloads").path
+    }
+
+    private var budgetReadout: String {
+        "\(Int(storageBudgetGb.rounded())) GB"
+    }
+
+    private var budgetSubtitle: String {
+        let gb = Int(storageBudgetGb.rounded())
+        return "Up to \(gb) GB of disk space reserved for offline music."
+    }
+}
+
+#Preview {
+    PreferencesDownloads()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// General preferences pane.
+///
+/// Launch-at-login, menu-bar presence, and language. These are the knobs that
+/// don't fit under a more specific pane but still belong in the p0 shipping
+/// set. All three are UI-only today:
+///
+/// - **Language**: only English ships; the picker is present so the setting
+///   is visible and the user can see i18n is on the roadmap. Real wiring is
+///   tracked in `TODO(i18n-#345)`.
+/// - **Auto-start on login**: persists the selection; real `SMAppService`
+///   registration lands alongside the rest of the launch-item scaffolding
+///   (see TODO below). A naive toggle is still useful to surface the feature
+///   so users can opt-in and the choice is remembered across a restart.
+/// - **Show in menu bar**: persists today; the actual `NSStatusItem` mount
+///   belongs with the mini-player / menu-bar companion work.
+///
+/// Spec: `research/03-ux-patterns.md` Issue 66 top-level General bullet.
+struct PreferencesGeneral: View {
+    @AppStorage("general.language") private var languageRaw: String = AppLanguage.system.rawValue
+    @AppStorage("general.autoStartOnLogin") private var autoStartOnLogin: Bool = false
+    @AppStorage("general.showInMenuBar") private var showInMenuBar: Bool = false
+
+    private var language: Binding<AppLanguage> {
+        Binding(
+            get: { AppLanguage(rawValue: languageRaw) ?? .system },
+            set: { languageRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Language",
+                footnote: "Only English ships today. The picker is here so you can see the setting exists — additional languages will appear as translations land. TODO(i18n-#345)."
+            ) {
+                PreferenceRow(
+                    label: "Language",
+                    help: language.wrappedValue.subtitle
+                ) {
+                    Picker("", selection: language) {
+                        ForEach(AppLanguage.allCases) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 180)
+                    .accessibilityLabel("Application language")
+                }
+            }
+
+            PreferenceSection(
+                title: "Startup",
+                footnote: "Auto-start launches Jellify in the background when you log in. The toggle persists today; TODO(#566) registers the login-item through SMAppService so the behaviour actually fires."
+            ) {
+                PreferenceRow(
+                    label: "Open at login",
+                    help: autoStartOnLogin
+                        ? "On — Jellify will launch in the background when you sign in."
+                        : "Off — Jellify only opens when you launch it manually."
+                ) {
+                    Toggle("", isOn: $autoStartOnLogin)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Launch Jellify at login")
+                }
+            }
+
+            PreferenceSection(
+                title: "Menu Bar",
+                footnote: "Keeps a transport icon in the macOS menu bar for quick play/pause, skip, and now-playing access. TODO(#567) — NSStatusItem mount lands with the mini-player work."
+            ) {
+                PreferenceRow(
+                    label: "Show in menu bar",
+                    help: showInMenuBar
+                        ? "On — a compact transport icon stays in the menu bar."
+                        : "Off — Jellify lives only in the Dock."
+                ) {
+                    Toggle("", isOn: $showInMenuBar)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Show in menu bar")
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("General")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Language, startup, and menu-bar presence.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+}
+
+/// Application language for the UI. Only `system` (effectively English today)
+/// and `english` are present in the v1 cut — additional cases land alongside
+/// the strings catalog in `TODO(i18n-#345)`. Raw values are stable user-
+/// defaults strings so on-disk preferences survive future additions.
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system
+    case english
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: return "System"
+        case .english: return "English"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .system: return "Follow macOS language settings."
+        case .english: return "Use English regardless of system language."
+        }
+    }
+}
+
+#Preview {
+    PreferencesGeneral()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesLibrary.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesLibrary.swift
@@ -1,0 +1,188 @@
+@preconcurrency import Nuke
+import SwiftUI
+
+/// Library preferences pane.
+///
+/// Minimal shell today — two actions users ask for on every music app:
+///
+/// 1. **Rescan Library**: re-pulls albums/artists/tracks from the server, the
+///    same way the Library tab does on pull-to-refresh. The button is wired
+///    to `AppModel.refreshLibrary()` so the action is real even though it's a
+///    shallow surface; the longer-horizon work tracked in `TODO(core-#569)`
+///    is a server-side metadata rescan trigger (`/Library/Refresh`).
+///
+/// 2. **Cache size + Clear Cache**: shows the current on-disk footprint of
+///    the Nuke artwork cache and lets the user nuke it. Artwork is the
+///    single biggest cache in the app (256 MB limit — see `Artwork.swift`),
+///    so a visible clear affordance is the pragmatic escape hatch when a
+///    user is tight on disk. Full cache sweeps (SDK caches, DB caches) land
+///    alongside the broader download-manager work.
+///
+/// Spec: `research/03-ux-patterns.md` Issue 71.
+struct PreferencesLibrary: View {
+    @Environment(AppModel.self) private var model
+
+    /// Human-readable representation of the artwork cache size. Refreshed
+    /// when the pane appears and after a clear. Initialised as a placeholder
+    /// so the text doesn't jump when the first read comes in.
+    @State private var cacheSizeLabel: String = "Calculating…"
+
+    /// Toggles the "Rescanning…" label on the button while the refresh is in
+    /// flight. Scoped to this view so the Library tab's own spinner isn't
+    /// tied to the pane being visible.
+    @State private var isRescanning: Bool = false
+
+    /// Set after a successful Clear Cache to acknowledge the action — the
+    /// label fades back to normal after a short pause so the button doesn't
+    /// stick in a confirmation state forever.
+    @State private var justCleared: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Refresh",
+                footnote: "Rescan pulls the latest albums, artists, tracks, and playlists from your server. The same action runs on pull-to-refresh in the Library tab."
+            ) {
+                PreferenceRow(
+                    label: "Library data",
+                    help: isRescanning
+                        ? "Refreshing from server…"
+                        : "Last refresh ran when you opened the Library tab."
+                ) {
+                    Button { rescan() } label: {
+                        Text(isRescanning ? "Rescanning…" : "Rescan Library")
+                            .font(Theme.font(13, weight: .semibold))
+                            .foregroundStyle(Theme.ink)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Theme.surface2)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(Theme.border, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isRescanning || model.session == nil)
+                    .accessibilityLabel("Rescan library")
+                }
+            }
+
+            PreferenceSection(
+                title: "Cache",
+                footnote: "Jellify keeps album art and artist images on disk so grids render instantly. Clearing the cache frees the space immediately; images re-download on first render."
+            ) {
+                PreferenceRow(
+                    label: "Artwork cache size",
+                    help: "Evicts least-recently-used images first. The limit is 256 MB; clearing drops back to zero."
+                ) {
+                    HStack(spacing: 10) {
+                        Text(cacheSizeLabel)
+                            .font(Theme.font(12, weight: .semibold))
+                            .foregroundStyle(Theme.ink2)
+                            .monospacedDigit()
+                            .frame(minWidth: 70, alignment: .trailing)
+                        Button { clearCache() } label: {
+                            Text(justCleared ? "Cleared ✓" : "Clear Cache")
+                                .font(Theme.font(13, weight: .semibold))
+                                .foregroundStyle(Theme.ink)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 7)
+                                .background(Theme.surface2)
+                                .clipShape(RoundedRectangle(cornerRadius: 7))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 7)
+                                        .stroke(Theme.border, lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Clear artwork cache")
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .task { refreshCacheSize() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Library")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Refresh server data and manage local caches.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Kick off the same refresh the Library tab uses. The pane disables the
+    /// button while it's in flight so repeat taps don't fan out.
+    private func rescan() {
+        guard !isRescanning else { return }
+        isRescanning = true
+        Task {
+            await model.refreshLibrary()
+            isRescanning = false
+        }
+    }
+
+    /// Evict the shared Nuke pipeline's memory + disk caches. `cache.removeAll`
+    /// sweeps every layer (image memory, encoded-image memory, and disk data)
+    /// in one call — equivalent to removing each cache individually.
+    private func clearCache() {
+        Artwork.pipeline.cache.removeAll()
+        justCleared = true
+        // Give Nuke's background queue a moment to flush before we re-read
+        // the footprint. 0.6s is generous — the NSCache eviction is instant,
+        // disk removal is a few milliseconds in practice.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            refreshCacheSize()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+                justCleared = false
+            }
+        }
+    }
+
+    /// Read the artwork cache's current on-disk size and render it as
+    /// `4.3 MB` / `1.7 GB`. Uses `ByteCountFormatter` so the locale and unit
+    /// match every other size-of-thing in macOS.
+    ///
+    /// The pipeline's `dataCache` is typed as the `DataCaching` protocol so
+    /// callers can swap implementations; `totalSize` lives on the concrete
+    /// `Nuke.DataCache` Jellify actually uses (wired in
+    /// `Artwork.pipeline`). A failed downcast means someone swapped the
+    /// cache implementation, so we fall back to a dash rather than a zero.
+    ///
+    /// `totalSize` walks the cache index (read-after-index is O(n) on the
+    /// count of entries, not the bytes), so wrapping the read in a Task keeps
+    /// the view's first paint snappy even with a full 256 MB cache. The Task
+    /// stays on the main actor because `Artwork.pipeline` and `DataCache` are
+    /// both main-actor isolated in this module.
+    private func refreshCacheSize() {
+        Task { @MainActor in
+            let cache = Artwork.pipeline.configuration.dataCache as? DataCache
+            let label: String = {
+                guard let cache else { return "—" }
+                let formatter = ByteCountFormatter()
+                formatter.allowedUnits = [.useKB, .useMB, .useGB]
+                formatter.countStyle = .file
+                return formatter.string(fromByteCount: Int64(cache.totalSize))
+            }()
+            cacheSizeLabel = label
+        }
+    }
+}
+
+#Preview {
+    PreferencesLibrary()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesPlayback.swift
@@ -2,12 +2,18 @@ import SwiftUI
 
 /// Playback preferences pane.
 ///
-/// Exposes streaming quality, download quality, and preferred audio codec as
-/// `@AppStorage`-backed pickers. These are UI-only knobs today — wiring into
-/// the AVPlayer source URL and the Jellyfin transcoding profile lives in
-/// follow-up work (see TODOs below). Persisting the selection now means the
-/// eventual stream builder can read the current choice on day one without a
-/// migration.
+/// Exposes streaming quality, download quality, preferred audio codec, and
+/// the behavioural knobs covered by issue #116 — crossfade, gapless, replay-
+/// gain normalization, pre-gain, and "stop after current track". Quality and
+/// codec live here historically; the Audio pane (#117) also surfaces quality
+/// pickers, so the two sections overlap intentionally — the values are the
+/// same `@AppStorage` keys behind the scenes.
+///
+/// These are UI-only knobs today — wiring into the AVPlayer source URL,
+/// Jellyfin transcoding profile, and the audio engine's crossfade/replay-gain
+/// paths lives in follow-up work (see TODOs below). Persisting the selection
+/// now means the eventual implementation can read the current choice on day
+/// one without a migration.
 ///
 /// Design: matches the native Preferences aesthetic inside the Jellify shell.
 /// Sections sit on `Theme.surface` with `Theme.border` outlines; labels use
@@ -19,12 +25,34 @@ import SwiftUI
 /// - `playback.streamingQuality`     — `PlaybackQuality`
 /// - `playback.downloadQuality`      — `PlaybackQuality`
 /// - `playback.preferredCodec`       — `PreferredAudioCodec`
+/// - `playback.crossfadeSeconds`     — `Double` (0 = off, 1…12)
+/// - `playback.gaplessEnabled`       — `Bool` (default true)
+/// - `playback.normalization`        — `NormalizationMode`
+/// - `playback.preGainDb`            — `Double` (±12)
+/// - `playback.stopAfterCurrent`     — `Bool`
 ///
-/// Spec: `research/06-screen-specs.md` Issue 61 and GitHub issue #260.
+/// Spec: `research/03-ux-patterns.md` Issue 68 and GitHub issues #260 / #116.
 struct PreferencesPlayback: View {
     @AppStorage("playback.streamingQuality") private var streamingQuality: PlaybackQuality = .automatic
     @AppStorage("playback.downloadQuality") private var downloadQuality: PlaybackQuality = .lossless
     @AppStorage("playback.preferredCodec") private var preferredCodec: PreferredAudioCodec = .automatic
+
+    // #116 gap-fill knobs. All UI-only until the audio engine grows the
+    // corresponding hooks. Raw types are chosen so the key names survive any
+    // later enum/struct refactor — a Double for the slider is portable and the
+    // Bool toggles are the obvious shape.
+    @AppStorage("playback.crossfadeSeconds") private var crossfadeSeconds: Double = 0
+    @AppStorage("playback.gaplessEnabled") private var gaplessEnabled: Bool = true
+    @AppStorage("playback.normalization") private var normalizationRaw: String = NormalizationMode.off.rawValue
+    @AppStorage("playback.preGainDb") private var preGainDb: Double = 0
+    @AppStorage("playback.stopAfterCurrent") private var stopAfterCurrent: Bool = false
+
+    private var normalization: Binding<NormalizationMode> {
+        Binding(
+            get: { NormalizationMode(rawValue: normalizationRaw) ?? .off },
+            set: { normalizationRaw = $0.rawValue }
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -69,6 +97,75 @@ struct PreferencesPlayback: View {
                 }
             }
 
+            PreferenceSection(
+                title: "Transitions",
+                footnote: "Gapless joins tracks with no silence when the source supports it. Crossfade overlaps the last and next track by the selected number of seconds."
+            ) {
+                PreferenceRow(
+                    label: "Gapless playback",
+                    help: gaplessEnabled
+                        ? "On — tracks on the same album play without a gap."
+                        : "Off — each track ends cleanly before the next starts."
+                ) {
+                    Toggle("", isOn: $gaplessEnabled)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Gapless playback")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Crossfade",
+                    help: crossfadeHelp
+                ) {
+                    CrossfadeSlider(seconds: $crossfadeSeconds)
+                }
+            }
+
+            PreferenceSection(
+                title: "Normalization",
+                footnote: "Reads ReplayGain tags from the source when available. Track matches the loudness of each song individually; Album keeps the relative levels inside an album intact."
+            ) {
+                PreferenceRow(
+                    label: "Volume matching",
+                    help: normalization.wrappedValue.subtitle
+                ) {
+                    NormalizationPicker(selection: normalization)
+                        .accessibilityLabel("Volume normalization")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Pre-gain",
+                    help: preGainHelp
+                ) {
+                    PreGainSlider(db: $preGainDb)
+                }
+            }
+
+            PreferenceSection(
+                title: "Queue",
+                footnote: "Stops automatically after the current track finishes. Resets to off the next time you start playback."
+            ) {
+                PreferenceRow(
+                    label: "Stop after current track",
+                    help: stopAfterCurrent
+                        ? "On — playback halts once the current track ends."
+                        : "Off — the queue continues to the next track."
+                ) {
+                    Toggle("", isOn: $stopAfterCurrent)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Stop after current track")
+                }
+            }
+
             Spacer(minLength: 0)
         }
     }
@@ -78,10 +175,32 @@ struct PreferencesPlayback: View {
             Text("Playback")
                 .font(Theme.font(28, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("Streaming and download quality, preferred audio codec.")
+            Text("Streaming, downloads, transitions, and normalization.")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }
+    }
+
+    /// Subtitle under the crossfade row. Reads "Off" when the slider is at
+    /// zero and "3 seconds" / "12 seconds" otherwise so the helper copy is
+    /// always a sentence a user can parse at a glance.
+    private var crossfadeHelp: String {
+        let rounded = Int(crossfadeSeconds.rounded())
+        if rounded <= 0 {
+            return "Off — tracks transition with no overlap."
+        }
+        return "\(rounded) second\(rounded == 1 ? "" : "s") of overlap between tracks."
+    }
+
+    /// Subtitle under the pre-gain slider. Shows "0 dB" as a neutral label and
+    /// "+3 dB" / "−6 dB" at the edges so the direction is unambiguous.
+    private var preGainHelp: String {
+        let rounded = Int(preGainDb.rounded())
+        if rounded == 0 {
+            return "0 dB — no adjustment."
+        }
+        let sign = rounded > 0 ? "+" : "−"
+        return "\(sign)\(abs(rounded)) dB applied before output."
     }
 }
 
@@ -100,6 +219,7 @@ enum PlaybackQuality: String, CaseIterable, Identifiable {
     case automatic
     case low
     case normal
+    case high
     case lossless
     case original
 
@@ -111,19 +231,56 @@ enum PlaybackQuality: String, CaseIterable, Identifiable {
         case .automatic: return "Auto"
         case .low: return "Low"
         case .normal: return "Normal"
+        case .high: return "High"
         case .lossless: return "Lossless"
         case .original: return "Original"
         }
     }
 
-    /// Helper copy shown beneath the row. Mirrors the options from the spec.
+    /// Helper copy shown beneath the row. Mirrors the bitrate tiers from
+    /// `research/03-ux-patterns.md` Issue 69 (GitHub #117).
     var subtitle: String {
         switch self {
         case .automatic: return "Picked by Jellify"
-        case .low: return "128 kbps MP3"
-        case .normal: return "320 kbps MP3"
+        case .low: return "96 kbps"
+        case .normal: return "192 kbps"
+        case .high: return "320 kbps"
         case .lossless: return "FLAC"
         case .original: return "Direct stream — no transcoding"
+        }
+    }
+}
+
+/// ReplayGain-style loudness normalization. `off` applies no correction,
+/// `track` matches each track's individual loudness, `album` uses the
+/// per-album gain so relative dynamics inside an album remain intact.
+///
+/// TODO(#116): feed these into the audio engine's playback path. The engine
+/// needs to read ReplayGain tags (`REPLAYGAIN_TRACK_GAIN` / `_ALBUM_GAIN`
+/// plus their peak siblings), fall back to scanning when tags are missing,
+/// and apply the selected gain on top of `preGainDb`. Until then the enum
+/// persists the user's choice so the engine can pick it up without a
+/// migration.
+enum NormalizationMode: String, CaseIterable, Identifiable {
+    case off
+    case track
+    case album
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .off: return "Off"
+        case .track: return "Track"
+        case .album: return "Album"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .off: return "No volume adjustment."
+        case .track: return "Match the loudness of each track individually."
+        case .album: return "Preserve album dynamics; match across albums."
         }
     }
 }
@@ -194,6 +351,87 @@ private struct CodecPicker: View {
         .labelsHidden()
         .pickerStyle(.menu)
         .frame(width: 140)
+    }
+}
+
+/// Segmented picker for the three-option normalization mode. Off / Track /
+/// Album — a segmented control reads best for a mutually-exclusive short
+/// list, matching the Appearance pane's density and mode controls.
+private struct NormalizationPicker: View {
+    @Binding var selection: NormalizationMode
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(NormalizationMode.allCases) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: 240)
+    }
+}
+
+/// Crossfade slider, 0…12 seconds in 1-second steps. 0 reads as "Off" and
+/// the numeric readout on the trailing edge updates live so the user knows
+/// exactly what they've committed to. Matches the slider + readout pattern
+/// used elsewhere in the app (queue volume, seek chrome) so the shape of
+/// the row feels native.
+private struct CrossfadeSlider: View {
+    @Binding var seconds: Double
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Slider(value: $seconds, in: 0...12, step: 1)
+                .frame(width: 200)
+                .accessibilityLabel("Crossfade duration")
+                .accessibilityValue(seconds <= 0 ? "Off" : "\(Int(seconds)) seconds")
+            Text(readout)
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+                .monospacedDigit()
+                .frame(width: 52, alignment: .trailing)
+        }
+    }
+
+    private var readout: String {
+        let rounded = Int(seconds.rounded())
+        return rounded <= 0 ? "Off" : "\(rounded) s"
+    }
+}
+
+/// Pre-gain slider, −12…+12 dB in 1 dB steps. 0 is the default; the readout
+/// shows a unicode minus sign so the value is visually aligned with typeset
+/// audio copy elsewhere (− vs -, the former is what VoiceOver reads cleanly).
+private struct PreGainSlider: View {
+    @Binding var db: Double
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Slider(value: $db, in: -12...12, step: 1)
+                .frame(width: 200)
+                .accessibilityLabel("Pre-gain")
+                .accessibilityValue(accessibilityReadout)
+            Text(readout)
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+                .monospacedDigit()
+                .frame(width: 64, alignment: .trailing)
+        }
+    }
+
+    private var readout: String {
+        let rounded = Int(db.rounded())
+        if rounded == 0 { return "0 dB" }
+        let sign = rounded > 0 ? "+" : "−"
+        return "\(sign)\(abs(rounded)) dB"
+    }
+
+    private var accessibilityReadout: String {
+        let rounded = Int(db.rounded())
+        if rounded == 0 { return "0 decibels" }
+        let direction = rounded > 0 ? "plus" : "minus"
+        return "\(direction) \(abs(rounded)) decibels"
     }
 }
 

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesServer.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesServer.swift
@@ -1,0 +1,348 @@
+import AppKit
+import NukeUI
+import SwiftUI
+
+/// Server preferences pane.
+///
+/// Shows the connected server — URL, product name, version — and the signed-
+/// in user (avatar + display name). Three actions: **Switch Server** (drops
+/// server URL + username so the login form is blank), **Change User** (keeps
+/// the server URL but clears the username so the login form skips straight
+/// to the credentials step), and **Sign Out** (keeps both so the user only
+/// re-enters the password).
+///
+/// Server info is pulled from `model.session` (the record handed back by
+/// `core.login` / `core.resumeSession`). When those fields are `nil` — e.g.
+/// the Jellyfin server didn't return a `version` — the UI renders an em-dash
+/// rather than an empty string so the row still has a visible value.
+///
+/// This pane replaces the standalone "Account" entry from the pre-#114 layout
+/// by incorporating the same sign-out / change-server flows. The old
+/// `PreferencesAccount` remains in the module as a smaller subset view any
+/// non-preferences caller can reuse, but the sidebar no longer routes to it.
+///
+/// Issue: #115.
+struct PreferencesServer: View {
+    @Environment(AppModel.self) private var model
+
+    @State private var confirmSwitchServer: Bool = false
+    @State private var confirmChangeUser: Bool = false
+    @State private var confirmSignOut: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Connected Server",
+                footnote: "Server info is reported by the connected Jellyfin instance. A dash means the server didn't include that field in its public info."
+            ) {
+                PreferenceRow(label: "URL") {
+                    valueText(serverURLText)
+                        .textSelection(.enabled)
+                        .accessibilityLabel("Server URL: \(serverURLText)")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(label: "Name") {
+                    valueText(serverNameText)
+                        .accessibilityLabel("Server name: \(serverNameText)")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(label: "Version") {
+                    valueText(serverVersionText)
+                        .monospacedDigit()
+                        .accessibilityLabel("Server version: \(serverVersionText)")
+                }
+            }
+
+            PreferenceSection(
+                title: "Signed In As",
+                footnote: "Your avatar comes from the Jellyfin server. If you haven't uploaded one, the default monogram shows your initial."
+            ) {
+                HStack(spacing: 14) {
+                    userAvatar
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(userDisplayName)
+                            .font(Theme.font(15, weight: .bold))
+                            .foregroundStyle(Theme.ink)
+                        Text(userSubtitle)
+                            .font(Theme.font(12, weight: .medium))
+                            .foregroundStyle(Theme.ink3)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Signed in as \(userDisplayName) on \(serverURLText)")
+            }
+
+            actions
+
+            Spacer(minLength: 0)
+        }
+        .alert("Switch to a different server?", isPresented: $confirmSwitchServer) {
+            Button("Cancel", role: .cancel) {}
+            Button("Switch Server", role: .destructive) { switchServer() }
+        } message: {
+            Text("You'll be signed out and returned to the login screen so you can connect to a different Jellyfin server.")
+        }
+        .alert("Sign in as a different user?", isPresented: $confirmChangeUser) {
+            Button("Cancel", role: .cancel) {}
+            Button("Change User", role: .destructive) { changeUser() }
+        } message: {
+            Text("You'll be signed out of \(displayServer). The server URL stays remembered so you can sign in as someone else with just their credentials.")
+        }
+        .alert("Sign out?", isPresented: $confirmSignOut) {
+            Button("Cancel", role: .cancel) {}
+            Button("Sign Out", role: .destructive) { signOut() }
+        } message: {
+            Text("You'll be signed out of \(displayServer). Your server URL and username are remembered so you can sign back in with just your password.")
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Server")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("The Jellyfin server you're connected to and the user you're signed in as.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    /// Circular avatar rendered at 48pt. Uses the Jellyfin `Users/{id}/Images/
+    /// Primary` endpoint via `AppModel.imageURL` when a primary image tag is
+    /// set on the session user; otherwise falls back to a monogram sitting on
+    /// `Theme.surface2`. Downloaded through Nuke's shared pipeline so it
+    /// benefits from the same cache + coalescing as the rest of the app's
+    /// artwork.
+    @ViewBuilder
+    private var userAvatar: some View {
+        let size: CGFloat = 48
+        ZStack {
+            Circle()
+                .fill(Theme.surface2)
+                .overlay(
+                    Circle().stroke(Theme.border, lineWidth: 1)
+                )
+            if let url = userAvatarURL {
+                LazyImage(url: url) { state in
+                    if let image = state.image {
+                        image.resizable().scaledToFill()
+                    } else {
+                        monogram
+                    }
+                }
+                .clipShape(Circle())
+            } else {
+                monogram
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private var monogram: some View {
+        Text(monogramCharacter)
+            .font(Theme.font(20, weight: .heavy))
+            .foregroundStyle(Theme.ink2)
+    }
+
+    private var actions: some View {
+        HStack(spacing: 12) {
+            secondaryButton(label: "Switch Server") { confirmSwitchServer = true }
+                .accessibilityHint("Signs out and clears the remembered server so you can connect to a different Jellyfin instance.")
+            secondaryButton(label: "Change User") { confirmChangeUser = true }
+                .accessibilityHint("Signs out of this server while keeping the URL so you can sign in as a different user.")
+            primaryButton(label: "Sign Out") { confirmSignOut = true }
+                .accessibilityHint("Signs out of the current server. URL and username are remembered so sign-in only asks for a password.")
+        }
+    }
+
+    private func secondaryButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(Theme.surface2)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+
+    private func primaryButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(Theme.font(13, weight: .bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(Theme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+
+    // MARK: - Display values
+
+    private var serverURLText: String {
+        model.serverURL.isEmpty ? "—" : model.serverURL
+    }
+
+    private var serverNameText: String {
+        if let name = model.session?.server.name, !name.isEmpty {
+            return name
+        }
+        return "—"
+    }
+
+    private var serverVersionText: String {
+        if let version = model.session?.server.version, !version.isEmpty {
+            return version
+        }
+        return "—"
+    }
+
+    private var userDisplayName: String {
+        let fromSession = model.session?.user.name ?? ""
+        if !fromSession.isEmpty { return fromSession }
+        return model.username.isEmpty ? "—" : model.username
+    }
+
+    /// Shown under the user's name. Keep it short and factual — which server
+    /// this user is signed in on.
+    private var userSubtitle: String {
+        if serverNameText != "—" {
+            return serverNameText
+        }
+        return serverURLText
+    }
+
+    private var monogramCharacter: String {
+        let name = userDisplayName
+        guard let first = name.first, first.isLetter else { return "?" }
+        return String(first).uppercased()
+    }
+
+    private var userAvatarURL: URL? {
+        guard
+            let user = model.session?.user,
+            let tag = user.primaryImageTag, !tag.isEmpty,
+            !model.serverURL.isEmpty,
+            var components = URLComponents(string: model.serverURL)
+        else { return nil }
+        // The core's `imageUrl` only knows about `/Items/{id}/Images/Primary`;
+        // user avatars live at `/Users/{id}/Images/Primary`. Build the URL
+        // manually so we don't need a new FFI just for this one surface.
+        // TODO(core-#568): promote this to `core.userImageUrl(userId:tag:)`
+        // so the URL gets the same signing + device-id plumbing as item art.
+        let base = components.path.hasSuffix("/") ? String(components.path.dropLast()) : components.path
+        components.path = "\(base)/Users/\(user.id)/Images/Primary"
+        components.queryItems = [
+            URLQueryItem(name: "tag", value: tag),
+            URLQueryItem(name: "maxWidth", value: "120"),
+            URLQueryItem(name: "quality", value: "90"),
+        ]
+        return components.url
+    }
+
+    /// Server string used in confirmation dialog bodies. Prefer the server's
+    /// product name so "this server" reads naturally, falling back to the URL
+    /// when name isn't known, and finally to "this server" if both are empty.
+    private var displayServer: String {
+        if serverNameText != "—" { return serverNameText }
+        if !model.serverURL.isEmpty { return model.serverURL }
+        return "this server"
+    }
+
+    // MARK: - Helper views
+
+    private func valueText(_ value: String) -> some View {
+        Text(value)
+            .font(Theme.font(14, weight: .medium))
+            .foregroundStyle(Theme.ink)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: 420, alignment: .leading)
+            .background(Theme.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Theme.border, lineWidth: 1)
+            )
+    }
+
+    // MARK: - Actions
+
+    /// Drop the stored token + session but keep the remembered server URL
+    /// and username on disk so the login form prefills on return — user only
+    /// re-enters the password.
+    private func signOut() {
+        model.forgetToken()
+        model.session = nil
+        model.authExpired = false
+        closePreferencesWindow()
+    }
+
+    /// Sign out and also clear the remembered username so the login form
+    /// keeps the server URL but lands on the credentials step empty. The user
+    /// can then sign in as a different user against the same Jellyfin
+    /// instance without retyping the URL.
+    private func changeUser() {
+        model.forgetToken()
+        model.session = nil
+        model.username = ""
+        model.authExpired = false
+        closePreferencesWindow()
+    }
+
+    /// Sign out and also clear the server URL + username so the login form
+    /// comes up blank, ready for a different Jellyfin instance.
+    private func switchServer() {
+        model.forgetToken()
+        model.session = nil
+        model.serverURL = ""
+        model.username = ""
+        model.authExpired = false
+        closePreferencesWindow()
+    }
+
+    /// Close the Preferences window after signing out — otherwise it sits on
+    /// top of LoginView, which is jarring. Running on the next runloop tick
+    /// gives SwiftUI a chance to commit the session=nil state change first so
+    /// the user sees Login under the (closing) Preferences rather than a
+    /// brief flash of MainShell.
+    private func closePreferencesWindow() {
+        DispatchQueue.main.async {
+            NSApplication.shared.keyWindow?.performClose(nil)
+        }
+    }
+}
+
+#Preview {
+    // Real rendering requires an `AppModel` in the environment; the Settings
+    // scene in `JellifyApp` injects one. Previews without a model will crash
+    // on `@Environment(AppModel.self)` — this preview is kept as documentation
+    // for where the view lives.
+    PreferencesServer()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesView.swift
@@ -2,46 +2,54 @@ import SwiftUI
 
 /// Top-level Preferences window. Presented via the `Settings { ... }` scene in
 /// `JellifyApp` so macOS handles the ⌘, shortcut and standard window behavior
-/// automatically. The shell (issue #258) started with every pane as a
-/// placeholder; real settings land in follow-up issues as they ship. Account
-/// (#259) is implemented in `PreferencesAccount.swift` and Playback (#260) in
-/// `PreferencesPlayback.swift`; the rest are still placeholders awaiting their
-/// respective tickets (#263 Appearance, #264 Library, #265 Downloads,
-/// #266 Keyboard, #267 Advanced).
+/// automatically.
+///
+/// Matches the native macOS System Settings two-pane layout: left sidebar
+/// lists sections, the right pane shows the currently selected one. Section
+/// order and naming come from the spec in `research/03-ux-patterns.md` — the
+/// shipping p0 set is **General / Server / Playback / Audio / Library /
+/// Appearance / Downloads / About**. Advanced, Keyboard, and Lyrics source
+/// live in follow-up work and intentionally aren't listed here yet.
+///
+/// Issues closed here: #114 (top-level org), #115 (Server section), #116
+/// (Playback gap-fill), #117 (Audio quality section). The Server pane
+/// incorporates the Account workflow previously split under its own sidebar
+/// entry (still available as `PreferencesAccount` for any other caller that
+/// wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case account, general, playback, appearance, library, downloads, keyboard, advanced
+        case general, server, playback, audio, library, appearance, downloads, about
 
         var id: String { rawValue }
 
         var title: String {
             switch self {
-            case .account: return "Account"
             case .general: return "General"
+            case .server: return "Server"
             case .playback: return "Playback"
-            case .appearance: return "Appearance"
+            case .audio: return "Audio"
             case .library: return "Library"
+            case .appearance: return "Appearance"
             case .downloads: return "Downloads"
-            case .keyboard: return "Keyboard"
-            case .advanced: return "Advanced"
+            case .about: return "About"
             }
         }
 
         var icon: String {
             switch self {
-            case .account: return "person.circle"
             case .general: return "gearshape"
+            case .server: return "server.rack"
             case .playback: return "play.circle"
-            case .appearance: return "paintpalette"
+            case .audio: return "speaker.wave.2"
             case .library: return "music.note.list"
+            case .appearance: return "paintpalette"
             case .downloads: return "arrow.down.circle"
-            case .keyboard: return "keyboard"
-            case .advanced: return "wrench.and.screwdriver"
+            case .about: return "info.circle"
             }
         }
     }
 
-    @State private var selection: Pane = .account
+    @State private var selection: Pane = .general
 
     var body: some View {
         HStack(spacing: 0) {
@@ -59,20 +67,20 @@ struct PreferencesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.bg)
         }
-        .frame(width: 780, height: 520)
+        .frame(width: 780, height: 560)
     }
 
     @ViewBuilder
     private func pane(for selection: Pane) -> some View {
         switch selection {
-        case .account: PreferencesAccount()
-        case .general: GeneralPane()
+        case .general: PreferencesGeneral()
+        case .server: PreferencesServer()
         case .playback: PreferencesPlayback()
+        case .audio: PreferencesAudio()
+        case .library: PreferencesLibrary()
         case .appearance: AppearancePane()
-        case .library: LibraryPane()
-        case .downloads: DownloadsPane()
-        case .keyboard: KeyboardPane()
-        case .advanced: AdvancedPane()
+        case .downloads: PreferencesDownloads()
+        case .about: PreferencesAbout()
         }
     }
 }
@@ -140,74 +148,6 @@ private struct PreferencesNav: View {
         .buttonStyle(.plain)
         .accessibilityLabel(pane.title)
         .accessibilityAddTraits(active ? [.isSelected] : [])
-    }
-}
-
-// MARK: - Placeholder panes
-// Each pane is a thin shell; real content lands in follow-up issues.
-
-private struct PlaceholderPane: View {
-    let title: String
-    let subtitle: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(Theme.font(28, weight: .black, italic: true))
-                .foregroundStyle(Theme.ink)
-            Text(subtitle)
-                .font(Theme.font(13, weight: .medium))
-                .foregroundStyle(Theme.ink3)
-            Text("Coming soon…")
-                .font(Theme.font(13, weight: .semibold))
-                .foregroundStyle(Theme.ink2)
-                .padding(.top, 24)
-        }
-    }
-}
-
-private struct GeneralPane: View {
-    var body: some View {
-        PlaceholderPane(
-            title: "General",
-            subtitle: "Launch-at-login, menubar, and default window behavior."
-        )
-    }
-}
-
-private struct LibraryPane: View {
-    var body: some View {
-        PlaceholderPane(
-            title: "Library",
-            subtitle: "Refresh, resync, and local cache."
-        )
-    }
-}
-
-private struct DownloadsPane: View {
-    var body: some View {
-        PlaceholderPane(
-            title: "Downloads",
-            subtitle: "Offline storage location, quality, and limits."
-        )
-    }
-}
-
-private struct KeyboardPane: View {
-    var body: some View {
-        PlaceholderPane(
-            title: "Keyboard",
-            subtitle: "Shortcut editor for transport and navigation commands."
-        )
-    }
-}
-
-private struct AdvancedPane: View {
-    var body: some View {
-        PlaceholderPane(
-            title: "Advanced",
-            subtitle: "Logs, developer options, and experimental features."
-        )
     }
 }
 


### PR DESCRIPTION
Closes #114, #115, #116, #117.

## Summary

Restructures the macOS Preferences window to match the native System Settings pattern — left sidebar with sections, right pane for the selected content — and fills in the six p0 sections not previously covered: **General**, **Server**, **Audio**, **Library**, **Downloads**, **About**. Extends the existing **Playback** pane with the #116 gap-fill (crossfade, gapless, normalization, pre-gain, stop-after-current).

## Changes

**Top-level org (#114)** — migrated `PreferencesView.swift` from the eight-pane shell (Account / General / Playback / Appearance / Library / Downloads / Keyboard / Advanced) to the System Settings-style sidebar (General / Server / Playback / Audio / Library / Appearance / Downloads / About). The merged Playback and Appearance panes stay as-is; the Account pane's sign-out / change-server workflow is incorporated into the new Server pane (the type is retained in the module for any non-preferences caller).

**General (new)** — language picker (System / English, with `TODO(i18n-#345)`), open-at-login toggle, show-in-menu-bar toggle. All persisted via `@AppStorage`; `SMAppService` + `NSStatusItem` wiring lands with their follow-ups.

**Server (#115)** — URL, server name, version (pulled from `session.server` / `session.user`), user avatar + name with graceful monogram fallback when no primary image tag is set, and three actions (Switch Server / Change User / Sign Out) with confirmation dialogs. Avatar URL is built inline against `/Users/{id}/Images/Primary` with a `TODO(core-#568)` to promote it to the core.

**Audio (#117)** — explicit 5-tier quality pickers (Low 96 / Normal 192 / High 320 / Lossless / Original) for streaming and downloads, plus Direct Play vs Always Transcode preference. Shares `@AppStorage` keys with the Playback pane.

**Library (new)** — Rescan Library button wired to `AppModel.refreshLibrary()`, plus live cache-size readout and Clear Cache button that sweeps `Artwork.pipeline.cache`.

**Downloads (new)** — read-only cache path from `FileManager.cachesDirectory`, 1-100 GB storage-budget slider.

**About (new)** — version + build from `Bundle.main.infoDictionary`, copyright, View on GitHub + Report an Issue buttons.

**Playback gap-fill (#116)** — added Gapless toggle (default on), Crossfade slider (Off / 1-12s), Normalization mode (Off / Track / Album), Pre-gain slider (±12 dB), Stop-after-current toggle. All UI-only until the audio engine grows the corresponding hooks; `@AppStorage` keys persist now so the engine can read them without a migration. `PlaybackQuality` gains an explicit `.high` tier and refreshed bitrate labels (96 / 192 / 320 kbps) to match the #117 spec.

## Test plan

- [ ] Open Preferences (⌘,) — sidebar shows eight sections in order, General is selected by default.
- [ ] Click each section — right pane renders without error.
- [ ] Server pane: signed-in user's avatar loads (or monogram fallback); Switch Server / Change User / Sign Out confirm dialogs and route correctly.
- [ ] Audio pane: changing streaming quality reflects in the Playback pane (shared keys).
- [ ] Playback pane: all new controls persist across app relaunch; crossfade slider shows "Off" at 0 and "3 seconds" / etc. above.
- [ ] Library pane: Clear Cache resets size readout to a small value after a moment; Rescan Library is disabled when signed out.
- [ ] About pane: version / build / copyright rendered; GitHub buttons open the repo and issues page.
- [ ] `swift build` from `macos/` succeeds with no new warnings from the pref panes.