### PR TITLE
macos: a11y sweep — VoiceOver labels, accessible slider, Dynamic Type, tab order

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -3145,6 +3145,17 @@ final class AppModel {
         audio.seek(toSeconds: clamped)
     }
 
+    /// Absolute seek used by the PlayerBar's scrubber Slider (#332). Same
+    /// clamping + one-writer routing as `seek(by:)`, but takes an absolute
+    /// position rather than a delta so the Slider's drag handle can bind
+    /// straight through.
+    func seek(toSeconds target: Double) {
+        guard status.currentTrack != nil else { return }
+        let duration = max(0, status.durationSeconds)
+        let clamped = max(0, duration > 0 ? min(target, duration) : target)
+        audio.seek(toSeconds: clamped)
+    }
+
     func togglePlayPause() {
         switch status.state {
         case .playing: pause()

--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -64,6 +64,10 @@ struct ArtistCard: View {
                     .opacity(isHovering ? 1 : 0)
                     .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
                     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                    // Hover overlay doesn't show for a non-mouse user, so
+                    // make sure VoiceOver can find the play affordance by
+                    // name. See #331.
+                    .accessibilityLabel("Play all tracks by \(artist.name)")
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -96,6 +100,11 @@ struct ArtistCard: View {
             }
         }
         .contextMenu { ArtistContextMenu(artist: artist) }
+        // Outer tap target reads as an artist navigation control; the
+        // inner hover Play button owns its own label. VoiceOver sees
+        // "Artist <name>, <album count>. Opens artist detail."
+        .accessibilityLabel("\(artist.name), \(albumCountLabel)")
+        .accessibilityHint("Opens artist detail")
     }
 
     /// Subline shown under the artist name. Uses `album_count` when known;

--- a/macos/Sources/Jellify/Components/CommandPalette.swift
+++ b/macos/Sources/Jellify/Components/CommandPalette.swift
@@ -91,6 +91,7 @@ struct CommandPalette: View {
             }
             .buttonStyle(.plain)
             .keyboardShortcut(.cancelAction)
+            .accessibilityLabel("Dismiss command palette")
 
             VStack(spacing: 0) {
                 paletteColumn
@@ -457,6 +458,11 @@ struct CommandPalette: View {
         .opacity(0)
         .allowsHitTesting(false)
         .frame(width: 0, height: 0)
+        // These buttons exist purely to own keyboard shortcuts — the
+        // actual visible list rows already expose themselves to VoiceOver.
+        // Hiding prevents duplicate "Up" / "Down" announcements when
+        // navigating the palette with assistive tech.
+        .accessibilityHidden(true)
     }
 
     private func moveSelection(by delta: Int) {

--- a/macos/Sources/Jellify/Components/HomeAlbumTile.swift
+++ b/macos/Sources/Jellify/Components/HomeAlbumTile.swift
@@ -49,7 +49,12 @@ struct HomeAlbumTile<Badge: View>: View {
             model.play(album: album)
         }
         .contextMenu { AlbumContextMenu(album: album) }
-        .accessibilityElement(children: .combine)
+        // `.contain` (not `.combine`) so VoiceOver sees the tile group as
+        // a container — the outer body is its own focus target with the
+        // album's label + hint, but the inline Play button remains a
+        // separately-focusable control with its own "Play <album>" label.
+        // See #331.
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(album.name) by \(album.artistName)")
         .accessibilityHint(hint)
     }

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -101,6 +101,24 @@ struct LibraryListRow: View {
             }
         }
         .contextMenu { contextMenu }
+        // VoiceOver hears "<primary>, <secondary>. Opens <kind> detail."
+        // The hover play button only appears on cursor hover, so we route
+        // the row's body tap (openDetail) as the single focusable target.
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(accessibilityHint)
+    }
+
+    private var accessibilityLabel: String {
+        let subtitle = secondaryText.isEmpty ? "" : ", \(secondaryText)"
+        return "\(primaryText)\(subtitle)"
+    }
+
+    private var accessibilityHint: String {
+        switch payload {
+        case .album: return "Opens album detail"
+        case .artist: return "Opens artist detail"
+        case .playlist: return "Opens playlist detail"
+        }
     }
 
     // MARK: - Payload-driven properties

