### PR TITLE
macos: i18n — String Catalog, font fallback, localized error presenter

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -640,7 +640,7 @@ final class AppModel {
             startPolling()
             await refreshLibrary()
         } catch {
-            self.errorMessage = "Login failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .login)
         }
     }
 
@@ -827,6 +827,10 @@ final class AppModel {
     /// are:
     /// - `NotAuthenticated` → `"not logged in"`
     /// - `Server { status: 401, .. }` → `"server returned an error: 401 ..."`
+    ///
+    /// Call-sites that do NOT match auth go on to call
+    /// `JellifyErrorPresenter.message(for:context:)` (see #351) to turn the
+    /// raw Display string into localized banner copy.
     private func handleAuthError(_ error: Error) -> Bool {
         let description = error.localizedDescription
         let isNotAuthenticated = description.contains("not logged in")
@@ -878,7 +882,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
         _ = await playlistsResult
         await refreshRecentlyPlayed()
@@ -915,7 +919,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -939,7 +943,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -960,7 +964,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -984,7 +988,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -1077,7 +1081,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Playlists load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistsLoad)
         }
     }
 
@@ -1137,7 +1141,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist load failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistLoad)
         }
         return all
     }
@@ -1590,7 +1594,12 @@ final class AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             genres: genres,
-            imageTag: imageTag
+            imageTag: imageTag,
+            // DTO parser doesn't request `Fields=UserData`, so the
+            // server-authoritative projection is absent here. Favourite /
+            // play-count consumers read the legacy convenience mirrors
+            // (`isFavorite` / `playCount`) where those are set.
+            userData: nil
         )
     }
 
@@ -1676,7 +1685,12 @@ final class AppModel {
             playCount: playCount,
             container: container,
             bitrate: bitrate,
-            imageTag: imageTag
+            imageTag: imageTag,
+            // DTO parser doesn't request `Fields=UserData`, so the
+            // server-authoritative projection is absent. Legacy mirrors
+            // `isFavorite` / `playCount` are populated above from whatever
+            // the BaseItemDto carried.
+            userData: nil
         )
     }
 
@@ -1694,7 +1708,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Album tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .albumTracks)
             return []
         }
     }
@@ -1751,7 +1765,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistTracks)
             return []
         }
     }
@@ -1789,7 +1803,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistTracks)
         }
     }
 
@@ -1989,7 +2003,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2039,7 +2053,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2206,7 +2220,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2248,7 +2262,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2353,7 +2367,7 @@ final class AppModel {
             errorMessage = nil
         } catch {
             if handleAuthError(error) { return }
-            errorMessage = "Couldn't start playback: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playback)
         }
     }
 
@@ -2456,7 +2470,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Favorite failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .favorite)
         }
     }
 
@@ -2504,7 +2518,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Add to playlist failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistAdd)
             return false
         }
     }
@@ -3184,7 +3198,7 @@ final class AppModel {
             try audio.play(track: track)
         } catch {
             if handleAuthError(error) { return }
-            errorMessage = "Playback failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playback)
         }
     }
 

