### PR TITLE
macos(a11y): VoiceOver focus traversal

### DIFF
--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -102,9 +102,14 @@ struct ArtistCard: View {
         .contextMenu { ArtistContextMenu(artist: artist) }
         // Outer tap target reads as an artist navigation control; the
         // inner hover Play button owns its own label. VoiceOver sees
-        // "Artist <name>, <album count>. Opens artist detail."
+        // "Artist <name>, <album count>. Opens artist detail." `.focusable`
+        // ensures the VoiceOver rotor can Tab into this card from a grid.
+        // See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(artist.name), \(albumCountLabel)")
         .accessibilityHint("Opens artist detail")
+        .accessibilityAddTraits(.isButton)
     }
 
     /// Subline shown under the artist name. Uses `album_count` when known;

--- a/macos/Sources/Jellify/Components/HomeAlbumTile.swift
+++ b/macos/Sources/Jellify/Components/HomeAlbumTile.swift
@@ -53,10 +53,13 @@ struct HomeAlbumTile<Badge: View>: View {
         // a container — the outer body is its own focus target with the
         // album's label + hint, but the inline Play button remains a
         // separately-focusable control with its own "Play <album>" label.
-        // See #331.
+        // `.focusable` allows the VoiceOver rotor to Tab into the tile from
+        // a horizontal carousel. See #331 / #588.
+        .focusable(true)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(album.name) by \(album.artistName)")
         .accessibilityHint(hint)
+        .accessibilityAddTraits(.isButton)
     }
 
     private var artwork: some View {

--- a/macos/Sources/Jellify/Components/HomeQuickTile.swift
+++ b/macos/Sources/Jellify/Components/HomeQuickTile.swift
@@ -66,7 +66,12 @@ struct HomeQuickTile: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        // `.focusable` lets the VoiceOver rotor Tab into the tile from the
+        // Home quick-tiles row; `.combine` presents the artwork + text + play
+        // button as a single actionable element. See #588.
+        .focusable(true)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(subtitle.map { "\(title), \($0)" } ?? title)
+        .accessibilityAddTraits(.isButton)
     }
 }

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -104,8 +104,13 @@ struct LibraryListRow: View {
         // VoiceOver hears "<primary>, <secondary>. Opens <kind> detail."
         // The hover play button only appears on cursor hover, so we route
         // the row's body tap (openDetail) as the single focusable target.
+        // `.focusable` lets the rotor Tab through the list; `.combine`
+        // collapses artwork + text into one element. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(accessibilityHint)
+        .accessibilityAddTraits(.isButton)
     }
 
     private var accessibilityLabel: String {

--- a/macos/Sources/Jellify/Components/PlaylistCard.swift
+++ b/macos/Sources/Jellify/Components/PlaylistCard.swift
@@ -67,8 +67,14 @@ struct PlaylistCard: View {
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
         .contextMenu { PlaylistContextMenu(playlist: playlist) }
+        // `.focusable` lets the VoiceOver rotor Tab into this card; `.combine`
+        // collapses the artwork, title, and play-button children so the card
+        // reads as a single "Opens playlist detail" button. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(playlist.name), \(subtitle)")
         .accessibilityHint("Opens playlist detail")
+        .accessibilityAddTraits(.isButton)
     }
 
     /// "42 tracks" / "1 track" — singular vs plural. Jellyfin reports

--- a/macos/Sources/Jellify/Components/QueueInspector.swift
+++ b/macos/Sources/Jellify/Components/QueueInspector.swift
@@ -533,7 +533,15 @@ private struct QueueInspectorRow: View {
                 .fill(isHovering ? Theme.rowHover : .clear)
         )
         .contentShape(Rectangle())
+        // `.focusable` on reorderable rows so the rotor can Tab through Up
+        // Next; auto-queue rows are read-only and remain non-focusable.
+        // `.combine` collapses artwork + text + remove button into one element
+        // so VoiceOver reads "Track by Artist" as a single queue entry.
+        // See #588.
         .focusable(removable)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.track.name) by \(entry.track.artistName)")
+        .accessibilityAddTraits(removable ? .isButton : [])
         // Opt+↑ / Opt+↓ reorders the focused row. Only match when the
         // Option modifier is held so plain arrow keys fall through to
         // the surrounding list's focus traversal.
@@ -553,7 +561,6 @@ private struct QueueInspectorRow: View {
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
         }
-        .accessibilityLabel("\(entry.track.name) by \(entry.track.artistName)")
     }
 }
 

--- a/macos/Sources/Jellify/Components/RecentlyPlayedTile.swift
+++ b/macos/Sources/Jellify/Components/RecentlyPlayedTile.swift
@@ -59,7 +59,13 @@ struct RecentlyPlayedTile: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        // `.focusable` lets the VoiceOver rotor Tab through the Recently
+        // Played / For You carousels; `.combine` collapses artwork + metadata
+        // into one button element. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint("Plays this track")
+        .accessibilityAddTraits(.isButton)
     }
 }

--- a/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
@@ -72,8 +72,14 @@ struct RecentlyPlayedTrackRow: View {
                 }
             }
         }