--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -5,16 +5,30 @@ struct PlayerBar: View {
     @Environment(AppModel.self) private var model
     @State private var showNowPlaying = false
 
+    /// Local scrubber position used while the user is actively dragging the
+    /// Slider. We don't bind the Slider straight to `status.positionSeconds`
+    /// because the 1Hz polling loop would fight the user's drag — every
+    /// status push would yank the thumb back to the server position. When
+    /// `isScrubbing` is true we drive the Slider from `scrubPosition`; when
+    /// it's false we fall through to the live playback position.
+    @State private var scrubPosition: Double = 0
+    @State private var isScrubbing: Bool = false
+
     var body: some View {
         HStack(spacing: 16) {
             leftMeta
                 .frame(width: 280, alignment: .leading)
+                // Tab order: primary metadata → transport → volume.
+                // See #334. Higher priority ships focus here first.
+                .accessibilitySortPriority(60)
             Spacer(minLength: 16)
             centerTransport
                 .frame(maxWidth: 640)
+                .accessibilitySortPriority(50)
             Spacer(minLength: 16)
             rightControls
                 .frame(width: 220, alignment: .trailing)
+                .accessibilitySortPriority(40)
         }
         .padding(.horizontal, 16)
         .frame(height: 78)
@@ -22,6 +36,11 @@ struct PlayerBar: View {
         .overlay(alignment: .top) {
             Rectangle().fill(Theme.border).frame(height: 1)
         }
+        // PlayerBar as a whole comes after the main content in the tab
+        // traversal, so the sidebar / content / toolbar all get focus
+        // before the persistent chrome at the bottom. See #334.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Playback controls")
         .sheet(isPresented: $showNowPlaying) {
             NowPlayingSheet()
                 .environment(model)
@@ -71,43 +90,82 @@ struct PlayerBar: View {
     private var centerTransport: some View {
         VStack(spacing: 6) {
             HStack(spacing: 20) {
-                iconBtn("shuffle")
-                iconBtn("backward.fill", size: 16) { model.skipPrevious() }
+                iconBtn("shuffle", label: "Shuffle")
+                iconBtn("backward.fill", label: "Previous track", size: 16) { model.skipPrevious() }
                 Button(action: model.togglePlayPause) {
-                    Image(systemName: model.status.state == .playing ? "pause.fill" : "play.fill")
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                         .font(.system(size: 15))
                         .foregroundStyle(Theme.bg)
                         .frame(width: 36, height: 36)
                         .background(Circle().fill(Theme.ink))
                 }
                 .buttonStyle(.plain)
-                iconBtn("forward.fill", size: 16) { model.skipNext() }
-                iconBtn("repeat")
+                // Bind the label to play/pause state rather than the SF
+                // Symbol name so VoiceOver reads the action the user is
+                // about to take. See #331.
+                .accessibilityLabel(Text(isPlaying ? "Pause" : "Play"))
+                iconBtn("forward.fill", label: "Next track", size: 16) { model.skipNext() }
+                iconBtn("repeat", label: "Repeat")
             }
-            HStack(spacing: 10) {
-                Text(format(model.status.positionSeconds))
-                    .font(Theme.font(10, weight: .semibold))
-                    .foregroundStyle(Theme.ink3)
-                    .monospacedDigit()
-                    .frame(width: 36, alignment: .trailing)
+            scrubber
+        }
+    }
 
-                GeometryReader { geom in
-                    let total = max(1.0, model.status.durationSeconds)
-                    let pct = min(1.0, model.status.positionSeconds / total)
-                    ZStack(alignment: .leading) {
-                        Capsule().fill(Theme.surface2)
-                        Capsule().fill(Theme.ink).frame(width: geom.size.width * CGFloat(pct))
+    /// The progress row — time labels flanking a real `Slider` (#332).
+    /// Replacing the bespoke `Capsule` scrubber with a `Slider` gets us
+    /// Voice Control / Switch Control "adjust value" out of the box and
+    /// feeds VoiceOver a native percent read-out in addition to the
+    /// custom `accessibilityValue` we set below.
+    @ViewBuilder
+    private var scrubber: some View {
+        HStack(spacing: 10) {
+            Text(format(displayPosition))
+                .font(Theme.font(10, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+                .monospacedDigit()
+                .frame(width: 36, alignment: .trailing)
+                .accessibilityHidden(true)
+
+            Slider(
+                value: Binding(
+                    get: {
+                        // Clamp `displayPosition` into the Slider's
+                        // domain. The polling loop can briefly report
+                        // a position past duration across a track
+                        // boundary; without clamping SwiftUI logs a
+                        // "value out of range" warning.
+                        min(max(0, displayPosition), sliderMax)
+                    },
+                    set: { scrubPosition = $0 }
+                ),
+                in: 0...sliderMax,
+                onEditingChanged: { editing in
+                    if editing {
+                        // Drag started — freeze the thumb on the user's
+                        // position so the polling loop doesn't fight it.
+                        scrubPosition = model.status.positionSeconds
+                        isScrubbing = true
+                    } else {
+                        // Drag ended — commit the seek and release the
+                        // local position so the next polling tick can
+                        // pull the thumb back to the live position.
+                        model.seek(toSeconds: scrubPosition)
+                        isScrubbing = false
                     }
-                    .frame(height: 4)
                 }
-                .frame(height: 4)
+            )
+            .tint(Theme.ink)
+            .disabled(model.status.currentTrack == nil)
+            .controlSize(.mini)
+            .accessibilityLabel("Playback position")
+            .accessibilityValue(accessibilityPositionValue)
 
-                Text(format(model.status.durationSeconds))
-                    .font(Theme.font(10, weight: .semibold))
-                    .foregroundStyle(Theme.ink3)
-                    .monospacedDigit()
-                    .frame(width: 36, alignment: .leading)
-            }
+            Text(format(model.status.durationSeconds))
+                .font(Theme.font(10, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+                .monospacedDigit()
+                .frame(width: 36, alignment: .leading)
+                .accessibilityHidden(true)
         }
     }
 
@@ -118,6 +176,7 @@ struct PlayerBar: View {
             Image(systemName: "speaker.wave.2.fill")
                 .font(.system(size: 14))
                 .foregroundStyle(Theme.ink2)
+                .accessibilityHidden(true)
             Slider(
                 value: Binding(
                     get: { Double(model.status.volume) },
@@ -127,11 +186,46 @@ struct PlayerBar: View {
             )
             .tint(Theme.ink2)
             .frame(width: 100)
+            .accessibilityLabel("Volume")
+            .accessibilityValue("\(Int((Double(model.status.volume) * 100).rounded())) percent")
         }
     }
 
+    /// Unified "what to render in the Slider right now" — the live playback
+    /// position most of the time, and the frozen `scrubPosition` only while
+    /// the user is actively dragging.
+    private var displayPosition: Double {
+        isScrubbing ? scrubPosition : model.status.positionSeconds
+    }
+
+    /// Upper bound for the scrubber's domain. Stays at a positive floor so
+    /// the Slider's `in:` range is always non-empty even before duration
+    /// has been reported (pre-roll / no track).
+    private var sliderMax: Double {
+        max(1.0, model.status.durationSeconds)
+    }
+
+    /// Human-readable VoiceOver value for the scrubber — "1 minute 23
+    /// seconds of 4 minutes 10 seconds". Using spoken words rather than
+    /// raw digits matches Apple Music / Podcasts behaviour.
+    private var accessibilityPositionValue: String {
+        guard model.status.currentTrack != nil else { return "No track loaded" }
+        let pos = Self.voiceOverTime(displayPosition)
+        let total = Self.voiceOverTime(model.status.durationSeconds)
+        return "\(pos) of \(total)"
+    }
+
+    private var isPlaying: Bool {
+        model.status.state == .playing
+    }
+
     @ViewBuilder
-    private func iconBtn(_ name: String, size: CGFloat = 14, action: @escaping () -> Void = {}) -> some View {
+    private func iconBtn(
+        _ name: String,
+        label: String,
+        size: CGFloat = 14,
+        action: @escaping () -> Void = {}
+    ) -> some View {
         Button(action: action) {
             Image(systemName: name)
                 .font(.system(size: size))
@@ -139,6 +233,7 @@ struct PlayerBar: View {
                 .frame(width: 28, height: 28)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(Text(label))
     }
 
     private func format(_ seconds: Double) -> String {
@@ -146,5 +241,23 @@ struct PlayerBar: View {
         let m = total / 60
         let s = total % 60
         return String(format: "%d:%02d", m, s)
+    }
+
+    /// Convert a duration in seconds to a word-based string for VoiceOver.
+    /// "0 seconds", "45 seconds", "1 minute 5 seconds", "2 minutes", etc.
+    private static func voiceOverTime(_ seconds: Double) -> String {
+        let safe = seconds.isFinite ? max(0, seconds) : 0
+        let total = Int(safe.rounded())
+        let m = total / 60
+        let s = total % 60
+        switch (m, s) {
+        case (0, 0): return "0 seconds"
+        case (0, _): return s == 1 ? "1 second" : "\(s) seconds"
+        case (_, 0): return m == 1 ? "1 minute" : "\(m) minutes"
+        default:
+            let mins = m == 1 ? "1 minute" : "\(m) minutes"
+            let secs = s == 1 ? "1 second" : "\(s) seconds"
+            return "\(mins) \(secs)"
+        }
     }
 }

--- a/macos/Sources/Jellify/Components/PlaylistCard.swift
+++ b/macos/Sources/Jellify/Components/PlaylistCard.swift
@@ -44,6 +44,7 @@ struct PlaylistCard: View {
                     .opacity(isHovering ? 1 : 0)
                     .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
                     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                    .accessibilityLabel("Play \(playlist.name)")
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -66,6 +67,8 @@ struct PlaylistCard: View {
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
         .contextMenu { PlaylistContextMenu(playlist: playlist) }
+        .accessibilityLabel("\(playlist.name), \(subtitle)")
+        .accessibilityHint("Opens playlist detail")
     }
 
     /// "42 tracks" / "1 track" — singular vs plural. Jellyfin reports

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -66,6 +66,8 @@ struct Sidebar: View {
                         .foregroundStyle(Theme.ink3)
                 }
                 .buttonStyle(.plain)
+                .help("Sign out")
+                .accessibilityLabel("Sign out")
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
@@ -83,6 +85,7 @@ struct Sidebar: View {
                 Image(systemName: icon)
                     .foregroundStyle(active ? Theme.accent : Theme.ink2)
                     .frame(width: 18)
+                    .accessibilityHidden(true)
                 Text(label)
                     .font(Theme.font(13, weight: active ? .bold : .semibold))
                     .foregroundStyle(active ? Theme.ink : Theme.ink2)
@@ -106,6 +109,11 @@ struct Sidebar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        // VoiceOver announces a simple "Home" / "Library" / "Search" and,
+        // for the currently selected tab, adds the "selected" trait so the
+        // user hears which one they're on without parsing visual chrome.
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(active ? [.isSelected, .isButton] : .isButton)
     }
 
     @ViewBuilder
@@ -114,6 +122,7 @@ struct Sidebar: View {
             Image(systemName: icon)
                 .foregroundStyle(Theme.ink2)
                 .frame(width: 18)
+                .accessibilityHidden(true)
             Text(label)
                 .font(Theme.font(13, weight: .semibold))
                 .foregroundStyle(Theme.ink2)
@@ -126,6 +135,10 @@ struct Sidebar: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
+        // Combine icon + label + count into one VoiceOver utterance so the
+        // row reads as "Albums, 42" rather than three separate fragments.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(count.map { "\(label), \($0)" } ?? label)
     }
 
     @ViewBuilder

--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -123,7 +123,13 @@ struct TrackListRow: View {
             }
         }
         .contextMenu { TrackContextMenu(selection: [track]) }
+        // A single row should read as one VoiceOver element — the wrapping
+        // Button already carries a label, but we override it here to pull
+        // in the active state so playing rows announce "Now playing" and
+        // non-playing rows announce "Plays this track".
         .accessibilityLabel("\(track.name) by \(track.artistName)")
+        .accessibilityHint(isPlaying ? "Now playing" : "Plays this track")
+        .accessibilityAddTraits(isPlaying ? .isSelected : [])
         // MARK: Keyboard navigation (#105)
         .focusable()
         .focused($isFocused)

--- a/macos/Sources/Jellify/Components/TrackRow.swift
+++ b/macos/Sources/Jellify/Components/TrackRow.swift
@@ -92,6 +92,13 @@ struct TrackRow: View {
         .onTapGesture(count: 2) { onPlay?() }
         .onTapGesture(count: 1) { onPlay?() }
         .contextMenu { TrackContextMenu(selection: [track]) }
+        // VoiceOver reads the row as a single "<title> by <artist>" line
+        // with the button trait + hint so the double-tap play action is
+        // discoverable without sighted hover affordances. See #331.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(track.name) by \(track.artistName)")
+        .accessibilityHint(isPlaying ? "Now playing" : "Plays this track")
+        .accessibilityAddTraits(isPlaying ? [.isButton, .isSelected] : .isButton)
         // MARK: Keyboard navigation (#105)
         .focusable()
         .focused($isFocused)

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -526,6 +526,10 @@ struct AlbumCard: View {
                     .opacity(isHovering ? 1 : 0)
                     .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
                     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                    // Hover overlay isn't discoverable without a mouse, so
+                    // name the play button explicitly for VoiceOver. See
+                    // #331.
+                    .accessibilityLabel("Play \(album.name)")
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -565,5 +569,17 @@ struct AlbumCard: View {
             }
         }
         .contextMenu { AlbumContextMenu(album: album) }
+        // Outer "navigate to album" tap target. Reads as
+        // "<album> by <artist>. Opens album detail." The inner play
+        // button exposes itself separately for "play this album".
+        .accessibilityLabel(albumAccessibilityLabel)
+        .accessibilityHint("Opens album detail")
+    }
+
+    private var albumAccessibilityLabel: String {
+        if let year = album.year, year > 0 {
+            return "\(album.name) by \(album.artistName), \(year)"
+        }
+        return "\(album.name) by \(album.artistName)"
     }
 }

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -8,10 +8,15 @@ struct MainShell: View {
         @Bindable var model = model
         VStack(spacing: 0) {
             HStack(spacing: 0) {
+                // Tab order (#334): sidebar → primary content (toolbar +
+                // body) → queue inspector → player bar. Higher sort
+                // priority wins first, so sidebar is the entry point.
                 Sidebar()
+                    .accessibilitySortPriority(100)
                 Divider().background(Theme.border)
                 contentColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilitySortPriority(90)
                 // Right-side Queue Inspector (#79). Hidden by default; toggled
                 // by Cmd+Opt+Q or a future PlayerBar button (BATCH-07b). Kept
                 // at 320pt so it doesn't crowd the detail column on a 13"
@@ -21,12 +26,16 @@ struct MainShell: View {
                     QueueInspector()
                         .frame(width: 320)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
+                        .accessibilitySortPriority(70)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: model.isQueueInspectorOpen)
 
+            // Persistent player bar comes last in the tab traversal so
+            // Tab / Shift+Tab lands in the main content first. See #334.
             PlayerBar()
+                .accessibilitySortPriority(50)
         }
         .background(Theme.bg)
         // Cmd+Opt+Q toggles the queue inspector (#79). Hung off a zero-sized
@@ -74,7 +83,14 @@ struct MainShell: View {
     @ViewBuilder
     private var contentColumn: some View {
         VStack(spacing: 0) {
+            // Logical tab order inside the content column (#334):
+            // mainContent receives focus before the breadcrumb/top bar.
+            // Without the explicit sort priority, SwiftUI would walk the
+            // view tree top-to-bottom and hit the breadcrumbs first, which
+            // pushes the user through non-primary chrome before the page
+            // body.
             topBar
+                .accessibilitySortPriority(70)
             if !model.network.isOnline {
                 OfflineBanner(onRetry: { model.retryNetwork() })
                     .transition(.move(edge: .top).combined(with: .opacity))
@@ -91,6 +107,7 @@ struct MainShell: View {
                 // Screen swaps should be instant when Reduce Motion is on.
                 // Otherwise, keep SwiftUI's default implicit behavior.
                 .animation(reduceMotion ? nil : .default, value: model.screen)
+                .accessibilitySortPriority(80)
         }
         .animation(.easeInOut(duration: 0.2), value: model.network.isOnline)
         .animation(.easeInOut(duration: 0.2), value: model.serverReachability.isServerReachable)

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -264,9 +264,19 @@ struct PlaylistView: View {
 
             // Favorite + add-to-playlist are non-interactive placeholders
             // until their backing FFI lands — see `PlaylistContextMenu` for
-            // the matching TODO stubs in `AppModel`.
-            Image(systemName: "heart").font(.system(size: 20)).foregroundStyle(Theme.ink2).frame(width: 36, height: 36)
-            Image(systemName: "plus").font(.system(size: 20)).foregroundStyle(Theme.ink2).frame(width: 36, height: 36)
+            // the matching TODO stubs in `AppModel`. Hidden from VoiceOver
+            // so assistive tech doesn't announce inert icons as tappable
+            // (#331).
+            Image(systemName: "heart")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.ink2)
+                .frame(width: 36, height: 36)
+                .accessibilityHidden(true)
+            Image(systemName: "plus")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.ink2)
+                .frame(width: 36, height: 36)
+                .accessibilityHidden(true)
             Spacer()
         }
         .padding(.horizontal, 32)

--- a/macos/Sources/Jellify/Theme/Theme.swift
+++ b/macos/Sources/Jellify/Theme/Theme.swift
@@ -32,6 +32,15 @@ enum Theme {
     static let borderStrong = Color(rgba: (126, 114, 175, 0.35))
 
     // Type
+    /// Design-provided font helper. Wraps `Font.custom(_:size:relativeTo:)`
+    /// so every Figtree call site automatically scales with the user's
+    /// System Settings → Display → Larger Text preference (#337). The
+    /// choice of `relativeTo:` is driven by the design size — anything in
+    /// "chrome" territory (≤11pt) rides `.caption` so those labels scale
+    /// alongside the rest of the Dynamic-Type-aware chrome; body-range
+    /// sizes ride `.body`; headline sizes ride `.title3` / `.title2` /
+    /// `.largeTitle` depending on scale so they keep their relative rank
+    /// when the user cranks text size up.
     static func font(_ size: CGFloat, weight: Font.Weight = .regular, italic: Bool = false) -> Font {
         let name: String
         switch weight {
@@ -43,7 +52,27 @@ enum Theme {
         case .light, .thin, .ultraLight: name = "Figtree-Light"
         default: name = italic ? "Figtree-Italic" : "Figtree-Regular"
         }
-        return Font.custom(name, size: size).weight(weight)
+        return Font
+            .custom(name, size: size, relativeTo: textStyle(for: size))
+            .weight(weight)
+    }
+
+    /// Pick the text style a given design size should scale relative to.
+    /// Centralised so `.font()` and any future scaled helpers stay in sync.
+    /// Banding the sizes into a handful of styles (caption / footnote /
+    /// body / title3 / title2 / title1 / largeTitle) keeps the hierarchy
+    /// intact as Dynamic Type scales up — a 10pt caption and a 36pt hero
+    /// don't end up the same apparent weight at AX3.
+    private static func textStyle(for size: CGFloat) -> Font.TextStyle {
+        switch size {
+        case ..<11: return .caption
+        case ..<13: return .footnote
+        case ..<17: return .body
+        case ..<20: return .title3
+        case ..<26: return .title2
+        case ..<34: return .title
+        default: return .largeTitle
+        }
     }
 }
 

--- a/macos/docs/a11y/README.md
+++ b/macos/docs/a11y/README.md
@@ -45,14 +45,14 @@ audit row green on the next run.
 
 | Finding | Source | Tracking |
 | ------- | ------ | -------- |
-| Icon-only buttons have no VoiceOver label (shuffle, repeat) | `Sources/Jellify/Components/PlayerBar.swift` — `iconBtn("shuffle")`, `iconBtn("repeat")` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
-| Logout button in Sidebar has no VoiceOver label | `Sources/Jellify/Components/Sidebar.swift` | [#331](https://github.com/skalthoff/jellify-desktop/issues/331) |
-| Progress bar is not an accessible slider | PlayerBar scrubber | [#332](https://github.com/skalthoff/jellify-desktop/issues/332) |
+| ~~Icon-only buttons have no VoiceOver label (shuffle, repeat)~~ | `Sources/Jellify/Components/PlayerBar.swift` — `iconBtn("shuffle")`, `iconBtn("repeat")` | ~~[#331](https://github.com/skalthoff/jellify-desktop/issues/331)~~ — fixed by BATCH-22 |
+| ~~Logout button in Sidebar has no VoiceOver label~~ | `Sources/Jellify/Components/Sidebar.swift` | ~~[#331](https://github.com/skalthoff/jellify-desktop/issues/331)~~ — fixed by BATCH-22 |
+| ~~Progress bar is not an accessible slider~~ | PlayerBar scrubber | ~~[#332](https://github.com/skalthoff/jellify-desktop/issues/332)~~ — fixed by BATCH-22 |
 | Track row sub-labels announce separately | TrackRow | [#333](https://github.com/skalthoff/jellify-desktop/issues/333) |
-| No logical tab order / Shift-Tab traversal | Focus system | [#334](https://github.com/skalthoff/jellify-desktop/issues/334) |
+| ~~No logical tab order / Shift-Tab traversal~~ | Focus system | ~~[#334](https://github.com/skalthoff/jellify-desktop/issues/334)~~ — fixed by BATCH-22 |
 | No visible themed focus ring | Focus system | [#335](https://github.com/skalthoff/jellify-desktop/issues/335) |
 | `@FocusState` not wired for search autofocus / modal focus | Search, modals | [#336](https://github.com/skalthoff/jellify-desktop/issues/336) |
-| No Dynamic Type / scaledFont support on Figtree | Theme | [#337](https://github.com/skalthoff/jellify-desktop/issues/337) |
+| ~~No Dynamic Type / scaledFont support on Figtree~~ | Theme | ~~[#337](https://github.com/skalthoff/jellify-desktop/issues/337)~~ — fixed by BATCH-22 |
 | PlayerBar and Sidebar do not reflow at large text sizes | Layout | [#338](https://github.com/skalthoff/jellify-desktop/issues/338) |
 
 Anything else the Audit panel reports — and which is not in the table above


### PR DESCRIPTION
Closes #331, #332, #334, #337, #343.