### PR TITLE
core(tests): contract test infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +422,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1330,6 +1347,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1417,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "insta",
  "keyring",
  "parking_lot",
  "reqwest",
@@ -2205,6 +2236,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ uniffi = { version = "0.29", features = ["cli"] }
 # Testing
 wiremock = "0.6"
 tempfile = "3"
+insta = { version = "1", features = ["yaml"] }
 
 [profile.release]
 lto = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,7 @@ wiremock.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
+insta.workspace = true
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/core/tests/contract.rs
+++ b/core/tests/contract.rs
@@ -1,0 +1,141 @@
+//! Contract-test harness — insta snapshots + wiremock fixtures.
+//!
+//! Each test:
+//! 1. Loads a golden JSON fixture from `tests/contract/fixtures/<name>.json`.
+//! 2. Mounts it behind a `wiremock::MockServer` route.
+//! 3. Calls the corresponding `JellyfinClient` method.
+//! 4. Snapshots the parsed Rust type with `insta::assert_yaml_snapshot!`.
+//!
+//! On the first run (or after a fixture change) run with `INSTA_UPDATE=always`
+//! to accept new snapshot files into `tests/contract/snapshots/`:
+//!
+//!   INSTA_UPDATE=always cargo test --test contract
+//!
+//! Subsequent CI runs without that env var will fail when the snapshot differs,
+//! catching silent server-side schema drift.
+//!
+//! See `tests/contract/README.md` for the full workflow.
+
+use jellify_core::client::JellyfinClient;
+use jellify_core::models::Paging;
+use std::path::Path;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Read a fixture file from `core/tests/contract/fixtures/<name>.json` and
+/// return its contents as a `serde_json::Value`. The path is resolved relative
+/// to the Cargo manifest directory so the test works regardless of the working
+/// directory `cargo test` chooses.
+fn load_fixture(name: &str) -> serde_json::Value {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let fixture_path = Path::new(manifest)
+        .join("tests")
+        .join("contract")
+        .join("fixtures")
+        .join(format!("{name}.json"));
+    let text = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|e| panic!("Could not read fixture {fixture_path:?}: {e}"));
+    serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("Invalid JSON in fixture {fixture_path:?}: {e}"))
+}
+
+/// Build an unauthenticated `JellyfinClient` pointing at the given mock server.
+fn unauthenticated_client(server: &MockServer) -> JellyfinClient {
+    JellyfinClient::new(
+        &server.uri(),
+        "contract-device".into(),
+        "Contract Test".into(),
+    )
+    .expect("client creation should not fail with a valid URL")
+}
+
+/// Build an authenticated `JellyfinClient` with a fake token and user-id.
+/// No round-trip to the server is needed — we inject the session directly.
+fn authenticated_client(server: &MockServer) -> JellyfinClient {
+    let mut client = unauthenticated_client(server);
+    client.set_session("fake-token".into(), "user-id-contract".into());
+    client
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+/// `GET /Users/{userId}/Items?ParentId=…&IncludeItemTypes=Audio` →
+/// `Vec<Track>`.
+///
+/// Fixture: `album_tracks.json` — a minimal Items envelope with two Audio
+/// items. The snapshot pins the parsed `Track` structs so any field-mapping
+/// regression in `RawItem → Track` is immediately visible as a snapshot diff.
+#[tokio::test]
+async fn contract_album_tracks() {
+    let server = MockServer::start().await;
+    let fixture = load_fixture("album_tracks");
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"/Users/[^/]+/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixture))
+        .mount(&server)
+        .await;
+
+    let client = authenticated_client(&server);
+    let tracks = client
+        .album_tracks("album-abc")
+        .await
+        .expect("album_tracks should succeed");
+
+    insta::assert_yaml_snapshot!("album_tracks", tracks);
+}
+
+/// `GET /Items/{itemId}/Similar` → `Vec<ItemRef>`.
+///
+/// Fixture: `similar_items.json` — two items of different types (`MusicAlbum`,
+/// `MusicArtist`). Pins the `ItemRef` shape including the `kind` field that
+/// drives UI dispatch.
+#[tokio::test]
+async fn contract_similar_items() {
+    let server = MockServer::start().await;
+    let fixture = load_fixture("similar_items");
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"/Items/[^/]+/Similar"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixture))
+        .mount(&server)
+        .await;
+
+    let client = authenticated_client(&server);
+    let refs = client
+        .similar_items("album-abc", 10)
+        .await
+        .expect("similar_items should succeed");
+
+    insta::assert_yaml_snapshot!("similar_items", refs);
+}
+
+/// `GET /Users/{userId}/Items?SearchTerm=…` → `SearchResults`.
+///
+/// Fixture: `search.json` — one artist, one album, one track. Pins the
+/// tri-bucket `SearchResults` shape so type-dispatch regressions are caught.
+#[tokio::test]
+async fn contract_search() {
+    let server = MockServer::start().await;
+    let fixture = load_fixture("search");
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"/Users/[^/]+/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixture))
+        .mount(&server)
+        .await;
+
+    let client = authenticated_client(&server);
+    let results = client
+        .search("Searchable", Paging::new(0, 50))
+        .await
+        .expect("search should succeed");
+
+    insta::assert_yaml_snapshot!("search", results);
+}

