### PR TITLE
core: playlist fields + optional position

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -785,7 +785,10 @@ impl JellyfinClient {
             q.append_pair("IncludeItemTypes", "Audio");
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "MediaSources,ParentId,Path,SortName");
+            q.append_pair(
+                "Fields",
+                "MediaSources,ParentId,Path,PlaylistItemId,SortName",
+            );
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
@@ -810,7 +813,12 @@ impl JellyfinClient {
     ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
-    pub async fn add_to_playlist(&self, playlist_id: &str, item_ids: &[&str]) -> Result<()> {
+    pub async fn add_to_playlist(
+        &self,
+        playlist_id: &str,
+        item_ids: &[&str],
+        position: Option<u32>,
+    ) -> Result<()> {
         let user_id = self
             .user_id
             .as_ref()
@@ -820,6 +828,9 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("Ids", &item_ids.join(","));
             q.append_pair("UserId", user_id);
+            if let Some(pos) = position {
+                q.append_pair("StartIndex", &pos.to_string());
+            }
         }
         self.send_with_retry(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
             .await?;
@@ -1353,12 +1364,21 @@ impl JellyfinClient {
     ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
-    pub async fn create_playlist(&self, name: &str, item_ids: &[&str]) -> Result<String> {
+    pub async fn create_playlist(
+        &self,
+        name: &str,
+        item_ids: &[&str],
+        position: Option<u32>,
+    ) -> Result<String> {
         let user_id = self
             .user_id
             .as_ref()
             .ok_or(JellifyError::NotAuthenticated)?;
-        let url = self.endpoint("Playlists")?;
+        let mut url = self.endpoint("Playlists")?;
+        if let Some(pos) = position {
+            url.query_pairs_mut()
+                .append_pair("StartIndex", &pos.to_string());
+        }
         let body = CreatePlaylistBody {
             name: name.to_string(),
             ids: item_ids.iter().map(|s| s.to_string()).collect(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -523,15 +523,20 @@ impl JellifyCore {
     /// Append items (tracks/albums/artists) to a playlist in a single
     /// round-trip. Mirrors Jellify's `addManyToPlaylist`; callers should
     /// invalidate their `playlist_tracks` cache after this returns.
+    ///
+    /// When `position` is `Some(n)`, the Jellyfin `StartIndex` query param is
+    /// set so the server inserts the items starting at index `n` rather than
+    /// appending to the end.
     pub fn add_to_playlist(
         &self,
         playlist_id: String,
         item_ids: Vec<String>,
+        position: Option<u32>,
     ) -> std::result::Result<(), JellifyError> {
         self.with_client(|c| {
             let id_refs: Vec<&str> = item_ids.iter().map(String::as_str).collect();
             self.runtime
-                .block_on(c.add_to_playlist(&playlist_id, &id_refs))
+                .block_on(c.add_to_playlist(&playlist_id, &id_refs, position))
         })
     }
 
@@ -611,14 +616,19 @@ impl JellifyCore {
     /// [`JellifyCore::fetch_item`] if they need the populated record.
     /// `item_ids` may be empty to create an empty playlist. Errors with
     /// [`JellifyError::NotAuthenticated`] if no session is active.
+    ///
+    /// When `position` is `Some(n)`, the Jellyfin `StartIndex` query param is
+    /// set so the server inserts the initial items starting at index `n`.
     pub fn create_playlist(
         &self,
         name: String,
         item_ids: Vec<String>,
+        position: Option<u32>,
     ) -> std::result::Result<String, JellifyError> {
         self.with_client(|c| {
             let id_refs: Vec<&str> = item_ids.iter().map(String::as_str).collect();
-            self.runtime.block_on(c.create_playlist(&name, &id_refs))
+            self.runtime
+                .block_on(c.create_playlist(&name, &id_refs, position))
         })
     }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1885,7 +1885,10 @@ async fn playlist_tracks_preserves_order_and_builds_query() {
         .and(query_param("IncludeItemTypes", "Audio"))
         .and(query_param("Limit", "50"))
         .and(query_param("StartIndex", "0"))
-        .and(query_param("Fields", "MediaSources,ParentId,Path,SortName"))
+        .and(query_param(
+            "Fields",
+            "MediaSources,ParentId,Path,PlaylistItemId,SortName",
+        ))
         .respond_with(|req: &Request| {
             // Playlist order is load-bearing: the client must NOT send
             // SortBy/SortOrder for this endpoint.
@@ -2997,7 +3000,7 @@ async fn create_playlist_posts_pascal_case_body_and_returns_id() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let id = client
-        .create_playlist("Road Trip", &["t1", "t2", "t3"])
+        .create_playlist("Road Trip", &["t1", "t2", "t3"], None)
         .await
         .unwrap();
     assert_eq!(id, "new-playlist-id");
@@ -3083,7 +3086,10 @@ async fn create_playlist_with_empty_ids_sends_empty_array() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client.create_playlist("Empty List", &[]).await.unwrap();
+    let id = client
+        .create_playlist("Empty List", &[], None)
+        .await
+        .unwrap();
     assert_eq!(id, "empty-playlist-id");
 
     let requests = server.received_requests().await.unwrap();
@@ -3119,7 +3125,7 @@ async fn create_playlist_propagates_server_errors() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let err = client.create_playlist("x", &[]).await.unwrap_err();
+    let err = client.create_playlist("x", &[], None).await.unwrap_err();
     match err {
         crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 500),
         other => panic!("expected Server 500, got {other:?}"),
@@ -3134,7 +3140,7 @@ async fn create_playlist_requires_authenticated_session() {
     // a real host.
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
-    let err = client.create_playlist("x", &[]).await.unwrap_err();
+    let err = client.create_playlist("x", &[], None).await.unwrap_err();
     assert!(
         matches!(err, crate::error::JellifyError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
@@ -3164,7 +3170,7 @@ async fn add_to_playlist_posts_ids_csv_and_user_id() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     client
-        .add_to_playlist("pl-123", &["t1", "t2", "t3"])
+        .add_to_playlist("pl-123", &["t1", "t2", "t3"], None)
         .await
         .unwrap();
 
@@ -3195,10 +3201,235 @@ async fn add_to_playlist_requires_authenticated_session() {
     // than silently hitting a real host.
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
-    let err = client.add_to_playlist("pl-123", &["t1"]).await.unwrap_err();
+    let err = client
+        .add_to_playlist("pl-123", &["t1"], None)
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, crate::error::JellifyError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// playlist_tracks — PlaylistItemId in Fields (#572)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn playlist_tracks_includes_playlist_item_id_in_fields() {
+    // #572: PlaylistItemId must appear in the Fields param so the server
+    // returns per-entry identifiers. Without it, duplicate tracks are
+    // indistinguishable and remove-by-entry operations delete all copies.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "dup-pl"))
+        .respond_with(|req: &Request| {
+            let pairs: std::collections::HashMap<_, _> =
+                req.url.query_pairs().into_owned().collect();
+            let fields = pairs.get("Fields").cloned().unwrap_or_default();
+            assert!(
+                fields.contains("PlaylistItemId"),
+                "Fields must contain PlaylistItemId, got: {fields}"
+            );
+            ResponseTemplate::new(200).set_body_json(json!({
+                "Items": [
+                    {
+                        "Id": "t1", "Name": "Repeated", "Type": "Audio",
+                        "AlbumId": "a1", "Album": "A", "AlbumArtist": "X",
+                        "Artists": ["X"], "RunTimeTicks": 1000000000u64,
+                        "PlaylistItemId": "pi-1",
+                        "ImageTags": {}
+                    },
+                    {
+                        "Id": "t1", "Name": "Repeated", "Type": "Audio",
+                        "AlbumId": "a1", "Album": "A", "AlbumArtist": "X",
+                        "Artists": ["X"], "RunTimeTicks": 1000000000u64,
+                        "PlaylistItemId": "pi-2",
+                        "ImageTags": {}
+                    }
+                ],
+                "TotalRecordCount": 2
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .playlist_tracks("dup-pl", Paging::new(0, 50))
+        .await
+        .unwrap();
+    // Both duplicate entries must be returned — the server distinguishes them
+    // via PlaylistItemId, which is now requested in Fields.
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total_count, 2);
+}
+
+// ---------------------------------------------------------------------------
+// add_to_playlist — optional position param (#607)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn add_to_playlist_with_position_sends_start_index() {
+    // #607: when position is Some(n) the client must include StartIndex=n in
+    // the query string so Jellyfin inserts at that position instead of
+    // appending.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists/pl-99/Items"))
+        .and(query_param("StartIndex", "3"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .add_to_playlist("pl-99", &["t1"], Some(3))
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists/pl-99/Items")
+        .expect("expected POST to /Playlists/pl-99/Items");
+    let q = post.url.query().expect("expected a query string");
+    assert!(q.contains("StartIndex=3"), "query: {q}");
+}
+
+#[tokio::test]
+async fn add_to_playlist_without_position_omits_start_index() {
+    // #607: when position is None, StartIndex must NOT appear in the query —
+    // Jellyfin interprets its absence as "append to end".
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists/pl-append/Items"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .add_to_playlist("pl-append", &["t2"], None)
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists/pl-append/Items")
+        .expect("expected POST to /Playlists/pl-append/Items");
+    let q = post.url.query().unwrap_or_default();
+    assert!(
+        !q.contains("StartIndex"),
+        "StartIndex must be absent when position is None, query: {q}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// create_playlist — optional position param (#607)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_playlist_with_position_sends_start_index() {
+    // #607: when position is Some(n) the client must include StartIndex=n as a
+    // query param on POST /Playlists.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists"))
+        .and(query_param("StartIndex", "5"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "Id": "pos-pl-id" })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let id = client
+        .create_playlist("Positioned", &["t1"], Some(5))
+        .await
+        .unwrap();
+    assert_eq!(id, "pos-pl-id");
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
+        .expect("expected POST to /Playlists");
+    let q = post.url.query().expect("expected a query string");
+    assert!(q.contains("StartIndex=5"), "query: {q}");
+}
+
+#[tokio::test]
+async fn create_playlist_without_position_omits_start_index() {
+    // #607: when position is None, StartIndex must NOT appear in the query.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "Id": "no-pos-pl-id" })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let id = client
+        .create_playlist("Appended", &["t1"], None)
+        .await
+        .unwrap();
+    assert_eq!(id, "no-pos-pl-id");
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
+        .expect("expected POST to /Playlists");
+    let q = post.url.query().unwrap_or_default();
+    assert!(
+        !q.contains("StartIndex"),
+        "StartIndex must be absent when position is None, query: {q}"
     );
 }
 


### PR DESCRIPTION
Fixes #572, #607.

## Summary
- **#572**: Added `PlaylistItemId` to the `Fields` query param in `playlist_tracks`. Jellyfin returns a unique per-slot `PlaylistItemId` for each playlist entry; without it, duplicate tracks are indistinguishable and remove/reorder operations affect all copies.
- **#607**: Added `position: Option<u32>` to `add_to_playlist` and `create_playlist`. When `Some(n)`, a `StartIndex=n` query param is sent so Jellyfin inserts at index `n` instead of always appending. FFI signatures in `lib.rs` updated to match.
- 5 new tests covering PlaylistItemId in Fields, position-present and position-absent for both endpoints.

## Test plan
- [ ] `cargo test` passes (132 tests, 0 failures)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] Verify playlist sidebar can remove a specific copy of a duplicate track
- [ ] Verify drag-to-position in playlist sidebar uses `add_to_playlist` with a non-None position