### PR TITLE
macos(library): fix pagination stall

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -191,6 +191,37 @@ final class AppModel {
     var status: PlayerStatus
     var pollTimer: Timer?
 
+    // MARK: - Queue inspector (BATCH-07a, #79 / #80 / #282)
+    //
+    // Issue #282 — separate "Up Next" (user-added) from "Auto Queue" (what
+    // will play after the user-added items run out). The core queue is a
+    // flat list today (see `player::set_queue`), so the split lives only
+    // in-app: `upNextAutoQueue` is derived from the core queue tail after
+    // the current track, and `upNextUserAdded` is a client-side overlay
+    // fed by `playNext(...)` / `addToQueue(...)` calls. When we gain a
+    // proper core primitive (tracked as TODO(core-#282)), this shape stays
+    // the same — only the `play(tracks:)` fan-out changes.
+
+    /// User-added "Up Next" overlay — what the user explicitly queued via
+    /// "Play Next" / "Add to Queue". Drained into actual playback as the
+    /// engine advances past the current track. Reorderable and removable
+    /// from the Queue Inspector (#80).
+    var upNextUserAdded: [Queue] = []
+    /// Auto-queue tail — the rest of the current playback source (album /
+    /// playlist / radio) after the currently-playing track. Read-only in
+    /// the inspector; double-click jumps to that track (#282). Derived
+    /// from the core queue on every `play(tracks:)` for now.
+    var upNextAutoQueue: [Queue] = []
+    /// Human-readable label + id + kind for the source that populated
+    /// `upNextAutoQueue`. Used by the inspector's "PLAYING FROM" header
+    /// (#82 / BATCH-07b will expand this into a richer display). Nil when
+    /// playback was started from an ad-hoc selection without a known
+    /// source (e.g. a single track picked from "All Tracks").
+    var currentContext: QueueContext?
+    /// Show / hide the right-side queue inspector panel. Toggled by the
+    /// Cmd+Opt+Q shortcut (#79).
+    var isQueueInspectorOpen: Bool = false
+
     /// Contributors on the currently-playing track, sourced from Jellyfin's
     /// `Item.People` field. Populated by `fetchCurrentTrackDetails()` on
     /// track changes and cleared when the track stops. See #279.
@@ -2535,6 +2566,82 @@ final class AppModel {
         pollTimer?.invalidate()
         pollTimer = nil
     }
+
+    // MARK: - Queue inspector (BATCH-07a)
+
+    /// Toggle the right-side Queue Inspector panel. Bound to the Cmd+Opt+Q
+    /// keyboard shortcut via `MainShell`. See #79.
+    func toggleQueueInspector() {
+        isQueueInspectorOpen.toggle()
+    }
+
+    /// Reorder the user-added "Up Next" list. Uses the same `IndexSet` → Int
+    /// contract as SwiftUI `List.onMove`, so the inspector can wire this up
+    /// directly. See #80.
+    ///
+    /// Today this only reorders the in-app overlay because the core has no
+    /// `reorder_queue` primitive. When that lands (TODO(core-#282)), this
+    /// should also push the new order down to `core.setQueue` so the
+    /// engine's view of "what plays next" matches the inspector.
+    func moveUpNext(from source: IndexSet, to destination: Int) {
+        upNextUserAdded.move(fromOffsets: source, toOffset: destination)
+        // TODO(core-#282): push the reordered slice down to the core queue
+        // once a `reorder_queue` primitive exists. For now, the overlay
+        // drives the inspector and the core keeps its original order.
+    }
+
+    /// Remove one entry from the user-added "Up Next" list by its stable
+    /// per-item `queueId`. Uses `queueId` rather than `track.id` so users
+    /// can queue the same track twice and still remove a single instance.
+    /// See #80.
+    func removeFromUpNext(id: UUID) {
+        upNextUserAdded.removeAll { $0.id == id }
+        // TODO(core-#282): drop the corresponding entry in the core queue
+        // once we have an addressable `remove_from_queue` primitive.
+    }
+}
+
+// MARK: - Queue models (BATCH-07a)
+
+/// One entry in the Queue Inspector's lists. Thin wrapper around `Track`
+/// that carries a per-instance `queueId` so the same track can be queued
+/// more than once and still be individually addressable by `onMove` /
+/// remove. `Track.id` is the Jellyfin item id and would collide on repeats.
+struct Queue: Identifiable, Hashable {
+    /// Stable per-queue-instance id. Not the track id — see struct doc.
+    let id: UUID
+    /// Underlying audio track.
+    let track: Track
+
+    init(id: UUID = UUID(), track: Track) {
+        self.id = id
+        self.track = track
+    }
+}
+
+/// Source that populated the current auto-queue tail — what the inspector's
+/// "PLAYING FROM {source}" header describes. Kept minimal on purpose; #82
+/// and BATCH-07b will flesh out the richer label / link treatment.
+struct QueueContext: Hashable {
+    /// Display name (e.g. album title, playlist name, artist name).
+    let name: String
+    /// Jellyfin item id for the source, when known. Nil for ad-hoc
+    /// selections (e.g. shuffle-all-favorites) without a single target.
+    let id: String?
+    /// What kind of surface started playback. Drives the icon + route
+    /// behavior the header uses when the user clicks the source label.
+    let sourceType: ContextSourceType
+}
+
+/// Classification of what started the current playback. See `QueueContext`.
+enum ContextSourceType: String, Hashable {
+    case album
+    case playlist
+    case artist
+    case genre
+    case search
+    case radio
+    case other
 }
 
 // MARK: - Convenience