--- a/core/tests/contract/README.md
+++ b/core/tests/contract/README.md
@@ -1,0 +1,77 @@
+# Contract Tests
+
+This directory contains the contract-test infrastructure for `jellify_core`.
+Each test replays a golden JSON fixture through a `wiremock` mock server,
+calls a `JellyfinClient` method, and snapshots the parsed Rust type with
+`insta`. Any schema drift between the Jellyfin server responses and the Rust
+models produces a snapshot diff that CI catches before it ships.
+
+## Directory layout
+
+```
+core/tests/
+  contract.rs                  # Integration test file (one test per endpoint)
+  contract/
+    fixtures/                  # Golden JSON responses (one file per endpoint)
+      album_tracks.json
+      similar_items.json
+      search.json
+    snapshots/                 # insta-managed snapshot files (committed to git)
+    README.md                  # This file
+```
+
+## Running the tests
+
+```bash
+# Run all contract tests (offline, no real server needed):
+cargo test --test contract
+
+# Run a single test by name:
+cargo test --test contract contract_album_tracks
+```
+
+## Accepting / updating snapshots
+
+When you add a new test or change a fixture, run with `INSTA_UPDATE=always`
+to write (or overwrite) the snapshot files:
+
+```bash
+INSTA_UPDATE=always cargo test --test contract
+```
+
+Review the diff with `git diff core/tests/contract/snapshots/` before
+committing. The snapshot files live under version control so future runs can
+detect regressions without a live server.
+
+You can also use the `cargo-insta` CLI for an interactive review workflow:
+
+```bash
+cargo install cargo-insta
+cargo insta review
+```
+
+## Adding a new contract test
+
+1. **Add a fixture** — create `core/tests/contract/fixtures/<endpoint>.json`
+   with a minimal but realistic Jellyfin response body (aim for ≤50 lines).
+   Mirror the exact field names Jellyfin uses (`PascalCase` keys, etc.).
+
+2. **Write the test** — add a `#[tokio::test]` function in
+   `core/tests/contract.rs` following the pattern of the existing tests:
+   - Call `load_fixture("<endpoint>")` to load the JSON.
+   - Mount it on a `wiremock::MockServer` route matching the real URL path.
+   - Construct an `authenticated_client(&server)`.
+   - Call the client method under test.
+   - Snapshot with `insta::assert_yaml_snapshot!("<endpoint>", result)`.
+
+3. **Accept the initial snapshot** — run
+   `INSTA_UPDATE=always cargo test --test contract contract_<your_test>`.
+
+4. **Commit both files** — the fixture JSON and the generated snapshot.
+
+## Reviewing snapshot diffs in CI
+
+When CI fails with a snapshot mismatch, the diff output shows the exact field
+that changed. Download the failing artifact (or fetch the updated
+`*.snap.new` file) and run `cargo insta review` locally to accept or reject
+the change.

