### PR TITLE
core+macos: playlist CRUD + favorite rollback + draft clear

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1828,6 +1828,82 @@ impl JellyfinClient {
         Ok(())
     }
 
+    /// Rename a playlist by updating its `Name` field via `POST /Items/{id}`.
+    ///
+    /// The `POST /Items/{id}` endpoint requires the full item body, so we first
+    /// fetch the existing item with `GET /Items/{id}` and then re-POST with only
+    /// `Name` changed. Responds 204 on success.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn rename_playlist(&self, playlist_id: &str, new_name: &str) -> Result<()> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        // Fetch the current item to prefill required fields.
+        let existing = self.fetch_item(playlist_id, &[]).await?;
+        // Build the update body from the existing item, overwriting Name.
+        let mut body = existing;
+        body["Name"] = serde_json::Value::String(new_name.to_string());
+        let mut url = self.endpoint(&format!("Items/{playlist_id}"))?;
+        url.query_pairs_mut().append_pair("UserId", user_id);
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&body))
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Delete a playlist via `DELETE /Items/{id}`.
+    ///
+    /// Responds 204 on success, 403 when the caller does not own the playlist
+    /// (some Jellyfin configurations also accept
+    /// `DELETE /Items?Ids={id}` for batch deletes — this method uses the
+    /// single-item path which is broadly supported). Callers should remove
+    /// the item from any in-memory caches after this returns.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn delete_playlist(&self, playlist_id: &str) -> Result<()> {
+        self.require_token()?;
+        let url = self.endpoint(&format!("Items/{playlist_id}"))?;
+        self.send_with_retry(|| Ok(self.http.delete(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        Ok(())
+    }
+
+    /// Move a playlist entry to a new position via
+    /// `POST /Playlists/{playlistId}/Items/{playlistItemId}/Move/{newIndex}`.
+    ///
+    /// `playlist_item_id` is the per-entry `PlaylistItemId` returned by
+    /// `playlist_tracks` (not the underlying `ItemId`). `new_index` is
+    /// zero-based and is the desired final position in the playlist.
+    ///
+    /// Responds 204 on success. Callers should invalidate their
+    /// `playlist_tracks` cache so the UI reflects the server order.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set.
+    pub async fn reorder_playlist_track(
+        &self,
+        playlist_id: &str,
+        playlist_item_id: &str,
+        new_index: u32,
+    ) -> Result<()> {
+        self.require_token()?;
+        let url = self.endpoint(&format!(
+            "Playlists/{playlist_id}/Items/{playlist_item_id}/Move/{new_index}"
+        ))?;
+        self.send_with_retry(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        Ok(())
+    }
+
     // ----- Streaming -----
 
     /// Fetch the full audio payload for a track, authenticated. Returns the
@@ -2066,6 +2142,8 @@ pub struct RawItem {
     pub bitrate: Option<u32>,
     #[serde(rename = "Path")]
     pub path: Option<String>,
+    #[serde(rename = "PlaylistItemId")]
+    pub playlist_item_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2262,6 +2340,7 @@ impl From<RawItem> for Track {
             container: r.container,
             bitrate: r.bitrate,
             image_tag: r.image_tags.get("Primary").cloned(),
+            playlist_item_id: r.playlist_item_id,
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -858,6 +858,51 @@ impl JellifyCore {
         })
     }
 
+    /// Rename a playlist on the server. Fetches the current item to prefill
+    /// the required `POST /Items/{id}` body, then re-POSTs with only `Name`
+    /// changed. UI callers should update their local playlist cache on success.
+    /// Errors with [`JellifyError::NotAuthenticated`] when no session is active.
+    pub fn rename_playlist(
+        &self,
+        playlist_id: String,
+        new_name: String,
+    ) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.rename_playlist(&playlist_id, &new_name))
+        })
+    }
+
+    /// Delete a playlist from the server via `DELETE /Items/{id}`. UI callers
+    /// should drop the item from their local cache on success.
+    /// Errors with [`JellifyError::NotAuthenticated`] when no session is active.
+    pub fn delete_playlist(&self, playlist_id: String) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.delete_playlist(&playlist_id)))
+    }
+
+    /// Move a playlist entry to a new position via
+    /// `POST /Playlists/{playlistId}/Items/{playlistItemId}/Move/{newIndex}`.
+    ///
+    /// `playlist_item_id` is the per-entry `PlaylistItemId` on the `Track`
+    /// (populated by `playlist_tracks`). `new_index` is zero-based.
+    /// Callers should reload playlist tracks after this returns so the UI
+    /// reflects the server order.
+    /// Errors with [`JellifyError::NotAuthenticated`] when no session is active.
+    pub fn reorder_playlist_track(
+        &self,
+        playlist_id: String,
+        playlist_item_id: String,
+        new_index: u32,
+    ) -> std::result::Result<(), JellifyError> {
+        self.with_client(|c| {
+            self.runtime.block_on(c.reorder_playlist_track(
+                &playlist_id,
+                &playlist_item_id,
+                new_index,
+            ))
+        })
+    }
+
     /// A default macOS [`DeviceProfile`] advertising direct-play for
     /// FLAC / ALAC / MP3 / AAC / Opus / OGG / WAV with an MP3 320
     /// transcode fallback. Intended as a one-liner for UIs that don't

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -64,6 +64,12 @@ pub struct Track {
     pub container: Option<String>,
     pub bitrate: Option<u32>,
     pub image_tag: Option<String>,
+    /// Jellyfin `PlaylistItemId` — only populated when the track was fetched
+    /// as part of a playlist (via `playlist_tracks`). Used by
+    /// `reorder_playlist_track` and `remove_from_playlist` to identify the
+    /// specific entry rather than the underlying item, so duplicate tracks in
+    /// the same playlist can be operated on independently.
+    pub playlist_item_id: Option<String>,
 }
 
 impl Track {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -265,6 +265,7 @@ mod tests {
             container: None,
             bitrate: None,
             image_tag: None,
+            playlist_item_id: None,
         }
     }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -5727,3 +5727,212 @@ async fn logout_tolerates_server_post_failure() {
     .await
     .expect("join task");
 }