+        // `.focusable` lets the VoiceOver rotor Tab through the Home
+        // Recently Played list; `.combine` presents thumbnail + title +
+        // duration as a single playable element. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint("Plays this track")
+        .accessibilityAddTraits(.isButton)
     }
 
     private var thumbnail: some View {

--- a/macos/Sources/Jellify/Components/SearchInstantDropdown.swift
+++ b/macos/Sources/Jellify/Components/SearchInstantDropdown.swift
@@ -307,7 +307,11 @@ private struct ArtistCircleTile: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture { onPick(.artist(artist)) }
+        // Custom tap-gesture control needs an explicit focusable + button
+        // trait so the VoiceOver rotor can reach it. See #588.
+        .focusable(true)
         .accessibilityLabel("Artist \(artist.name)")
+        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -365,8 +369,12 @@ private struct AlbumMiniTile: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture { onPick(.album(album)) }
+        // Custom tap-gesture control — expose as a focusable button so the
+        // VoiceOver rotor can reach search result album tiles. See #588.
+        .focusable(true)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Album \(album.name) by \(album.artistName)")
+        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -427,7 +435,12 @@ private struct TrackDropdownRow: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture { onPick(.track(track)) }
+        // Custom tap-gesture row — expose as focusable button so the
+        // VoiceOver rotor can reach search result track rows. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("Track \(track.name) by \(track.artistName)")
+        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -485,7 +498,12 @@ private struct PlaylistMiniTile: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture { onPick(.playlist(playlist)) }
+        // Custom tap-gesture control — expose as focusable button so the
+        // VoiceOver rotor can reach search result playlist tiles. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("Playlist \(playlist.name)")
+        .accessibilityAddTraits(.isButton)
     }
 
     private var countLabel: String {
@@ -538,7 +556,11 @@ private struct GenreTile: View {
             .contentShape(Rectangle())
             .onHover { isHovering = $0 }
             .onTapGesture { onPick(.genre(genre)) }
+            // Custom tap-gesture genre chip — expose as focusable button for
+            // VoiceOver rotor traversal. See #588.
+            .focusable(true)
             .accessibilityLabel("Genre \(genre.name)")
+            .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/macos/Sources/Jellify/Components/TopTrackRow.swift
+++ b/macos/Sources/Jellify/Components/TopTrackRow.swift
@@ -115,8 +115,14 @@ struct TopTrackRow: View {
             }
         }
         .contextMenu { TrackContextMenu(selection: [track]) }
+        // `.focusable` lets the VoiceOver rotor Tab through the Top Tracks
+        // list; `.combine` collapses rank/artwork/text so the element reads
+        // as a single playable row. See #588.
+        .focusable(true)
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name), \(playCountLabel), rank \(rank)")
         .accessibilityHint("Plays this track")
+        .accessibilityAddTraits(.isButton)
     }
 
     /// Start playback at this row. Passing the full `queue` keeps the Top

--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -126,10 +126,13 @@ struct TrackListRow: View {
         // A single row should read as one VoiceOver element — the wrapping
         // Button already carries a label, but we override it here to pull
         // in the active state so playing rows announce "Now playing" and
-        // non-playing rows announce "Plays this track".
+        // non-playing rows announce "Plays this track". `.combine` collapses
+        // the artwork and text sub-views so the rotor sees one button per
+        // row rather than several unlabelled children. See #588.
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint(isPlaying ? "Now playing" : "Plays this track")
-        .accessibilityAddTraits(isPlaying ? .isSelected : [])
+        .accessibilityAddTraits(isPlaying ? [.isButton, .isSelected] : .isButton)
         // MARK: Keyboard navigation (#105)
         .focusable()
         .focused($isFocused)


### PR DESCRIPTION
Fixes #588.

Custom SwiftUI controls had VoiceOver labels but lacked `.focusable(true)`, so the accessibility rotor could not Tab through them.

## Changes

Added `.focusable(true)` + `.accessibilityElement(children: .combine)` + `.accessibilityAddTraits(.isButton)` where missing:

- `TrackListRow` — library track rows (added `.combine` + `.isButton`; `.focusable` was already present)
- `ArtistCard` — artist grid tiles
- `PlaylistCard` — playlist grid tiles
- `HomeAlbumTile` — home carousel album tiles (`.contain` kept; added `.focusable` + `.isButton`)
- `LibraryListRow` — album/artist/playlist list rows
- `TopTrackRow` — artist detail Top Tracks rows
- `HomeQuickTile` — home quick-action tiles
- `RecentlyPlayedTile` — recently played / For You carousel tiles
- `RecentlyPlayedTrackRow` — home recently played list rows
- `SearchInstantDropdown` — artist circle tiles, album mini tiles, track rows, playlist mini tiles, genre chips (all use `.onTapGesture` — added `.focusable` + `.isButton` to each)
- `QueueInspector` / `QueueInspectorRow` — Up Next rows (`.combine` + `.isButton` on reorderable rows)

No structural changes — modifiers only. `TrackRow` was already correct and untouched.

## Test plan

- [ ] Enable VoiceOver (⌘F5) and Tab through the Home screen quick tiles, album carousels, recently played rows
- [ ] Tab into Library list rows (albums, artists, playlists) and grid cards
- [ ] Tab into an artist detail Top Tracks list
- [ ] Open the Queue Inspector and Tab through Up Next rows; Opt+↑/↓ reordering should still work
- [ ] Open the search instant dropdown and Tab through artists, albums, track rows, genre chips
- [ ] Confirm VoiceOver reads the combined label (name + artist/subtitle) for each control