### PR TITLE
core: switch genres to /Genres endpoint

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1062,18 +1062,19 @@ impl JellyfinClient {
     }
 
     /// All music genres in the user's library, paginated. Backed by
-    /// `GET /MusicGenres` with `Fields=ItemCounts` so each returned
-    /// [`Genre`] carries `song_count` / `album_count` in a single round-trip.
-    /// The plain `/Genres` controller is obsolete for music.
+    /// `GET /Genres?IncludeItemTypes=Audio,MusicAlbum,MusicArtist` with
+    /// `Fields=ItemCounts` so each returned [`Genre`] carries `song_count` /
+    /// `album_count` in a single round-trip.
     pub async fn genres(&self, paging: Paging) -> Result<PaginatedGenres> {
         let user_id = self
             .user_id
             .as_ref()
             .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint("MusicGenres")?;
+        let mut url = self.endpoint("Genres")?;
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("userId", user_id);
+            q.append_pair("IncludeItemTypes", "Audio,MusicAlbum,MusicArtist");
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
             q.append_pair("SortBy", "SortName");

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1099,7 +1099,7 @@ async fn genres_builds_query_and_parses_counts() {
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(path("/MusicGenres"))
+        .and(path("/Genres"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "Items": [
                 {
@@ -1133,10 +1133,29 @@ async fn genres_builds_query_and_parses_counts() {
         .iter()
         .find(|r| r.method.as_str() == "GET")
         .expect("expected a GET request");
+    assert_eq!(
+        get.url.path(),
+        "/Genres",
+        "should call /Genres, not /MusicGenres"
+    );
     let q = get.url.query().expect("expected a query string");
     assert!(q.contains("userId=u1"), "query: {q}");
     assert!(q.contains("Limit=100"), "query: {q}");
     assert!(q.contains("StartIndex=0"), "query: {q}");
+    let include_types = get
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "IncludeItemTypes")
+        .map(|(_, v)| v.into_owned())
+        .expect("expected IncludeItemTypes query param");
+    assert!(
+        include_types.split(',').any(|t| t == "Audio"),
+        "IncludeItemTypes should include Audio, got: {include_types}"
+    );
+    assert!(
+        include_types.split(',').any(|t| t == "MusicAlbum"),
+        "IncludeItemTypes should include MusicAlbum, got: {include_types}"
+    );
     let fields = get
         .url
         .query_pairs()


### PR DESCRIPTION
Fixes #606.

Replaces the deprecated `GET /MusicGenres` endpoint with `GET /Genres?IncludeItemTypes=Audio,MusicAlbum,MusicArtist`, which is the supported way to fetch music-specific genres. The response shape is identical so no model changes were needed.

Tests updated to assert the new path and verify the `IncludeItemTypes` parameter is sent.