### PR TITLE
macos(prefs): wire launch-at-login + menu-bar toggles

### DIFF
--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
@@ -2,19 +2,16 @@ import SwiftUI
 
 /// General preferences pane.
 ///
-/// Launch-at-login, menu-bar presence, and language. These are the knobs that
-/// don't fit under a more specific pane but still belong in the p0 shipping
-/// set. All three are UI-only today:
+/// Launch-at-login, menu-bar presence, and language.
 ///
 /// - **Language**: only English ships; the picker is present so the setting
 ///   is visible and the user can see i18n is on the roadmap. Real wiring is
 ///   tracked in `TODO(i18n-#345)`.
-/// - **Auto-start on login**: persists the selection; real `SMAppService`
-///   registration lands alongside the rest of the launch-item scaffolding
-///   (see TODO below). A naive toggle is still useful to surface the feature
-///   so users can opt-in and the choice is remembered across a restart.
-/// - **Show in menu bar**: persists today; the actual `NSStatusItem` mount
-///   belongs with the mini-player / menu-bar companion work.
+/// - **Auto-start on login**: wired to `SMAppService.mainApp` via
+///   `LaunchAtLogin`. The stored `@AppStorage` value shadows the system
+///   registration so the toggle reflects the true state on every launch.
+/// - **Show in menu bar**: wired to `MenuBarController.shared`. The
+///   `NSStatusItem` is created on enable and released on disable.
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 66 top-level General bullet.
 struct PreferencesGeneral: View {
@@ -26,6 +23,34 @@ struct PreferencesGeneral: View {
         Binding(
             get: { AppLanguage(rawValue: languageRaw) ?? .system },
             set: { languageRaw = $0.rawValue }
+        )
+    }
+
+    /// Binding that syncs `@AppStorage` with the real `SMAppService`
+    /// registration whenever the value changes.
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { autoStartOnLogin },
+            set: { newValue in
+                autoStartOnLogin = newValue
+                if newValue {
+                    LaunchAtLogin.enable()
+                } else {
+                    LaunchAtLogin.disable()
+                }
+            }
+        )
+    }
+
+    /// Binding that syncs `@AppStorage` with `MenuBarController` whenever
+    /// the value changes.
+    private var showInMenuBarBinding: Binding<Bool> {
+        Binding(
+            get: { showInMenuBar },
+            set: { newValue in
+                showInMenuBar = newValue
+                MenuBarController.shared.setVisible(newValue)
+            }
         )
     }
 