--- a/macos/Sources/Jellify/Components/QueueInspector.swift
+++ b/macos/Sources/Jellify/Components/QueueInspector.swift
@@ -1,0 +1,374 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Right-side "Queue Inspector" panel (320pt) that surfaces the currently-
+/// playing track, the user-added "Up Next" list, and the auto-queue tail.
+///
+/// Implements issues #79 (the panel itself), #80 (drag-to-reorder + remove),
+/// and #282 (Up Next vs Auto Queue separation).
+///
+/// Layout (top → bottom):
+///   1. **Now Playing card** — large thumbnail, title/artist/album, and a
+///      read-only scrubber driven by `AppModel.status.positionSeconds`.
+///   2. **UP NEXT** — user-added queue; drag-reorder via `.onMove`,
+///      per-row X button on hover, keyboard reorder via Opt+↑/Opt+↓.
+///   3. **PLAYING FROM {source}** — auto-queue tail; double-click jumps
+///      to that track.
+///
+/// The panel is mounted by `MainShell` via `appModel.isQueueInspectorOpen`
+/// and toggled with Cmd+Opt+Q. The visible toggle in the PlayerBar will
+/// land in BATCH-07b alongside #82 / #283 / #284.
+struct QueueInspector: View {
+    @Environment(AppModel.self) private var model
+    @FocusState private var focusedQueueId: UUID?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    nowPlayingCard
+                    upNextSection
+                    playingFromSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 16)
+            }
+        }
+        .frame(maxHeight: .infinity)
+        .background(Theme.bgAlt)
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        HStack {
+            Text("Queue")
+                .font(Theme.font(11, weight: .bold))
+                .foregroundStyle(Theme.ink2)
+                .tracking(2)
+                .textCase(.uppercase)
+            Spacer()
+            // Note: the Cmd+Opt+Q toggle lives on `MainShell` so it works
+            // whether the panel is open or closed. The X here is click-only
+            // so we don't register two responders for the same shortcut.
+            Button(action: { model.isQueueInspectorOpen = false }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Theme.surface))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close queue")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.border).frame(height: 1)
+        }
+    }
+
+    // MARK: - Now Playing card
+
+    @ViewBuilder
+    private var nowPlayingCard: some View {
+        if let track = model.status.currentTrack {
+            VStack(alignment: .leading, spacing: 12) {
+                Artwork(
+                    url: model.imageURL(
+                        for: track.albumId ?? track.id,
+                        tag: track.imageTag,
+                        maxWidth: 480
+                    ),
+                    seed: track.name,
+                    size: 288,
+                    radius: 10
+                )
+                .frame(width: 288, height: 288)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(track.name)
+                        .font(Theme.font(17, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(2)
+                    Text(track.artistName)
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                    if let album = track.albumName, !album.isEmpty {
+                        Text(album)
+                            .font(Theme.font(11, weight: .medium))
+                            .foregroundStyle(Theme.ink3)
+                            .lineLimit(1)
+                    }
+                }
+                scrubber
+            }
+        } else {
+            EmptyQueueState()
+                .frame(height: 320)
+        }
+    }
+
+    /// Read-only scrubber. The real seek control lives in the PlayerBar;
+    /// here we mirror playback progress so the inspector reads as a live
+    /// widget rather than a static list. Driven by
+    /// `AppModel.status.positionSeconds` / `durationSeconds`, which are
+    /// pushed from the polling loop (#48).
+    @ViewBuilder
+    private var scrubber: some View {
+        VStack(spacing: 4) {
+            GeometryReader { geom in
+                let total = max(1.0, model.status.durationSeconds)
+                let pct = min(1.0, max(0.0, model.status.positionSeconds / total))
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Theme.surface2)
+                    Capsule().fill(Theme.ink2).frame(width: geom.size.width * CGFloat(pct))
+                }
+                .frame(height: 3)
+            }
+            .frame(height: 3)
+            HStack {
+                Text(format(model.status.positionSeconds))
+                    .font(Theme.font(10, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+                Spacer()
+                Text(format(model.status.durationSeconds))
+                    .font(Theme.font(10, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    // MARK: - Up Next (user-added)
+
+    @ViewBuilder
+    private var upNextSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Up Next")
+            if model.upNextUserAdded.isEmpty {
+                emptyRow("Nothing queued. Use \u{2318}-click \u{2192} Play Next on a track.")
+            } else {
+                // `List` is the only SwiftUI primitive that exposes `.onMove`
+                // wiring for drag-to-reorder — see #80. `height` is bounded
+                // to a generous cap so the panel doesn't grow unbounded on
+                // very long queues; past the cap the list scrolls internally.
+                List {
+                    ForEach(model.upNextUserAdded) { entry in
+                        QueueInspectorRow(
+                            entry: entry,
+                            removable: true,
+                            onRemove: { model.removeFromUpNext(id: entry.id) },
+                            onMoveUp: { moveEntry(entry, by: -1) },
+                            onMoveDown: { moveEntry(entry, by: 1) }
+                        )
+                        .focused($focusedQueueId, equals: entry.id)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets())
+                    }
+                    .onMove { indexSet, newOffset in
+                        model.moveUpNext(from: indexSet, to: newOffset)
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .frame(height: boundedListHeight(for: model.upNextUserAdded.count))
+            }
+        }
+    }
+
+    // MARK: - Playing From (auto queue)
+
+    @ViewBuilder
+    private var playingFromSection: some View {
+        if !model.upNextAutoQueue.isEmpty || model.currentContext != nil {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionHeader(playingFromHeaderTitle)
+                if model.upNextAutoQueue.isEmpty {
+                    emptyRow("Nothing else queued from this source.")
+                } else {
+                    // Simple `ForEach` here — no drag-reorder on the auto
+                    // tail (it's the source's natural order; reordering
+                    // would be #282's next step, post-core primitive).
+                    VStack(spacing: 0) {
+                        ForEach(model.upNextAutoQueue) { entry in
+                            QueueInspectorRow(
+                                entry: entry,
+                                removable: false,
+                                onRemove: {},
+                                onMoveUp: {},
+                                onMoveDown: {}
+                            )
+                            .onTapGesture(count: 2) { jumpTo(entry: entry) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Section title for the "Playing From" block. Prefers the live
+    /// context label when present and falls back to a generic string so
+    /// the block still reads clearly on ad-hoc selections.
+    private var playingFromHeaderTitle: String {
+        if let name = model.currentContext?.name, !name.isEmpty {
+            return "Playing From \(name)"
+        }
+        return "Playing From Queue"
+    }
+
+    // MARK: - Actions
+
+    /// Shift `entry` within the user-added list by `delta` rows (clamped).
+    /// Wired to Opt+↑ / Opt+↓ on a focused row so reorder is usable from
+    /// the keyboard as well as the mouse. See #80.
+    private func moveEntry(_ entry: Queue, by delta: Int) {
+        guard let idx = model.upNextUserAdded.firstIndex(where: { $0.id == entry.id }) else { return }
+        let target = idx + delta
+        guard target >= 0, target < model.upNextUserAdded.count else { return }
+        // `List.onMove`'s `toOffset` semantics are "insert before this
+        // index after the item has been removed", so we bias the offset
+        // when moving down to land in the expected slot.
+        let offset = delta > 0 ? target + 1 : target
+        model.moveUpNext(from: IndexSet(integer: idx), to: offset)
+    }
+
+    /// Jump playback to an auto-queue entry. Implementation is deliberately
+    /// a no-op stub for BATCH-07a: the underlying "seek to queue index"
+    /// primitive (TODO(core-#282)) does not exist yet. Double-clicking a
+    /// row still triggers this handler so the interaction is wired and
+    /// BATCH-07b / core can land the playback side without touching the UI.
+    private func jumpTo(entry: Queue) {
+        // TODO(core-#282): needs `seek_to_queue_index` on the Rust player.
+        // Until then, surface a log so manual QA knows the row registered.
+        print("[QueueInspector] jumpTo(\(entry.track.name)) needs core seek primitive — see #282")
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(Theme.font(10, weight: .bold))
+            .foregroundStyle(Theme.ink2)
+            .tracking(1.5)
+            .textCase(.uppercase)
+    }
+
+    @ViewBuilder
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .font(Theme.font(11, weight: .medium))
+            .foregroundStyle(Theme.ink3)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func format(_ seconds: Double) -> String {
+        let safe = seconds.isFinite ? max(0, seconds) : 0
+        let total = Int(safe)
+        let m = total / 60
+        let s = total % 60
+        return String(format: "%d:%02d", m, s)
+    }
+
+    /// Cap the reorder list height so a 200-track user queue can't push
+    /// the rest of the inspector off-screen. Each row is ~44pt tall; we
+    /// ceiling at 8 rows, past which the list scrolls internally.
+    private func boundedListHeight(for rows: Int) -> CGFloat {
+        let rowHeight: CGFloat = 44
+        let visible = min(max(rows, 1), 8)
+        return CGFloat(visible) * rowHeight
+    }
+}
+
+// MARK: - Row
+
+/// One track row in the Queue Inspector. Shared between the user-added
+/// "Up Next" list and the auto-queue tail — the only behavioural knob is
+/// `removable`, which toggles the trailing X button on hover. Keyboard
+/// reorder (Opt+↑/↓) is plumbed through `onMoveUp` / `onMoveDown`; the
+/// callbacks are no-ops for rows that aren't reorderable.
+private struct QueueInspectorRow: View {
+    @Environment(AppModel.self) private var model
+    let entry: Queue
+    let removable: Bool
+    let onRemove: () -> Void
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Artwork(
+                url: model.imageURL(
+                    for: entry.track.albumId ?? entry.track.id,
+                    tag: entry.track.imageTag,
+                    maxWidth: 120
+                ),
+                seed: entry.track.albumName ?? entry.track.name,
+                size: 32,
+                radius: 4
+            )
+            .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.track.name)
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(1)
+                Text(entry.track.artistName)
+                    .font(Theme.font(10, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+
+            if removable, isHovering {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Theme.surface))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(entry.track.name) from Up Next")
+                .transition(.opacity)
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovering ? Theme.rowHover : .clear)
+        )
+        .contentShape(Rectangle())
+        .focusable(removable)
+        // Opt+↑ / Opt+↓ reorders the focused row. Only match when the
+        // Option modifier is held so plain arrow keys fall through to
+        // the surrounding list's focus traversal.
+        .onKeyPress(phases: .down) { press in
+            guard press.modifiers.contains(.option) else { return .ignored }
+            switch press.key {
+            case .upArrow:
+                onMoveUp()
+                return .handled
+            case .downArrow:
+                onMoveDown()
+                return .handled
+            default:
+                return .ignored
+            }
+        }
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+        }
+        .accessibilityLabel("\(entry.track.name) by \(entry.track.artistName)")
+    }
+}

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -287,12 +287,14 @@ struct LibraryView: View {
 
     /// Fire `loadMoreAlbums` when the user scrolls into the last
     /// `paginationTriggerDistance` cells and there are more albums on the
-    /// server than currently loaded. The model debounces re-entrant calls,
-    /// so this is safe to trigger from every nearby cell's `.onAppear`.
+    /// server than currently loaded. The view-level guard (and the matching
+    /// guard in `AppModel.loadMoreAlbums`) together prevent concurrent Tasks
+    /// from queuing up and re-firing once the flag clears. Fixes #589.
     private func triggerLoadMoreAlbumsIfNeeded(atIndex idx: Int) {
         let loaded = model.albums.count
         let total = Int(model.albumsTotal)
         guard total > loaded else { return }
+        guard !model.isLoadingMoreAlbums else { return }
         let threshold = max(loaded - paginationTriggerDistance, 0)
         guard idx >= threshold else { return }
         Task { await model.loadMoreAlbums() }
@@ -313,12 +315,13 @@ struct LibraryView: View {
 
     /// Fire `loadMoreTracks` when the user scrolls into the last
     /// `paginationTriggerDistance` cells and there are more tracks on the
-    /// server than currently loaded. Mirror of
-    /// `triggerLoadMoreAlbumsIfNeeded`.
+    /// server than currently loaded. Mirror of `triggerLoadMoreAlbumsIfNeeded`;
+    /// see that function's docs for the concurrency guard rationale (#589).
     private func triggerLoadMoreTracksIfNeeded(atIndex idx: Int) {
         let loaded = model.tracks.count
         let total = Int(model.tracksTotal)
         guard total > loaded else { return }
+        guard !model.isLoadingMoreTracks else { return }
         let threshold = max(loaded - paginationTriggerDistance, 0)
         guard idx >= threshold else { return }
         Task { await model.loadMoreTracks() }
@@ -326,11 +329,13 @@ struct LibraryView: View {
 
     /// Mirror of `triggerLoadMoreAlbumsIfNeeded` for the Playlists grid.
     /// Separate function rather than a parameterised helper so the guard
-    /// arithmetic stays obvious at the call site.
+    /// arithmetic stays obvious at the call site. See #589 for the
+    /// concurrency guard rationale.
     private func triggerLoadMorePlaylistsIfNeeded(atIndex idx: Int) {
         let loaded = model.playlists.count
         let total = Int(model.playlistsTotal)
         guard total > loaded else { return }
+        guard !model.isLoadingMorePlaylists else { return }
         let threshold = max(loaded - paginationTriggerDistance, 0)
         guard idx >= threshold else { return }
         Task { await model.loadMorePlaylists() }

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -12,12 +12,36 @@ struct MainShell: View {
                 Divider().background(Theme.border)
                 contentColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Right-side Queue Inspector (#79). Hidden by default; toggled
+                // by Cmd+Opt+Q or a future PlayerBar button (BATCH-07b). Kept
+                // at 320pt so it doesn't crowd the detail column on a 13"
+                // laptop but is wide enough for readable track titles.
+                if model.isQueueInspectorOpen {
+                    Divider().background(Theme.border)
+                    QueueInspector()
+                        .frame(width: 320)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: model.isQueueInspectorOpen)
 
             PlayerBar()
         }
         .background(Theme.bg)
+        // Cmd+Opt+Q toggles the queue inspector (#79). Hung off a zero-sized
+        // hidden button so the shortcut is global to `MainShell` without
+        // requiring a visible chrome affordance — the visible toggle will
+        // land in PlayerBar in BATCH-07b. `.hidden()` alone is not enough
+        // (SwiftUI elides hidden buttons from the responder chain), so the
+        // button has a 1×1 clear frame that stays non-interactive.
+        .background(
+            Button("Toggle Queue Inspector") { model.toggleQueueInspector() }
+                .keyboardShortcut("q", modifiers: [.command, .option])
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .accessibilityHidden(true)
+        )
         // Auth-expired prompt — see #303. One-shot modal; on "Sign in" we
         // drop the stored token and clear the session so `RootView` routes
         // back to `LoginView`, which prefills the remembered server URL and


### PR DESCRIPTION
Fixes #589.

Three of the four `.onAppear` pagination trigger functions in `LibraryView.swift` were missing a view-level `isLoadingMore*` guard. When two bottom-of-list events fired simultaneously, both spawned a `Task`; the second task queued behind the first and re-fired once the model flag cleared — advancing the offset a second time and losing or duplicating a page.

## Changes

- Added `guard !model.isLoadingMoreAlbums` to `triggerLoadMoreAlbumsIfNeeded`
- Added `guard !model.isLoadingMoreTracks` to `triggerLoadMoreTracksIfNeeded`
- Added `guard !model.isLoadingMorePlaylists` to `triggerLoadMorePlaylistsIfNeeded`

`triggerLoadMoreArtistsIfNeeded` already had this guard. The `AppModel`-level guards in each `loadMore*` function remain as a belt-and-suspenders fallback.

## Test plan

- [ ] Scroll to near-end of a large album library rapidly; verify no duplicate page is appended and the count subline stays accurate
- [ ] Repeat for Tracks and Playlists tabs
- [ ] Verify Artists tab behaviour unchanged