### PR TITLE
core: complete playback reports + ClientCapabilities

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1375,26 +1375,16 @@ impl JellyfinClient {
     ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] when no token is set.
-    pub async fn report_playback_progress(
-        &self,
-        item_id: &str,
-        position_ticks: i64,
-        is_paused: bool,
-    ) -> Result<()> {
+    pub async fn report_playback_progress(&self, info: PlaybackProgressInfo) -> Result<()> {
         self.require_token()?;
 
         let url = self.endpoint("Sessions/Playing/Progress")?;
-        let body = PlaybackProgressBody {
-            item_id: item_id.to_string(),
-            position_ticks,
-            is_paused,
-        };
         self.send_with_retry(|| {
             Ok(self
                 .http
                 .post(url.clone())
                 .headers(self.build_headers()?)
-                .json(&body))
+                .json(&info))
         })
         .await?;
         Ok(())
@@ -1499,30 +1489,25 @@ impl JellyfinClient {
 
     /// Report that playback of an item has stopped.
     ///
-    /// Backed by `POST /Sessions/Playing/Stopped` with body
-    /// `{ItemId, PositionTicks}`. Drives Jellyfin's server-side PlayCount
-    /// increment (for tracks) — the server treats a stop report with
-    /// `PositionTicks` near `RunTimeTicks` as a completed play.
+    /// Backed by `POST /Sessions/Playing/Stopped`. Drives Jellyfin's
+    /// server-side PlayCount increment for tracks — the server treats a
+    /// stop report with `PositionTicks` near `RunTimeTicks` as a completed
+    /// play. `MediaSourceId` must match the value from `/PlaybackInfo` so
+    /// the server can clean up any active transcode job.
     ///
     /// Callers invoke this on track end, user-driven skip, and app quit.
-    /// Pass the full `RunTimeTicks` as `position_ticks` when a song
-    /// completed normally.
     ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no token is set.
-    pub async fn report_playback_stopped(&self, item_id: &str, position_ticks: i64) -> Result<()> {
+    pub async fn report_playback_stopped(&self, info: PlaybackStopInfo) -> Result<()> {
         self.require_token()?;
         let url = self.endpoint("Sessions/Playing/Stopped")?;
-        let body = PlaybackStoppedBody {
-            item_id: item_id.to_string(),
-            position_ticks,
-        };
         self.send_with_retry(|| {
             Ok(self
                 .http
                 .post(url.clone())
                 .headers(self.build_headers()?)
-                .json(&body))
+                .json(&info))
         })
         .await?;
         Ok(())
@@ -1878,23 +1863,12 @@ struct AuthByNameBody {
     pw: String,
 }
 
-#[derive(Serialize)]
-struct PlaybackProgressBody {
-    #[serde(rename = "ItemId")]
-    item_id: String,
-    #[serde(rename = "PositionTicks")]
-    position_ticks: i64,
-    #[serde(rename = "IsPaused")]
-    is_paused: bool,
-}
-
-#[derive(Serialize)]
-struct PlaybackStoppedBody {
-    #[serde(rename = "ItemId")]
-    item_id: String,
-    #[serde(rename = "PositionTicks")]
-    position_ticks: i64,
-}
+// PlaybackProgressBody and PlaybackStoppedBody are kept as thin private
+// wrappers so the public PlaybackProgressInfo / PlaybackStopInfo models can
+// be serialised directly — the rename_all = "PascalCase" attribute on those
+// models handles the wire format without a separate private type.
+// (These aliases are no longer needed; serialisation is done via the public
+// models directly in the client methods below.)
 
 #[derive(Serialize)]
 struct CreatePlaylistBody {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -707,18 +707,14 @@ impl JellifyCore {
     /// Report that playback has stopped for an item — backed by
     /// `POST /Sessions/Playing/Stopped`.
     ///
-    /// Drives Jellyfin's server-side PlayCount increment for tracks. Callers
-    /// invoke this on track end, user-driven skip, and app quit. When a song
-    /// completed normally, pass the full `RunTimeTicks` as `position_ticks`.
+    /// Drives Jellyfin's server-side PlayCount increment for tracks and
+    /// cleans up any active transcode job. Callers invoke this on track
+    /// end, user-driven skip, and app quit.
     pub fn report_playback_stopped(
         &self,
-        item_id: String,
-        position_ticks: i64,
+        info: PlaybackStopInfo,
     ) -> std::result::Result<(), JellifyError> {
-        self.with_client(|c| {
-            self.runtime
-                .block_on(c.report_playback_stopped(&item_id, position_ticks))
-        })
+        self.with_client(|c| self.runtime.block_on(c.report_playback_stopped(info)))
     }
 
     /// Report that playback of an item has started — backed by
@@ -814,17 +810,12 @@ impl JellifyCore {
     /// Report playback progress to the server. Called by the platform
     /// playback engine roughly every 10 seconds and on pause/resume/seek
     /// transitions so Jellyfin can drive "Now Playing" state and resume
-    /// points. `position_ticks` is in Jellyfin's 100-ns tick units.
+    /// points.
     pub fn report_playback_progress(
         &self,
-        item_id: String,
-        position_ticks: i64,
-        is_paused: bool,
+        info: PlaybackProgressInfo,
     ) -> std::result::Result<(), JellifyError> {
-        self.with_client(|c| {
-            self.runtime
-                .block_on(c.report_playback_progress(&item_id, position_ticks, is_paused))
-        })
+        self.with_client(|c| self.runtime.block_on(c.report_playback_progress(info)))
     }
 
     pub fn skip_next(&self) -> Option<Track> {

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -560,6 +560,71 @@ pub struct PlaybackStartInfo {
     pub is_muted: bool,
 }
 
+// ============================================================================
+// Playback progress report — sent to `POST /Sessions/Playing/Progress`
+// periodically during playback and on pause/resume/seek transitions.
+// ============================================================================
+
+/// The body for `POST /Sessions/Playing/Progress`. Mirrors Jellyfin's
+/// `PlaybackProgressInfo` DTO.
+///
+/// `Failed` must always be sent (Jellyfin 10.9+ validates its presence).
+/// `PlayMethod` is one of `"DirectPlay"`, `"DirectStream"`, `"Transcode"`.
+/// `PlaybackRate` is `1.0` during normal playback; set to the actual
+/// speed when the user changes playback rate. All tick fields are in
+/// Jellyfin's 100-ns tick units (`seconds * 10_000_000`).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct PlaybackProgressInfo {
+    pub item_id: String,
+    /// Whether playback failed. Must be sent; typically `false`.
+    pub failed: bool,
+    pub is_paused: bool,
+    pub is_muted: bool,
+    pub position_ticks: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub play_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub play_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_level: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub playback_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_stream_index: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+// ============================================================================
+// Playback stopped report — sent to `POST /Sessions/Playing/Stopped`.
+// ============================================================================
+
+/// The body for `POST /Sessions/Playing/Stopped`. Mirrors Jellyfin's
+/// `PlaybackStopInfo` DTO.
+///
+/// `Failed` must always be sent; set to `true` if playback ended due to
+/// an error. `MediaSourceId` must match the value returned by
+/// `/PlaybackInfo` so the server can clean up the transcode job.
+/// `PositionTicks` near `RunTimeTicks` signals a completed play and
+/// triggers the server-side play-count increment.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+#[serde(rename_all = "PascalCase")]
+pub struct PlaybackStopInfo {
+    pub item_id: String,
+    /// Whether playback ended due to an error. Must be sent; typically `false`.
+    pub failed: bool,
+    pub position_ticks: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub play_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
 /// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
 /// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -2460,6 +2460,8 @@ async fn toggle_favorite_dispatches_to_unset_when_false() {
 
 #[tokio::test]
 async fn report_playback_progress_posts_pascal_case_body() {
+    use crate::models::PlaybackProgressInfo;
+
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -2479,7 +2481,18 @@ async fn report_playback_progress_posts_pascal_case_body() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     client
-        .report_playback_progress("track-xyz", 1_234_567_890, true)
+        .report_playback_progress(PlaybackProgressInfo {
+            item_id: "track-xyz".into(),
+            position_ticks: 1_234_567_890,
+            is_paused: true,
+            is_muted: false,
+            failed: false,
+            media_source_id: Some("src-1".into()),
+            play_session_id: Some("session-abc".into()),
+            play_method: Some("DirectPlay".into()),
+            playback_rate: Some(1.0),
+            ..Default::default()
+        })
         .await
         .unwrap();
 
@@ -2500,7 +2513,7 @@ async fn report_playback_progress_posts_pascal_case_body() {
         "unexpected content-type: {content_type}"
     );
 
-    // Body must use Jellyfin's PascalCase keys.
+    // Body must use Jellyfin's PascalCase keys and include all required fields.
     let body: serde_json::Value =
         serde_json::from_slice(&post.body).expect("body should be valid JSON");
     assert_eq!(
@@ -2518,6 +2531,37 @@ async fn report_playback_progress_posts_pascal_case_body() {
         Some(true),
         "body: {body}"
     );
+    assert_eq!(
+        body.get("IsMuted").and_then(|v| v.as_bool()),
+        Some(false),
+        "body: {body}"
+    );
+    // Failed is required by Jellyfin — must always be present.
+    assert_eq!(
+        body.get("Failed").and_then(|v| v.as_bool()),
+        Some(false),
+        "Failed must be present in progress body: {body}"
+    );
+    assert_eq!(
+        body.get("MediaSourceId").and_then(|v| v.as_str()),
+        Some("src-1"),
+        "body: {body}"
+    );
+    assert_eq!(
+        body.get("PlaySessionId").and_then(|v| v.as_str()),
+        Some("session-abc"),
+        "body: {body}"
+    );
+    assert_eq!(
+        body.get("PlayMethod").and_then(|v| v.as_str()),
+        Some("DirectPlay"),
+        "body: {body}"
+    );
+    assert_eq!(
+        body.get("PlaybackRate").and_then(|v| v.as_f64()),
+        Some(1.0),
+        "body: {body}"
+    );
 
     // Ensure keys are PascalCase only — no snake_case leakage.
     let obj = body.as_object().expect("body should be an object");
@@ -2530,6 +2574,8 @@ async fn report_playback_progress_posts_pascal_case_body() {
 
 #[tokio::test]
 async fn report_playback_progress_propagates_server_errors() {
+    use crate::models::PlaybackProgressInfo;
+
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -2548,7 +2594,10 @@ async fn report_playback_progress_propagates_server_errors() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client
-        .report_playback_progress("track-xyz", 0, false)
+        .report_playback_progress(PlaybackProgressInfo {
+            item_id: "track-xyz".into(),
+            ..Default::default()
+        })
         .await
         .unwrap_err();
     match err {
@@ -2559,6 +2608,8 @@ async fn report_playback_progress_propagates_server_errors() {
 
 #[tokio::test]
 async fn report_playback_progress_without_session_returns_not_authenticated() {
+    use crate::models::PlaybackProgressInfo;
+
     // No MockServer routes registered: the guard must short-circuit before
     // any network call. Pointing at a live MockServer means a regression
     // would surface as an unmatched-route error rather than silently hitting
@@ -2566,7 +2617,10 @@ async fn report_playback_progress_without_session_returns_not_authenticated() {
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
     let err = client
-        .report_playback_progress("track-xyz", 0, false)
+        .report_playback_progress(PlaybackProgressInfo {
+            item_id: "track-xyz".into(),
+            ..Default::default()
+        })
         .await
         .unwrap_err();
     assert!(
@@ -2577,6 +2631,8 @@ async fn report_playback_progress_without_session_returns_not_authenticated() {
 
 #[tokio::test]
 async fn report_playback_stopped_posts_expected_body() {
+    use crate::models::PlaybackStopInfo;
+
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -2595,7 +2651,14 @@ async fn report_playback_stopped_posts_expected_body() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     client
-        .report_playback_stopped("track-xyz", 2_220_000_000)
+        .report_playback_stopped(PlaybackStopInfo {
+            item_id: "track-xyz".into(),
+            position_ticks: 2_220_000_000,
+            failed: false,
+            media_source_id: Some("src-1".into()),
+            play_session_id: Some("session-abc".into()),
+            session_id: None,
+        })
         .await
         .unwrap();
 
@@ -2613,20 +2676,34 @@ async fn report_playback_stopped_posts_expected_body() {
         body.get("PositionTicks").and_then(|v| v.as_i64()),
         Some(2_220_000_000)
     );
-    // Only the minimum set of fields we send.
-    let keys: std::collections::HashSet<&str> = body
-        .as_object()
-        .expect("object body")
-        .keys()
-        .map(String::as_str)
-        .collect();
-    let expected: std::collections::HashSet<&str> =
-        ["ItemId", "PositionTicks"].into_iter().collect();
-    assert_eq!(keys, expected, "unexpected body keys: {keys:?}");
+    // Failed is required by Jellyfin — must always be present.
+    assert_eq!(
+        body.get("Failed").and_then(|v| v.as_bool()),
+        Some(false),
+        "Failed must be present in stop body: {body}"
+    );
+    // MediaSourceId lets the server clean up the transcode job.
+    assert_eq!(
+        body.get("MediaSourceId").and_then(|v| v.as_str()),
+        Some("src-1"),
+        "body: {body}"
+    );
+    assert_eq!(
+        body.get("PlaySessionId").and_then(|v| v.as_str()),
+        Some("session-abc"),
+        "body: {body}"
+    );
+    // Unset optional SessionId should be absent.
+    assert!(
+        !body.as_object().unwrap().contains_key("SessionId"),
+        "unset optional should not appear: {body}"
+    );
 }
 
 #[tokio::test]
 async fn report_playback_stopped_requires_authenticated_session() {
+    use crate::models::PlaybackStopInfo;
+
     // No MockServer endpoints registered for /Sessions/Playing/Stopped:
     // the auth guard must short-circuit before any HTTP call. We still
     // point at a live MockServer so that a regression would surface as
@@ -2634,7 +2711,10 @@ async fn report_playback_stopped_requires_authenticated_session() {
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
     let err = client
-        .report_playback_stopped("anything", 0)
+        .report_playback_stopped(PlaybackStopInfo {
+            item_id: "anything".into(),
+            ..Default::default()
+        })
         .await
         .unwrap_err();
     assert!(


### PR DESCRIPTION
Fixes #573, #595.

## Summary

- **#573** — Replace thin private `PlaybackProgressBody`/`PlaybackStoppedBody` structs with public `PlaybackProgressInfo` and `PlaybackStopInfo` models that mirror Jellyfin's DTOs. Both now carry `Failed` (required by the server to accept the request), `MediaSourceId` (lets the server tear down transcode jobs on stop), and `PlaySessionId`. `PlaybackProgressInfo` additionally includes `IsMuted`, `PlaybackRate`, and `PlayMethod`.
- **#595** — `ClientCapabilities` already had all `ClientCapabilitiesDto` fields (`PlayableMediaTypes`, `SupportedCommands`, `SupportsMediaControl`, `SupportsPersistentIdentifier`, `AppStoreUrl`, `IconUrl`, `DeviceProfile`); no struct changes needed.
- `report_playback_progress` and `report_playback_stopped` in both `client.rs` and `lib.rs` now accept the typed structs (matching the existing `report_playback_started` pattern). Tests updated to construct full payloads and assert each required field is present with the correct PascalCase key.

## Test plan

- All 112 unit tests pass (`cargo test`)
- `cargo clippy -- -D warnings` clean
- `cargo fmt` applied