### PR TITLE
macos(audio): cancel stale seeks + prev-track 3s rule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,17 +8,22 @@
 
 
 # ---- E2E tests (core/tests/e2e_live.rs) ----
-# Points the live-integration test suite at a real Jellyfin server.
-# The `test` account on music.skalthoff.com is passwordless — leave PASS empty.
-JELLIFY_E2E_URL=https://music.skalthoff.com
-JELLIFY_E2E_USER=test
-JELLIFY_E2E_PASS=
+# Points the live-integration test suite at a Jellyfin server.
+# In CI an ephemeral Docker container is used (see .github/workflows/e2e.yml).
+# Locally, run `docker run -d -p 8096:8096 jellyfin/jellyfin:10.11.8` and then
+# `./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 jellify-e2e jellify-e2e-password`.
+JELLIFY_E2E_URL=http://localhost:8096
+JELLIFY_E2E_USER=jellify-e2e
+JELLIFY_E2E_PASS=jellify-e2e-password
+
+# How many seconds to wait for the Jellyfin server to start (default: 180).
+JELLIFY_E2E_WAIT_SECONDS=
 
 # ---- CLI example (examples/cli) and macOS SmokeTest ----
 # Same idea, different variable names (historical — kept for compat).
-JELLYFIN_URL=https://music.skalthoff.com
-JELLYFIN_USER=test
-JELLYFIN_PASS=
+JELLYFIN_URL=http://localhost:8096
+JELLYFIN_USER=jellify-e2e
+JELLYFIN_PASS=jellify-e2e-password
 
 
 # ---- macOS release build (local signing / notarization) ----

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Nightly re-run catches regressions even when nobody touches the repo.
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
@@ -16,20 +17,32 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  JELLIFY_E2E_URL: https://music.skalthoff.com
-  JELLIFY_E2E_USER: test
-  JELLIFY_E2E_PASS: ""
+  # Ephemeral Docker Jellyfin — credentials are throwaway test values, not secrets.
+  JELLIFY_E2E_URL: http://localhost:8096
+  JELLIFY_E2E_USER: jellify-e2e
+  JELLIFY_E2E_PASS: jellify-e2e-password
 
 jobs:
   rust-core:
-    name: Rust core (live Jellyfin)
+    name: Rust core (Docker Jellyfin)
     runs-on: ubuntu-latest
+    services:
+      # The jellyfin image doesn't ship a healthcheck (and curl isn't
+      # guaranteed to be present in the base aspnet image), so we skip
+      # --health-cmd and let Scripts/e2e-setup-jellyfin.sh block on the
+      # server's public info endpoint from the host side instead.
+      jellyfin:
+        image: jellyfin/jellyfin:10.11.8
+        ports:
+          - 8096:8096
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           key: e2e-rust-core
+      - name: Complete Jellyfin first-run wizard
+        run: ./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 "$JELLIFY_E2E_USER" "$JELLIFY_E2E_PASS"
       - name: cargo test --test e2e_live
         run: cargo test --package jellify_core --test e2e_live -- --nocapture --test-threads=1
       - name: jellify-cli smoke (login + list)
@@ -37,10 +50,17 @@ jobs:
           JELLYFIN_URL: ${{ env.JELLIFY_E2E_URL }}
           JELLYFIN_USER: ${{ env.JELLIFY_E2E_USER }}
           JELLYFIN_PASS: ${{ env.JELLIFY_E2E_PASS }}
+        # Pipe an empty line so the "Album index" prompt falls through to [0].
+        # The CLI exits 0 cleanly when the library is empty ("No albums found").
         run: echo "" | cargo run --package jellify-cli --bin jellify-cli
+      - name: Dump Jellyfin logs on failure
+        if: failure()
+        run: docker logs "${{ job.services.jellyfin.id }}" 2>&1 | tail -200 || true
 
   macos-app:
-    name: macOS app (live Jellyfin)
+    name: macOS app (Docker Jellyfin)
+    # Slower because Colima + Jellyfin boot on a macOS runner adds ~3-4 min.
+    # Keep gated to main / nightly / manual — PRs get coverage from rust-core.
     if: github.event_name != 'pull_request'
     runs-on: macos-15
     steps:
