### PR TITLE
macos(perf): memoize imageURL to fix scroll-time main-thread hang

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -732,6 +732,7 @@ final class AppModel {
         audio.stop()
         try? core.logout()
         session = nil
+        imageURLCache.removeAll()
         albums = []
         artists = []
         tracks = []
@@ -2384,9 +2385,26 @@ final class AppModel {
 
     }
 
+    /// Memoized cache keyed on (itemID, tag, maxWidth). Each grid cell calls
+    /// `imageURL` during every scroll-driven body recomputation; without this
+    /// cache every cell crosses the UniFFI boundary (Swift → C → Rust) and
+    /// locks `Inner` — an O(n) mutex hit per frame that serialized against
+    /// every background `loadMore*` and caused the main-thread beach ball.
+    /// The URL string is deterministic for a given (itemID, tag, maxWidth),
+    /// so one FFI crossing per tuple is all we ever need.
+    private var imageURLCache: [String: URL?] = [:]
+
     func imageURL(for itemID: String, tag: String?, maxWidth: UInt32 = 400) -> URL? {
-        guard let s = try? core.imageUrl(itemId: itemID, tag: tag, maxWidth: maxWidth) else { return nil }
-        return URL(string: s)
+        let key = "\(itemID)|\(tag ?? "")|\(maxWidth)"
+        if let cached = imageURLCache[key] { return cached }
+        let result: URL?
+        if let s = try? core.imageUrl(itemId: itemID, tag: tag, maxWidth: maxWidth) {
+            result = URL(string: s)
+        } else {
+            result = nil
+        }
+        imageURLCache[key] = result
+        return result
     }
 
     // MARK: - Playback


### PR DESCRIPTION
Fixes the spinning beach ball on library scroll.

## Root cause
`model.imageURL(...)` called `core.imageUrl(...)` through UniFFI on every grid cell body-recomputation. Each call:
1. Crossed the Swift→C→Rust FFI boundary
2. Took a `parking_lot::Mutex` lock on `Inner`
3. Formatted a deterministic URL string
4. Returned it back through FFI

During a fast scroll ~20 cells recompute per frame. That's 20+ mutex-serialized FFI calls per frame, racing against any background `loadMore*` page request. Main thread blocks → beach ball.

## Fix
Memoize the result. The URL is deterministic for a given (itemID, tag, maxWidth) tuple — one FFI crossing per tuple is all that's needed for the session. Cache cleared on logout so a new user's image URLs don't inherit stale entries.

After this, the first render of each cell still goes through FFI once, but every subsequent re-render (the common case during scroll) is a dictionary lookup.