--- a/core/tests/contract/fixtures/album_tracks.json
+++ b/core/tests/contract/fixtures/album_tracks.json
@@ -1,0 +1,45 @@
+{
+  "Items": [
+    {
+      "Id": "track-001",
+      "Name": "Intro",
+      "Type": "Audio",
+      "IndexNumber": 1,
+      "ParentIndexNumber": 1,
+      "AlbumId": "album-abc",
+      "Album": "Test Album",
+      "AlbumArtist": "Test Artist",
+      "AlbumArtistId": "artist-xyz",
+      "ArtistItems": [{ "Id": "artist-xyz", "Name": "Test Artist" }],
+      "Artists": ["Test Artist"],
+      "ProductionYear": 2022,
+      "RunTimeTicks": 2100000000,
+      "Genres": [],
+      "UserData": { "IsFavorite": false, "PlayCount": 3 },
+      "ImageTags": { "Primary": "tag-001" },
+      "Container": "flac",
+      "Bitrate": 900000
+    },
+    {
+      "Id": "track-002",
+      "Name": "Verse",
+      "Type": "Audio",
+      "IndexNumber": 2,
+      "ParentIndexNumber": 1,
+      "AlbumId": "album-abc",
+      "Album": "Test Album",
+      "AlbumArtist": "Test Artist",
+      "AlbumArtistId": "artist-xyz",
+      "ArtistItems": [{ "Id": "artist-xyz", "Name": "Test Artist" }],
+      "Artists": ["Test Artist"],
+      "ProductionYear": 2022,
+      "RunTimeTicks": 3500000000,
+      "Genres": ["Rock"],
+      "UserData": { "IsFavorite": true, "PlayCount": 7 },
+      "ImageTags": { "Primary": "tag-002" },
+      "Container": "flac",
+      "Bitrate": 850000
+    }
+  ],
+  "TotalRecordCount": 2
+}

--- a/core/tests/contract/fixtures/search.json
+++ b/core/tests/contract/fixtures/search.json
@@ -1,0 +1,50 @@
+{
+  "Items": [
+    {
+      "Id": "artist-001",
+      "Name": "The Searchables",
+      "Type": "MusicArtist",
+      "ArtistItems": [],
+      "Artists": [],
+      "Genres": ["Pop"],
+      "RunTimeTicks": 0,
+      "UserData": { "IsFavorite": false, "PlayCount": 0 },
+      "ImageTags": { "Primary": "img-a01" }
+    },
+    {
+      "Id": "album-001",
+      "Name": "Searchable Record",
+      "Type": "MusicAlbum",
+      "AlbumArtist": "The Searchables",
+      "AlbumArtistId": "artist-001",
+      "ArtistItems": [{ "Id": "artist-001", "Name": "The Searchables" }],
+      "Artists": ["The Searchables"],
+      "ProductionYear": 2021,
+      "Genres": ["Pop"],
+      "RunTimeTicks": 0,
+      "UserData": { "IsFavorite": false, "PlayCount": 0 },
+      "ImageTags": { "Primary": "img-al1" }
+    },
+    {
+      "Id": "track-001",
+      "Name": "Searchable Song",
+      "Type": "Audio",
+      "IndexNumber": 1,
+      "ParentIndexNumber": 1,
+      "AlbumId": "album-001",
+      "Album": "Searchable Record",
+      "AlbumArtist": "The Searchables",
+      "AlbumArtistId": "artist-001",
+      "ArtistItems": [{ "Id": "artist-001", "Name": "The Searchables" }],
+      "Artists": ["The Searchables"],
+      "ProductionYear": 2021,
+      "RunTimeTicks": 2400000000,
+      "Genres": ["Pop"],
+      "UserData": { "IsFavorite": false, "PlayCount": 1 },
+      "ImageTags": { "Primary": "img-tr1" },
+      "Container": "mp3",
+      "Bitrate": 320000
+    }
+  ],
+  "TotalRecordCount": 3
+}

--- a/core/tests/contract/fixtures/similar_items.json
+++ b/core/tests/contract/fixtures/similar_items.json
@@ -1,0 +1,29 @@
+{
+  "Items": [
+    {
+      "Id": "album-111",
+      "Name": "Alike Album",
+      "Type": "MusicAlbum",
+      "AlbumArtist": "Similar Artist",
+      "AlbumArtistId": "artist-sim",
+      "ArtistItems": [],
+      "Artists": [],
+      "Genres": ["Rock"],
+      "RunTimeTicks": 0,
+      "UserData": { "IsFavorite": false, "PlayCount": 0 },
+      "ImageTags": { "Primary": "tag-111" }
+    },
+    {
+      "Id": "artist-222",
+      "Name": "Related Artist",
+      "Type": "MusicArtist",
+      "ArtistItems": [],
+      "Artists": [],
+      "Genres": ["Indie"],
+      "RunTimeTicks": 0,
+      "UserData": { "IsFavorite": false, "PlayCount": 0 },
+      "ImageTags": {}
+    }
+  ],
+  "TotalRecordCount": 2
+}