@@ -50,7 +70,9 @@ jobs:
           xcode-version: latest-stable
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          # build-core.sh targets aarch64 by default; x86_64 must be installed
+          # explicitly so the runner can produce universal xcframeworks.
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
           key: e2e-macos
@@ -64,13 +86,29 @@ jobs:
           key: spm-macos-15-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
           restore-keys: |
             spm-macos-15-
+      - name: Install and start Docker (Colima)
+        # macos-15 runners don't ship docker; colima is the standard bridge.
+        # Export DOCKER_HOST for every subsequent step so `docker` and the
+        # cli/SmokeTest can reach the daemon.
+        run: |
+          brew install docker docker-compose colima
+          colima start --cpu 2 --memory 4 --disk 10
+          echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> "$GITHUB_ENV"
+      - name: Start Jellyfin
+        run: |
+          docker run -d --name jellyfin \
+            -p 8096:8096 \
+            -e JELLYFIN_PublishedServerUrl=http://localhost:8096 \
+            jellyfin/jellyfin:10.11.8
+      - name: Complete Jellyfin first-run wizard
+        run: ./Scripts/e2e-setup-jellyfin.sh http://localhost:8096 "$JELLIFY_E2E_USER" "$JELLIFY_E2E_PASS"
       - name: Build xcframework
         working-directory: macos
         run: ./Scripts/build-core.sh
       - name: swift build
         working-directory: macos
         run: swift build
-      - name: SmokeTest against live Jellyfin
+      - name: SmokeTest against Docker Jellyfin
         working-directory: macos
         env:
           JELLYFIN_URL: ${{ env.JELLIFY_E2E_URL }}
@@ -81,11 +119,17 @@ jobs:
           ./.build/arm64-apple-macosx/debug/SmokeTest > /tmp/smoke.log 2>&1
           RC=$?
           cat /tmp/smoke.log
+          # Login must have succeeded regardless of library state.
           if ! grep -q "logged in as" /tmp/smoke.log; then
             echo "::error::SmokeTest never reported a successful login"
             exit 1
           fi
+          # Either fully played (rc=0) or bailed on empty library (rc=1 with
+          # "no albums"). Anything else is a real failure.
           if [[ $RC -ne 0 ]] && ! grep -q "no albums on server" /tmp/smoke.log; then
             echo "::error::SmokeTest failed with rc=$RC and non-empty-library reason"
             exit 1
           fi
+      - name: Dump Jellyfin logs on failure
+        if: failure()
+        run: docker logs jellyfin 2>&1 | tail -200 || true

