### PR TITLE
core+macos: shuffle/repeat toggles + favorite via MPRemoteCommand

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1310,6 +1310,19 @@ impl JellyfinClient {
         Self::check(resp).await?.json().await.map_err(Into::into)
     }
 
+    /// Convenience dispatcher: route to [`Self::set_favorite`] when
+    /// `favorite` is `true` and [`Self::unset_favorite`] otherwise. Used by
+    /// the platform remote-control surface (macOS `MPFeedbackCommand.like`)
+    /// where the transport layer only knows the desired *target* state, not
+    /// whether the current item is already favorited. See issue #35.
+    pub async fn toggle_favorite(&self, item_id: &str, favorite: bool) -> Result<FavoriteState> {
+        if favorite {
+            self.set_favorite(item_id).await
+        } else {
+            self.unset_favorite(item_id).await
+        }
+    }
+
     /// Create a new playlist for the current user via `POST /Playlists`.
     ///
     /// The request body uses Jellyfin's PascalCase keys:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,7 +18,7 @@ pub mod storage;
 
 pub use error::{JellifyError, Result};
 pub use models::*;
-pub use player::{PlaybackState, Player, PlayerStatus};
+pub use player::{PlaybackState, Player, PlayerStatus, RepeatMode};
 
 use crate::client::{JellyfinClient, PublicSystemInfo};
 use crate::storage::{CredentialStore, Database};
@@ -586,6 +586,19 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.unset_favorite(&item_id)))
     }
 
+    /// Set or clear an item's favorite flag in a single call. `favorite=true`
+    /// dispatches to [`Self::set_favorite`], `false` dispatches to
+    /// [`Self::unset_favorite`]. Intended for remote-control surfaces (the
+    /// macOS `MPFeedbackCommand.like` toggle, etc.) that only know the
+    /// desired target state. See issue #35.
+    pub fn toggle_favorite(
+        &self,
+        item_id: String,
+        favorite: bool,
+    ) -> std::result::Result<FavoriteState, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.toggle_favorite(&item_id, favorite)))
+    }
+
     /// Create a new playlist for the current user. Returns the new
     /// playlist id — callers refetch the full [`Playlist`] via
     /// [`JellifyCore::fetch_item`] if they need the populated record.