+
+// ============================================================================
+// Playlist CRUD — rename / delete / reorder (#564)
+// ============================================================================
+
+/// `rename_playlist` must GET the current item body, overwrite `Name`, then
+/// POST back to `/Items/{id}`.
+#[tokio::test]
+async fn rename_playlist_fetches_then_posts() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // GET /Items?Ids=pl-1 — fetch_item uses the /Items?Ids= endpoint.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("Ids", "pl-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "pl-1", "Name": "Old Name", "Type": "Playlist" }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // POST /Items/pl-1 — server accepts the update.
+    Mock::given(method("POST"))
+        .and(path("/Items/pl-1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.rename_playlist("pl-1", "New Name").await.unwrap();
+
+    // Verify the POST body has the updated Name.
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Items/pl-1")
+        .expect("expected POST to /Items/pl-1");
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("body should be valid JSON");
+    assert_eq!(
+        body["Name"].as_str(),
+        Some("New Name"),
+        "body Name must be updated, got: {body}"
+    );
+}
+
+/// `rename_playlist` must require an authenticated session.
+#[tokio::test]
+async fn rename_playlist_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .rename_playlist("pl-1", "Anything")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+/// `delete_playlist` must send `DELETE /Items/{id}`.
+#[tokio::test]
+async fn delete_playlist_sends_delete_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/Items/pl-42"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client.delete_playlist("pl-42").await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE" && r.url.path() == "/Items/pl-42"),
+        "expected DELETE /Items/pl-42"
+    );
+}
+
+/// `delete_playlist` must require an authenticated session.
+#[tokio::test]
+async fn delete_playlist_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.delete_playlist("pl-1").await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+/// `reorder_playlist_track` must POST to
+/// `/Playlists/{playlistId}/Items/{playlistItemId}/Move/{newIndex}`.
+#[tokio::test]
+async fn reorder_playlist_track_sends_move_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists/pl-7/Items/pi-99/Move/2"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .reorder_playlist_track("pl-7", "pi-99", 2)
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| {
+            r.method.as_str() == "POST" && r.url.path() == "/Playlists/pl-7/Items/pi-99/Move/2"
+        }),
+        "expected POST to /Playlists/pl-7/Items/pi-99/Move/2"
+    );
+}
+
+/// `reorder_playlist_track` must require an authenticated session.
+#[tokio::test]
+async fn reorder_playlist_track_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .reorder_playlist_track("pl-1", "pi-1", 0)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+/// `playlist_tracks` must populate `playlist_item_id` on each returned track.
+#[tokio::test]
+async fn playlist_tracks_populates_playlist_item_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // playlist_tracks uses GET /Items?ParentId=...&UserId=...
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "pl-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track One", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Album A",
+                    "AlbumArtist": "Artist A", "Artists": ["Artist A"],
+                    "RunTimeTicks": 1000000000u64,
+                    "PlaylistItemId": "pi-alpha",
+                    "ImageTags": {}
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .playlist_tracks("pl-1", crate::models::Paging::new(0, 50))
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(
+        page.items[0].playlist_item_id.as_deref(),
+        Some("pi-alpha"),
+        "playlist_item_id must be populated from the server response"
+    );
+}

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import MediaPlayer
 import Observation
 import SwiftUI
 @preconcurrency import JellifyCore