--- a/core/tests/snapshots/contract__album_tracks.snap
+++ b/core/tests/snapshots/contract__album_tracks.snap
@@ -1,0 +1,34 @@
+---
+source: core/tests/contract.rs
+expression: tracks
+---
+- id: track-001
+  name: Intro
+  album_id: album-abc
+  album_name: Test Album
+  artist_name: Test Artist
+  artist_id: artist-xyz
+  index_number: 1
+  disc_number: 1
+  year: 2022
+  runtime_ticks: 2100000000
+  is_favorite: false
+  play_count: 3
+  container: flac
+  bitrate: 900000
+  image_tag: tag-001
+- id: track-002
+  name: Verse
+  album_id: album-abc
+  album_name: Test Album
+  artist_name: Test Artist
+  artist_id: artist-xyz
+  index_number: 2
+  disc_number: 1
+  year: 2022
+  runtime_ticks: 3500000000
+  is_favorite: true
+  play_count: 7
+  container: flac
+  bitrate: 850000
+  image_tag: tag-002

--- a/core/tests/snapshots/contract__search.snap
+++ b/core/tests/snapshots/contract__search.snap
@@ -1,0 +1,40 @@
+---
+source: core/tests/contract.rs
+expression: results
+---
+artists:
+  - id: artist-001
+    name: The Searchables
+    album_count: 0
+    song_count: 0
+    genres:
+      - Pop
+    image_tag: img-a01
+albums:
+  - id: album-001
+    name: Searchable Record
+    artist_name: The Searchables
+    artist_id: artist-001
+    year: 2021
+    track_count: 0
+    runtime_ticks: 0
+    genres:
+      - Pop
+    image_tag: img-al1
+tracks:
+  - id: track-001
+    name: Searchable Song
+    album_id: album-001
+    album_name: Searchable Record
+    artist_name: The Searchables
+    artist_id: artist-001
+    index_number: 1
+    disc_number: 1
+    year: 2021
+    runtime_ticks: 2400000000
+    is_favorite: false
+    play_count: 1
+    container: mp3
+    bitrate: 320000
+    image_tag: img-tr1
+total_record_count: 3

--- a/core/tests/snapshots/contract__similar_items.snap
+++ b/core/tests/snapshots/contract__similar_items.snap
@@ -1,0 +1,12 @@
+---
+source: core/tests/contract.rs
+expression: refs
+---
+- id: album-111
+  name: Alike Album
+  kind: MusicAlbum
+  image_tag: tag-111
+- id: artist-222
+  name: Related Artist
+  kind: MusicArtist
+  image_tag: ~


### PR DESCRIPTION
Fixes #598.

## Summary

- Adds `insta = { version = "1", features = ["yaml"] }` to workspace and `core` dev-dependencies.
- New integration test file `core/tests/contract.rs` with a `wiremock`-based helper that loads a golden JSON fixture, mounts it on a mock server, calls the real `JellyfinClient` method, and snapshots the parsed Rust struct with `insta::assert_yaml_snapshot!`.
- Three contract tests: `album_tracks`, `similar_items`, `search` — covering the most schema-sensitive endpoints.
- Golden JSON fixtures in `core/tests/contract/fixtures/` (≤50 lines each).
- Committed insta snapshots in `core/tests/contract/snapshots/` so CI catches drift without a live server.
- `core/tests/contract/README.md` documents the add-a-test workflow and how to accept snapshot updates.

## Test plan

- [ ] `cargo test --test contract` passes offline (3/3 green).
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [ ] Modify a fixture field → `cargo test --test contract` fails with a snapshot diff.
- [ ] `INSTA_UPDATE=always cargo test --test contract` re-accepts the snapshot.