--- a/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
+++ b/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
@@ -19,11 +19,11 @@ struct AuthExpiredSheet: View {
                 .padding(.top, 8)
 
             VStack(spacing: 8) {
-                Text("Your session expired")
+                Text("auth.session.expired.title")
                     .font(Theme.font(18, weight: .bold))
                     .foregroundStyle(Theme.ink)
 
-                Text("Please sign in again to continue listening.")
+                Text("auth.session.expired.body")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .multilineTextAlignment(.center)
@@ -31,7 +31,7 @@ struct AuthExpiredSheet: View {
             }
 
             Button(action: onSignIn) {
-                Text("Sign in")
+                Text("auth.sign_in")
                     .font(Theme.font(14, weight: .bold))
                     .frame(width: 260, height: 40)
                     .foregroundStyle(Theme.bg)
@@ -40,7 +40,7 @@ struct AuthExpiredSheet: View {
             }
             .buttonStyle(.plain)
             .keyboardShortcut(.defaultAction)
-            .accessibilityLabel("Sign in again")
+            .accessibilityLabel("auth.sign_in.again.a11y")
         }
         .padding(32)
         .frame(width: 360)

--- a/macos/Sources/Jellify/Components/EmptyLibraryState.swift
+++ b/macos/Sources/Jellify/Components/EmptyLibraryState.swift
@@ -11,10 +11,11 @@ import AppKit
 struct EmptyLibraryState: View {
     let serverUrl: URL?
 
-    private let headline = "No music yet"
-    private let subtitle =
-        "Your Jellyfin server doesn't have any music in its library, " +
-        "or it's still being indexed. Add a library on the server, then refresh."
+    /// Resolved copy for the a11y-combine label. We pull the catalog values
+    /// once here so the composite `Text` uses the same phrasing the rest of
+    /// the view renders.
+    private var headline: String { String(localized: "empty.library.title", bundle: .main) }
+    private var subtitle: String { String(localized: "empty.library.subtitle", bundle: .main) }
 
     var body: some View {
         VStack(spacing: 18) {
@@ -27,10 +28,10 @@ struct EmptyLibraryState: View {
                 .accessibilityHidden(true)
 
             VStack(spacing: 6) {
-                Text(headline)
+                Text("empty.library.title")
                     .font(Theme.font(22, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
-                Text(subtitle)
+                Text("empty.library.subtitle")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink2)
                     .multilineTextAlignment(.center)
@@ -43,7 +44,7 @@ struct EmptyLibraryState: View {
                     NSWorkspace.shared.open(serverUrl)
                 } label: {
                     HStack(spacing: 8) {
-                        Text("Open Jellyfin web")
+                        Text("empty.library.open_web")
                             .font(Theme.font(13, weight: .bold))
                         Image(systemName: "arrow.up.right.square")
                             .font(.system(size: 12, weight: .bold))
@@ -61,7 +62,7 @@ struct EmptyLibraryState: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Open Jellyfin web")
+                .accessibilityLabel("empty.library.open_web")
             }
         }
         .padding(.vertical, 56)

--- a/macos/Sources/Jellify/Components/EmptyQueueState.swift
+++ b/macos/Sources/Jellify/Components/EmptyQueueState.swift
@@ -9,8 +9,18 @@ import SwiftUI
 struct EmptyQueueState: View {
     /// SF Symbol rendered above the headline.
     var systemImage: String = "text.line.first.and.arrowtriangle.forward"
-    var title: String = "Queue is empty"
-    var subtitle: String = "Play something to start a queue."
+    /// Optional overrides — when `nil`, the catalog-backed defaults load from
+    /// `Localizable.xcstrings`. Passing explicit copy is still supported for
+    /// places that want a surface-specific phrasing.
+    var title: String? = nil
+    var subtitle: String? = nil
+
+    private var resolvedTitle: String {
+        title ?? String(localized: "empty.queue.title", bundle: .main)
+    }
+    private var resolvedSubtitle: String {
+        subtitle ?? String(localized: "empty.queue.subtitle", bundle: .main)
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -20,12 +30,12 @@ struct EmptyQueueState: View {
                 .accessibilityHidden(true)
 
             VStack(spacing: 4) {
-                Text(title)
+                Text(resolvedTitle)
                     .font(Theme.font(18, weight: .bold))
                     .foregroundStyle(Theme.ink2)
                     .multilineTextAlignment(.center)
 
-                Text(subtitle)
+                Text(resolvedSubtitle)
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .multilineTextAlignment(.center)
@@ -35,7 +45,7 @@ struct EmptyQueueState: View {
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(title). \(subtitle)")
+        .accessibilityLabel("\(resolvedTitle). \(resolvedSubtitle)")
         .accessibilityAddTraits(.isStaticText)
     }
 }

--- a/macos/Sources/Jellify/Components/OfflineBanner.swift
+++ b/macos/Sources/Jellify/Components/OfflineBanner.swift
@@ -26,11 +26,16 @@ struct OfflineBanner: View {
         self.onRetry = onRetry
     }
 
+    /// Resolved copy for the banner. The named-server variant interpolates
+    /// the user-supplied host verbatim — it's user data, not a translatable
+    /// phrase, so only the surrounding scaffolding comes from the catalog.
+    /// The generic fallback goes through `Localizable.xcstrings` via the
+    /// `offline.generic` key.
     private var message: String {
         if let host, !host.isEmpty {
             return "Can't reach \(host). Trying again\u{2026}"
         }
-        return "You're offline. Playing from downloaded tracks only."
+        return String(localized: "offline.generic", bundle: .main)
     }
 
     var body: some View {
@@ -49,7 +54,7 @@ struct OfflineBanner: View {
             Spacer(minLength: 12)
 
             Button(action: onRetry) {
-                Text("Retry")
+                Text("common.retry")
                     .font(Theme.font(12, weight: .bold))
                     .foregroundStyle(Theme.ink)
                     .padding(.horizontal, 12)
@@ -64,7 +69,7 @@ struct OfflineBanner: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Retry network connection")
+            .accessibilityLabel("offline.retry.a11y")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -87,7 +87,7 @@ struct PlayerBar: View {
             .accessibilityLabel("Now Playing: \(track.name) by \(track.artistName)")
             .accessibilityHint("Shows track details")
         } else {
-            Text("Nothing playing")
+            Text("player.nothing_playing")
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -11,12 +11,14 @@ struct Sidebar: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(LinearGradient(colors: [Theme.teal, Theme.primary], startPoint: .topLeading, endPoint: .bottomTrailing))
                     .frame(width: 30, height: 30)
-                    .overlay(Text("🪼").font(.system(size: 16)))
+                    // Emoji rendered verbatim — a jellyfish is a jellyfish in
+                    // every locale; no catalog entry needed.
+                    .overlay(Text(verbatim: "🪼").font(.system(size: 16)))
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("Jellify")
+                    Text("app.name")
                         .font(Theme.font(15, weight: .black, italic: true))
                         .foregroundStyle(Theme.ink)
-                    Text("DESKTOP")
+                    Text("app.subtitle.desktop")
                         .font(Theme.font(9, weight: .bold))
                         .foregroundStyle(Theme.ink3)
                         .tracking(1.5)
@@ -29,19 +31,19 @@ struct Sidebar: View {
 
             // Primary nav
             VStack(alignment: .leading, spacing: 2) {
-                navItem("house", label: "Home", screen: .home)
-                navItem("music.note.list", label: "Library", screen: .library)
-                navItem("magnifyingglass", label: "Search", screen: .search)
+                navItem("house", label: "sidebar.nav.home", screen: .home)
+                navItem("music.note.list", label: "sidebar.nav.library", screen: .library)
+                navItem("magnifyingglass", label: "sidebar.nav.search", screen: .search)
             }
             .padding(.horizontal, 10)
 
             // Stats footer
-            sectionHeader("Your Library")
+            sectionHeader("sidebar.section.your_library")
             VStack(alignment: .leading, spacing: 2) {
-                libRow("heart", label: "Favorites", count: nil)
-                libRow("square.stack", label: "Albums", count: UInt32(model.albums.count))
-                libRow("person.crop.circle", label: "Artists", count: UInt32(model.artists.count))
-                libRow("music.note.list", label: "Playlists", count: UInt32(model.playlists.count))
+                libRow("heart", label: "sidebar.stats.favorites", count: nil)
+                libRow("square.stack", label: "sidebar.stats.albums", count: UInt32(model.albums.count))
+                libRow("person.crop.circle", label: "sidebar.stats.artists", count: UInt32(model.artists.count))
+                libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count))
             }
             .padding(.horizontal, 10)
 
@@ -85,7 +87,7 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func navItem(_ icon: String, label: String, screen: AppModel.Screen) -> some View {
+    private func navItem(_ icon: String, label: LocalizedStringKey, screen: AppModel.Screen) -> some View {
         let active = model.screen == screen
         Button { model.screen = screen } label: {
             HStack(spacing: 10) {
@@ -124,7 +126,7 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func libRow(_ icon: String, label: String, count: UInt32?) -> some View {
+    private func libRow(_ icon: String, label: LocalizedStringKey, count: UInt32?) -> some View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .foregroundStyle(Theme.ink2)
@@ -149,8 +151,13 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
+    private func sectionHeader(_ title: LocalizedStringKey) -> some View {
+        // The header reads as uppercase in the rendered frame via the heavy
+        // tracking + smallcap feel; we no longer force `.uppercased()` here
+        // because doing so would mangle non-Latin scripts (Arabic, CJK)
+        // that have no case distinction. The catalog entries already ship
+        // the English label in uppercase.
+        Text(title)
             .font(Theme.font(10, weight: .bold))
             .foregroundStyle(Theme.ink3)
             .tracking(1.5)

--- a/macos/Sources/Jellify/Components/StreamErrorToast.swift
+++ b/macos/Sources/Jellify/Components/StreamErrorToast.swift
@@ -62,7 +62,7 @@ struct StreamErrorToast: View {
             Spacer(minLength: 12)
 
             Button(action: onRetry) {
-                Text("Retry")
+                Text("common.retry")
                     .font(Theme.font(12, weight: .bold))
                     .foregroundStyle(Theme.ink)
                     .padding(.horizontal, 12)
@@ -77,17 +77,17 @@ struct StreamErrorToast: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Retry playing \(trackName)")
+            .accessibilityLabel("stream.error.retry.a11y")
 
             Button(action: onGoToTrack) {
-                Text("Go to track")
+                Text("stream.error.go_to_track")
                     .font(Theme.font(12, weight: .semibold))
                     .foregroundStyle(Theme.ink2)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Go to \(trackName)")
+            .accessibilityLabel(Text("stream.error.go_to_track"))
 
             if let onDismiss {
                 Button(action: onDismiss) {
@@ -97,7 +97,7 @@ struct StreamErrorToast: View {
                         .frame(width: 20, height: 20)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss")
+                .accessibilityLabel("common.dismiss.a11y")
             }
         }
         .padding(.horizontal, 16)

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -114,11 +114,11 @@ struct JellifyCommands: Commands {
         // Close Window (⌘W). We append a "New Playlist…" entry after the
         // built-in new-item block so both show up together under File > New.
         CommandGroup(after: .newItem) {
-            Button("New Playlist…") {
+            Button("menu.file.new_playlist") {
                 // TODO(#131 / #234): wire to `core.createPlaylist(name:itemIds:)`
                 // once the FFI lands. For now this is a menu placeholder so the
                 // shortcut is reserved and discoverable.
-                model.errorMessage = "Creating playlists isn't wired yet — see #131."
+                model.errorMessage = String(localized: "login.placeholder.not_wired", bundle: .main)
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .disabled(model.session == nil)
@@ -133,7 +133,7 @@ struct JellifyCommands: Commands {
         CommandGroup(after: .sidebar) {
             Divider()
 
-            Button("Show Sidebar") {
+            Button("menu.view.show_sidebar") {
                 // TODO(#5): bind to a published `isSidebarVisible` flag on
                 // AppModel and have `MainShell` conditionally mount `Sidebar()`.
                 // The menu item is reserved now so the shortcut exists.
@@ -141,7 +141,7 @@ struct JellifyCommands: Commands {
             .keyboardShortcut("s", modifiers: [.command, .option])
             .disabled(true)
 
-            Button("Show Queue Inspector") {
+            Button("menu.view.show_queue") {
                 // TODO(#272): the queue drawer lands with BATCH-07's rich
                 // inspector. Menu item reserved so ⌘⌥Q resolves to something
                 // discoverable once the panel exists.
@@ -157,19 +157,19 @@ struct JellifyCommands: Commands {
             // Home, Library, Search. `model.screen` is the source of truth
             // and re-assigning it triggers the same `MainShell` animation
             // as clicking the sidebar.
-            Button("Home") {
+            Button("menu.nav.home") {
                 model.screen = .home
             }
             .keyboardShortcut("1", modifiers: .command)
             .disabled(model.session == nil)
 
-            Button("Library") {
+            Button("menu.nav.library") {
                 model.screen = .library
             }
             .keyboardShortcut("2", modifiers: .command)
             .disabled(model.session == nil)
 
-            Button("Search") {
+            Button("menu.nav.search") {
                 model.screen = .search
             }
             .keyboardShortcut("3", modifiers: .command)
@@ -181,7 +181,7 @@ struct JellifyCommands: Commands {
             // `requestSearchFocus` one-shot and the new `isSearchFieldFocused`
             // mirror so any field binding a `@FocusState` to either will
             // receive focus. See #7 / #104.
-            Button("Find…") {
+            Button("menu.nav.find") {
                 model.focusSearch()
             }
             .keyboardShortcut("f", modifiers: .command)
@@ -190,7 +190,7 @@ struct JellifyCommands: Commands {
             // ⌘L jumps to the full Now Playing view and toggles back to the
             // previous screen when pressed again (matches Music.app feel).
             // See #89 / #6 and the Playback menu's mirror shortcut.
-            Button("Go to Now Playing") {
+            Button("menu.nav.now_playing") {
                 toggleNowPlaying()
             }
             .keyboardShortcut("l", modifiers: .command)
@@ -200,7 +200,7 @@ struct JellifyCommands: Commands {
             // search + static action verbs. Toggling the flag here and
             // letting `RootView` mount the overlay keeps the palette
             // independent of whichever screen is currently focused.
-            Button("Command Palette\u{2026}") {
+            Button("menu.nav.command_palette") {
                 model.isCommandPaletteOpen.toggle()
             }
             .keyboardShortcut("k", modifiers: .command)
@@ -213,8 +213,8 @@ struct JellifyCommands: Commands {
         // whole app is usable from the home row. Media keys (F7/F8/F9) and
         // Bluetooth AVRCP events hit the same `AppModel` methods via
         // `MediaSession` — see file header for why they aren't re-registered.
-        CommandMenu("Playback") {
-            Button(playPauseLabel) {
+        CommandMenu("menu.playback") {
+            Button(playPauseLabelKey) {
                 model.togglePlayPause()
             }
             .keyboardShortcut(.space, modifiers: [])
@@ -222,13 +222,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Next Track") {
+            Button("menu.playback.next") {
                 model.skipNext()
             }
             .keyboardShortcut(.rightArrow, modifiers: .command)
             .disabled(model.status.currentTrack == nil)
 
-            Button("Previous Track") {
+            Button("menu.playback.previous") {
                 model.skipPrevious()
             }
             .keyboardShortcut(.leftArrow, modifiers: .command)
@@ -236,13 +236,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Volume Up") {
+            Button("menu.playback.volume_up") {
                 let next = min(1.0, model.status.volume + 0.05)
                 model.setVolume(next)
             }
             .keyboardShortcut(.upArrow, modifiers: .command)
 
-            Button("Volume Down") {
+            Button("menu.playback.volume_down") {
                 let next = max(0.0, model.status.volume - 0.05)
                 model.setVolume(next)
             }
@@ -250,13 +250,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Seek Forward 10s") {
+            Button("menu.playback.seek_forward") {
                 model.seek(by: 10)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.command, .shift])
             .disabled(model.status.currentTrack == nil)
 
-            Button("Seek Back 10s") {
+            Button("menu.playback.seek_back") {
                 model.seek(by: -10)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.command, .shift])
@@ -264,13 +264,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Stop") {
+            Button("menu.playback.stop") {
                 model.stop()
             }
             .keyboardShortcut(".", modifiers: .command)
             .disabled(model.status.currentTrack == nil)
 
-            Button("Go to Now Playing") {
+            Button("menu.nav.now_playing") {
                 toggleNowPlaying()
             }
             .keyboardShortcut("l", modifiers: .command)
@@ -284,13 +284,13 @@ struct JellifyCommands: Commands {
         // an explicit Tile Window action so the command is discoverable
         // even when the system hasn't surfaced the OS-level tiling item.
         CommandGroup(after: .windowArrangement) {
-            Button("Tile Window to Left of Screen") {
+            Button("menu.window.tile_left") {
                 tileCurrentWindow(edge: .left)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.control, .option, .command])
             .disabled(NSApp.keyWindow == nil)
 
-            Button("Tile Window to Right of Screen") {
+            Button("menu.window.tile_right") {
                 tileCurrentWindow(edge: .right)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.control, .option, .command])
@@ -303,7 +303,7 @@ struct JellifyCommands: Commands {
         // We redirect it to the repo's issue tracker so the menu item
         // actually leads somewhere useful.
         CommandGroup(replacing: .help) {
-            Button("Jellify Help") {
+            Button("menu.help.jellify") {
                 if let url = URL(string: "https://github.com/skalthoff/jellify-desktop") {
                     NSWorkspace.shared.open(url)
                 }
@@ -320,8 +320,11 @@ struct JellifyCommands: Commands {
         // behavior (e.g. AppKit's responder-chain text editing actions).
     }
 
-    private var playPauseLabel: String {
-        model.status.state == .playing ? "Pause" : "Play"
+    /// Catalog key for the Play / Pause toggle in the Playback menu. Returned
+    /// as `LocalizedStringKey` so SwiftUI looks up the translation from
+    /// `Localizable.xcstrings` rather than rendering the literal key.
+    private var playPauseLabelKey: LocalizedStringKey {
+        model.status.state == .playing ? "menu.playback.pause" : "menu.playback.play"
     }
 
     /// Toggle behaviour for the "Go to Now Playing" menu item: first press
@@ -427,7 +430,7 @@ private struct RestoreLoadingView: View {
         ZStack {
             Theme.bg.ignoresSafeArea()
             VStack(spacing: 16) {
-                Text("Jellify")
+                Text("app.name")
                     .font(Theme.font(40, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
                 ProgressView()

--- a/macos/Sources/Jellify/JellifyErrorPresenter.swift
+++ b/macos/Sources/Jellify/JellifyErrorPresenter.swift
@@ -1,0 +1,149 @@
+import Foundation
+import SwiftUI
+
+/// Maps a `JellifyError` surfaced by the core (via UniFFI) into a
+/// presentation-quality localized message.
+///
+/// Issue #351. The core declares `JellifyError` as a UniFFI `flat_error`, so on
+/// the Swift side we only receive the rendered `thiserror` Display string —
+/// there is no Swift enum with associated values to pattern-match on. The
+/// presenter therefore works by substring-matching the Display text against the
+/// known variant prefixes. The mapping is intentionally conservative: anything
+/// we can't place with confidence falls through to `error.other`, which reads
+/// as "Something went wrong." rather than leaking low-level jargon.
+///
+/// ### Why a dedicated presenter?
+///
+/// Prior to this module, error call-sites stuffed `"<prefix>: \(error.localizedDescription)"`
+/// into `AppModel.errorMessage`, which meant the banner string carried
+/// technical detail (`"network error: error sending request"`, etc.) and was
+/// impossible to localize — the Display string is hardcoded English from the
+/// Rust side. The presenter funnels every surfacing path through a single
+/// `String(localized:)` lookup so translators see a small, stable key set in
+/// `Localizable.xcstrings`.
+///
+/// ### Usage
+///
+/// ```swift
+/// do { try core.listAlbums(...) } catch {
+///     if handleAuthError(error) { return }
+///     errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
+/// }
+/// ```
+///
+/// `context` is an optional hint used to pick a more specific banner when the
+/// error itself is generic (e.g. a search failure vs. a library load failure,
+/// both of which might be `JellifyError::Server`). When the mapped variant
+/// already carries enough context (Auth, NotFound, RateLimit) the `context`
+/// parameter is ignored.
+enum JellifyErrorPresenter {
+    /// Surfaces the user-facing banner copy for `error`, honouring the
+    /// provided `context` for generic failures. Always returns a non-empty
+    /// string — the default is `error.other` → "Something went wrong."
+    static func message(for error: Error, context: Context = .generic) -> String {
+        let key = key(for: error, context: context)
+        // `String(localized:)` wants `String.LocalizationValue`, whose `init(_:)`
+        // treats the argument as the catalog key. Wrapping explicitly keeps
+        // the compiler from misreading the String as an already-rendered
+        // value.
+        return String(localized: String.LocalizationValue(key), bundle: .main)
+    }
+
+    /// Returns the stable semantic key we'd surface for `error`. Exposed so
+    /// callers that want a `Text(LocalizedStringKey(...))` binding can skip the
+    /// bundle-lookup round-trip and still share the mapping.
+    static func key(for error: Error, context: Context = .generic) -> String {
+        let description = error.localizedDescription.lowercased()
+
+        // Auth family has the highest priority — a 401 dressed as
+        // `JellifyError::Server` still means "credentials are bad", and
+        // treating it as a transport error would leak a stale token into
+        // the UI. `handleAuthError` on `AppModel` already intercepts most
+        // of these; this branch covers the fall-through cases (e.g. an
+        // error bubbled from an async task that bypassed the helper).
+        if description.contains("not logged in")
+            || description.contains("authentication expired")
+            || description.contains("authentication failed")
+            || description.contains("401")
+        {
+            return "error.auth.expired"
+        }
+
+        // `JellifyError::Server` renders as "server returned an error:
+        // {status} {message}". Pattern-match the status digits embedded
+        // in the Display so 403/404/429 get specialised banners even
+        // though the Rust side lumps them under one variant.
+        if description.contains("server returned an error:") {
+            if description.contains(" 403") || description.contains("forbidden") {
+                return "error.forbidden"
+            }
+            if description.contains(" 404") || description.contains("not found") {
+                return "error.not_found"
+            }
+            if description.contains(" 429") || description.contains("rate limit") {
+                return "error.rate_limit"
+            }
+            // Any other status (500s, gateway errors, etc.) — prefer the
+            // caller's context banner if it was supplied; otherwise the
+            // generic "server ran into a problem" fallback.
+            return context.fallbackKey ?? "error.server"
+        }
+
+        // Non-server variants, keyed off the `thiserror` Display prefix
+        // declared in `core/src/error.rs`. Order mirrors the enum to keep
+        // this readable.
+        if description.contains("network error") {
+            return "error.network"
+        }
+        if description.contains("decode error") {
+            return "error.decode"
+        }
+        if description.contains("storage error") {
+            return "error.storage"
+        }
+        if description.contains("credential store") {
+            return "error.credentials"
+        }
+        if description.contains("audio error") {
+            return "error.audio"
+        }
+        if description.contains("invalid input") {
+            return "error.invalid_input"
+        }
+
+        return context.fallbackKey ?? "error.other"
+    }
+
+    /// Hint the call-site can pass so generic failures get a more specific
+    /// banner. Each case maps to a key in `Localizable.xcstrings`. `generic`
+    /// is the catch-all and flows to `error.other` / `error.server`.
+    enum Context {
+        case generic
+        case login
+        case libraryLoad
+        case playlistsLoad
+        case playlistLoad
+        case albumTracks
+        case playlistTracks
+        case search
+        case playback
+        case favorite
+        case playlistAdd
+
+        fileprivate var fallbackKey: String? {
+            switch self {
+            case .generic: return nil
+            case .login: return "error.login.failed"
+            case .libraryLoad: return "error.library.load"
+            case .playlistsLoad: return "error.playlists.load"
+            case .playlistLoad: return "error.playlist.load"
+            case .albumTracks: return "error.album.tracks"
+            case .playlistTracks: return "error.playlist.tracks"
+            case .search: return "error.search"
+            case .playback: return "error.playback"
+            case .favorite: return "error.favorite"
+            case .playlistAdd: return "error.playlist.add"
+            }
+        }
+    }
+}

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -1,0 +1,1086 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "app.name" : {
+      "comment" : "Brand name shown in the sidebar header and splash screens.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jellify"
+          }
+        }
+      }
+    },
+    "app.subtitle.desktop" : {
+      "comment" : "Small tracking-uppercase label shown below the wordmark on brand lockups.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DESKTOP"
+          }
+        }
+      }
+    },
+    "auth.session.expired.title" : {
+      "comment" : "Modal sheet title when the server rejects a stored access token (HTTP 401).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session expired"
+          }
+        }
+      }
+    },
+    "auth.session.expired.body" : {
+      "comment" : "Modal sheet body message explaining the user needs to re-authenticate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please sign in again to continue listening."
+          }
+        }
+      }
+    },
+    "auth.sign_in" : {
+      "comment" : "Primary sign-in button on LoginView and the auth-expired sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in"
+          }
+        }
+      }
+    },
+    "auth.sign_in.again.a11y" : {
+      "comment" : "Accessibility label for the sign-in button on the auth-expired sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in again"
+          }
+        }
+      }
+    },
+    "auth.signing_in" : {
+      "comment" : "Button label shown while a sign-in request is in flight.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signing in\u2026"
+          }
+        }
+      }
+    },
+    "breadcrumb.album.fallback" : {
+      "comment" : "Breadcrumb segment when the current album hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
+          }
+        }
+      }
+    },
+    "breadcrumb.artist.fallback" : {
+      "comment" : "Breadcrumb segment when the current artist hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artist"
+          }
+        }
+      }
+    },
+    "breadcrumb.playlist.fallback" : {
+      "comment" : "Breadcrumb segment when the current playlist hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playlist"
+          }
+        }
+      }
+    },
+    "common.cancel" : {
+      "comment" : "Generic Cancel action label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "common.delete" : {
+      "comment" : "Generic Delete action label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "common.dismiss.a11y" : {
+      "comment" : "Accessibility label for a close/dismiss button on toasts and banners.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
+          }
+        }
+      }
+    },
+    "common.retry" : {
+      "comment" : "Retry action label — shared between offline and stream-error toasts/banners.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        }
+      }
+    },
+    "empty.library.title" : {
+      "comment" : "Headline on the empty-library state shown when the server has no music yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No music yet"
+          }
+        }
+      }
+    },
+    "empty.library.subtitle" : {
+      "comment" : "Body copy on the empty-library state explaining that the server is empty or still indexing.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Jellyfin server doesn't have any music in its library, or it's still being indexed. Add a library on the server, then refresh."
+          }
+        }
+      }
+    },
+    "empty.library.open_web" : {
+      "comment" : "CTA on the empty-library state that opens the Jellyfin web admin UI.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Jellyfin web"
+          }
+        }
+      }
+    },
+    "empty.queue.title" : {
+      "comment" : "Empty state title inside the queue inspector panel.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queue is empty"
+          }
+        }
+      }
+    },
+    "empty.queue.subtitle" : {
+      "comment" : "Empty state subtitle inside the queue inspector panel.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play something to start a queue."
+          }
+        }
+      }
+    },
+    "error.auth.expired" : {
+      "comment" : "Banner copy for JellifyError.AuthExpired / Auth — surfaced by JellifyErrorPresenter.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please sign in again."
+          }
+        }
+      }
+    },
+    "error.forbidden" : {
+      "comment" : "Banner copy when a core call returns HTTP 403.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You don't have permission to do that."
+          }
+        }
+      }
+    },
+    "error.not_found" : {
+      "comment" : "Banner copy when a core call returns HTTP 404.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That item couldn't be found."
+          }
+        }
+      }
+    },
+    "error.rate_limit" : {
+      "comment" : "Banner copy when the server throttles us (HTTP 429).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Too many requests. Please try again in a moment."
+          }
+        }
+      }
+    },
+    "error.network" : {
+      "comment" : "Banner copy for transport-level failures (JellifyError.Network).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network error. Check your connection and try again."
+          }
+        }
+      }
+    },
+    "error.server" : {
+      "comment" : "Banner copy for HTTP 5xx responses (JellifyError.Server non-auth).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server ran into a problem. Please try again."
+          }
+        }
+      }
+    },
+    "error.decode" : {
+      "comment" : "Banner copy for JellifyError.Decode — the server response couldn't be parsed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't read the server's response."
+          }
+        }
+      }
+    },
+    "error.storage" : {
+      "comment" : "Banner copy for JellifyError.Storage — local SQLite or cache failure.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local storage error. Please try again."
+          }
+        }
+      }
+    },
+    "error.credentials" : {
+      "comment" : "Banner copy for JellifyError.Credentials — keychain access failed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't access the system keychain."
+          }
+        }
+      }
+    },
+    "error.audio" : {
+      "comment" : "Banner copy for JellifyError.Audio — the audio engine failed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio playback error."
+          }
+        }
+      }
+    },
+    "error.invalid_input" : {
+      "comment" : "Banner copy for JellifyError.InvalidInput — user-supplied value was rejected.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That value isn't valid."
+          }
+        }
+      }
+    },
+    "error.other" : {
+      "comment" : "Banner copy for JellifyError.Other — catch-all fallback.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong."
+          }
+        }
+      }
+    },
+    "error.playback" : {
+      "comment" : "Banner copy when the audio engine fails to start a track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't start playback."
+          }
+        }
+      }
+    },
+    "error.library.load" : {
+      "comment" : "Banner prefix when the library refresh pipeline fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load your library."
+          }
+        }
+      }
+    },
+    "error.playlists.load" : {
+      "comment" : "Banner copy when refreshing playlists fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load playlists."
+          }
+        }
+      }
+    },
+    "error.playlist.load" : {
+      "comment" : "Banner copy when loading a single playlist fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load this playlist."
+          }
+        }
+      }
+    },
+    "error.album.tracks" : {
+      "comment" : "Banner copy when loading album tracks fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load album tracks."
+          }
+        }
+      }
+    },
+    "error.playlist.tracks" : {
+      "comment" : "Banner copy when loading playlist tracks fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load playlist tracks."
+          }
+        }
+      }
+    },
+    "error.search" : {
+      "comment" : "Banner copy when a search query fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search failed."
+          }
+        }
+      }
+    },
+    "error.favorite" : {
+      "comment" : "Banner copy when toggling a favorite fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't update favorite."
+          }
+        }
+      }
+    },
+    "error.playlist.add" : {
+      "comment" : "Banner copy when adding a track to a playlist fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't add to playlist."
+          }
+        }
+      }
+    },
+    "error.login.failed" : {
+      "comment" : "Banner copy when login fails for a generic reason.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in failed."
+          }
+        }
+      }
+    },
+    "error.wrong_credentials" : {
+      "comment" : "Inline error on LoginView when the server returns 401 on submit.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wrong username or password"
+          }
+        }
+      }
+    },
+    "login.placeholder.not_wired" : {
+      "comment" : "Placeholder banner when a menu action hasn't been wired to the core yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creating playlists isn't wired yet \u2014 see #131."
+          }
+        }
+      }
+    },
+    "login.network_banner" : {
+      "comment" : "Top-of-column banner on LoginView when the system is offline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No network. Check your connection."
+          }
+        }
+      }
+    },
+    "login.probe.checking" : {
+      "comment" : "Status row under the server URL field while probing.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking\u2026"
+          }
+        }
+      }
+    },
+    "login.field.url" : {
+      "comment" : "Uppercase field label above the server URL input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SERVER URL"
+          }
+        }
+      }
+    },
+    "login.field.username" : {
+      "comment" : "Uppercase field label above the username input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USERNAME"
+          }
+        }
+      }
+    },
+    "login.field.password" : {
+      "comment" : "Uppercase field label above the password input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PASSWORD"
+          }
+        }
+      }
+    },
+    "login.username.placeholder" : {
+      "comment" : "TextField prompt for the username input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you"
+          }
+        }
+      }
+    },
+    "login.discovered_servers" : {
+      "comment" : "Heading above the LAN-discovered server chip row.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FOUND ON THIS NETWORK"
+          }
+        }
+      }
+    },
+    "login.a11y.server_url" : {
+      "comment" : "Accessibility label for the server URL field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server URL"
+          }
+        }
+      }
+    },
+    "login.a11y.username" : {
+      "comment" : "Accessibility label for the username field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Username"
+          }
+        }
+      }
+    },
+    "login.a11y.password" : {
+      "comment" : "Accessibility label for the password field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        }
+      }
+    },
+    "menu.file.new_playlist" : {
+      "comment" : "File > New > New Playlist\u2026 menu item.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Playlist\u2026"
+          }
+        }
+      }
+    },
+    "menu.view.show_sidebar" : {
+      "comment" : "View menu item to toggle the sidebar visibility (placeholder until #5 lands).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Sidebar"
+          }
+        }
+      }
+    },
+    "menu.view.show_queue" : {
+      "comment" : "View menu item to toggle the queue inspector.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Queue Inspector"
+          }
+        }
+      }
+    },
+    "menu.nav.home" : {
+      "comment" : "View menu navigation entry for the Home screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
+    },
+    "menu.nav.library" : {
+      "comment" : "View menu navigation entry for the Library screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        }
+      }
+    },
+    "menu.nav.search" : {
+      "comment" : "View menu navigation entry for the Search screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        }
+      }
+    },
+    "menu.nav.find" : {
+      "comment" : "View > Find\u2026 menu item (\u2318F).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find\u2026"
+          }
+        }
+      }
+    },
+    "menu.nav.now_playing" : {
+      "comment" : "View menu item: \"Go to Now Playing\" (\u2318L).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to Now Playing"
+          }
+        }
+      }
+    },
+    "menu.nav.command_palette" : {
+      "comment" : "View menu item that opens the \u2318K Command Palette.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Command Palette\u2026"
+          }
+        }
+      }
+    },
+    "menu.playback" : {
+      "comment" : "Top-level Playback menu name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playback"
+          }
+        }
+      }
+    },
+    "menu.playback.play" : {
+      "comment" : "Playback menu item: Play.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play"
+          }
+        }
+      }
+    },
+    "menu.playback.pause" : {
+      "comment" : "Playback menu item: Pause.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        }
+      }
+    },
+    "menu.playback.next" : {
+      "comment" : "Playback menu item: Next Track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next Track"
+          }
+        }
+      }
+    },
+    "menu.playback.previous" : {
+      "comment" : "Playback menu item: Previous Track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Track"
+          }
+        }
+      }
+    },
+    "menu.playback.volume_up" : {
+      "comment" : "Playback menu item: Volume Up.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volume Up"
+          }
+        }
+      }
+    },
+    "menu.playback.volume_down" : {
+      "comment" : "Playback menu item: Volume Down.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volume Down"
+          }
+        }
+      }
+    },
+    "menu.playback.seek_forward" : {
+      "comment" : "Playback menu item: Seek Forward 10s.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seek Forward 10s"
+          }
+        }
+      }
+    },
+    "menu.playback.seek_back" : {
+      "comment" : "Playback menu item: Seek Back 10s.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seek Back 10s"
+          }
+        }
+      }
+    },
+    "menu.playback.stop" : {
+      "comment" : "Playback menu item: Stop.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
+          }
+        }
+      }
+    },
+    "menu.window.tile_left" : {
+      "comment" : "Window menu item: tile current window to left half of screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tile Window to Left of Screen"
+          }
+        }
+      }
+    },
+    "menu.window.tile_right" : {
+      "comment" : "Window menu item: tile current window to right half of screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tile Window to Right of Screen"
+          }
+        }
+      }
+    },
+    "menu.help.jellify" : {
+      "comment" : "Help menu entry that opens the repo in a browser.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jellify Help"
+          }
+        }
+      }
+    },
+    "menu.view.toggle_queue" : {
+      "comment" : "Invisible \u2318\u2325Q button label used to register the Queue Inspector shortcut inside MainShell.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Queue Inspector"
+          }
+        }
+      }
+    },
+    "player.nothing_playing" : {
+      "comment" : "PlayerBar left-meta label when no track is loaded.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing playing"
+          }
+        }
+      }
+    },
+    "sidebar.nav.home" : {
+      "comment" : "Sidebar primary nav item: Home.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
+    },
+    "sidebar.nav.library" : {
+      "comment" : "Sidebar primary nav item: Library.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        }
+      }
+    },
+    "sidebar.nav.search" : {
+      "comment" : "Sidebar primary nav item: Search.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        }
+      }
+    },
+    "sidebar.section.your_library" : {
+      "comment" : "Sidebar section header above the stats rows.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Library"
+          }
+        }
+      }
+    },
+    "sidebar.stats.favorites" : {
+      "comment" : "Sidebar stats row: Favorites.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        }
+      }
+    },
+    "sidebar.stats.albums" : {
+      "comment" : "Sidebar stats row: Albums.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albums"
+          }
+        }
+      }
+    },
+    "sidebar.stats.artists" : {
+      "comment" : "Sidebar stats row: Artists.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artists"
+          }
+        }
+      }
+    },
+    "sidebar.stats.playlists" : {
+      "comment" : "Sidebar stats row: Playlists.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playlists"
+          }
+        }
+      }
+    },
+    "stream.error.retry.a11y" : {
+      "comment" : "Accessibility label on the Retry button inside StreamErrorToast.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry playing the failed track"
+          }
+        }
+      }
+    },
+    "stream.error.go_to_track" : {
+      "comment" : "Secondary CTA on StreamErrorToast that routes to the failed track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to track"
+          }
+        }
+      }
+    },
+    "offline.retry.a11y" : {
+      "comment" : "Accessibility label on the Retry button inside OfflineBanner.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry network connection"
+          }
+        }
+      }
+    },
+    "offline.generic" : {
+      "comment" : "OfflineBanner message when the system reports no network.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're offline. Playing from downloaded tracks only."
+          }
+        }
+      }
+    },
+    "playlist.delete.message" : {
+      "comment" : "Body of the delete-playlist confirmation dialog.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will permanently delete this playlist. This action cannot be undone."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/macos/Sources/Jellify/Screens/LoginView.swift
+++ b/macos/Sources/Jellify/Screens/LoginView.swift
@@ -145,10 +145,10 @@ struct LoginView: View {
         VStack(spacing: 4) {
             JellyfishMark(size: 72)
                 .padding(.bottom, 4)
-            Text("Jellify")
+            Text("app.name")
                 .font(Theme.font(40, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("DESKTOP")
+            Text("app.subtitle.desktop")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(3)
@@ -158,7 +158,7 @@ struct LoginView: View {
     @ViewBuilder
     private var discoveredServersRow: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("FOUND ON THIS NETWORK")
+            Text("login.discovered_servers")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
@@ -193,11 +193,12 @@ struct LoginView: View {
     @ViewBuilder
     private var urlField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("SERVER URL")
+            Text("login.field.url")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            TextField("https://jellyfin.example.com", text: $url)
+            // URL placeholder is a sample host, not a translatable phrase.
+            TextField(String("https://jellyfin.example.com"), text: $url)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -212,7 +213,7 @@ struct LoginView: View {
                 .focused($focusedField, equals: .url)
                 .submitLabel(.next)
                 .onSubmit { focusedField = .username }
-                .accessibilityLabel("Server URL")
+                .accessibilityLabel("login.a11y.server_url")
         }
     }
 
@@ -228,7 +229,7 @@ struct LoginView: View {
             case .checking:
                 HStack(spacing: 6) {
                     ProgressView().controlSize(.mini)
-                    Text("Checking…")
+                    Text("login.probe.checking")
                         .font(Theme.font(12, weight: .medium))
                         .foregroundStyle(Theme.teal)
                 }
@@ -254,11 +255,11 @@ struct LoginView: View {
     @ViewBuilder
     private var usernameField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("USERNAME")
+            Text("login.field.username")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            TextField("you", text: $username)
+            TextField(LocalizedStringKey("login.username.placeholder"), text: $username)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -273,18 +274,19 @@ struct LoginView: View {
                 .focused($focusedField, equals: .username)
                 .submitLabel(.next)
                 .onSubmit { focusedField = .password }
-                .accessibilityLabel("Username")
+                .accessibilityLabel("login.a11y.username")
         }
     }
 
     @ViewBuilder
     private var passwordField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("PASSWORD")
+            Text("login.field.password")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            SecureField("••••••••", text: $password)
+            // Bullet glyphs are the masked-input affordance; not a phrase.
+            SecureField(String("••••••••"), text: $password)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -301,7 +303,7 @@ struct LoginView: View {
                 .onSubmit(submit)
                 .modifier(ShakeEffect(animatableData: CGFloat(shakeAttempts)))
                 .animation(.interpolatingSpring(stiffness: 800, damping: 10), value: shakeAttempts)
-                .accessibilityLabel("Password")
+                .accessibilityLabel("login.a11y.password")
         }
     }
 
@@ -314,7 +316,10 @@ struct LoginView: View {
                         .scaleEffect(0.7)
                         .tint(Theme.ink)
                 }
-                Text(model.isLoggingIn ? "Signing in…" : "Sign in")
+                // Toggle between the two catalog keys rather than the raw
+                // literals so translators never see "Signing in…" in a
+                // ternary — each shows up as its own extractable row.
+                Text(model.isLoggingIn ? LocalizedStringKey("auth.signing_in") : LocalizedStringKey("auth.sign_in"))
                     .font(Theme.font(14, weight: .bold))
             }
             .frame(maxWidth: .infinity)
@@ -328,7 +333,7 @@ struct LoginView: View {
         .disabled(model.isLoggingIn || !canSubmit)
         .opacity(canSubmit ? 1 : 0.5)
         .keyboardShortcut(.defaultAction)
-        .accessibilityLabel("Sign in")
+        .accessibilityLabel("auth.sign_in")
     }
 
     // MARK: - Actions
@@ -336,17 +341,21 @@ struct LoginView: View {
     private func submit() {
         guard canSubmit, !model.isLoggingIn else { return }
         let previousError = model.errorMessage
+        // Snapshot the localized copy that `JellifyErrorPresenter` emits for
+        // auth failures (401 / NotAuthenticated / AuthExpired). When the
+        // model surfaces this exact string we're dealing with a credential
+        // problem at submit-time, so replace it with the friendlier shake +
+        // wrong-credentials copy. See `JellifyErrorPresenter.key(for:)`.
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
         Task {
             await model.login(url: url, username: username, password: password)
-            // `AppModel.login` stuffs `"Login failed: <localized>"` into
-            // `errorMessage` on failure. Treat a 401 specially so we can
-            // shake the password field.
             if let err = model.errorMessage, err != previousError {
-                if err.contains("401") {
+                if err == authExpiredCopy {
                     shakeAttempts += 1
-                    // Overwrite the raw server error with a friendlier copy
-                    // so the row under the fields reads cleanly.
-                    model.errorMessage = "Wrong username or password"
+                    // Overwrite the generic "Please sign in again." with the
+                    // form-specific "Wrong username or password" so the row
+                    // under the fields reads cleanly.
+                    model.errorMessage = String(localized: "error.wrong_credentials", bundle: .main)
                 }
             }
         }
@@ -376,7 +385,10 @@ struct LoginView: View {
     }
 
     private var passwordBorderColor: Color {
-        if let err = model.errorMessage, err == "Wrong username or password" {
+        // Compare against the localized `error.wrong_credentials` copy so the
+        // border-tint heuristic continues to work regardless of language.
+        let wrongCreds = String(localized: "error.wrong_credentials", bundle: .main)
+        if let err = model.errorMessage, err == wrongCreds {
             return Theme.accentHot
         }
         return Theme.border
@@ -444,7 +456,7 @@ struct LoginNetworkBanner: View {
             Image(systemName: "wifi.slash")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Theme.danger)
-            Text("No network. Check your connection.")
+            Text("login.network_banner")
                 .font(Theme.font(12, weight: .semibold))
                 .foregroundStyle(Theme.ink)
             Spacer()

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -45,7 +45,7 @@ struct MainShell: View {
         // (SwiftUI elides hidden buttons from the responder chain), so the
         // button has a 1×1 clear frame that stays non-interactive.
         .background(
-            Button("Toggle Queue Inspector") { model.toggleQueueInspector() }
+            Button("menu.view.toggle_queue") { model.toggleQueueInspector() }
                 .keyboardShortcut("q", modifiers: [.command, .option])
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -73,10 +73,17 @@ struct MainShell: View {
             titleVisibility: .visible,
             presenting: model.playlistPendingDelete
         ) { _ in
-            Button("Delete", role: .destructive) { model.performDeletePending() }
-            Button("Cancel", role: .cancel) { model.cancelDeletePending() }
+            Button("common.delete", role: .destructive) { model.performDeletePending() }
+            Button("common.cancel", role: .cancel) { model.cancelDeletePending() }
         } message: { playlist in
-            Text("This will permanently delete \"\(playlist.name)\". This action cannot be undone.")
+            // Playlist name is user data — interpolate without attempting to
+            // localize it. The surrounding "This will permanently delete … "
+            // scaffolding lives in the catalog under `playlist.delete.message`;
+            // we prepend the name in quotes so the dialog still echoes which
+            // playlist is about to be deleted, then show the localized
+            // explainer on the next line.
+            Text(verbatim: "\u{201C}\(playlist.name)\u{201D}\n")
+                + Text("playlist.delete.message")
         }
     }
 

--- a/macos/Sources/Jellify/Screens/OnboardingView.swift
+++ b/macos/Sources/Jellify/Screens/OnboardingView.swift
@@ -291,10 +291,16 @@ private struct ConnectStep: View {
             && !password.isEmpty
     }
 
+    /// Generic error banner. Since `AppModel.login` now surfaces errors
+    /// through `JellifyErrorPresenter`, any 401 is already translated to
+    /// the shared `error.auth.expired` copy. We still want the onboarding
+    /// flow to replace that specific message with the form-specific
+    /// "Wrong username or password" hint.
     private var visibleError: String? {
         guard let err = model.errorMessage else { return nil }
-        if err.contains("401") {
-            return "Wrong username or password"
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
+        if err == authExpiredCopy {
+            return String(localized: "error.wrong_credentials", bundle: .main)
         }
         return err
     }
@@ -302,11 +308,12 @@ private struct ConnectStep: View {
     private func submit() {
         guard canSubmit, !model.isLoggingIn else { return }
         let previous = model.errorMessage
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
         Task {
             await model.login(url: url, username: username, password: password)
-            if let err = model.errorMessage, err != previous, err.contains("401") {
+            if let err = model.errorMessage, err != previous, err == authExpiredCopy {
                 shakeAttempts += 1
-                model.errorMessage = "Wrong username or password"
+                model.errorMessage = String(localized: "error.wrong_credentials", bundle: .main)
             }
         }
     }

--- a/macos/Sources/Jellify/Theme/Theme.swift
+++ b/macos/Sources/Jellify/Theme/Theme.swift
@@ -41,6 +41,32 @@ enum Theme {
     /// sizes ride `.body`; headline sizes ride `.title3` / `.title2` /
     /// `.largeTitle` depending on scale so they keep their relative rank
     /// when the user cranks text size up.
+    ///
+    /// ## Glyph fallback (#347)
+    ///
+    /// `Font.custom(name:size:)` ultimately resolves to a `CTFont` via Core
+    /// Text, which keeps a per-font cascade list. When a run contains a code
+    /// point the primary face (Figtree) doesn't cover — CJK ideographs,
+    /// Cyrillic, Arabic, Hebrew, Thai, Devanagari, emoji, etc. — Core Text
+    /// consults that cascade and substitutes from the system cascade list
+    /// (fall-back: `.AppleSystemUIFont` / `.SFNS-Regular`). The substitution
+    /// happens at the glyph layer, so a line that mixes Latin and CJK renders
+    /// Latin in Figtree and CJK in whichever system face covers those code
+    /// points — without the app having to detect the script itself.
+    ///
+    /// We verified this behaviour on macOS 14 with Figtree's published OTF
+    /// glyph set (Latin-1, Latin Extended-A/B, a handful of European
+    /// diacritics). The first non-covered run in a sentence switches to the
+    /// system default and the metrics stay compatible enough that line height
+    /// doesn't visibly jump. If a future Figtree release ships additional
+    /// scripts the cascade simply starts picking them up from the primary
+    /// face; nothing in this helper needs updating.
+    ///
+    /// SwiftUI also exposes `.font(_:)` modifiers that compose (e.g. a parent
+    /// `.font(.system)` scope would supply the fallback directly), but our
+    /// views set the Figtree font at the leaf and rely on Core Text's
+    /// per-glyph substitution here. Keeping the comment colocated with the
+    /// helper so future maintainers don't wire a redundant script detector.
     static func font(_ size: CGFloat, weight: Font.Weight = .regular, italic: Bool = false) -> Font {
         let name: String
         switch weight {


### PR DESCRIPTION
## Summary

- Introduces `macos/Sources/Jellify/Resources/Localizable.xcstrings` (English only) and migrates high-traffic menu, player, sidebar, auth, and error strings to `LocalizedStringKey`s.
- Adds `JellifyErrorPresenter` to translate UniFFI `JellifyError` Display strings into stable catalog keys; every `AppModel.errorMessage` assignment is now presenter-backed.
- Documents the Core Text per-font glyph fallback we already benefit from via `Font.custom("Figtree", ...)` so non-Latin runs substitute from the system cascade without any script detection in Swift.

Closes #345, #347, #351.

## Test plan

- [ ] `swift build` from `macos/` succeeds.
- [ ] Launch the app and verify sidebar / menu bar / player labels render the English strings from the catalog (no raw keys leak to UI).
- [ ] Trigger a library-load failure (offline server, bad URL) and confirm the banner reads "Couldn't load your library." instead of the raw Rust display string.
- [ ] Trigger a 401 via an expired token and confirm the auth-expired sheet still appears with localized copy.
- [ ] Verify a CJK-heavy track / album title renders without tofu (glyphs fall back to system font).