@@ -3033,20 +3034,18 @@ final class AppModel {
         }
     }
 
-    /// Rename a playlist by id. Local-only update until the core exposes
-    /// `update_playlist` (see core-#130); on the next full library refresh
-    /// a local-only rename will be overwritten by the server's persisted
-    /// name. Shared by the sidebar inline rename and the playlist hero
-    /// click-to-edit title.
+    /// Rename a playlist by id. Optimistically updates the in-memory list
+    /// first for instant UI feedback, then persists to the server via
+    /// `core.renamePlaylist`. On failure the old name is restored and
+    /// `errorMessage` surfaces the failure.
     func renamePlaylist(id: String, newName: String) {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         guard let idx = playlists.firstIndex(where: { $0.id == id }) else { return }
         let existing = playlists[idx]
         guard trimmed != existing.name else { return }
-        // TODO(core-#130): call `core.updatePlaylist(playlistId:, name:)`
-        // once the FFI lands. For now, optimistically update in place.
-        print("[AppModel] renamePlaylist(\(id)) local-only — see core-#130")
+        // Optimistic update so the sidebar / hero reflects the new name
+        // before the network round-trip completes.
         playlists[idx] = Playlist(
             id: existing.id,
             name: trimmed,
@@ -3054,6 +3053,24 @@ final class AppModel {
             runtimeTicks: existing.runtimeTicks,
             imageTag: existing.imageTag
         )
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.renamePlaylist(playlistId: id, newName: trimmed)
+                }.value
+                serverReachability.noteSuccess()
+            } catch {
+                if handleAuthError(error) { return }
+                // Rollback the optimistic rename on failure.
+                if let rollbackIdx = playlists.firstIndex(where: { $0.id == id }) {
+                    playlists[rollbackIdx] = existing
+                }
+                errorMessage = "Rename failed: \(error.localizedDescription)"
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+            }
+        }
     }
 
     /// Duplicate a playlist: create "<original> Copy" and seed it with the
@@ -3099,16 +3116,39 @@ final class AppModel {
         }
     }
 
