### PR TITLE
core: SearchHint image fields + similar_items params

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1019,6 +1019,13 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("Limit", &limit.max(1).to_string());
+            q.append_pair(
+                "Fields",
+                "PrimaryImageAspectRatio,BasicSyncInfo,MediaSourceCount,UserData",
+            );
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
@@ -2049,6 +2056,12 @@ struct RawSearchHint {
     matched_term: Option<String>,
     #[serde(rename = "PrimaryImageTag")]
     primary_image_tag: Option<String>,
+    #[serde(rename = "ThumbImageTag")]
+    thumb_image_tag: Option<String>,
+    #[serde(rename = "BackdropImageTag")]
+    backdrop_image_tag: Option<String>,
+    #[serde(rename = "PrimaryImageAspectRatio")]
+    primary_image_aspect_ratio: Option<f64>,
     #[serde(rename = "ProductionYear")]
     production_year: Option<i32>,
     #[serde(rename = "IndexNumber")]
@@ -2075,6 +2088,9 @@ impl From<RawSearchHint> for SearchHint {
             album_artist: r.album_artist,
             matched_term: r.matched_term,
             primary_image_tag: r.primary_image_tag,
+            thumb_image_tag: r.thumb_image_tag,
+            backdrop_image_tag: r.backdrop_image_tag,
+            primary_image_aspect_ratio: r.primary_image_aspect_ratio,
             production_year: r.production_year,
             index_number: r.index_number,
             parent_index_number: r.parent_index_number,

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -241,6 +241,18 @@ pub struct SearchHint {
     /// highlighting the matched portion of `name` in the UI.
     pub matched_term: Option<String>,
     pub primary_image_tag: Option<String>,
+    /// Tag for the item's thumbnail image (`ThumbImageTag` in the Jellyfin
+    /// DTO). Used to build a `/Items/{id}/Images/Thumb?tag=…` URL.
+    #[serde(rename = "ThumbImageTag")]
+    pub thumb_image_tag: Option<String>,
+    /// Tag for the item's backdrop image (`BackdropImageTag` in the Jellyfin
+    /// DTO). Used to build a `/Items/{id}/Images/Backdrop?tag=…` URL.
+    #[serde(rename = "BackdropImageTag")]
+    pub backdrop_image_tag: Option<String>,
+    /// Server-reported aspect ratio for the primary image so the UI can
+    /// reserve the correct amount of space before the image loads.
+    #[serde(rename = "PrimaryImageAspectRatio")]
+    pub primary_image_aspect_ratio: Option<f64>,
     pub production_year: Option<i32>,
     pub index_number: Option<u32>,
     pub parent_index_number: Option<u32>,

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1026,6 +1026,21 @@ async fn similar_items_builds_query_and_parses() {
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].kind.as_deref(), Some("MusicAlbum"));
     assert_eq!(items[1].kind.as_deref(), Some("Audio"));
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("Fields="), "query should include Fields: {q}");
+    assert!(
+        q.contains("PrimaryImageAspectRatio"),
+        "Fields should include PrimaryImageAspectRatio: {q}"
+    );
+    assert!(q.contains("EnableUserData=true"), "query: {q}");
+    assert!(q.contains("EnableImages=true"), "query: {q}");
+    assert!(q.contains("ImageTypeLimit=1"), "query: {q}");
 }
 
 #[tokio::test]
@@ -2204,6 +2219,103 @@ async fn search_hints_builds_expected_query_and_parses() {
     assert_eq!(track.album_id.as_deref(), Some("album-1"));
     assert_eq!(track.index_number, Some(3));
     assert_eq!(track.parent_index_number, Some(1));
+}
+
+/// Verify that the three image-related fields added in #596
+/// (`ThumbImageTag`, `BackdropImageTag`, `PrimaryImageAspectRatio`) are
+/// correctly deserialised from the Jellyfin `SearchHint` DTO.
+#[tokio::test]
+async fn search_hint_parses_image_fields() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Search/Hints"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "SearchHints": [
+                {
+                    "Id": "album-99",
+                    "Name": "Wide Screen Album",
+                    "Type": "MusicAlbum",
+                    "MediaType": "Unknown",
+                    "Artists": [],
+                    "PrimaryImageTag": "img-primary",
+                    "ThumbImageTag": "img-thumb",
+                    "BackdropImageTag": "img-backdrop",
+                    "PrimaryImageAspectRatio": 1.777_777_8_f64
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let results = client
+        .search_hints("Wide Screen", Paging::new(0, 8))
+        .await
+        .unwrap();
+
+    assert_eq!(results.total_record_count, 1);
+    let hint = &results.search_hints[0];
+    assert_eq!(hint.primary_image_tag.as_deref(), Some("img-primary"));
+    assert_eq!(hint.thumb_image_tag.as_deref(), Some("img-thumb"));
+    assert_eq!(hint.backdrop_image_tag.as_deref(), Some("img-backdrop"));
+    let ratio = hint.primary_image_aspect_ratio.expect("aspect ratio");
+    assert!((ratio - 1.777_777_8_f64).abs() < 1e-5, "ratio: {ratio}");
+}
+
+/// Hints whose optional image fields are absent must deserialise cleanly
+/// (all three fields must be `None`).
+#[tokio::test]
+async fn search_hint_image_fields_absent_is_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Search/Hints"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "SearchHints": [
+                {
+                    "Id": "artist-42",
+                    "Name": "No Image Artist",
+                    "Type": "MusicArtist",
+                    "MediaType": "Unknown",
+                    "Artists": []
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let results = client
+        .search_hints("No Image", Paging::new(0, 8))
+        .await
+        .unwrap();
+
+    let hint = &results.search_hints[0];
+    assert!(hint.thumb_image_tag.is_none(), "thumb should be None");
+    assert!(hint.backdrop_image_tag.is_none(), "backdrop should be None");
+    assert!(
+        hint.primary_image_aspect_ratio.is_none(),
+        "aspect ratio should be None"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #596, #597.

**#596** — `SearchHint` now carries `ThumbImageTag`, `BackdropImageTag`, and `PrimaryImageAspectRatio`. Both the public struct (`models.rs`) and the internal `RawSearchHint` deserialiser (`client.rs`) are updated. The `From` conversion maps all three new fields through.

**#597** — `similar_items` now appends `Fields=PrimaryImageAspectRatio,BasicSyncInfo,MediaSourceCount,UserData`, `EnableUserData=true`, `EnableImages=true`, and `ImageTypeLimit=1` — matching the pattern used by other Items-returning methods in `client.rs`.

Tests added in `core/src/tests.rs`:
- `search_hint_parses_image_fields` — round-trips all three new fields through a wiremock response
- `search_hint_image_fields_absent_is_none` — confirms absent fields deserialise to `None`
- Extended `similar_items_builds_query_and_parses` — asserts the new query params are present

All 129 tests pass (`cargo test`), clippy clean (`-D warnings`).