### PR TITLE
macos: re-seal ad-hoc sig after install_name_tool

### DIFF
--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -129,6 +129,14 @@ if [[ -d "$SPARKLE_SRC" ]]; then
     # Sparkle.framework after we drop it under Contents/Frameworks.
     install_name_tool -add_rpath "@executable_path/../Frameworks" \
         "$APP/Contents/MacOS/Jellify" 2>/dev/null || true
+
+    # install_name_tool rewrote load commands in page 0 of __TEXT, invalidating
+    # the ad-hoc signature swift-build stamped on the executable. macOS 26's
+    # kernel refuses to map pages whose hashes don't match the embedded seal
+    # and kills the process on launch with "CODESIGNING Invalid Page" before
+    # main runs. Re-seal ad-hoc here so dev builds launch; sign.sh supersedes
+    # this with a real Developer ID signature for distribution.
+    codesign --force --sign - "$APP/Contents/MacOS/Jellify"
 fi
 
 # Drop the template into the bundle, then patch $VERSION / $BUILD in place.


### PR DESCRIPTION
Re-seal the executable's ad-hoc code signature after `install_name_tool` so dev bundles launch on macOS 26.

## Why

Dev builds of `Jellify.app` crash immediately on macOS 26 with `EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))` and `Termination Reason: Namespace CODESIGNING, Code 2, Invalid Page`. The crash fires inside dyld on the very first read of `Contents/MacOS/Jellify`'s `__TEXT` page 0, before `main` runs:

```
Thread 0 Crashed:
0  dyld  mach_o::UnsafeHeader::isMachO(...) + 12
1  dyld  dyld4::ExternallyViewableState::createMinimalInfo(...) + 372
2  dyld  start + 4700
```

Root cause is `make-bundle.sh` itself:

1. `swift build` ad-hoc signs the executable it produces (required by the kernel to execute on Apple Silicon).
2. `make-bundle.sh` copies that executable into `Contents/MacOS/` and, when Sparkle is present, runs `install_name_tool -add_rpath "@executable_path/../Frameworks"` on it so dyld can resolve `Sparkle.framework`.
3. `install_name_tool` rewrites load commands, which live in page 0 of `__TEXT`. The page hashes recorded in the embedded signature no longer match what's on disk.
4. macOS 26's kernel enforces page hashes strictly at load time and kills the process; earlier releases were more forgiving.

Since `Sparkle` is a hard dependency in `Package.swift`, this path fires on every dev build. `codesign --verify --strict --verbose=4` on a crashing bundle confirms the diagnosis:

```
macos/build/Jellify.app: invalid signature (code or signature have been modified)
macos/build/Jellify.app/Contents/MacOS/Jellify: invalid signature (code or signature have been modified)
```

Closes #

## What changed

- `macos/Scripts/make-bundle.sh` — after `install_name_tool`, run `codesign --force --sign -` on the executable to recompute page hashes and re-seal the ad-hoc signature. Placed inside the existing ``if [[ -d "$SPARKLE_SRC" ]]`` block since that's the only path that modifies the binary.

`sign.sh`'s Developer ID pass is unaffected — it re-signs with `--force` anyway, so the ad-hoc seal from this new step is just overwritten on release builds.

## Verification

- [x] ~~`cargo test --workspace` passes~~ (N/A — no Rust changes)
- [ ] `swift build` clean (if macOS change) — only the build script changed, no Swift/C code touched
- [x] ~~`SmokeTest` runs against a real Jellyfin server~~ (N/A — no audio/API changes)
- [x] ~~Screenshot attached~~ (N/A — no UI changes)
- [x] `shellcheck macos/Scripts/make-bundle.sh` clean
- [x] Reproduced the crash on macOS 26.4; `codesign --verify --strict --verbose=4` confirmed `invalid signature (code or signature have been modified)` on a pre-patch bundle
- [ ] Local rebuild + `open macos/build/Jellify.app` launches cleanly after patch (to be confirmed before merge)

## Out of scope

- Re-sealing the full bundle (`_CodeSignature/`) — `make-bundle.sh` doesn't produce a bundle-level seal; `codesign --verify` on the bundle delegates to the executable's embedded signature, so re-signing the executable is sufficient.
- Hardened-runtime flag (`--options runtime`) on the ad-hoc seal — left off intentionally for dev-build debuggability (e.g. `DYLD_INSERT_LIBRARIES`). `sign.sh` applies it on release builds.