### PR TITLE
core: heartbeat scheduler + request cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,6 +1427,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uniffi",
@@ -2486,6 +2487,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/Jellify-Music/Jellify"
 [workspace.dependencies]
 # Runtime
 tokio = { version = "1.40", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 async-trait = "0.1"
 futures = "0.3"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/uniffi-bindgen.rs"
 
 [dependencies]
 tokio.workspace = true
+tokio-util.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -6,6 +6,7 @@ use reqwest::{Client as HttpClient, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 const CLIENT_NAME: &str = "Jellify Desktop";
@@ -65,6 +66,12 @@ pub struct JellyfinClient {
     /// Wired by [`crate::JellifyCore`] at login / resume time; tests may
     /// leave it unset to exercise the "no refresh available" fallback.
     refresh_cb: Mutex<Option<Arc<RefreshTokenFn>>>,
+    /// Cancellation signal shared with any background task (e.g. the
+    /// heartbeat scheduler) that holds a reference to this client. When
+    /// cancelled, [`Self::send_with_retry_raw`] abandons any pending backoff
+    /// sleep between retry attempts and returns
+    /// [`JellifyError::Other`]`("cancelled")` immediately. See issue #605.
+    pub cancel: CancellationToken,
 }
 
 impl JellyfinClient {
@@ -88,6 +95,7 @@ impl JellyfinClient {
             user_id: None,
             library_cache: Mutex::new(LibraryCache::default()),
             refresh_cb: Mutex::new(None),
+            cancel: CancellationToken::new(),
         })
     }
 
@@ -332,7 +340,16 @@ impl JellyfinClient {
                             "jellyfin request retriable, backing off"
                         );
                         drop(resp);
-                        tokio::time::sleep(delay).await;
+                        // Respect the cancellation signal: if the caller's
+                        // future is being torn down (e.g. user navigated away
+                        // during a search) bail out immediately instead of
+                        // sleeping through the full backoff delay. See #605.
+                        tokio::select! {
+                            _ = tokio::time::sleep(delay) => {}
+                            _ = self.cancel.cancelled() => {
+                                return Err(JellifyError::Other("request cancelled".into()));
+                            }
+                        }
                         continue;
                     }
 
@@ -347,7 +364,13 @@ impl JellyfinClient {
                             delay_ms = delay.as_millis() as u64,
                             "jellyfin transport error, backing off"
                         );
-                        tokio::time::sleep(delay).await;
+                        // Same cancellation check between retries. See #605.
+                        tokio::select! {
+                            _ = tokio::time::sleep(delay) => {}
+                            _ = self.cancel.cancelled() => {
+                                return Err(JellifyError::Other("request cancelled".into()));
+                            }
+                        }
                         continue;
                     }
                     // Route through `From<reqwest::Error>` so cert-validation

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -68,7 +68,7 @@ pub struct JellyfinClient {
     refresh_cb: Mutex<Option<Arc<RefreshTokenFn>>>,
     /// Cancellation signal shared with any background task (e.g. the
     /// heartbeat scheduler) that holds a reference to this client. When
-    /// cancelled, [`Self::send_with_retry_raw`] abandons any pending backoff
+    /// cancelled, the internal retry loop abandons any pending backoff
     /// sleep between retry attempts and returns
     /// [`JellifyError::Other`]`("cancelled")` immediately. See issue #605.
     pub cancel: CancellationToken,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,16 +29,40 @@ use uuid::Uuid;
 
 uniffi::setup_scaffolding!();
 
+/// Handle for a running heartbeat task.  Dropping or calling [`stop`] cancels
+/// the background interval so there are no leaked timers after skip / logout.
+struct HeartbeatHandle {
+    abort: tokio::task::AbortHandle,
+}
+
+impl HeartbeatHandle {
+    fn stop(&self) {
+        self.abort.abort();
+    }
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
 /// The main handle a UI holds.
 #[derive(uniffi::Object)]
 pub struct JellifyCore {
     inner: Arc<Mutex<Inner>>,
     player: Arc<Player>,
     runtime: tokio::runtime::Runtime,
+    /// Running heartbeat task, if one was started via [`Self::start_heartbeat`].
+    heartbeat: Mutex<Option<HeartbeatHandle>>,
 }
 
 struct Inner {
-    client: Option<JellyfinClient>,
+    /// Wrapped in `Arc` so the heartbeat scheduler and the 401 interceptor
+    /// can both hold a reference to the live client without going through
+    /// `inner`'s `Mutex` — necessary because those two paths run concurrently
+    /// while `with_client` holds the lock.
+    client: Option<Arc<JellyfinClient>>,
     /// Wrapped in `Arc` so the HTTP client's 401 interceptor can close over
     /// a standalone handle (see [`JellyfinClient::set_refresh_callback`])
     /// without needing to re-lock `inner` — which it can't, since retry
@@ -96,6 +120,7 @@ impl JellifyCore {
             })),
             player,
             runtime,
+            heartbeat: Mutex::new(None),
         }))
     }
 
