### PR TITLE
core: persist shuffle + repeat across launches

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,6 +80,13 @@ impl JellifyCore {
             .build()
             .map_err(|e| JellifyError::Other(format!("tokio runtime: {e}")))?;
 
+        // Restore shuffle/repeat state from the previous launch.
+        let player = Arc::new(Player::new());
+        if let Ok((shuffle, repeat)) = db.load_shuffle_repeat() {
+            player.set_shuffle(shuffle);
+            player.set_repeat_mode(repeat);
+        }
+
         Ok(Arc::new(Self {
             inner: Arc::new(Mutex::new(Inner {
                 client: None,
@@ -87,7 +94,7 @@ impl JellifyCore {
                 device_id,
                 device_name: config.device_name,
             })),
-            player: Arc::new(Player::new()),
+            player,
             runtime,
         }))
     }
@@ -845,16 +852,30 @@ impl JellifyCore {
     /// SMTC `ShuffleEnabled` on Windows) stay in sync with the app. The
     /// core does not reorder the underlying queue — callers hand over
     /// already-shuffled tracks via [`Self::set_queue`] and use this to
-    /// reflect the current mode. See issue #34.
+    /// reflect the current mode. Persisted to the local database so the
+    /// setting survives app restarts. See issue #34 / #583.
     pub fn set_shuffle(&self, on: bool) {
         self.player.set_shuffle(on);
+        let status = self.player.status();
+        let _ = self
+            .inner
+            .lock()
+            .db
+            .save_shuffle_repeat(on, status.repeat_mode);
     }
 
     /// Set the queue-wide [`RepeatMode`]. Consumed by the platform audio
     /// engine at end-of-track (replay vs. advance vs. stop) and exposed on
-    /// the remote-control surface. See issue #34.
+    /// the remote-control surface. Persisted to the local database so the
+    /// setting survives app restarts. See issue #34 / #583.
     pub fn set_repeat_mode(&self, mode: RepeatMode) {
         self.player.set_repeat_mode(mode);
+        let status = self.player.status();
+        let _ = self
+            .inner
+            .lock()
+            .db
+            .save_shuffle_repeat(status.shuffle, mode);
     }
 
     pub fn stop(&self) {

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -1,4 +1,5 @@
 use crate::error::{JellifyError, Result};
+use crate::player::RepeatMode;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection};
 use std::path::{Path, PathBuf};
@@ -87,6 +88,36 @@ impl Database {
             .lock()
             .execute("DELETE FROM settings WHERE key = ?1", params![key])?;
         Ok(())
+    }
+
+    /// Persist the current shuffle flag and repeat mode so they survive an app
+    /// restart. Values are stored as two rows in the `settings` table under
+    /// `"shuffle_enabled"` and `"repeat_mode"`.
+    pub fn save_shuffle_repeat(&self, shuffle: bool, repeat: RepeatMode) -> Result<()> {
+        let repeat_str = match repeat {
+            RepeatMode::Off => "off",
+            RepeatMode::One => "one",
+            RepeatMode::All => "all",
+        };
+        self.set_setting("shuffle_enabled", if shuffle { "true" } else { "false" })?;
+        self.set_setting("repeat_mode", repeat_str)?;
+        Ok(())
+    }
+
+    /// Read back the shuffle flag and repeat mode written by
+    /// [`Self::save_shuffle_repeat`]. Returns `(false, RepeatMode::Off)` when
+    /// no values have been stored yet (first launch or fresh install).
+    pub fn load_shuffle_repeat(&self) -> Result<(bool, RepeatMode)> {
+        let shuffle = self
+            .get_setting("shuffle_enabled")?
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        let repeat = match self.get_setting("repeat_mode")?.as_deref().unwrap_or("off") {
+            "one" => RepeatMode::One,
+            "all" => RepeatMode::All,
+            _ => RepeatMode::Off,
+        };
+        Ok((shuffle, repeat))
     }
 
     pub fn record_play(&self, track_id: &str, played_at: i64) -> Result<()> {

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -4373,3 +4373,71 @@ fn refresh_token_from_keyring_returns_token_when_present() {
         .expect("token should be present");
     assert_eq!(got, "refreshed-token");
 }
+
+// ---------------------------------------------------------------------------
+// Shuffle + repeat persistence — round-trip tests (#583)
+// ---------------------------------------------------------------------------
+
+use crate::player::RepeatMode;
+
+/// Fresh database returns the safe defaults (shuffle off, repeat off) so a
+/// first launch does not accidentally start in an unexpected mode.
+#[test]
+fn shuffle_repeat_defaults_on_empty_db() {
+    let db = Database::in_memory().expect("in-memory db");
+    let (shuffle, repeat) = db.load_shuffle_repeat().unwrap();
+    assert!(!shuffle, "default shuffle should be off");
+    assert_eq!(repeat, RepeatMode::Off, "default repeat should be Off");
+}
+
+/// Every `(shuffle, RepeatMode)` combination round-trips correctly through the
+/// key-value store. We create a second `Database` instance open on the same
+/// file to verify the values are actually persisted rather than just cached in
+/// memory.
+#[test]
+fn shuffle_repeat_round_trips_all_variants() {
+    // Use a uniquely-named file in the OS temp directory so parallel test
+    // runs do not collide. Best-effort removal at the end — it is fine if
+    // the process exits before the remove; the OS will clean up temp files.
+    let tmp = std::env::temp_dir().join(format!(
+        "jellify_test_sr_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+
+    let cases: &[(bool, RepeatMode)] = &[
+        (true, RepeatMode::Off),
+        (false, RepeatMode::One),
+        (true, RepeatMode::All),
+        (false, RepeatMode::Off),
+        (true, RepeatMode::One),
+        (false, RepeatMode::All),
+    ];
+
+    for &(shuffle, repeat) in cases {
+        // Write via one Database handle.
+        {
+            let db = Database::open(&tmp).expect("open db for write");
+            db.save_shuffle_repeat(shuffle, repeat)
+                .expect("save_shuffle_repeat");
+        }
+        // Read back via a fresh Database handle — exercises the actual SQLite
+        // persistence path rather than any in-process cache.
+        {
+            let db = Database::open(&tmp).expect("open db for read");
+            let (got_shuffle, got_repeat) = db.load_shuffle_repeat().expect("load_shuffle_repeat");
+            assert_eq!(
+                got_shuffle, shuffle,
+                "shuffle mismatch for case ({shuffle}, {repeat:?})"
+            );
+            assert_eq!(
+                got_repeat, repeat,
+                "repeat mismatch for case ({shuffle}, {repeat:?})"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_file(&tmp);
+}


### PR DESCRIPTION
Fixes #583.

Shuffle and repeat settings are now saved to the `settings` table on every toggle and reloaded at startup, so they survive app restarts.

## Changes

- `core/src/storage.rs` — `Database::save_shuffle_repeat` / `load_shuffle_repeat` helpers using the existing KV `settings` table
- `core/src/lib.rs` — load on `JellifyCore::new`; save on `set_shuffle` / `set_repeat_mode`
- `core/src/tests.rs` — two new unit tests: defaults on empty DB, and a full round-trip across all six `(shuffle, RepeatMode)` combinations via a real on-disk SQLite file