### PR TITLE
macos: fix compile break — stream_url + Track call-sites

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -1721,7 +1721,8 @@ final class AppModel {
             playCount: playCount,
             container: container,
             bitrate: bitrate,
-            imageTag: imageTag
+            imageTag: imageTag,
+            playlistItemId: nil
         )
     }
 

--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -120,7 +120,7 @@ public final class AudioEngine: NSObject {
     // MARK: - Public
 
     public func play(track: Track) throws {
-        let urlString = try core.streamUrl(trackId: track.id)
+        let urlString = try core.streamUrl(trackId: track.id, mediaSourceId: nil, playSessionId: nil)
         guard let url = URL(string: urlString) else {
             throw AudioEngineError.invalidURL(urlString)
         }
@@ -241,7 +241,7 @@ public final class AudioEngine: NSObject {
     public func preloadNextTrack(_ track: Track) throws {
         guard let player else { return }
 
-        let urlString = try core.streamUrl(trackId: track.id)
+        let urlString = try core.streamUrl(trackId: track.id, mediaSourceId: nil, playSessionId: nil)
         guard let url = URL(string: urlString) else {
             throw AudioEngineError.invalidURL(urlString)
         }


### PR DESCRIPTION
Main was broken at build time for ~30 min after #634 and #641 landed without their Swift call-sites updated.

- `AudioEngine.swift` — `core.streamUrl` now requires `mediaSourceId` + `playSessionId`
- `AppModel.swift` — `Track()` now requires `playlistItemId`

Both passed `nil` to preserve existing behavior. PlaybackInfo-based threading is a separate Swift-layer wire-up that can happen in a follow-up.

Confirmed `swift build` is clean after this patch.