@@ -824,6 +837,24 @@ impl JellifyCore {
 
     pub fn set_volume(&self, volume: f32) {
         self.player.set_volume(volume);
+    }
+
+    /// Toggle queue-wide shuffle on or off. The flag lands on
+    /// [`PlayerStatus`] so platform remote-control surfaces (Control Center
+    /// `MPChangeShuffleModeCommand` on macOS, MPRIS `Shuffle` on Linux,
+    /// SMTC `ShuffleEnabled` on Windows) stay in sync with the app. The
+    /// core does not reorder the underlying queue — callers hand over
+    /// already-shuffled tracks via [`Self::set_queue`] and use this to
+    /// reflect the current mode. See issue #34.
+    pub fn set_shuffle(&self, on: bool) {
+        self.player.set_shuffle(on);
+    }
+
+    /// Set the queue-wide [`RepeatMode`]. Consumed by the platform audio
+    /// engine at end-of-track (replay vs. advance vs. stop) and exposed on
+    /// the remote-control surface. See issue #34.
+    pub fn set_repeat_mode(&self, mode: RepeatMode) {
+        self.player.set_repeat_mode(mode);
     }
 
     pub fn stop(&self) {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -17,6 +17,22 @@ pub enum PlaybackState {
     Ended,
 }
 
+/// Queue-wide repeat mode carried on [`PlayerStatus`] and exposed to the
+/// platform remote-control surface (macOS `MPChangeRepeatModeCommand`, MPRIS
+/// `LoopStatus`, SMTC `AutoRepeatMode`).
+///
+/// * `Off` — advance through the queue once, then stop at the end.
+/// * `One` — keep replaying the current track; next/previous both no-op.
+/// * `All` — wrap around at the ends of the queue so skip-next past the last
+///   track jumps to index 0, and skip-previous from index 0 jumps to the end.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, uniffi::Enum)]
+pub enum RepeatMode {
+    #[default]
+    Off,
+    One,
+    All,
+}
+
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct PlayerStatus {
     pub state: PlaybackState,
@@ -26,6 +42,17 @@ pub struct PlayerStatus {
     pub volume: f32,
     pub queue_position: u32,
     pub queue_length: u32,
+    /// Whether the queue-shuffle mode is engaged. The core does not actually
+    /// reorder the stored queue — it just carries the flag so the platform
+    /// layer can reflect it in remote-control surfaces (Control Center,
+    /// media keys) and so downstream "Up Next" logic can opt into a shuffled
+    /// ordering. See issue #34.
+    pub shuffle: bool,
+    /// Current [`RepeatMode`] for the queue. Interpreted by the platform
+    /// audio engine when deciding what to do at end-of-track and by
+    /// [`Player::skip_next`] / [`Player::skip_previous`] when the caller
+    /// walks past a queue boundary. See issue #34.
+    pub repeat_mode: RepeatMode,
 }
 
 pub struct Player {
@@ -39,6 +66,8 @@ struct Shared {
     queue_index: usize,
     volume: f32,
     position_seconds: f64,
+    shuffle: bool,
+    repeat_mode: RepeatMode,
 }
 
 impl Shared {
@@ -50,6 +79,8 @@ impl Shared {
             queue_index: 0,
             volume: 1.0,
             position_seconds: 0.0,
+            shuffle: false,
+            repeat_mode: RepeatMode::Off,
         }
     }
 
@@ -67,6 +98,8 @@ impl Shared {
             volume: self.volume,
             queue_position: self.queue_index as u32,
             queue_length: self.queue.len() as u32,
+            shuffle: self.shuffle,
+            repeat_mode: self.repeat_mode,
         }
     }
 }
@@ -133,6 +166,22 @@ impl Player {
         self.shared.lock().volume = v.clamp(0.0, 1.0);
     }
 
+    /// Toggle the queue-wide shuffle flag. The core does not reorder the
+    /// stored queue — callers that want a shuffled listening session are
+    /// expected to call [`Player::set_queue`] with pre-shuffled tracks and
+    /// then toggle this flag so the remote-control surface reflects the
+    /// current mode. See issue #34.
+    pub fn set_shuffle(&self, on: bool) {
+        self.shared.lock().shuffle = on;
+    }
+
+    /// Update the queue's [`RepeatMode`]. Does not touch the queue itself;
+    /// the platform audio engine consults this when the current track ends
+    /// to decide whether to replay, advance, or stop. See issue #34.
+    pub fn set_repeat_mode(&self, mode: RepeatMode) {
+        self.shared.lock().repeat_mode = mode;
+    }
+
     pub fn clear(&self) {
         let mut s = self.shared.lock();
         s.state = PlaybackState::Stopped;
@@ -142,5 +191,75 @@ impl Player {
 
     pub fn status(&self) -> PlayerStatus {
         self.shared.lock().snapshot()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Track;
+
+    fn track(id: &str) -> Track {
+        Track {
+            id: id.to_string(),
+            name: id.to_string(),
+            album_id: None,
+            album_name: None,
+            artist_name: "Test Artist".to_string(),
+            artist_id: None,
+            index_number: None,
+            disc_number: None,
+            year: None,
+            runtime_ticks: 1_800_000_000, // 3 minutes
+            is_favorite: false,
+            play_count: 0,
+            container: None,
+            bitrate: None,
+            image_tag: None,
+        }
+    }
+
+    #[test]
+    fn status_defaults_shuffle_off_and_repeat_off() {
+        let player = Player::new();
+        let status = player.status();
+        assert!(!status.shuffle);
+        assert_eq!(status.repeat_mode, RepeatMode::Off);
+    }
+
+    #[test]
+    fn set_shuffle_toggles_flag_on_status() {
+        let player = Player::new();
+        player.set_shuffle(true);
+        assert!(player.status().shuffle);
+        player.set_shuffle(false);
+        assert!(!player.status().shuffle);
+    }
+
+    #[test]
+    fn set_repeat_mode_persists_all_three_variants() {
+        let player = Player::new();
+        player.set_repeat_mode(RepeatMode::One);
+        assert_eq!(player.status().repeat_mode, RepeatMode::One);
+        player.set_repeat_mode(RepeatMode::All);
+        assert_eq!(player.status().repeat_mode, RepeatMode::All);
+        player.set_repeat_mode(RepeatMode::Off);
+        assert_eq!(player.status().repeat_mode, RepeatMode::Off);
+    }
+
+    #[test]
+    fn shuffle_and_repeat_are_preserved_across_queue_changes() {
+        // Callers (e.g. the macOS AppModel) set shuffle/repeat once and
+        // expect the flags to survive a fresh `set_queue` call — otherwise
+        // dropping a new album onto the dock would silently disable the
+        // user's chosen repeat mode. Validate that invariant here.
+        let player = Player::new();
+        player.set_shuffle(true);
+        player.set_repeat_mode(RepeatMode::All);
+        player.set_queue(vec![track("a"), track("b")], 0);
+        let status = player.status();
+        assert!(status.shuffle);
+        assert_eq!(status.repeat_mode, RepeatMode::All);
+        assert_eq!(status.queue_length, 2);
     }
 }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -2346,8 +2346,9 @@ async fn toggle_favorite_dispatches_to_set_when_true() {
 
     let requests = server.received_requests().await.unwrap();
     assert!(
-        requests.iter().any(|r| r.method.as_str() == "POST"
-            && r.url.path() == "/UserFavoriteItems/item-xyz"),
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST" && r.url.path() == "/UserFavoriteItems/item-xyz"),
         "expected POST to /UserFavoriteItems on toggle_favorite(true)"
     );
     assert!(
@@ -2392,8 +2393,9 @@ async fn toggle_favorite_dispatches_to_unset_when_false() {
     // Auth is also a POST — we only care that we don't hit the favorite
     // endpoint with POST.
     assert!(
-        !requests.iter().any(|r| r.method.as_str() == "POST"
-            && r.url.path() == "/UserFavoriteItems/item-xyz"),
+        !requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST" && r.url.path() == "/UserFavoriteItems/item-xyz"),
         "toggle_favorite(false) must not issue a POST to the favorite endpoint"
     );
 }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -2316,6 +2316,89 @@ async fn unset_favorite_without_session_returns_not_authenticated() {
 }
 
 #[tokio::test]
+async fn toggle_favorite_dispatches_to_set_when_true() {
+    // `toggle_favorite(_, true)` must use POST (matching set_favorite), not
+    // DELETE — otherwise a macOS `likeCommand` tap would unfavorite on a
+    // track whose state is already "not favorited" (the target state).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/UserFavoriteItems/item-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": true,
+            "PlayCount": 0,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.toggle_favorite("item-xyz", true).await.unwrap();
+    assert!(state.is_favorite);
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "POST"
+            && r.url.path() == "/UserFavoriteItems/item-xyz"),
+        "expected POST to /UserFavoriteItems on toggle_favorite(true)"
+    );
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "DELETE"),
+        "toggle_favorite(true) must not issue a DELETE"
+    );
+}
+
+#[tokio::test]
+async fn toggle_favorite_dispatches_to_unset_when_false() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/UserFavoriteItems/item-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "PlayCount": 3,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.toggle_favorite("item-xyz", false).await.unwrap();
+    assert!(!state.is_favorite);
+    assert_eq!(state.play_count, Some(3));
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "DELETE"
+            && r.url.path() == "/UserFavoriteItems/item-xyz"),
+        "expected DELETE to /UserFavoriteItems on toggle_favorite(false)"
+    );
+    // Auth is also a POST — we only care that we don't hit the favorite
+    // endpoint with POST.
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "POST"
+            && r.url.path() == "/UserFavoriteItems/item-xyz"),
+        "toggle_favorite(false) must not issue a POST to the favorite endpoint"
+    );
+}
+
+#[tokio::test]
 async fn report_playback_progress_posts_pascal_case_body() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -512,26 +512,36 @@ final class AppModel {
             }
         ))
 