-    /// Delete a playlist. Today this is an in-memory drop with a matching
-    /// TODO stub — the core's `delete_playlist` FFI hasn't landed yet
-    /// (see core-#131). When it does, swap the `print` line for a
-    /// `try core.deletePlaylist(id:)` call.
+    /// Delete a playlist. Optimistically removes the playlist from
+    /// the in-memory list for instant UI feedback, then persists the
+    /// deletion to the server via `core.deletePlaylist`. On failure
+    /// the playlist is re-inserted at its original position and
+    /// `errorMessage` surfaces the failure.
     func deletePlaylist(id: String) {
-        playlists.removeAll { $0.id == id }
+        guard let idx = playlists.firstIndex(where: { $0.id == id }) else { return }
+        let removed = playlists[idx]
+        let removedTracks = playlistTracks[id]
+        let removedDescription = playlistDescriptions[id]
+        // Optimistic drop.
+        playlists.remove(at: idx)
         playlistTracks.removeValue(forKey: id)
         playlistDescriptions.removeValue(forKey: id)
-        // TODO(core-#131): delete_playlist FFI not yet wired — local drop only.
-        print("[AppModel] deletePlaylist(\(id)) local-only — see core-#131")
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.deletePlaylist(playlistId: id)
+                }.value
+                serverReachability.noteSuccess()
+            } catch {
+                if handleAuthError(error) { return }
+                // Rollback the optimistic delete on failure.
+                let insertIdx = min(idx, playlists.count)
+                playlists.insert(removed, at: insertIdx)
+                if let tracks = removedTracks { playlistTracks[id] = tracks }
+                if let desc = removedDescription { playlistDescriptions[id] = desc }
+                errorMessage = "Delete failed: \(error.localizedDescription)"
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+            }
+        }
     }
 
     /// Resolve a dropped track id (from the drag-reorder affordance in
@@ -3122,14 +3162,15 @@ final class AppModel {
         moveTrackInPlaylist(playlistId: playlistId, from: sourceIndex, to: destinationIndex)
     }
 
-    /// Reorder a track within a playlist. Swaps the local cache entry so
-    /// the UI reflects the new order immediately, then defers the server
-    /// round trip until `move_playlist_item` (core-#129) lands. Matches
-    /// the optimistic-update pattern used for rename/delete above.
+    /// Reorder a track within a playlist. Applies the move to the local
+    /// cache immediately (optimistic update), then calls
+    /// `core.reorderPlaylistTrack` to persist the new position on the server.
+    /// Requires the moved track to carry a `playlistItemId` — if it doesn't
+    /// (e.g. old cached data pre-dating the `PlaylistItemId` field), the move
+    /// is local-only and an error is logged.
     ///
     /// Indices are relative to the current cached order in
-    /// `playlistTracks[playlistId]`. Out-of-range indices are silently
-    /// dropped. The semantics match SwiftUI's native
+    /// `playlistTracks[playlistId]`. The semantics match SwiftUI's native
     /// `Array.move(fromOffsets:toOffset:)` so the detail view can feed its
     /// drop position straight through.
     func moveTrackInPlaylist(playlistId: String, from: Int, to: Int) {
@@ -3141,13 +3182,38 @@ final class AppModel {
         // no-ops — bail early to avoid a needless assignment + notify.
         guard to >= 0, to <= tracks.count else { return }
         guard to != from, to != from + 1 else { return }
-        let track = tracks.remove(at: from)
+        let movedTrack = tracks[from]
+        tracks.remove(at: from)
         let insertIndex = to > from ? to - 1 : to
-        tracks.insert(track, at: insertIndex)
+        tracks.insert(movedTrack, at: insertIndex)
         playlistTracks[playlistId] = tracks
-        // TODO(core-#129): call `core.movePlaylistItem(playlistId:, fromIndex:, toIndex:)`
-        // once the FFI lands. Local-only for now.
-        print("[AppModel] moveTrackInPlaylist(\(playlistId)) \(from) → \(to) local-only — see core-#129")
+        // Keep currentPlaylistTracks in sync if this playlist is currently shown.
+        if !currentPlaylistTracks.isEmpty {
+            currentPlaylistTracks = tracks
+        }
+        // Persist the reorder to the server if the track carries a PlaylistItemId.
+        guard let playlistItemId = movedTrack.playlistItemId else {
+            print("[AppModel] moveTrackInPlaylist(\(playlistId)) — track missing PlaylistItemId, local-only")
+            return
+        }
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.reorderPlaylistTrack(
+                        playlistId: playlistId,
+                        playlistItemId: playlistItemId,
+                        newIndex: UInt32(insertIndex)
+                    )
+                }.value
+                serverReachability.noteSuccess()
+            } catch {
+                if handleAuthError(error) { return }
+                errorMessage = "Reorder failed: \(error.localizedDescription)"
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+            }
+        }
     }
 
     // MARK: - Playlist sharing
