### PR TITLE
core: structured self-signed cert error

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -335,7 +335,10 @@ impl JellyfinClient {
                         tokio::time::sleep(delay).await;
                         continue;
                     }
-                    return Err(JellifyError::Network(err.to_string()));
+                    // Route through `From<reqwest::Error>` so cert-validation
+                    // failures are mapped to `JellifyError::SelfSignedCertificate`
+                    // rather than the generic `Network` variant.
+                    return Err(err.into());
                 }
             }
         }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -6,6 +6,13 @@ pub enum JellifyError {
     #[error("network error: {0}")]
     Network(String),
 
+    /// The server presented a TLS certificate that could not be verified (e.g.
+    /// self-signed or issued by an unknown CA). Separated from the generic
+    /// [`JellifyError::Network`] variant so the UI can offer a "Trust this
+    /// server" action instead of a generic error message.
+    #[error("the server at '{host}' uses a certificate that could not be verified — it may be self-signed")]
+    SelfSignedCertificate { host: String },
+
     #[error("authentication failed: {0}")]
     Auth(String),
 
@@ -49,8 +56,43 @@ pub enum JellifyError {
 
 impl From<reqwest::Error> for JellifyError {
     fn from(e: reqwest::Error) -> Self {
+        // Walk the error source chain looking for a rustls certificate-
+        // validation failure. rustls 0.23 renders these as
+        // "invalid peer certificate: …" in its `Display` impl.  We detect
+        // the pattern here rather than taking a direct `rustls` dependency
+        // so that the detection stays in sync with whatever rustls version
+        // reqwest pulls in transitively.
+        if is_cert_error(&e) {
+            let host = e
+                .url()
+                .and_then(|u| u.host_str().map(str::to_string))
+                .unwrap_or_else(|| "unknown".to_string());
+            return JellifyError::SelfSignedCertificate { host };
+        }
         JellifyError::Network(e.to_string())
     }
+}
+
+/// Returns `true` when the error chain contains a TLS certificate-validation
+/// failure.  Compatible with both rustls 0.22 and 0.23.
+pub(crate) fn is_cert_error(e: &reqwest::Error) -> bool {
+    use std::error::Error as StdError;
+    let mut source: Option<&(dyn StdError + 'static)> = Some(e);
+    while let Some(err) = source {
+        let msg = err.to_string();
+        // rustls 0.23: "invalid peer certificate: …"
+        // older rustls / webpki: "invalid certificate: …"
+        if msg.contains("invalid peer certificate")
+            || msg.contains("invalid certificate")
+            || msg.contains("certificate verify failed")
+            || msg.contains("UnknownIssuer")
+            || msg.contains("self-signed certificate")
+        {
+            return true;
+        }
+        source = err.source();
+    }
+    false
 }
 
 impl From<serde_json::Error> for JellifyError {

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -4706,7 +4706,6 @@ fn refresh_token_from_keyring_returns_token_when_present() {
     assert_eq!(got, "refreshed-token");
 }
 
-<<<<<<< HEAD
 // ---------------------------------------------------------------------------
 // Shuffle + repeat persistence — round-trip tests (#583)
 // ---------------------------------------------------------------------------
@@ -4787,33 +4786,14 @@ fn shuffle_repeat_round_trips_all_variants() {
 /// `From<reqwest::Error>` mapping without a live TLS server.
 #[test]
 fn self_signed_cert_error_detected_from_error_chain() {
-    use crate::error::JellifyError;
-    use std::fmt;
-
-    // A minimal error whose Display output matches the rustls 0.23 pattern.
-    #[derive(Debug)]
-    struct FakeCertError;
-    impl fmt::Display for FakeCertError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("invalid peer certificate: UnknownIssuer")
-        }
-    }
-    impl std::error::Error for FakeCertError {}
-
-    // Build a reqwest::Error whose source chain contains our fake cert error.
-    // `reqwest::Error` can be constructed from a boxed `std::error::Error`
-    // via the `reqwest::Error` public constructor path.  The cleanest way
-    // available in reqwest's public API is `reqwest::get` on a URL that wraps
-    // our error, but that requires async.  Instead we test `is_cert_error`
-    // directly (pub(crate)) since the `From` impl delegates to it, and pair
-    // it with a separate live-URL smoke-test below.
-    //
-    // Confirm that a non-cert network error is NOT flagged.
+    // We can't synthesise a real reqwest cert error without a live TLS server,
+    // so this test exercises the negative path: a URL parse error must NOT be
+    // classified as a cert error. Positive-path coverage lives in the
+    // `#[ignore]`-tagged integration test against self-signed.badssl.com below.
     let plain_err = reqwest::Client::new()
         .get("not-a-url-at-all")
         .build()
         .unwrap_err();
-    // The URL parse error is not a cert error.
     assert!(
         !crate::error::is_cert_error(&plain_err),
         "URL parse error must not be treated as cert error"

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -4706,6 +4706,7 @@ fn refresh_token_from_keyring_returns_token_when_present() {
     assert_eq!(got, "refreshed-token");
 }
 
+<<<<<<< HEAD
 // ---------------------------------------------------------------------------
 // Shuffle + repeat persistence — round-trip tests (#583)
 // ---------------------------------------------------------------------------
@@ -4772,4 +4773,111 @@ fn shuffle_repeat_round_trips_all_variants() {
     }
 
     let _ = std::fs::remove_file(&tmp);
+}
+
+// ============================================================================
+// Self-signed certificate error mapping (issue #601)
+// ============================================================================
+
+/// Verify that the cert-error detector recognises the rustls 0.23 message
+/// `"invalid peer certificate: …"` that appears anywhere in the error chain.
+///
+/// We synthesise a reqwest error that wraps a custom error whose `Display`
+/// output matches that pattern.  This lets us test the detection logic and
+/// `From<reqwest::Error>` mapping without a live TLS server.
+#[test]
+fn self_signed_cert_error_detected_from_error_chain() {
+    use crate::error::JellifyError;
+    use std::fmt;
+
+    // A minimal error whose Display output matches the rustls 0.23 pattern.
+    #[derive(Debug)]
+    struct FakeCertError;
+    impl fmt::Display for FakeCertError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("invalid peer certificate: UnknownIssuer")
+        }
+    }
+    impl std::error::Error for FakeCertError {}
+
+    // Build a reqwest::Error whose source chain contains our fake cert error.
+    // `reqwest::Error` can be constructed from a boxed `std::error::Error`
+    // via the `reqwest::Error` public constructor path.  The cleanest way
+    // available in reqwest's public API is `reqwest::get` on a URL that wraps
+    // our error, but that requires async.  Instead we test `is_cert_error`
+    // directly (pub(crate)) since the `From` impl delegates to it, and pair
+    // it with a separate live-URL smoke-test below.
+    //
+    // Confirm that a non-cert network error is NOT flagged.
+    let plain_err = reqwest::Client::new()
+        .get("not-a-url-at-all")
+        .build()
+        .unwrap_err();
+    // The URL parse error is not a cert error.
+    assert!(
+        !crate::error::is_cert_error(&plain_err),
+        "URL parse error must not be treated as cert error"
+    );
+}
+
+/// End-to-end mapping test: a reqwest request to a server using a self-signed
+/// certificate must produce `JellifyError::SelfSignedCertificate { host }`,
+/// not `JellifyError::Network`.
+///
+/// This test hits `https://self-signed.badssl.com/` (a public test endpoint
+/// intentionally using a self-signed cert). It is tagged `#[ignore]` so it
+/// is skipped in offline / CI-without-network environments; run it explicitly
+/// with `cargo test -- --ignored cert_error_maps_to_structured_variant`.
+#[tokio::test]
+#[ignore = "requires outbound HTTPS to self-signed.badssl.com"]
+async fn cert_error_maps_to_structured_variant() {
+    use crate::error::JellifyError;
+
+    // A default reqwest client uses rustls and will reject the self-signed cert.
+    let result = reqwest::Client::builder()
+        .build()
+        .unwrap()
+        .get("https://self-signed.badssl.com/")
+        .send()
+        .await;
+
+    let reqwest_err = result.expect_err("badssl.com must fail cert validation");
+    let jellify_err: JellifyError = reqwest_err.into();
+
+    match jellify_err {
+        JellifyError::SelfSignedCertificate { ref host } => {
+            assert!(
+                host.contains("badssl.com"),
+                "host should be 'self-signed.badssl.com', got '{host}'"
+            );
+        }
+        other => panic!("expected SelfSignedCertificate, got {other:?}"),
+    }
+}
+
+/// Confirm that a plain connection-refused error (not a cert issue) continues
+/// to map to `JellifyError::Network`, not `SelfSignedCertificate`.
+#[tokio::test]
+async fn non_cert_transport_error_stays_network() {
+    use crate::error::JellifyError;
+
+    // Connect to a port that is (almost certainly) not listening.  This
+    // produces a connect-refused transport error, not a cert error.
+    let result = reqwest::Client::builder()
+        .build()
+        .unwrap()
+        .get("http://127.0.0.1:19999/")
+        .send()
+        .await;
+
+    // May succeed if something happens to be on that port; skip in that case.
+    let Some(reqwest_err) = result.err() else {
+        return;
+    };
+    let jellify_err: JellifyError = reqwest_err.into();
+
+    assert!(
+        matches!(jellify_err, JellifyError::Network(_)),
+        "connection-refused must map to Network, got {jellify_err:?}"
+    );
 }


### PR DESCRIPTION
Fixes #601.

When the Jellyfin server uses a self-signed certificate, the client previously returned an opaque `JellifyError::Network` with a reqwest error string. This change:

- Adds `JellifyError::SelfSignedCertificate { host: String }` variant to `error.rs`
- Walks the `reqwest::Error` source chain in `From<reqwest::Error>` to detect the rustls 0.23 pattern `"invalid peer certificate: …"` (and compatible older patterns) and maps it to the new variant
- Updates `send_with_retry_raw` in `client.rs` to route through `Into` so the structured mapping fires automatically
- Adds three tests: a unit test confirming non-cert errors are not misclassified, a `#[ignore]`-tagged integration test against `self-signed.badssl.com`, and a connection-refused test asserting `Network` is preserved for non-cert transport errors

The UI can now pattern-match on `SelfSignedCertificate { host }` to display an actionable "Trust this server" prompt instead of a raw network error string. Certificate trust bypass is not implemented here — that remains a UI-driven decision.