### PR TITLE
ci: archive macOS .app with ditto before artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,18 @@ jobs:
             exit 1
           fi
           kill $PID
+      # upload-artifact strips the common ancestor (so passing Jellify.app
+      # uploads its *contents*), and GitHub's zip layer drops symlinks —
+      # which silently breaks Sparkle.framework. ditto produces a proper
+      # macOS zip that preserves the bundle; we upload that.
+      - name: Archive .app bundle
+        working-directory: macos/build
+        run: ditto -c -k --sequesterRsrc --keepParent Jellify.app Jellify-macos-arm64.zip
       - name: Upload macOS app bundle
         uses: actions/upload-artifact@v4
         with:
           name: Jellify-macos-arm64
-          path: macos/build/Jellify.app
+          path: macos/build/Jellify-macos-arm64.zip
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
Fix the `Jellify-macos-arm64` CI artifact so the downloaded zip contains a working `.app` instead of a loose `Contents/` directory.

## Why

Two bugs in the current artifact upload:

1. **`upload-artifact@v4` strips the common ancestor.** Passing `macos/build/Jellify.app` as `path:` puts the bundle's *contents* (`Contents/`, `_CodeSignature/`, …) at the zip root — so the downloaded artifact is not a usable `.app`.
2. **GitHub's zip layer drops symlinks.** `Sparkle.framework` (and any future framework) relies on `Versions/Current -> A`; without symlink preservation the framework is silently broken at runtime.

## What changed

- `ci.yml` `macos-app` job: new `Archive .app bundle` step runs `ditto -c -k --sequesterRsrc --keepParent Jellify.app Jellify-macos-arm64.zip`, and `upload-artifact` uploads that single zip.
- `ditto` produces a macOS-aware zip that preserves the bundle directory and framework symlinks. Users double-unzip (GitHub wrapper → inner zip), but the inner zip opens to an intact, launchable `.app`.

## Verification

Reproduced locally with a release build from this commit:

- `ditto` zip contains `Jellify.app/` at the root (not loose `Contents/`).
- `unzip -l` shows `Sparkle.framework/Versions/Current` as a 1-byte entry (symlink), not a directory.
- After `ditto -x -k`, `ls -la Versions/` shows `Current -> B` as a real symlink.
- Extracted `Jellify.app/Contents/MacOS/Jellify` launches and stays up (same smoke pattern as the in-job test).

- [ ] `cargo test --workspace` passes — n/a (CI-only change)
- [ ] `swift build` clean — n/a
- [ ] `SmokeTest` — n/a
- [ ] Screenshot — n/a

## Out of scope

- No change to the signed/notarized DMG produced by `macos-release.yml` for tagged `v*` releases.
- Not switching to a single-zip distribution (GitHub always wraps artifacts in its own zip).
- Not adding a nightly GitHub Release — the auth-gated CI artifact is sufficient for the immediate use case.