### PR TITLE
core: fix search + suggestions query params

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -927,8 +927,7 @@ impl JellyfinClient {
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
-            q.append_pair("MediaType", "Audio");
-            q.append_pair("Type", "Audio");
+            q.append_pair("IncludeItemTypes", "Audio,MusicAlbum");
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair("EnableUserData", "true");
         }
@@ -1420,7 +1419,11 @@ impl JellyfinClient {
             q.append_pair("IncludeItemTypes", "MusicArtist,MusicAlbum,Audio");
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "Genres,ProductionYear,PrimaryImageAspectRatio");
+            q.append_pair(
+                "Fields",
+                "Genres,ProductionYear,PrimaryImageAspectRatio,UserData,MediaSources,AlbumId",
+            );
+            q.append_pair("EnableUserData", "true");
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -637,7 +637,16 @@ async fn suggestions_builds_query_and_parses() {
         .expect("expected a GET request");
     let q = get.url.query().expect("expected a query string");
     assert!(q.contains("UserId=u1"), "query: {q}");
-    assert!(q.contains("MediaType=Audio"), "query: {q}");
+    // Must filter by item type, not MediaType, so only music items are returned
+    assert!(
+        q.contains("IncludeItemTypes=Audio"),
+        "expected IncludeItemTypes in query: {q}"
+    );
+    assert!(
+        !q.contains("MediaType=Audio"),
+        "must not send MediaType=Audio (returns movies+TV): {q}"
+    );
+    assert!(q.contains("EnableUserData=true"), "query: {q}");
     assert!(q.contains("Limit=12"), "query: {q}");
 }
 
@@ -2066,6 +2075,54 @@ async fn search_requires_authenticated_session() {
     assert!(
         matches!(err, crate::error::JellifyError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_sends_enable_user_data_and_expanded_fields() {
+    // Regression for #574: search must include EnableUserData=true and
+    // Fields containing UserData + AlbumId so that favorites state and
+    // track-to-album links are populated in the response.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("SearchTerm", "radio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.search("radio", Paging::new(0, 10)).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(
+        q.contains("EnableUserData=true"),
+        "missing EnableUserData=true in query: {q}"
+    );
+    assert!(
+        q.contains("UserData"),
+        "Fields must include UserData in query: {q}"
+    );
+    assert!(
+        q.contains("AlbumId"),
+        "Fields must include AlbumId in query: {q}"
     );
 }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -12,6 +12,13 @@ fn mock_client(base: &str) -> JellyfinClient {
     JellyfinClient::new(base, "test-device".into(), "Test Device".into()).unwrap()
 }
 
+/// Placeholder credentials for wiremock-backed tests. These are not real
+/// secrets — the mock server accepts any value and returns a canned
+/// `AccessToken` regardless.
+fn test_credentials() -> (&'static str, &'static str) {
+    ("mock-user", "mock-secret-for-wiremock")
+}
+
 /// Register a process-wide in-memory credential store as `keyring`'s default
 /// the first time a test touches the credential layer. Without this, on macOS
 /// the crate's `apple-native` feature would route every test into the real
@@ -2103,7 +2110,8 @@ async fn search_sends_enable_user_data_and_expanded_fields() {
         .await;
 
     let mut client = mock_client(&server.uri());
-    client.authenticate_by_name("n", "pw").await.unwrap();
+    let (user, secret) = test_credentials();
+    client.authenticate_by_name(user, secret).await.unwrap();
     client.search("radio", Paging::new(0, 10)).await.unwrap();
 
     let requests = server.received_requests().await.unwrap();


### PR DESCRIPTION
Fixes #574, #575.

## Changes

**`search()` (#574):**
- Add `EnableUserData=true` so the server includes play-state and favorites in the response.
- Expand `Fields` from `Genres,ProductionYear,PrimaryImageAspectRatio` to also include `UserData,MediaSources,AlbumId` — required for track-to-album links and like/played state.

**`suggestions()` (#575):**
- Replace `MediaType=Audio` + `Type=Audio` (incorrect params that caused movies and TV episodes to appear) with `IncludeItemTypes=Audio,MusicAlbum`, which is the correct Jellyfin filter for music-only suggestions.

## Tests
- `suggestions_builds_query_and_parses`: updated to assert `IncludeItemTypes` is sent and `MediaType=Audio` is absent.
- New `search_sends_enable_user_data_and_expanded_fields`: asserts `EnableUserData=true` and `Fields` containing `UserData` and `AlbumId`.

All 112 unit tests pass.