### PR TITLE
macos(lyrics): add empty state

### DIFF
--- a/macos/Sources/Jellify/Components/LyricsView.swift
+++ b/macos/Sources/Jellify/Components/LyricsView.swift
@@ -195,20 +195,12 @@ struct LyricsView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "quote.bubble")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(Theme.ink3)
-            Text("No lyrics available")
-                .font(Theme.font(14, weight: .semibold))
-                .foregroundStyle(Theme.ink2)
-            Text("Lyrics haven't been provided for this track.")
-                .font(Theme.font(11, weight: .medium))
-                .foregroundStyle(Theme.ink3)
-                .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .combine)
+        ContentUnavailableView(
+            "No Lyrics",
+            systemImage: "music.note.list",
+            description: Text("This track doesn't have lyrics available.")
+        )
+        .foregroundStyle(Theme.ink3)
     }
 
     // MARK: - Static (untimed) text


### PR DESCRIPTION
Closes #603.

## Summary
- Replaces the hand-rolled `VStack` empty-state in `LyricsView` with `ContentUnavailableView("No Lyrics", systemImage: "music.note.list", ...)` — the system-standard component available since macOS 14, which matches the project's minimum deployment target.
- When `lines` is empty (track has no lyrics / lyrics fetch returned nil), the panel now shows a consistent, accessible placeholder instead of a blank view.
- No other files touched.

## Test plan
- [ ] Open Now Playing on a track that has no lyrics → Lyrics tab shows "No Lyrics" with `music.note.list` symbol.
- [ ] Open Now Playing on a track with LRC lyrics → scrolling view renders normally.
- [ ] Open Now Playing on a track with plain-text lyrics → static text view renders normally.
- [ ] Xcode Preview "Lyrics — empty" confirms the `ContentUnavailableView` renders correctly.