### PR TITLE
core: PlaybackInfo + PlaySessionId threading

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1787,7 +1787,7 @@ impl JellyfinClient {
     /// Fetch the full audio payload for a track, authenticated. Returns the
     /// bytes plus the reported Content-Type (needed to pick the right decoder).
     pub async fn stream_bytes(&self, track_id: &str) -> Result<(Vec<u8>, Option<String>)> {
-        let url = self.stream_url(track_id)?;
+        let url = self.stream_url(track_id, None, None)?;
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
@@ -1802,10 +1802,21 @@ impl JellyfinClient {
 
     /// Build the URL to stream a given track.
     ///
+    /// `media_source_id` should come from `MediaSourceInfo::id` returned by
+    /// `POST /Items/{id}/PlaybackInfo` so the server streams the correct source
+    /// when an item has multiple audio versions. `play_session_id` should be
+    /// the `PlaySessionId` returned by the same endpoint and must be echoed on
+    /// every subsequent progress/stop report.
+    ///
     /// Advertises all containers AVFoundation / MediaPlayer handle natively,
     /// so Jellyfin direct-streams whenever the source matches. Exotic source
     /// formats fall back to a transcoded MP3 stream.
-    pub fn stream_url(&self, track_id: &str) -> Result<Url> {
+    pub fn stream_url(
+        &self,
+        track_id: &str,
+        media_source_id: Option<&str>,
+        play_session_id: Option<&str>,
+    ) -> Result<Url> {
         let mut url = self.endpoint(&format!("Audio/{track_id}/universal"))?;
         {
             let mut q = url.query_pairs_mut();
@@ -1816,6 +1827,12 @@ impl JellyfinClient {
             q.append_pair("AudioCodec", "mp3,aac,flac,alac,pcm,vorbis,opus");
             q.append_pair("TranscodingContainer", "mp3");
             q.append_pair("TranscodingProtocol", "http");
+            if let Some(msid) = media_source_id {
+                q.append_pair("MediaSourceId", msid);
+            }
+            if let Some(psid) = play_session_id {
+                q.append_pair("PlaySessionId", psid);
+            }
             if let Some(token) = self.token.lock().as_deref() {
                 q.append_pair("api_key", token);
             }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -688,11 +688,27 @@ impl JellifyCore {
 
     // ---------- Playback ----------
 
-    /// Returns the fully-authenticated stream URL for a track. The platform
-    /// audio engine (AVPlayer etc.) fetches from this, attaching the
-    /// `Authorization` header returned by [`Self::auth_header`].
-    pub fn stream_url(&self, track_id: String) -> std::result::Result<String, JellifyError> {
-        self.with_client(|c| Ok(c.stream_url(&track_id)?.to_string()))
+    /// Returns the fully-authenticated stream URL for a track.
+    ///
+    /// `media_source_id` should be `MediaSourceInfo::id` from the
+    /// `PlaybackInfo` response so Jellyfin streams the correct source when an
+    /// item has multiple audio versions (fixes #593). `play_session_id` should
+    /// be the `PlaySessionId` returned by `PlaybackInfo` and is embedded in the
+    /// URL so the server can correlate the stream with its transcode job.
+    pub fn stream_url(
+        &self,
+        track_id: String,
+        media_source_id: Option<String>,
+        play_session_id: Option<String>,
+    ) -> std::result::Result<String, JellifyError> {
+        self.with_client(|c| {
+            Ok(c.stream_url(
+                &track_id,
+                media_source_id.as_deref(),
+                play_session_id.as_deref(),
+            )?
+            .to_string())
+        })
     }
 
     /// The `Authorization` header value to attach to streaming requests.
@@ -719,6 +735,15 @@ impl JellifyCore {
         self.player.set_current(track.clone());
         let now = chrono::Utc::now().timestamp();
         let _ = self.inner.lock().db.record_play(&track.id, now);
+    }
+
+    /// Store the `PlaySessionId` returned by `PlaybackInfo` on the current
+    /// player state. Must be called at playback start; the id is then
+    /// available via `status().play_session_id` so platform layers can echo
+    /// it on every `PlaybackProgressInfo` / `PlaybackStopInfo` report.
+    /// See issue #569.
+    pub fn set_play_session_id(&self, play_session_id: Option<String>) {
+        self.player.set_play_session_id(play_session_id);
     }
 
     /// Report that playback has stopped for an item — backed by

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -54,6 +54,12 @@ pub struct PlayerStatus {
     /// [`Player::skip_next`] / [`Player::skip_previous`] when the caller
     /// walks past a queue boundary. See issue #34.
     pub repeat_mode: RepeatMode,
+    /// The `PlaySessionId` assigned by Jellyfin's `POST /Items/{id}/PlaybackInfo`
+    /// for the current track. Must be echoed on every subsequent
+    /// `PlaybackProgressInfo` / `PlaybackStopInfo` report so the server can
+    /// correlate the stream with its transcode job. `None` when no session is
+    /// active. See issue #569.
+    pub play_session_id: Option<String>,
 }
 
 pub struct Player {
@@ -69,6 +75,7 @@ struct Shared {
     position_seconds: f64,
     shuffle: bool,
     repeat_mode: RepeatMode,
+    play_session_id: Option<String>,
 }
 
 impl Shared {
@@ -82,6 +89,7 @@ impl Shared {
             position_seconds: 0.0,
             shuffle: false,
             repeat_mode: RepeatMode::Off,
+            play_session_id: None,
         }
     }
 
@@ -101,6 +109,7 @@ impl Shared {
             queue_length: self.queue.len() as u32,
             shuffle: self.shuffle,
             repeat_mode: self.repeat_mode,
+            play_session_id: self.play_session_id.clone(),
         }
     }
 }
@@ -180,6 +189,19 @@ impl Player {
         s.state = PlaybackState::Playing;
     }
 
+    /// Store the `PlaySessionId` from `POST /Items/{id}/PlaybackInfo`.
+    /// Must be called at playback start and echoed on every subsequent
+    /// `PlaybackProgressInfo` / `PlaybackStopInfo` report. See issue #569.
+    pub fn set_play_session_id(&self, id: Option<String>) {
+        self.shared.lock().play_session_id = id;
+    }
+
+    /// The current session's `PlaySessionId`, or `None` when no playback
+    /// session is active.
+    pub fn play_session_id(&self) -> Option<String> {
+        self.shared.lock().play_session_id.clone()
+    }
+
     pub fn mark_state(&self, state: PlaybackState) {
         self.shared.lock().state = state;
     }
@@ -213,6 +235,7 @@ impl Player {
         s.state = PlaybackState::Stopped;
         s.current = None;
         s.position_seconds = 0.0;
+        s.play_session_id = None;
     }
 
     pub fn status(&self) -> PlayerStatus {

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -4174,11 +4174,114 @@ fn stream_url_contains_api_key() {
     let mut client =
         JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
     client.set_session("mytoken".into(), "u1".into());
-    let url = client.stream_url("track-id").unwrap();
+    let url = client.stream_url("track-id", None, None).unwrap();
     let s = url.as_str();
     assert!(s.contains("api_key=mytoken"), "url: {s}");
     assert!(s.contains("DeviceId=dev"), "url: {s}");
     assert!(s.contains("/Audio/track-id/universal"), "url: {s}");
+}
+
+// ---------------------------------------------------------------------------
+// stream_url — MediaSourceId + PlaySessionId threading (#593, #569)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stream_url_includes_media_source_id_when_provided() {
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client
+        .stream_url("track-abc", Some("source-xyz"), None)
+        .unwrap();
+    let s = url.as_str();
+    assert!(
+        s.contains("MediaSourceId=source-xyz"),
+        "expected MediaSourceId in url: {s}"
+    );
+    assert!(
+        s.contains("/Audio/track-abc/universal"),
+        "expected universal path in url: {s}"
+    );
+}
+
+#[test]
+fn stream_url_includes_play_session_id_when_provided() {
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client
+        .stream_url("track-abc", None, Some("session-42"))
+        .unwrap();
+    let s = url.as_str();
+    assert!(
+        s.contains("PlaySessionId=session-42"),
+        "expected PlaySessionId in url: {s}"
+    );
+}
+
+#[test]
+fn stream_url_omits_optional_params_when_none() {
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client.stream_url("track-abc", None, None).unwrap();
+    let s = url.as_str();
+    assert!(
+        !s.contains("MediaSourceId"),
+        "MediaSourceId should be absent when None: {s}"
+    );
+    assert!(
+        !s.contains("PlaySessionId"),
+        "PlaySessionId should be absent when None: {s}"
+    );
+}
+
+#[test]
+fn stream_url_includes_both_media_source_id_and_play_session_id() {
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client
+        .stream_url("track-abc", Some("src-1"), Some("sess-99"))
+        .unwrap();
+    let s = url.as_str();
+    assert!(s.contains("MediaSourceId=src-1"), "url: {s}");
+    assert!(s.contains("PlaySessionId=sess-99"), "url: {s}");
+    assert!(s.contains("api_key=tok"), "url: {s}");
+}
+
+// ---------------------------------------------------------------------------
+// Player — play_session_id threading (#569)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn player_play_session_id_defaults_to_none() {
+    use crate::player::Player;
+    let player = Player::new();
+    assert!(player.play_session_id().is_none());
+    assert!(player.status().play_session_id.is_none());
+}
+
+#[test]
+fn player_set_play_session_id_round_trips() {
+    use crate::player::Player;
+    let player = Player::new();
+    player.set_play_session_id(Some("sess-abc".into()));
+    assert_eq!(player.play_session_id().as_deref(), Some("sess-abc"));
+    assert_eq!(player.status().play_session_id.as_deref(), Some("sess-abc"));
+}
+
+#[test]
+fn player_clear_resets_play_session_id() {
+    use crate::player::Player;
+    let player = Player::new();
+    player.set_play_session_id(Some("sess-abc".into()));
+    player.clear();
+    assert!(
+        player.play_session_id().is_none(),
+        "clear() must reset play_session_id"
+    );
+    assert!(player.status().play_session_id.is_none());
 }
 
 #[test]

--- a/examples/cli/src/main.rs
+++ b/examples/cli/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
 
     if let Some(first) = tracks.first() {
         let url = core
-            .stream_url(first.id.clone())
+            .stream_url(first.id.clone(), None, None)
             .map_err(|e| anyhow!("stream_url: {e}"))?;
         println!("\nStream URL for {}:\n  {}", first.name, url);
     }


### PR DESCRIPTION
Fixes #569, #593.

## Summary

- `stream_url` on `JellyfinClient` now accepts `media_source_id: Option<&str>` and `play_session_id: Option<&str>`. When provided, `MediaSourceId` and `PlaySessionId` are appended to the `/Audio/{id}/universal` URL so Jellyfin streams the correct source for multi-version items and can correlate the stream with its transcode job.
- `JellifyCore::stream_url` updated to accept `Option<String>` for both new params and pass them through.
- `Player`/`Shared` gains a `play_session_id: Option<String>` field surfaced on `PlayerStatus`. `Player::set_play_session_id()` / `Player::play_session_id()` added; `clear()` resets it.
- `JellifyCore::set_play_session_id()` exposed so platform layers can store the id returned by `PlaybackInfo` and echo it on progress/stop reports.

## Test plan

- `stream_url_includes_media_source_id_when_provided` — MediaSourceId in URL
- `stream_url_includes_play_session_id_when_provided` — PlaySessionId in URL
- `stream_url_omits_optional_params_when_none` — no leakage when None
- `stream_url_includes_both_media_source_id_and_play_session_id` — both together
- `player_play_session_id_defaults_to_none` — fresh player has no id
- `player_set_play_session_id_round_trips` — set → get round-trip
- `player_clear_resets_play_session_id` — clear() wipes the id
- All 141 existing tests continue to pass.