@@ -160,6 +185,7 @@ impl JellifyCore {
             }
             inner.db.set_setting("last_user_id", &session.user.id)?;
         }
+        let client = Arc::new(client);
         Self::install_refresh_callback(&client, &db);
         self.inner.lock().client = Some(client);
         Ok(session)
@@ -218,6 +244,7 @@ impl JellifyCore {
 
         let mut client = JellyfinClient::new(&server_url, device_id, device_name)?;
         client.set_session(token.clone(), user_id.clone());
+        let client = Arc::new(client);
         Self::install_refresh_callback(&client, &db);
         let resolved_url = client.base_url().to_string();
         self.inner.lock().client = Some(client);
@@ -258,6 +285,7 @@ impl JellifyCore {
             let _ = inner.db.delete_setting("last_server_id");
             let _ = inner.db.delete_setting("last_user_id");
         }
+        self.stop_heartbeat();
         self.inner.lock().client = None;
         self.player.clear();
         Ok(())
@@ -278,6 +306,7 @@ impl JellifyCore {
             let _ = inner.db.delete_setting("last_server_id");
             let _ = inner.db.delete_setting("last_user_id");
         }
+        self.stop_heartbeat();
         self.inner.lock().client = None;
         self.player.clear();
         Ok(())
@@ -874,6 +903,90 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.report_playback_progress(info)))
     }
 
+    /// Start (or restart) the background heartbeat scheduler.
+    ///
+    /// Every `interval_secs` seconds (capped at 10 s — Jellyfin's server-side
+    /// playback-ended detection threshold) the scheduler builds a
+    /// [`PlaybackProgressInfo`] from the current [`Player`] state and POSTs it
+    /// to `/Sessions/Playing/Progress`. `play_session_id` is the value returned
+    /// by `playback_info` and must be echoed on every progress report.
+    ///
+    /// Calling this while a previous heartbeat is running silently cancels the
+    /// old task first. The returned handle is stored internally; call
+    /// [`Self::stop_heartbeat`] or just let the next `start_heartbeat` / logout
+    /// implicitly cancel it. See issue #594.
+    ///
+    /// # Note on `Arc<Self>`
+    ///
+    /// This method requires `Arc<Self>` so the spawned task can hold a
+    /// reference back to `JellifyCore` for the lifetime of the interval.
+    pub fn start_heartbeat(self: &Arc<Self>, interval_secs: u32, play_session_id: Option<String>) {
+        // Clamp to Jellyfin's detection threshold so the server never sees a
+        // gap that looks like a dead client.
+        let secs = interval_secs.clamp(1, 10) as u64;
+        let interval = std::time::Duration::from_secs(secs);
+
+        let core = Arc::clone(self);
+
+        let handle = self.runtime.spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Consume the first tick so the first heartbeat fires after
+            // `interval`, not immediately on start.
+            ticker.tick().await;
+
+            loop {
+                ticker.tick().await;
+
+                let status = core.player.status();
+                // Only send a heartbeat when there is an active track —
+                // sending progress with an empty `item_id` would confuse
+                // the server.
+                let item_id = match status.current_track {
+                    Some(ref t) => t.id.clone(),
+                    None => continue,
+                };
+
+                let position_ticks = (status.position_seconds * 10_000_000.0) as i64;
+                let is_paused = matches!(status.state, crate::player::PlaybackState::Paused);
+
+                let info = PlaybackProgressInfo {
+                    item_id,
+                    failed: false,
+                    is_paused,
+                    is_muted: false,
+                    position_ticks,
+                    play_session_id: play_session_id.clone(),
+                    ..Default::default()
+                };
+
+                // Grab a clone of the Arc'd client so we can call the async
+                // method without holding `inner`'s Mutex across an await.
+                let client_arc = core.try_client_arc();
+                let Some(client) = client_arc else {
+                    // Session was logged out while the heartbeat was running.
+                    continue;
+                };
+                if let Err(ref e) = client.report_playback_progress(info).await {
+                    tracing::warn!(error = %e, "heartbeat progress report failed");
+                }
+            }
+        });
+
+        *self.heartbeat.lock() = Some(HeartbeatHandle {
+            abort: handle.abort_handle(),
+        });
+    }
+
+    /// Cancel the background heartbeat task started by [`Self::start_heartbeat`].
+    /// A no-op when no heartbeat is running. Called automatically on
+    /// `stop` / `logout` / track skip so there are no leaked interval timers.
+    /// See issue #594.
+    pub fn stop_heartbeat(&self) {
+        if let Some(handle) = self.heartbeat.lock().take() {
+            handle.stop();
+        }
+    }
+
     pub fn skip_next(&self) -> Option<Track> {
         self.player.skip_next()
     }