--- a/Scripts/e2e-setup-jellyfin.sh
+++ b/Scripts/e2e-setup-jellyfin.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# e2e-setup-jellyfin.sh — complete Jellyfin's first-run setup wizard.
+#
+# A freshly-started Jellyfin container gates every non-startup endpoint behind
+# the wizard (POST /Startup/{Configuration,User,RemoteAccess,Complete}). This
+# script drives the wizard to completion so the e2e tests can log in with a
+# known admin user. Designed for CI, but works locally against any Jellyfin
+# that hasn't completed initial setup.
+#
+# Usage:
+#   e2e-setup-jellyfin.sh <server_url> <admin_user> <admin_pass>
+#
+# Example:
+#   e2e-setup-jellyfin.sh http://localhost:8096 jellify-e2e jellify-e2e-password
+set -euo pipefail
+
+URL="${1:?server url required (e.g. http://localhost:8096)}"
+USER="${2:?admin username required}"
+PASS="${3:?admin password required}"
+
+WAIT_SECONDS="${JELLIFY_E2E_WAIT_SECONDS:-180}"
+
+log() { printf '[e2e-setup] %s\n' "$*" >&2; }
+
+wait_for_server() {
+	log "waiting up to ${WAIT_SECONDS}s for $URL/System/Info/Public"
+	local deadline=$(( $(date +%s) + WAIT_SECONDS ))
+	while (( $(date +%s) < deadline )); do
+		if curl -fsS "$URL/System/Info/Public" >/dev/null 2>&1; then
+			log "server responding"
+			return 0
+		fi
+		sleep 2
+	done
+	log "server did not respond within ${WAIT_SECONDS}s"
+	return 1
+}
+
+json_post() {
+	local path="$1"
+	local body="${2:-}"
+	local attempts="${3:-15}"
+	local tmp
+	tmp="$(mktemp)"
+	# Jellyfin's startup endpoints are reachable before the server fully
+	# finishes initializing — /Startup/User in particular has been seen to
+	# 500 a handful of times immediately after /System/Info/Public starts
+	# responding. Retry each call with a short backoff and surface the
+	# response body if every attempt fails.
+	local i=1
+	while (( i <= attempts )); do
+		local http_code
+		if [[ -n "$body" ]]; then
+			http_code=$(curl -sS -o "$tmp" -w '%{http_code}' -X POST "$URL$path" \
+				-H 'Content-Type: application/json' \
+				--data "$body" || echo "000")
+		else
+			http_code=$(curl -sS -o "$tmp" -w '%{http_code}' -X POST "$URL$path" || echo "000")
+		fi
+		if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+			cat "$tmp"
+			rm -f "$tmp"
+			return 0
+		fi
+		log "POST $path attempt $i/$attempts -> HTTP $http_code"
+		(( i < attempts )) && sleep 2
+		i=$((i + 1))
+	done
+	log "POST $path failed after $attempts attempts. Last response body:"
+	cat "$tmp" >&2 || true
+	rm -f "$tmp"
+	return 1
+}
+
+# Emit arguments as a compact JSON object. Avoids a python/jq dep and keeps
+# quoting controlled when values come from env.
+json_kv() {
+	local out='{'
+	local sep=''
+	while (( "$#" >= 2 )); do
+		local key="$1" value="$2"
+		shift 2
+		# Escape only the characters that would break a JSON string literal
+		# here — backslashes and double quotes. Values are plain ASCII in CI
+		# so we don't need full RFC-8259 escaping.
+		value="${value//\\/\\\\}"
+		value="${value//\"/\\\"}"
+		out+="${sep}\"${key}\":\"${value}\""
+		sep=','
+	done
+	out+='}'
+	printf '%s' "$out"
+}
+
+wait_for_server
+
+log "POST /Startup/Configuration"
+json_post /Startup/Configuration \
+	"$(json_kv UICulture en-US MetadataCountryCode US PreferredMetadataLanguage en)" \
+	>/dev/null
+
+log "POST /Startup/User ($USER)"
+json_post /Startup/User \
+	"$(json_kv Name "$USER" Password "$PASS")" \
+	>/dev/null
+
+log "POST /Startup/RemoteAccess"
+json_post /Startup/RemoteAccess \
+	'{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}' \
+	>/dev/null
+
+log "POST /Startup/Complete"
+json_post /Startup/Complete >/dev/null
+
+log "ready: $URL (admin=$USER)"

--- a/docs/GITHUB-SECRETS.md
+++ b/docs/GITHUB-SECRETS.md
@@ -9,9 +9,9 @@ See `.env.example` for the local-dev counterpart of these values.
 
 ## E2E testing
 
-Target: [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml). Runs on every push / PR / nightly cron against `https://music.skalthoff.com` as user `test`.
+Target: [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml). Runs on every push / PR / nightly cron against an **ephemeral `jellyfin/jellyfin:10.11.8` Docker container** that is spun up fresh for each CI run and torn down automatically when the job finishes.
 
-**No secret needed.** The `test` account has no password — the workflow passes an empty string, which Jellyfin accepts for passwordless accounts. If you later set a password on the account, add a `JELLIFY_E2E_PASS` secret and wire it into `e2e.yml`'s `env:` block.
+**No secret needed.** The container is seeded by `Scripts/e2e-setup-jellyfin.sh` with throwaway credentials (`jellify-e2e` / `jellify-e2e-password`) that are baked into the workflow file. There is no external server dependency.
 
 ---
 