@@ -4029,8 +4095,38 @@ extension AppModel: MediaSessionDelegate {
         // one we signal `.noActionableNowPlayingItem` back to the remote
         // surface via a `nil` return.
         guard let track = status.currentTrack else { return nil }
-        let target = !(isFavorite(id: track.id) || track.isFavorite)
-        Task { await setFavorite(itemId: track.id, enabled: target) }
+        let previous = isFavorite(id: track.id) || track.isFavorite
+        let target = !previous
+        // Optimistic local update so the heart glyph responds instantly.
+        favoriteById[track.id] = target
+        let trackId = track.id
+        Task {
+            do {
+                let state = try await Task.detached(priority: .userInitiated) { [core] in
+                    if target {
+                        return try core.setFavorite(itemId: trackId)
+                    } else {
+                        return try core.unsetFavorite(itemId: trackId)
+                    }
+                }.value
+                favoriteById[trackId] = state.isFavorite
+                serverReachability.noteSuccess()
+                // Reconcile the remote-command surface with the server's
+                // authoritative answer (handles the edge case where the server
+                // disagrees with the local optimistic flip).
+                MPRemoteCommandCenter.shared().likeCommand.isActive = state.isFavorite
+            } catch {
+                if handleAuthError(error) { return }
+                // Rollback the optimistic flip — restore the previous state
+                // in both the local cache and the Control Center widget.
+                favoriteById[trackId] = previous
+                MPRemoteCommandCenter.shared().likeCommand.isActive = previous
+                errorMessage = "Favorite toggle failed: \(error.localizedDescription)"
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+            }
+        }
         return target
     }
 

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -75,6 +75,16 @@ struct PlaylistView: View {
         .onChange(of: model.playlistTracks[playlistID]) { _, newValue in
             if let newValue = newValue { tracks = newValue }
         }
+        // Clear click-to-edit drafts when the user navigates away (#602).
+        // SwiftUI may reuse the view struct across back-forward navigations
+        // (especially with `NavigationStack`), so stale `titleDraft` /
+        // `descriptionDraft` from a prior session would appear pre-filled
+        // on the next visit to the same playlist. Resetting on disappear
+        // ensures the next open starts with the committed (server) values.
+        .onDisappear {
+            titleDraft = nil
+            descriptionDraft = nil
+        }
     }
 
     // MARK: - Hero


### PR DESCRIPTION
Fixes #564, #586, #602.

## Summary

- **#564 — Playlist CRUD FFI**: adds `rename_playlist`, `delete_playlist`, and `reorder_playlist_track` to the Rust core and exposes them via UniFFI. Also surfaces `PlaylistItemId` on the `Track` model so the reorder call can identify the specific playlist entry. AppModel handlers are wired to call these instead of updating local state only.
- **#586 — Favorite rollback**: `mediaSessionToggleFavorite` now captures the pre-toggle state, applies the optimistic flip, and on server failure restores both `favoriteById` and `MPRemoteCommandCenter.likeCommand.isActive`, then shows an error toast.
- **#602 — Draft clear on dismiss**: `PlaylistView` gets an `.onDisappear` that resets `titleDraft` and `descriptionDraft` so returning to the same playlist never shows stale edit state.

## Test plan

- [ ] Rust: `cd core && cargo test` — 143 unit tests pass, including 9 new wiremock tests covering rename/delete/reorder (success + unauthenticated paths) and `playlist_item_id` population.
- [ ] Swift: CI build verifies the module compiles with the updated FFI surface (`playlist_item_id` on Track, three new core methods).
- [ ] Manual: rename a playlist in the sidebar — name persists after the next app relaunch.
- [ ] Manual: delete a playlist — confirm it's gone from server on next Jellyfin Web open.
- [ ] Manual: drag-reorder a track — confirm order matches on server after a reload.
- [ ] Manual: tap the heart in Control Center while offline — heart reverts and error toast shows.
- [ ] Manual: open "New Playlist" sheet, type a name, dismiss — reopening the sheet starts blank.