### PR TITLE
ci: clean swift build when FFI-relevant files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,12 +142,32 @@ jobs:
           key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-
+      # Did the PR touch anything that could make the cached .build go
+      # stale vs a fresh xcframework? Keeping the cache for unrelated
+      # PRs (docs, Swift-only UI tweaks, etc.) still wins on CI time —
+      # this just invalidates it when the FFI surface moves.
+      - name: Detect FFI-relevant changes
+        id: ffi_changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            core/src/lib.rs
+            core/src/models.rs
+            core/src/player.rs
+            core/src/error.rs
+            macos/Jellify.xcframework/**
+            macos/Sources/JellifyCore/Generated/jellify_core.swift
       - name: Build xcframework
         working-directory: macos
         run: ./Scripts/build-core.sh
-      - name: swift build
+      - name: swift build (clean when FFI-relevant)
         working-directory: macos
-        run: swift build
+        run: |
+          if [[ "${{ steps.ffi_changed.outputs.any_changed }}" == "true" ]]; then
+            echo "FFI-relevant files changed — clean build to invalidate stale object cache."
+            rm -rf .build
+          fi
+          swift build
       - name: Bundle .app
         working-directory: macos
         run: ./Scripts/make-bundle.sh


### PR DESCRIPTION
Close the \"stale xcframework passes CI, fresh rebuild fails\" gap that shipped a compile-broken main during the April 2026 audit iteration. Per the CLAUDE.md playbook, \`swift build\` alone is not a reliable pre-merge gate for FFI-adjacent work because it incrementally skips files whose sources didn't change — even when the cached object files were compiled against a previous xcframework.

## Approach

Watch a small set of FFI-surface inputs via \`tj-actions/changed-files@v45\`:

- \`core/src/lib.rs\`
- \`core/src/models.rs\`
- \`core/src/player.rs\`
- \`core/src/error.rs\`
- \`macos/Jellify.xcframework/**\`
- \`macos/Sources/JellifyCore/Generated/jellify_core.swift\`

When any of those change in a PR, blow away \`macos/.build\` before \`swift build\`. When they don't, the existing \`spm-\` cache still carries Swift-only / docs-only PRs fast.

## Test plan

- [x] yaml well-formed (no syntax errors in the diff)
- [ ] Bitwise unchanged FFI \u2192 cached build still hits (fast)
- [ ] Modify \`core/src/lib.rs\` \u2192 clean build (slower but catches drift)

## Why now

The previous audit iteration had a subtle bug where a commit that modified \`PlayerStatus\` in Rust without regenerating the bindings compiled locally (incremental) but failed a fresh pull. This gate would have caught it.