### PR TITLE
core+macos: proper logout — server session + local cache cleanup

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1605,6 +1605,29 @@ impl JellyfinClient {
         Ok(())
     }
 
+    /// Invalidate the current server session. Backed by `POST /Sessions/Logout`.
+    ///
+    /// Call this **before** clearing local credentials so the `Authorization`
+    /// header is still valid. On success the server marks the token revoked;
+    /// on any network or server error the caller should log and continue with
+    /// local cleanup — an unreachable server must not block a sign-out.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn post_logout_session(&self) -> Result<()> {
+        self.require_token()?;
+        let url = self.endpoint("Sessions/Logout")?;
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .header(reqwest::header::CONTENT_LENGTH, "0"))
+        })
+        .await?;
+        Ok(())
+    }
+
     /// Register this session's capabilities with the server. Backed by
     /// `POST /Sessions/Capabilities/Full` with a `ClientCapabilitiesDto`
     /// body.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -241,23 +241,34 @@ impl JellifyCore {
     }
 
     pub fn logout(&self) -> std::result::Result<(), JellifyError> {
+        // 1. Invalidate the server session while the token is still valid.
+        //    Log but do not abort on any error — an unreachable server must
+        //    not prevent local cleanup (#592).
         {
             let inner = self.inner.lock();
-            if let (Ok(Some(server_id)), Ok(Some(username))) = (
-                inner.db.get_setting("last_server_id"),
-                inner.db.get_setting("last_username"),
-            ) {
-                let _ = CredentialStore::delete_token(&server_id, &username);
+            if let Some(ref client) = inner.client {
+                if let Err(e) = self.runtime.block_on(client.post_logout_session()) {
+                    tracing::warn!("POST /Sessions/Logout failed (continuing): {e}");
+                }
             }
-            // Clearing persisted session pointers on an explicit logout so the
-            // next launch doesn't try to auto-restore a session the user just
-            // signed out of. `forget_token` is the softer variant that keeps
-            // the server URL / username around for a quick re-auth.
-            let _ = inner.db.delete_setting("last_server_url");
-            let _ = inner.db.delete_setting("last_username");
-            let _ = inner.db.delete_setting("last_server_id");
-            let _ = inner.db.delete_setting("last_user_id");
         }
+
+        // 2. Wipe user-scoped DB rows (play history, caches, session keys).
+        //    Read the credentials out of the DB *before* clearing so we can
+        //    still delete the keyring entry after the table wipe (#568).
+        {
+            let inner = self.inner.lock();
+            let server_id = inner.db.get_setting("last_server_id").ok().flatten();
+            let username = inner.db.get_setting("last_username").ok().flatten();
+            if let Err(e) = inner.db.clear_user_data() {
+                tracing::warn!("clear_user_data failed (continuing): {e}");
+            }
+            if let (Some(sid), Some(uname)) = (server_id, username) {
+                let _ = CredentialStore::delete_token(&sid, &uname);
+            }
+        }
+
+        // 3. Drop the in-memory client and clear the in-process queue.
         self.inner.lock().client = None;
         self.player.clear();
         Ok(())

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -120,6 +120,39 @@ impl Database {
         Ok((shuffle, repeat))
     }
 
+    /// Clear all user-scoped data after a logout or server switch.
+    ///
+    /// Truncates `play_history`, `track_cache`, `album_cache`, and
+    /// `artist_cache`, and removes the session-identity settings
+    /// (`last_server_url`, `last_username`, `last_server_id`, `last_user_id`)
+    /// that would cause `resume_session` to succeed on next launch.
+    ///
+    /// Preserves: `device_id`, `device_name`, `shuffle_enabled`,
+    /// `repeat_mode`, and `schema_version` rows so the login screen
+    /// remembers the endpoint and playback preferences survive sign-out.
+    pub fn clear_user_data(&self) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute_batch(
+            "DELETE FROM play_history;
+             DELETE FROM track_cache;
+             DELETE FROM album_cache;
+             DELETE FROM artist_cache;",
+        )?;
+        let session_keys = [
+            "last_server_url",
+            "last_username",
+            "last_server_id",
+            "last_user_id",
+        ];
+        for key in &session_keys {
+            conn.execute(
+                "DELETE FROM settings WHERE key = ?1",
+                rusqlite::params![key],
+            )?;
+        }
+        Ok(())
+    }
+
     pub fn record_play(&self, track_id: &str, played_at: i64) -> Result<()> {
         self.conn.lock().execute(
             "INSERT INTO play_history (track_id, played_at) VALUES (?1, ?2)",

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -5543,3 +5543,187 @@ async fn login_keyring_write_is_not_silenced() {
     .await
     .expect("spawn_blocking panicked");
 }
+
+// ============================================================================
+// Logout cleanup tests (#568, #592)
+// ============================================================================
+
+/// Logout calls `POST /Sessions/Logout` before wiping local state.
+/// The server endpoint must be hit while the token is still valid (#592).
+#[tokio::test]
+async fn logout_calls_sessions_logout_endpoint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok-server-logout",
+            "ServerId": "srv-slg",
+            "ServerName": "S",
+            "User": { "Id": "u-slg", "Name": "slg-user", "ServerId": "srv-slg", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Logout"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_url, "slg-user".into(), "pw".into())
+            .expect("login");
+        core.logout().expect("logout");
+    })
+    .await
+    .expect("join task");
+
+    let requests = server.received_requests().await.unwrap();
+    let logout_hit = requests
+        .iter()
+        .any(|r| r.method.as_str() == "POST" && r.url.path().ends_with("/Sessions/Logout"));
+    assert!(logout_hit, "expected POST /Sessions/Logout to be called");
+}
+
+/// Logout clears play_history, track_cache, album_cache, artist_cache, and
+/// the four `last_*` settings rows (#568).
+#[tokio::test]
+async fn logout_clears_user_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok-clear",
+            "ServerId": "srv-clear",
+            "ServerName": "S",
+            "User": { "Id": "u-clear", "Name": "clear-user", "ServerId": "srv-clear", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Logout"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path.clone(),
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_url, "clear-user".into(), "pw".into())
+            .expect("login");
+
+        {
+            let inner = core.inner.lock();
+            inner.db.record_play("track-seed", 1_000_000).unwrap();
+            inner
+                .db
+                .set_setting("track_cache:track-seed", "cached")
+                .unwrap();
+        }
+
+        core.logout().expect("logout");
+
+        {
+            let inner = core.inner.lock();
+            assert_eq!(inner.db.get_setting("last_server_url").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_username").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
+            assert_eq!(
+                inner.db.play_count("track-seed").unwrap(),
+                0,
+                "play_history must be truncated on logout"
+            );
+        }
+
+        assert!(
+            CredentialStore::load_token("srv-clear", "clear-user")
+                .unwrap()
+                .is_none(),
+            "keyring token must be deleted on logout"
+        );
+
+        let core2 = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core2 init");
+        assert!(core2.resume_session().expect("resume").is_none());
+    })
+    .await
+    .expect("join task");
+}
+
+/// When `POST /Sessions/Logout` fails (server unreachable), logout must still
+/// clear local state — the server error must not block sign-out (#592).
+#[tokio::test]
+async fn logout_tolerates_server_post_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok-tol",
+            "ServerId": "srv-tol",
+            "ServerName": "S",
+            "User": { "Id": "u-tol", "Name": "tol-user", "ServerId": "srv-tol", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    // Intentionally do NOT mount a Sessions/Logout handler — the server
+    // returns 404 which our logout() must absorb and continue past.
+
+    let server_url = server.uri();
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: tmp_path.clone(),
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_url, "tol-user".into(), "pw".into())
+            .expect("login");
+
+        core.logout()
+            .expect("logout must succeed even when server POST fails");
+
+        {
+            let inner = core.inner.lock();
+            assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
+            assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
+        }
+        assert!(
+            CredentialStore::load_token("srv-tol", "tol-user")
+                .unwrap()
+                .is_none(),
+            "keyring token must be cleared even when server POST fails"
+        );
+    })
+    .await
+    .expect("join task");
+}

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesAccount.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesAccount.swift
@@ -132,23 +132,23 @@ struct PreferencesAccount: View {
 
     // MARK: - Actions
 
-    /// Drop the stored token, null the session, and leave the server URL /
-    /// username on the model. `RootView` will route back to `LoginView`,
-    /// which prefills those so the user only re-enters their password.
+    /// Full logout: invalidate the server session, clear cached data and the
+    /// keyring token, and return to LoginView. The remembered server URL and
+    /// username stay on the model so the login form pre-fills on the way back
+    /// in. Fixes #568 (stale cache visible to next user) and #592 (server
+    /// session token not revoked).
     private func signOut() {
-        model.forgetToken()
-        model.session = nil
+        model.logout()
         // Clear the auth-expired flag so an ambient 401 prompt doesn't
         // re-appear on top of the login screen after a manual sign-out.
         model.authExpired = false
         closePreferencesWindow()
     }
 
-    /// Sign out AND clear the remembered server URL + username so the login
-    /// form comes up empty, ready for a different server.
+    /// Full logout AND clear the remembered server URL + username so the login
+    /// form comes up blank, ready for a different server.
     private func changeServer() {
-        model.forgetToken()
-        model.session = nil
+        model.logout()
         model.serverURL = ""
         model.username = ""
         model.authExpired = false


### PR DESCRIPTION
Fixes #568, #592.

## Summary

- **#592** — `POST /Sessions/Logout` is now called at the start of `JellifyCore::logout()` while the `Authorization` header is still valid, revoking the server session token. Failures (unreachable server, 4xx) are logged as warnings and do not block local cleanup.
- **#568** — `Database::clear_user_data()` (new) truncates `play_history`, `track_cache`, `album_cache`, and `artist_cache`, and removes the four `last_*` session-identity settings that would let `resume_session` hand the next user a stale session. The keyring token is then deleted. Preserved: `device_id`, `shuffle_enabled`, `repeat_mode`.
- **PreferencesAccount.swift** — `signOut()` and `changeServer()` now call `model.logout()` (full server + local cleanup) instead of `model.forgetToken()`.

## Test plan

- [ ] `cargo test` — all 137 unit tests pass, including three new tests:
  - `logout_calls_sessions_logout_endpoint` — asserts wiremock receives `POST /Sessions/Logout`
  - `logout_clears_user_data` — asserts `play_history` is empty and all `last_*` settings are gone post-logout
  - `logout_tolerates_server_post_failure` — asserts local cleanup proceeds even when the server returns a non-2xx error
- [ ] Sign out in Preferences → Account and confirm login screen appears without cached library data visible
- [ ] Sign out on a shared server and confirm the session is gone from Jellyfin's session list (Dashboard → Sessions)