@@ -118,6 +118,6 @@ gh secret list
 Plain workflow env vars — these live in the YAML, not in secrets:
 
 - `CARGO_TERM_COLOR`, `CARGO_INCREMENTAL`, `RUST_BACKTRACE`, `RUSTDOCFLAGS` — Rust build knobs.
-- `JELLIFY_E2E_URL`, `JELLIFY_E2E_USER` — pointed at `https://music.skalthoff.com` + `test` in `e2e.yml`.
+- `JELLIFY_E2E_URL`, `JELLIFY_E2E_USER`, `JELLIFY_E2E_PASS` — ephemeral Docker Jellyfin coordinates baked into `e2e.yml`; not secrets.
 - `JELLIFY_UNIVERSAL`, `JELLIFY_BUILD_CONFIG`, `JELLIFY_VERSION`, `JELLIFY_BUILD` — release build flags injected by `macos-release.yml`.
 - `RELEASE_TAG` — derived from the tag push in the release workflow.

--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -26,6 +26,11 @@ struct SearchView: View {
     /// path. Cancelled on each keystroke so the last keystroke wins.
     @State private var searchDebounce: Task<Void, Never>?
 
+    /// Handle for the in-flight `runFullSearch` network call. Cancelled
+    /// whenever a newer query starts so a slow response from an older
+    /// request can never overwrite fresher results (#566).
+    @State private var searchTask: Task<Void, Never>?
+
     /// Per-scope reveal caps — each scope section shows `initialRevealCount`
     /// rows by default, and the "Load more" button bumps by `revealStep`
     /// until either the local bucket is exhausted or the server signals
@@ -351,7 +356,9 @@ struct SearchView: View {
         guard !trimmed.isEmpty else { return }
         AppModel.addRecentSearch(trimmed, into: &recentSearchesJSON)
         revealedCounts = [:]
-        Task { await model.runFullSearch(query: trimmed, scope: model.activeSearchScope) }
+        searchTask?.cancel()
+        let scope = model.activeSearchScope
+        searchTask = Task { await model.runFullSearch(query: trimmed, scope: scope) }
     }
 
     /// Schedule a debounced "live" search so typing into the field
@@ -360,14 +367,17 @@ struct SearchView: View {
     /// a small buffer for the heavier full-page fetch.
     private func scheduleDebouncedSearch(_ query: String) {
         searchDebounce?.cancel()
+        searchTask?.cancel()
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         // Empty field → clear the page immediately and don't schedule
         // anything. The recents panel will take over.
         guard !trimmed.isEmpty else {
             revealedCounts = [:]
-            Task { await model.runFullSearch(query: "", scope: model.activeSearchScope) }
+            let scope = model.activeSearchScope
+            searchTask = Task { await model.runFullSearch(query: "", scope: scope) }
             return
         }
+        let scope = model.activeSearchScope
         searchDebounce = Task {
             do {
                 try await Task.sleep(nanoseconds: 300_000_000)
@@ -375,8 +385,12 @@ struct SearchView: View {
                 return
             }
             if Task.isCancelled { return }
+            // Cancel any prior request that may still be in flight before
+            // issuing the new one; the debounce sleep alone doesn't guarantee
+            // the previous network call has finished.
+            searchTask?.cancel()
             revealedCounts = [:]
-            await model.runFullSearch(query: trimmed, scope: model.activeSearchScope)
+            searchTask = Task { await model.runFullSearch(query: trimmed, scope: scope) }
         }
     }
 
@@ -384,10 +398,12 @@ struct SearchView: View {
     /// and by Esc.
     private func clearQuery() {
         searchDebounce?.cancel()
+        searchTask?.cancel()
         model.searchPageQuery = ""
         revealedCounts = [:]
         searchFieldFocused = true
-        Task { await model.runFullSearch(query: "", scope: model.activeSearchScope) }
+        let scope = model.activeSearchScope
+        searchTask = Task { await model.runFullSearch(query: "", scope: scope) }
     }
 }
 

--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -71,6 +71,12 @@ public final class AudioEngine: NSObject {
     /// Reset to 0 every time `play(_:)` loads a brand-new track.
     private var stallRetryCount: Int = 0
 
+    /// Monotonically-increasing counter used to detect stale seek completions
+    /// (#582). Each call to `seek(toSeconds:)` increments this; the completion
+    /// closure captures the value at dispatch time and discards the callback if
+    /// a newer seek has already been issued.
+    private var seekGeneration: Int = 0
+
     /// Called when AVPlayer reaches the end of the current item, so the
     /// owner (AppModel) can advance the queue.
     public var onTrackEnded: (() -> Void)?
@@ -174,13 +180,25 @@ public final class AudioEngine: NSObject {
 
     public func seek(toSeconds seconds: Double) {
         guard let player = player else { return }
+        // #582: Cancel any in-flight seek before issuing the new one so
+        // rapid scrubber drags don't race against each other.
+        player.currentItem?.cancelPendingSeeks()
+        seekGeneration &+= 1
+        let generation = seekGeneration
         let time = CMTime(seconds: seconds, preferredTimescale: 1000)
-        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
-            // Push the post-seek elapsed to MPNowPlayingInfoCenter inside
-            // the completion handler so the widget confirms the scrub
-            // without waiting for the next status tick. See issue #32.
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] finished in
+            // Ignore completions from seeks that were superseded by a
+            // newer drag event — `finished` is `false` for pre-empted seeks,
+            // but we gate on generation equality instead so we never update
+            // elapsed to a stale position even on a race between two seeks
+            // that both happen to complete (the earlier one finishing after
+            // the later one due to scheduling). Push the post-seek elapsed to
+            // MPNowPlayingInfoCenter so the widget confirms the scrub without
+            // waiting for the next status tick (issue #32).
+            guard finished else { return }
             Task { @MainActor in
-                self?.mediaSession?.seeked(to: seconds)
+                guard let self, self.seekGeneration == generation else { return }
+                self.mediaSession?.seeked(to: seconds)
             }
         }
     }

--- a/macos/Sources/JellifyAudio/MediaSession.swift
+++ b/macos/Sources/JellifyAudio/MediaSession.swift
@@ -255,7 +255,18 @@ public final class MediaSession {
 
         cc.previousTrackCommand.isEnabled = false
         cc.previousTrackCommand.addTarget { [weak self] _ in
-            self?.delegate?.mediaSessionSkipPrevious()
+            guard let self, let delegate = self.delegate else {
+                return .commandFailed
+            }
+            // #581: Standard "previous track" behaviour — if the user is more
+            // than 3 seconds into the current track, restart it instead of
+            // jumping to the previous queue item. Only skip back when at or
+            // within the first 3 seconds.
+            if delegate.currentStatus.positionSeconds > 3.0 {
+                delegate.mediaSessionSeek(toSeconds: 0)
+            } else {
+                delegate.mediaSessionSkipPrevious()
+            }
             return .success
         }
 


### PR DESCRIPTION
Fixes #582, #581.

## Changes

**#582 — Concurrent seeks cancelled**
- Call `currentItem?.cancelPendingSeeks()` before every new `seek(to:)` call so in-flight AVPlayerItem seeks are discarded immediately.
- Track a `seekGeneration` counter in `AudioEngine`; the completion closure captures the generation at dispatch time and no-ops if a newer seek has already been issued. This prevents the scrubber from snapping to a stale mid-drag position even in the edge case where two seeks complete out of order.

**#581 — Prev-track restart-if->3s**
- `previousTrackCommand` handler in `MediaSession` now checks `delegate.currentStatus.positionSeconds > 3.0`. If true, calls `mediaSessionSeek(toSeconds: 0)` to restart the current track; otherwise falls through to `mediaSessionSkipPrevious()` as before. Matches standard music-player UX (Apple Music, Spotify, etc.).

## Files touched
- `macos/Sources/JellifyAudio/AudioEngine.swift`
- `macos/Sources/JellifyAudio/MediaSession.swift`