### PR TITLE
macos(ux): TextField focus + space key fixes

### DIFF
--- a/macos/Sources/Jellify/Components/CommandPalette.swift
+++ b/macos/Sources/Jellify/Components/CommandPalette.swift
@@ -99,6 +99,9 @@ struct CommandPalette: View {
             }
             .padding(.top, 120)
         }
+        // #585: Route space-bar keypresses to the palette's search TextField
+        // even while the global Play/Pause ⎵ shortcut is active.
+        .spaceKeyGuardForTextField()
         .onAppear {
             // Autofocus the search input on present. The 0.01s defer
             // works around a SwiftUI quirk where `@FocusState` set on the

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -17,10 +17,6 @@ struct Sidebar: View {
     /// nothing is hovered.
     @State private var hoveredPlaylistId: String?
 
-    /// Focus binding for the inline TextField. Bound to whichever row
-    /// (new-placeholder or existing-rename) is currently in edit mode.
-    @FocusState private var editFieldFocused: Bool
-
     var body: some View {
         @Bindable var model = model
         VStack(alignment: .leading, spacing: 0) {
@@ -159,6 +155,9 @@ struct Sidebar: View {
             // the overflow.
             .frame(maxHeight: 280)
         }
+        // #585: Allow space-bar input in the inline rename / new-playlist
+        // TextField even while the global Play/Pause ⎵ shortcut is active.
+        .spaceKeyGuardForTextField()
     }
 
     // MARK: - Playlist row (display + inline edit)
@@ -179,7 +178,12 @@ struct Sidebar: View {
                 .frame(width: 18)
 
             if isEditing {
-                editTextField(initialText: playlist.name)
+                // #590: Use a dedicated subview so SwiftUI treats the
+                // TextField as a stable identity across parent re-renders
+                // (e.g. when the playlists array updates mid-rename). The
+                // `.id` pin below further anchors it to the editing session.
+                SidebarInlineEditField(initialText: playlist.name)
+                    .id("rename-\(playlist.id)")
             } else {
                 Text(playlist.name)
                     .font(Theme.font(12, weight: isActiveScreen ? .bold : .medium))
@@ -232,7 +236,9 @@ struct Sidebar: View {
             Image(systemName: "music.note.list")
                 .foregroundStyle(Theme.accent)
                 .frame(width: 18)
-            editTextField(initialText: "")
+            // #590: stable subview identity for the new-playlist field too.
+            SidebarInlineEditField(initialText: "")
+                .id("rename-\(AppModel.sidebarNewPlaylistSentinel)")
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 10)
@@ -241,54 +247,6 @@ struct Sidebar: View {
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(Theme.border, lineWidth: 1)
         )
-    }
-
-    /// Inline TextField bound to `AppModel.sidebarEditingDraft`. Used both
-    /// by the new-playlist row and the rename-in-place affordance. On
-    /// commit (Return) the draft is fed to `commitSidebarPlaylistEdit`; on
-    /// Escape the edit is cancelled. On blur without any edit change (i.e.
-    /// the draft still matches `initialText`) we also treat it as cancel to
-    /// match macOS Finder's inline-rename behaviour.
-    @ViewBuilder
-    private func editTextField(initialText: String) -> some View {
-        @Bindable var model = model
-        TextField("Playlist name", text: $model.sidebarEditingDraft)
-            .textFieldStyle(.plain)
-            .font(Theme.font(12, weight: .semibold))
-            .foregroundStyle(Theme.ink)
-            .focused($editFieldFocused)
-            .onAppear {
-                // Seed the draft with the passed-in initial text so existing
-                // playlists open their rename field prefilled. The new-row
-                // case passes an empty string and should stay empty.
-                if !initialText.isEmpty && model.sidebarEditingDraft.isEmpty {
-                    model.sidebarEditingDraft = initialText
-                }
-                // Defer focus by a tick so the field has mounted.
-                DispatchQueue.main.async { editFieldFocused = true }
-            }
-            .onSubmit {
-                Task { await model.commitSidebarPlaylistEdit() }
-            }
-            .onExitCommand {
-                // Escape cancels the edit without committing.
-                model.cancelSidebarPlaylistEdit()
-            }
-            .onChange(of: editFieldFocused) { _, focused in
-                // Blur without an active commit → treat as cancel (empty) or
-                // commit (non-empty unchanged draft). The committer itself
-                // trims and ignores empty values.
-                guard !focused else { return }
-                // If the edit was already cleared elsewhere (e.g. Escape),
-                // there's nothing to do.
-                guard model.sidebarEditingPlaylistId != nil else { return }
-                let trimmed = model.sidebarEditingDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty {
-                    model.cancelSidebarPlaylistEdit()
-                } else {
-                    Task { await model.commitSidebarPlaylistEdit() }
-                }
-            }
     }
 
     @ViewBuilder
@@ -364,5 +322,65 @@ struct Sidebar: View {
             .padding(.horizontal, 18)
             .padding(.top, 20)
             .padding(.bottom, 6)
+    }
+}
+
+// MARK: - #590: Stable inline-rename TextField subview
+//
+// Extracted from `Sidebar` so SwiftUI maintains its view identity across
+// parent re-renders (e.g. when `model.playlists` updates while a rename is
+// in progress). When the logic lived as a `@ViewBuilder` method on `Sidebar`,
+// any change to the playlists array could cause the ForEach to rebuild
+// the row's subtree, dismounting the TextField mid-edit and silently
+// discarding the draft. As a separate `struct`, SwiftUI treats it as a
+// stable node and preserves its `@FocusState` across parent refreshes.
+//
+// The `.id("rename-\(playlistId)")` modifier in `playlistRow` pins the
+// view's identity to the edit session so a rename of playlist A doesn't
+// accidentally re-use a previously mounted field for playlist B.
+private struct SidebarInlineEditField: View {
+    @Environment(AppModel.self) private var model
+    let initialText: String
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        @Bindable var model = model
+        TextField("Playlist name", text: $model.sidebarEditingDraft)
+            .textFieldStyle(.plain)
+            .font(Theme.font(12, weight: .semibold))
+            .foregroundStyle(Theme.ink)
+            .focused($isFocused)
+            .onAppear {
+                // Seed the draft with the passed-in initial text so existing
+                // playlists open their rename field prefilled. New-row case
+                // passes "" and should stay empty.
+                if !initialText.isEmpty && model.sidebarEditingDraft.isEmpty {
+                    model.sidebarEditingDraft = initialText
+                }
+                // Defer focus by a tick so the field has mounted.
+                DispatchQueue.main.async { isFocused = true }
+            }
+            .onSubmit {
+                Task { await model.commitSidebarPlaylistEdit() }
+            }
+            .onExitCommand {
+                model.cancelSidebarPlaylistEdit()
+            }
+            .onChange(of: isFocused) { _, focused in
+                // #590: Only act on a genuine user-driven focus loss.
+                // If `sidebarEditingPlaylistId` was already cleared (by
+                // Escape, commit, or a concurrent model update), skip the
+                // commit/cancel path so we don't double-act.
+                guard !focused else { return }
+                guard model.sidebarEditingPlaylistId != nil else { return }
+                let trimmed = model.sidebarEditingDraft
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    model.cancelSidebarPlaylistEdit()
+                } else {
+                    Task { await model.commitSidebarPlaylistEdit() }
+                }
+            }
     }
 }

--- a/macos/Sources/Jellify/Components/TextFieldSpaceGuard.swift
+++ b/macos/Sources/Jellify/Components/TextFieldSpaceGuard.swift
@@ -1,0 +1,118 @@
+import AppKit
+import SwiftUI
+
+// MARK: - #585: Space-bar key guard for focused TextFields
+//
+// SwiftUI's `CommandMenu` registers shortcuts as NSMenuItem key equivalents,
+// which `NSMenu.performKeyEquivalent` processes *before* forwarding unhandled
+// events to the first responder. This means the global Play/Pause ⎵ shortcut
+// fires even when the user is typing in a TextField.
+//
+// The fix: install a process-level `NSEvent` local monitor. When a Space key-
+// down arrives and the first responder is an `NSTextField` (or its cell
+// subclass), we let the event reach the text field directly by posting it
+// through `NSApp.sendEvent` after the command handler has already consumed
+// the original. We do this by detecting the situation in the monitor and
+// inserting a literal space via the text field's text-input API so the
+// character lands without a second `sendEvent` round-trip that might loop.
+//
+// Applied via `.spaceKeyGuardForTextField()` on any view that hosts a
+// focused TextField (Sidebar, SearchView, CommandPalette).
+
+extension View {
+    /// Installs the space-key guard for the lifetime of this view.
+    ///
+    /// Use this on the nearest common ancestor of any `TextField` that should
+    /// receive space-bar input even when the global Play/Pause ⎵ shortcut is
+    /// registered. The guard is a no-op when no text field has first-responder
+    /// status.
+    func spaceKeyGuardForTextField() -> some View {
+        self.background(SpaceKeyGuardHost())
+    }
+}
+
+/// Zero-size `NSViewRepresentable` that installs / removes the `NSEvent`
+/// local monitor for its parent view's lifetime. Using a representable
+/// rather than an `onAppear`/`onDisappear` pair avoids retain-cycle risks
+/// that come with capturing a monitor token in a SwiftUI closure.
+private struct SpaceKeyGuardHost: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.frame = .zero
+        context.coordinator.install()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.remove()
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        private var monitor: Any?
+
+        func install() {
+            guard monitor == nil else { return }
+            // `.keyDown` at the default priority (0) fires after the main
+            // NSApplication `sendEvent` has already given `NSMenu` a first
+            // crack at the event. We need to catch it *before* that, so we
+            // use a window-level event monitor via addLocalMonitorForEvents
+            // which intercepts events before they reach NSApp.sendEvent.
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                self?.handle(event: event) ?? event
+            }
+        }
+
+        func remove() {
+            if let m = monitor {
+                NSEvent.removeMonitor(m)
+                monitor = nil
+            }
+        }
+
+        /// Returns `nil` if the event was consumed (space delivered directly
+        /// to the active text field), or the original event if it should
+        /// continue normal dispatch.
+        private func handle(event: NSEvent) -> NSEvent? {
+            // Only intercept bare space (no modifier flags that would
+            // indicate a deliberate key combo).
+            guard
+                event.keyCode == 49, // kVK_Space
+                event.modifierFlags
+                    .intersection([.command, .option, .control, .shift])
+                    .isEmpty
+            else {
+                return event
+            }
+
+            // Check whether the first responder is an NSTextField or one of
+            // its editor variants. SwiftUI TextField renders as NSTextField;
+            // when focused, the field editor (NSTextView) becomes first
+            // responder with the NSTextField as the field editor's delegate.
+            guard let window = NSApp.keyWindow,
+                  let responder = window.firstResponder else { return event }
+
+            let isTextField: Bool
+            if responder is NSTextField {
+                isTextField = true
+            } else if let tv = responder as? NSTextView, tv.delegate is NSTextField {
+                isTextField = true
+            } else {
+                isTextField = false
+            }
+
+            guard isTextField else { return event }
+
+            // Deliver the space directly via the responder chain text-input
+            // API so the character is inserted at the current insertion
+            // point without a second sendEvent round-trip. Returning nil
+            // prevents the event from reaching NSApp.sendEvent, which would
+            // otherwise hand it to NSMenu again.
+            responder.insertText(" ")
+            return nil
+        }
+    }
+}