@@ -55,7 +80,7 @@ struct PreferencesGeneral: View {
 
             PreferenceSection(
                 title: "Startup",
-                footnote: "Auto-start launches Jellify in the background when you log in. The toggle persists today; TODO(#566) registers the login-item through SMAppService so the behaviour actually fires."
+                footnote: "Auto-start launches Jellify in the background when you log in."
             ) {
                 PreferenceRow(
                     label: "Open at login",
@@ -63,7 +88,7 @@ struct PreferencesGeneral: View {
                         ? "On — Jellify will launch in the background when you sign in."
                         : "Off — Jellify only opens when you launch it manually."
                 ) {
-                    Toggle("", isOn: $autoStartOnLogin)
+                    Toggle("", isOn: launchAtLoginBinding)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .accessibilityLabel("Launch Jellify at login")
@@ -72,15 +97,15 @@ struct PreferencesGeneral: View {
 
             PreferenceSection(
                 title: "Menu Bar",
-                footnote: "Keeps a transport icon in the macOS menu bar for quick play/pause, skip, and now-playing access. TODO(#567) — NSStatusItem mount lands with the mini-player work."
+                footnote: "Keeps a transport icon in the macOS menu bar for quick access."
             ) {
                 PreferenceRow(
                     label: "Show in menu bar",
                     help: showInMenuBar
-                        ? "On — a compact transport icon stays in the menu bar."
+                        ? "On — a compact icon stays in the menu bar."
                         : "Off — Jellify lives only in the Dock."
                 ) {
-                    Toggle("", isOn: $showInMenuBar)
+                    Toggle("", isOn: showInMenuBarBinding)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .accessibilityLabel("Show in menu bar")
@@ -88,6 +113,15 @@ struct PreferencesGeneral: View {
             }
 
             Spacer(minLength: 0)
+        }
+        .onAppear {
+            // Reconcile stored value with true SMAppService state on every
+            // pane open so the toggle is never stale (e.g. if the user
+            // toggled the login item from System Settings).
+            autoStartOnLogin = LaunchAtLogin.isEnabled
+            // Re-apply the menu-bar state in case the controller lost its
+            // item during a Settings window close/reopen cycle.
+            MenuBarController.shared.setVisible(showInMenuBar)
         }
     }
 

--- a/macos/Sources/Jellify/System/LaunchAtLogin.swift
+++ b/macos/Sources/Jellify/System/LaunchAtLogin.swift
@@ -1,0 +1,33 @@
+import ServiceManagement
+
+/// Thin wrapper around `SMAppService.mainApp` that exposes launch-at-login
+/// as a simple Bool property. Requires macOS 13+, which matches the app's
+/// deployment target. Both `enable()` and `disable()` are fire-and-forget
+/// — errors are logged rather than propagated because a failure to register
+/// should not block the UI thread or crash the prefs pane.
+struct LaunchAtLogin {
+    /// Whether Jellify is currently registered as a login item.
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    /// Register Jellify as a login item. No-op if already registered.
+    static func enable() {
+        guard SMAppService.mainApp.status != .enabled else { return }
+        do {
+            try SMAppService.mainApp.register()
+        } catch {
+            debugPrint("[LaunchAtLogin] register() failed: \(error)")
+        }
+    }
+
+    /// Unregister Jellify as a login item. No-op if not registered.
+    static func disable() {
+        guard SMAppService.mainApp.status == .enabled else { return }
+        do {
+            try SMAppService.mainApp.unregister()
+        } catch {
+            debugPrint("[LaunchAtLogin] unregister() failed: \(error)")
+        }
+    }
+}

--- a/macos/Sources/Jellify/System/MenuBarController.swift
+++ b/macos/Sources/Jellify/System/MenuBarController.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// Manages the optional menu-bar `NSStatusItem` for Jellify.
+///
+/// The controller is a singleton owned for the lifetime of the process.
+/// Callers drive visibility through `setVisible(_:)`. When the status item
+/// is visible it shows a fixed music-note template image; a richer
+/// mini-player popover can be attached here in a follow-up once the
+/// mini-player surface lands (see #567).
+final class MenuBarController {
+    static let shared = MenuBarController()
+
+    private var statusItem: NSStatusItem?
+
+    private init() {}
+
+    /// Show or hide the menu-bar icon. Safe to call repeatedly with the
+    /// same value — it checks current state before creating / destroying
+    /// the status item.
+    func setVisible(_ visible: Bool) {
+        if visible {
+            guard statusItem == nil else { return }
+            let item = NSStatusBar.system.statusItem(
+                withLength: NSStatusItem.squareLength
+            )
+            if let button = item.button {
+                // `"music.note"` is available on macOS 11+. The template
+                // rendering mode lets AppKit invert the icon for light /
+                // dark menu bars automatically.
+                button.image = NSImage(
+                    systemSymbolName: "music.note",
+                    accessibilityDescription: "Jellify"
+                )
+                button.image?.isTemplate = true
+                button.toolTip = "Jellify"
+            }
+            statusItem = item
+        } else {
+            if let item = statusItem {
+                NSStatusBar.system.removeStatusItem(item)
+                statusItem = nil
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #576.

## Summary
- Add `LaunchAtLogin.swift` — thin `SMAppService.mainApp` wrapper with `isEnabled`, `enable()`, `disable()` statics (macOS 13+).
- Add `MenuBarController.swift` — singleton that owns an optional `NSStatusItem`; `setVisible(_:)` creates or destroys it.
- Update `PreferencesGeneral.swift` — replace the two plain `$appStorage` bindings with computed bindings that call through to the real system APIs on change; add `.onAppear` to reconcile stored state against SMAppService truth on every pane open.