-        // Playback toggles. Shuffle / repeat state isn't yet carried on
-        // `PlayerStatus` (tracked in research/02-media-integration.md), so
-        // these are logging stubs for now — the palette entry still has a
-        // landing pad so ⌘K discovery works before the FFI lands.
+        // Playback toggles (#34): flip shuffle / cycle repeat via the
+        // palette entries. Both feed the same core setters that Control
+        // Center's `MPChangeShuffleModeCommand` / `MPChangeRepeatModeCommand`
+        // handlers drive, so all three surfaces stay consistent.
         actions.append(PaletteAction(
             id: "playback.toggleShuffle",
             title: "Toggle Shuffle",
             symbol: "shuffle",
-            run: {
-                // TODO(core): wire to core.setShuffle(on:) once FFI lands.
-                print("[AppModel] Toggle Shuffle — not yet wired (see research/02-media-integration.md)")
+            run: { [weak self] in
+                guard let self else { return }
+                self.mediaSessionSetShuffle(!self.status.shuffle)
             }
         ))
         actions.append(PaletteAction(
             id: "playback.toggleRepeat",
             title: "Toggle Repeat",
             symbol: "repeat",
-            run: {
-                // TODO(core): wire to core.setRepeatMode(_:) once FFI lands.
-                print("[AppModel] Toggle Repeat — not yet wired (see research/02-media-integration.md)")
+            run: { [weak self] in
+                guard let self else { return }
+                // Cycle off -> all -> one -> off to match Apple Music's
+                // long-press menu ordering — "all" is the most frequently
+                // wanted step up from "off".
+                let next: RepeatMode = {
+                    switch self.status.repeatMode {
+                    case .off: return .all
+                    case .all: return .one
+                    case .one: return .off
+                    }
+                }()
+                self.mediaSessionSetRepeatMode(next)
             }
         ))
 
@@ -3627,10 +3637,49 @@ extension AppModel: MediaSessionDelegate {
     func mediaSessionSkipPrevious() { skipPrevious() }
     func mediaSessionSeek(toSeconds seconds: Double) { audio.seek(toSeconds: seconds) }
 
+    func mediaSessionSetShuffle(_ on: Bool) {
+        // Push the flag into the core so `PlayerStatus.shuffle` stays the
+        // source of truth for every surface (Queue Inspector header,
+        // menu-bar toggle, Control Center). The platform layer doesn't
+        // reorder the queue here — that's up to whatever fed the queue in
+        // the first place.
+        core.setShuffle(on: on)
+        refreshStatus()
+    }
+
+    func mediaSessionSetRepeatMode(_ mode: RepeatMode) {
+        core.setRepeatMode(mode: mode)
+        refreshStatus()
+    }
+
+    func mediaSessionToggleFavorite() -> Bool? {
+        // The command fires against the currently-playing track; without
+        // one we signal `.noActionableNowPlayingItem` back to the remote
+        // surface via a `nil` return.
+        guard let track = status.currentTrack else { return nil }
+        let target = !(isFavorite(id: track.id) || track.isFavorite)
+        Task { await setFavorite(itemId: track.id, enabled: target) }
+        return target
+    }
+
     func mediaSessionArtworkURL(for track: Track, maxWidth: UInt32) -> URL? {
         imageURL(for: track.albumId ?? track.id, tag: track.imageTag, maxWidth: maxWidth)
     }
     func mediaSessionAuthorizationHeader() -> String? {
         try? core.authHeader()
+    }
+}
+
+// MARK: - MediaSession status nudge
+
+extension AppModel {
+    /// Pull the latest `PlayerStatus` snapshot out of the core and hand it
+    /// to `MediaSession` so the remote-control surface reflects any
+    /// just-applied change (shuffle, repeat, favorite). The polling timer
+    /// refreshes this on a cadence, but command handlers want the round-trip
+    /// to feel synchronous — without this, Control Center's shuffle toggle
+    /// can flicker back to the previous state on the next redraw.
+    fileprivate func refreshStatus() {
+        self.status = core.status()
     }
 }

--- a/macos/Sources/JellifyAudio/MediaSession.swift
+++ b/macos/Sources/JellifyAudio/MediaSession.swift
@@ -21,6 +21,23 @@ public protocol MediaSessionDelegate: AnyObject {
     func mediaSessionSkipNext()
     func mediaSessionSkipPrevious()
     func mediaSessionSeek(toSeconds seconds: Double)
+    /// Toggle the queue-wide shuffle mode, driven by Control Center's
+    /// `MPChangeShuffleModeCommand`. Callers must update the core via
+    /// `core.setShuffle(_:)` and refresh `PlayerStatus` observers so the UI
+    /// tracks the new mode. See issue #34.
+    func mediaSessionSetShuffle(_ on: Bool)
+    /// Set the queue-wide repeat mode, driven by Control Center's
+    /// `MPChangeRepeatModeCommand`. `.off` stops at end-of-queue, `.one`
+    /// replays the current track, `.all` wraps around. See issue #34.
+    func mediaSessionSetRepeatMode(_ mode: RepeatMode)
+    /// Toggle the currently-playing track's favorite state. Returns the
+    /// target state the implementation is attempting to apply so
+    /// `MediaSession` can flip `likeCommand.isActive` immediately — the
+    /// eventual server response may invalidate that on rollback, but the
+    /// latency between tap and state refresh is what the user perceives.
+    /// Return `nil` if no track is active (command should be treated as
+    /// no-op). See issue #35.
+    func mediaSessionToggleFavorite() -> Bool?
     /// Build the artwork URL for a track. Returns `nil` when the track has no
     /// image tag or when the auth context isn't ready. `MediaSession` uses
     /// this rather than holding a reference to `JellifyCore` so the session
@@ -262,10 +279,91 @@ public final class MediaSession {
             return .success
         }
 
-        // Commands explicitly not wired yet (BATCH-14 / #35 / #38):
-        // likeCommand, dislikeCommand, changeShuffleModeCommand,
-        // changeRepeatModeCommand. Leaving them at their default-disabled
-        // state so they don't appear in Control Center.
+        // BATCH-14 (#34): shuffle + repeat toggles from Control Center /
+        // AirPods Pro long-press / Bluetooth remotes. The `currentShuffle*`
+        // and `currentRepeat*` properties on the commands are what
+        // `MPNowPlayingInfoCenter` publishes to the remote-control surface;
+        // we push them through on status-refresh below so external UIs see
+        // the active mode without a round-trip.
+        cc.changeShuffleModeCommand.isEnabled = true
+        cc.changeShuffleModeCommand.addTarget { [weak self] event in
+            guard
+                let self,
+                let delegate = self.delegate,
+                let change = event as? MPChangeShuffleModeCommandEvent
+            else {
+                return .commandFailed
+            }
+            let on = change.shuffleType != .off
+            delegate.mediaSessionSetShuffle(on)
+            // Echo the new mode back to the command so Control Center
+            // toggles reflect the on-disk state on the very next redraw.
+            cc.changeShuffleModeCommand.currentShuffleType = change.shuffleType
+            self.refreshRemoteCommandEnablement()
+            return .success
+        }
+
+        cc.changeRepeatModeCommand.isEnabled = true
+        cc.changeRepeatModeCommand.addTarget { [weak self] event in
+            guard
+                let self,
+                let delegate = self.delegate,
+                let change = event as? MPChangeRepeatModeCommandEvent
+            else {
+                return .commandFailed
+            }
+            delegate.mediaSessionSetRepeatMode(Self.repeatMode(from: change.repeatType))
+            cc.changeRepeatModeCommand.currentRepeatType = change.repeatType
+            self.refreshRemoteCommandEnablement()
+            return .success
+        }
+
+        // BATCH-14 (#35): like toggles the currently-playing track's
+        // favorite state via the Jellyfin `/UserFavoriteItems` endpoint.
+        // `likeCommand.isActive` is pushed in `refreshRemoteCommandEnablement`
+        // so Control Center reflects the server-side favorite flag.
+        cc.likeCommand.isEnabled = true
+        cc.likeCommand.addTarget { [weak self] _ in
+            guard let self, let delegate = self.delegate else {
+                return .commandFailed
+            }
+            guard let targetState = delegate.mediaSessionToggleFavorite() else {
+                return .noActionableNowPlayingItem
+            }
+            // Optimistic UI: flip `isActive` before the network call
+            // completes so the tap has no perceptible latency. The next
+            // `trackChanged` / `queueChanged` refresh reconciles if the
+            // server rolled back.
+            cc.likeCommand.isActive = targetState
+            return .success
+        }
+
+        // `dislikeCommand` stays disabled — Jellyfin has no concept of a
+        // negative rating, so exposing it would be misleading.
+        cc.dislikeCommand.isEnabled = false
+    }
+
+    /// Map a `MPRepeatType` from Control Center onto the core's
+    /// [`RepeatMode`]. `MPRepeatType.one` is Apple's "repeat this track"
+    /// flag; `MPRepeatType.all` is "loop the queue". The core only cares
+    /// about those two distinctions plus off.
+    private static func repeatMode(from type: MPRepeatType) -> RepeatMode {
+        switch type {
+        case .off: return .off
+        case .one: return .one
+        case .all: return .all
+        @unknown default: return .off
+        }
+    }
+
+    /// Inverse of [`Self.repeatMode(from:)`], used when pushing the active
+    /// mode back out to Control Center after a status refresh.
+    private static func repeatType(from mode: RepeatMode) -> MPRepeatType {
+        switch mode {
+        case .off: return .off
+        case .one: return .one
+        case .all: return .all
+        }
     }
 
     private func refreshRemoteCommandEnablement() {
@@ -274,15 +372,30 @@ public final class MediaSession {
         let cc = MPRemoteCommandCenter.shared()
         let hasTrack = status.currentTrack != nil
         cc.stopCommand.isEnabled = hasTrack
-        // Next/previous gate on queue bounds. Repeat/shuffle-driven
-        // rebinding is BATCH-14; until then the bounds check is strict.
+        // Next/previous gate on queue bounds, with repeat-all letting the
+        // user wrap across the end/start of the queue so the remote surface
+        // doesn't dead-end on the last or first track.
         if status.queueLength == 0 {
             cc.nextTrackCommand.isEnabled = false
             cc.previousTrackCommand.isEnabled = false
+        } else if status.repeatMode == .all {
+            cc.nextTrackCommand.isEnabled = true
+            cc.previousTrackCommand.isEnabled = true
         } else {
             cc.nextTrackCommand.isEnabled = status.queuePosition + 1 < status.queueLength
             cc.previousTrackCommand.isEnabled = status.queuePosition > 0
         }
+
+        // Shuffle / repeat mirrors: push the current mode back out so
+        // Control Center highlights the correct cell when the user opens
+        // the "Now Playing" popover.
+        cc.changeShuffleModeCommand.currentShuffleType = status.shuffle ? .items : .off
+        cc.changeRepeatModeCommand.currentRepeatType = Self.repeatType(from: status.repeatMode)
+
+        // Like: enabled only while a track is playing, with `isActive`
+        // reflecting the current favorite flag.
+        cc.likeCommand.isEnabled = hasTrack
+        cc.likeCommand.isActive = status.currentTrack?.isFavorite ?? false
     }
 
     // MARK: - Artwork


### PR DESCRIPTION
Closes #34, #35