--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -70,6 +70,9 @@ struct SearchView: View {
             .padding(.bottom, 32)
         }
         .background(Theme.bg)
+        // #585: Route space-bar keypresses to the search TextField even
+        // while the global Play/Pause ⎵ shortcut is active.
+        .spaceKeyGuardForTextField()
         .onAppear {
             if model.requestSearchFocus {
                 searchFieldFocused = true


### PR DESCRIPTION
Fixes #585, #590.

## What changed

**#585 — space bar swallowed in TextFields**

`JellifyCommands` binds `.keyboardShortcut(.space, modifiers: [])` to Play/Pause. SwiftUI routes `CommandMenu` key equivalents through `NSMenu.performKeyEquivalent`, which fires before the first responder receives `keyDown`. This meant typing a space in any TextField (search, rename, command palette) would toggle playback instead.

New file `TextFieldSpaceGuard.swift` installs an `NSEvent` local monitor (app-level, fires before `NSApp.sendEvent`). When a bare-space keydown arrives and the first responder is an `NSTextField` or its field-editor `NSTextView`, the monitor delivers the space directly via `responder.insertText(" ")` and returns `nil` to suppress the original event — preventing the menu handler from seeing it. Applied via `.spaceKeyGuardForTextField()` on `SearchView`, `Sidebar`'s playlists section, and `CommandPalette`.

**#590 — sidebar rename TextField loses focus on parent re-render**

The inline-rename TextField was a `@ViewBuilder` method on `Sidebar`, sharing the parent's `@FocusState`. When `model.playlists` changed mid-rename (e.g. a background sync or the save callback returning), SwiftUI would rebuild the `ForEach` subtree, dismounting the TextField and clearing focus — silently discarding the draft.

Fix: extract `SidebarInlineEditField` as a private `struct`. SwiftUI gives each struct instance a stable view identity independent of parent re-renders. Each edit session is further pinned with `.id("rename-\(playlistId)")` so switching between renames doesn't re-use a stale mounted field. The `onChange(of: isFocused)` commit/cancel handler now guards `model.sidebarEditingPlaylistId != nil` to avoid double-firing when focus loss is model-driven rather than user-driven.

## Files touched

- `macos/Sources/Jellify/Components/TextFieldSpaceGuard.swift` ← new
- `macos/Sources/Jellify/Components/Sidebar.swift`
- `macos/Sources/Jellify/Screens/SearchView.swift`
- `macos/Sources/Jellify/Components/CommandPalette.swift`

No changes to `JellifyApp.swift`, `AppModel.swift`, `AudioEngine.swift`, or the Rust core.