### PR TITLE
macos: thread PlaybackInfo MediaSourceId + PlaySessionId into stream URL

### DIFF
--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -117,13 +117,48 @@ public final class AudioEngine: NSObject {
         }
     }
 
+    // MARK: - Private helpers
+
+    /// Resolve `(MediaSourceId, PlaySessionId)` via `POST /PlaybackInfo`
+    /// ahead of stream-URL construction. Both are `nil` on error so the
+    /// caller falls back to the server's default source and an
+    /// opportunistic (uncorrelated) session — the URL is still playable.
+    private func resolvePlaybackSource(for trackId: String) -> (mediaSourceId: String?, playSessionId: String?) {
+        let opts = PlaybackInfoOpts(
+            userId: nil,
+            startTimeTicks: nil,
+            mediaSourceId: nil,
+            maxStreamingBitrate: nil,
+            enableDirectPlay: nil,
+            enableDirectStream: nil,
+            enableTranscoding: nil,
+            autoOpenLiveStream: nil,
+            deviceProfile: nil
+        )
+        guard let info = try? core.playbackInfo(itemId: trackId, opts: opts) else {
+            return (nil, nil)
+        }
+        return (info.mediaSources.first?.id, info.playSessionId)
+    }
+
     // MARK: - Public
 
     public func play(track: Track) throws {
-        let urlString = try core.streamUrl(trackId: track.id, mediaSourceId: nil, playSessionId: nil)
+        // Resolve media source + play session id via PlaybackInfo so the
+        // server picks the right source for multi-version items and can
+        // correlate subsequent /Sessions/Playing* reports with the stream.
+        // Falling back to nil is harmless — the server just picks its
+        // default source and correlation stays opportunistic.
+        let (mediaSourceId, playSessionId) = resolvePlaybackSource(for: track.id)
+        let urlString = try core.streamUrl(
+            trackId: track.id,
+            mediaSourceId: mediaSourceId,
+            playSessionId: playSessionId
+        )
         guard let url = URL(string: urlString) else {
             throw AudioEngineError.invalidURL(urlString)
         }
+        core.setPlaySessionId(playSessionId: playSessionId)
         let authHeader = try core.authHeader()
         let asset = AVURLAsset(
             url: url,
@@ -241,7 +276,16 @@ public final class AudioEngine: NSObject {
     public func preloadNextTrack(_ track: Track) throws {
         guard let player else { return }
 
-        let urlString = try core.streamUrl(trackId: track.id, mediaSourceId: nil, playSessionId: nil)
+        // Preload uses the same PlaybackInfo resolution as play(track:)
+        // so the gapless transition doesn't swap to a different source
+        // mid-queue. The session id isn't installed yet — setPlaySessionId
+        // runs when the item actually becomes current (see play path).
+        let (mediaSourceId, playSessionId) = resolvePlaybackSource(for: track.id)
+        let urlString = try core.streamUrl(
+            trackId: track.id,
+            mediaSourceId: mediaSourceId,
+            playSessionId: playSessionId
+        )
         guard let url = URL(string: urlString) else {
             throw AudioEngineError.invalidURL(urlString)
         }


### PR DESCRIPTION
## Summary

Real fix for the stub #642 left behind. When #634 made \`mediaSourceId\` + \`playSessionId\` required on \`stream_url\`, #642 passed \`nil\` to both just to restore the build. Server-side consequences:
- Multi-version items pick a random source.
- Transcode jobs can't be correlated to their stream.
- Once \`/Sessions/Playing*\` reporting is wired, reports won't join to the stream either.

## Fix

- New \`AudioEngine.resolvePlaybackSource(for:)\` helper calls \`core.playbackInfo()\`.
- \`play(track:)\` uses it, threads both ids into \`streamUrl\`, and installs the session id via \`core.setPlaySessionId\` so progress/stop reports echo it.
- \`preloadNextTrack(_:)\` routes through the same helper so the gapless transition doesn't swap sources mid-queue.

Errors from PlaybackInfo fall back to \`(nil, nil)\` — the stream still plays against the server's default source, correlation just stays opportunistic. Same shape as #642's stub, but now opt-in rather than always-on.

## Not in scope

The \`/Sessions/Playing*\` report FFIs (\`report_playback_started\`, \`report_playback_progress\`, \`report_playback_stopped\`) exist on the core but no Swift caller invokes them today. That means PlayCount never increments, other Jellyfin clients never see \"Now Playing on macOS\", and resume points never update. Separate body of work.

## Test plan

- [x] \`swift build\` clean
- [ ] Play a track — verify server logs a PlaybackInfo POST
- [ ] Play a track with multiple MediaSources — verify the same source plays consistently