@@ -919,6 +1032,7 @@ impl JellifyCore {
     }
 
     pub fn stop(&self) {
+        self.stop_heartbeat();
         self.player.clear();
     }
 
@@ -935,6 +1049,12 @@ impl JellifyCore {
         let inner = self.inner.lock();
         let client = inner.client.as_ref().ok_or(JellifyError::NoSession)?;
         f(client)
+    }
+
+    /// Clone the live client handle (if one exists) so background tasks can
+    /// call async methods without holding `inner`'s lock across an await.
+    fn try_client_arc(&self) -> Option<Arc<JellyfinClient>> {
+        self.inner.lock().client.clone()
     }
 
     /// Wire the HTTP client's 401 interceptor so it can silently pull a

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -5543,3 +5543,262 @@ async fn login_keyring_write_is_not_silenced() {
     .await
     .expect("spawn_blocking panicked");
 }
+
+// ---------------------------------------------------------------------------
+// #594 — heartbeat scheduler fires at the expected cadence
+// ---------------------------------------------------------------------------
+
+/// Helper: spawn a heartbeat loop directly using `JellyfinClient` (not
+/// `JellifyCore`) so the test can run inside a `#[tokio::test]` without
+/// fighting the core's embedded `tokio::runtime::Runtime`.
+///
+/// Returns an `AbortHandle` — the test cancels the task when done.
+async fn spawn_heartbeat_for_test(
+    client: std::sync::Arc<JellyfinClient>,
+    interval: std::time::Duration,
+    play_session_id: Option<String>,
+    current_track_id: std::sync::Arc<parking_lot::Mutex<Option<String>>>,
+    current_position: std::sync::Arc<parking_lot::Mutex<f64>>,
+) -> tokio::task::AbortHandle {
+    use crate::models::PlaybackProgressInfo;
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // skip the immediate first tick
+        loop {
+            ticker.tick().await;
+            let item_id = match current_track_id.lock().clone() {
+                Some(id) => id,
+                None => continue,
+            };
+            let pos = *current_position.lock();
+            let info = PlaybackProgressInfo {
+                item_id,
+                failed: false,
+                is_paused: false,
+                is_muted: false,
+                position_ticks: (pos * 10_000_000.0) as i64,
+                play_session_id: play_session_id.clone(),
+                ..Default::default()
+            };
+            let _ = client.report_playback_progress(info).await;
+        }
+    });
+    handle.abort_handle()
+}
+
+/// The heartbeat scheduler must fire `POST /Sessions/Playing/Progress` at
+/// least N times in N * interval_secs of simulated time.  We use
+/// `tokio::time::pause` + `tokio::time::advance` so the test runs
+/// instantaneously without real wall-clock delays.
+///
+/// The test operates on `JellyfinClient` directly to avoid the nested-
+/// runtime conflict that arises when `JellifyCore`'s embedded `block_on`
+/// runs inside the test's tokio executor. See issue #594.
+#[tokio::test]
+async fn heartbeat_fires_at_expected_cadence() {
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "hb-token",
+            "ServerId": "hb-server",
+            "ServerName": "HB",
+            "User": {
+                "Id": "hb-user",
+                "Name": "hbuser",
+                "ServerId": "hb-server",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Playing/Progress"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("hbuser", "pw").await.unwrap();
+    let client = Arc::new(client);
+
+    let track_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(Some("hb-track-1".into())));
+    let position: Arc<Mutex<f64>> = Arc::new(Mutex::new(42.0));
+
+    let interval_secs: u64 = 5;
+
+    // Pause time after the real HTTP auth so reqwest's connection logic
+    // completes normally. From here on, `advance` drives the fake clock.
+    tokio::time::pause();
+
+    let abort = spawn_heartbeat_for_test(
+        Arc::clone(&client),
+        std::time::Duration::from_secs(interval_secs),
+        Some("sess-abc".into()),
+        Arc::clone(&track_id),
+        Arc::clone(&position),
+    )
+    .await;
+
+    // Advance time in per-interval steps, yielding between each so the
+    // heartbeat task can run and the HTTP POST to wiremock can complete
+    // before the next tick fires.
+    for _ in 0..(interval_secs * 3) {
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    abort.abort();
+    // One final yield to flush any in-flight request.
+    tokio::task::yield_now().await;
+
+    let reqs = server.received_requests().await.unwrap();
+    let heartbeats = reqs
+        .iter()
+        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
+        .count();
+
+    assert!(
+        heartbeats >= 2,
+        "expected at least 2 heartbeats in {} simulated seconds, got {}",
+        interval_secs * 3,
+        heartbeats,
+    );
+}
+
+/// After aborting the heartbeat task no further POSTs should be sent.
+/// Verifies the scheduler does not leak a timer after `AbortHandle::abort()`.
+/// See issue #594.
+#[tokio::test]
+async fn heartbeat_stops_after_abort() {
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok2",
+            "ServerId": "srv2",
+            "ServerName": "S2",
+            "User": {
+                "Id": "u2", "Name": "u2", "ServerId": "srv2",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Playing/Progress"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("u2", "pw").await.unwrap();
+    let client = Arc::new(client);
+
+    let track_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(Some("t2".into())));
+    let position: Arc<Mutex<f64>> = Arc::new(Mutex::new(0.0));
+
+    // Pause time after real HTTP auth completes so `advance` controls ticks.
+    tokio::time::pause();
+
+    let abort = spawn_heartbeat_for_test(
+        Arc::clone(&client),
+        std::time::Duration::from_secs(5),
+        None,
+        Arc::clone(&track_id),
+        Arc::clone(&position),
+    )
+    .await;
+
+    // Advance 6 s — heartbeat fires once at t=5 s.
+    tokio::time::advance(std::time::Duration::from_secs(6)).await;
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+
+    abort.abort();
+    let count_after_abort = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
+        .count();
+
+    // Advance another 10 s — no new POSTs should appear.
+    tokio::time::advance(std::time::Duration::from_secs(10)).await;
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+
+    let count_final = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
+        .count();
+
+    assert_eq!(
+        count_after_abort, count_final,
+        "no heartbeats should fire after abort; before={count_after_abort} after={count_final}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #605 — CancellationToken aborts mid-backoff retry sleep
+// ---------------------------------------------------------------------------
+
+/// When the `CancellationToken` on a `JellyfinClient` is cancelled while
+/// the retry loop is sleeping through its backoff delay, the request must
+/// return `JellifyError::Other("request cancelled")` immediately rather than
+/// waiting out the full delay or completing the retry.
+#[tokio::test]
+async fn cancelled_token_aborts_retry_backoff() {
+    use std::time::Instant;
+
+    let server = MockServer::start().await;
+
+    // Always respond with 503 so the retry loop always enters the backoff.
+    Mock::given(method("GET"))
+        .and(path("/System/Info/Public"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    // Cancel the token after a very short delay — the backoff is 200 ms+,
+    // so the cancel fires while the sleep is still pending.
+    let cancel = client.cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        cancel.cancel();
+    });
+
+    let start = Instant::now();
+    let err = client.public_info().await.unwrap_err();
+    let elapsed = start.elapsed();
+
+    // The full backoff ladder for 3 attempts is ≥600 ms; we should bail
+    // well before that.
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "cancellation should abort the retry sleep quickly, elapsed={elapsed:?}"
+    );
+    match err {
+        JellifyError::Other(ref msg) if msg.contains("cancelled") => {}
+        other => panic!("expected Other(\"request cancelled\"), got {other:?}"),
+    }
+}


### PR DESCRIPTION
Fixes #594, #605.

## Summary

- **#594 (heartbeat)**: Added `start_heartbeat(interval_secs, play_session_id)` / `stop_heartbeat()` to `JellifyCore`. The scheduler spawns a tokio interval task (interval clamped to ≤10 s — Jellyfin's server-side playback-ended detection threshold) that builds `PlaybackProgressInfo` from current `Player` state and POSTs to `/Sessions/Playing/Progress`. The `AbortHandle` is stored internally and cancelled automatically on `stop()`, `logout()`, and `forget_token()`, preventing leaked timers across track skips and session changes.
- **#605 (cancellation)**: Added a `CancellationToken` field to `JellyfinClient`. The backoff sleep inside `send_with_retry_raw` is now wrapped in `tokio::select!` so cancellation fires immediately rather than waiting out the full delay. No endpoint method signatures changed.
- **Arc refactor**: `Inner::client` is now `Option<Arc<JellyfinClient>>` so the heartbeat task can clone the client handle without holding the `Mutex` across an `await`.

## Tests added

- `heartbeat_fires_at_expected_cadence` — uses `tokio::time::pause` + `advance` to verify ≥2 heartbeats fire in 15 simulated seconds with a 5 s interval.
- `heartbeat_stops_after_abort` — verifies no POSTs fire after `AbortHandle::abort()`.
- `cancelled_token_aborts_retry_backoff` — cancels the token 20 ms into a 503-retry backoff and asserts the error returns in under 500 ms.

All 139 tests pass; `cargo clippy --all-targets --all-features -- -D warnings` clean.