### PR TITLE
core+macos: albums_by_artist FFI for real Discography on large libraries

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -542,6 +542,57 @@ impl JellyfinClient {
         })
     }
 
+    /// Every album where the given artist is the primary (album) artist,
+    /// paginated and sorted by `SortName` ascending. Scopes via
+    /// `AlbumArtistIds` (not `ArtistIds`) so compilations the artist only
+    /// appears on don't show up in their Discography — the rule music
+    /// players conventionally apply for "artist's own work".
+    ///
+    /// Backed by `GET /Users/{id}/Items?AlbumArtistIds={artist_id}
+    /// &IncludeItemTypes=MusicAlbum&Recursive=true`. Returns a
+    /// [`PaginatedAlbums`] whose `total_count` is the server's authoritative
+    /// count so callers can drive "N of M" sublines.
+    ///
+    /// See issue #60: closes the `ArtistDetailView` gap where the
+    /// Discography section silently rendered empty for any artist past
+    /// the first page of the library-wide `albums` cache.
+    pub async fn albums_by_artist(
+        &self,
+        artist_id: &str,
+        paging: Paging,
+    ) -> Result<PaginatedAlbums> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("AlbumArtistIds", artist_id);
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", "MusicAlbum");
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            q.append_pair("SortBy", "SortName");
+            q.append_pair("SortOrder", "Ascending");
+            q.append_pair(
+                "Fields",
+                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+            );
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        Ok(PaginatedAlbums {
+            items: raw.items.into_iter().map(Album::from).collect(),
+            total_count: raw.total_record_count,
+        })
+    }
+
     /// Fetch the most recently added albums in a library, respecting the
     /// authenticated user's parental controls (enforced server-side via
     /// `userId`). Backed by `GET /Items/Latest`.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -351,6 +351,23 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.artists(Paging::new(offset, limit))))
     }
 
+    /// Every album where the given artist is the primary (album) artist,
+    /// paginated. Scopes by `AlbumArtistIds` on the server so compilations
+    /// the artist only appears on don't leak into the Discography section.
+    /// See issue #60 — closes the `ArtistDetailView` gap where the
+    /// Discography was rendered by filtering a paged library-wide cache.
+    pub fn albums_by_artist(
+        &self,
+        artist_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedAlbums, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.albums_by_artist(&artist_id, Paging::new(offset, limit)))
+        })
+    }
+
     pub fn album_tracks(&self, album_id: String) -> std::result::Result<Vec<Track>, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.album_tracks(&album_id)))
     }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -6195,3 +6195,128 @@ async fn cancelled_token_aborts_retry_backoff() {
         other => panic!("expected Other(\"request cancelled\"), got {other:?}"),
     }
 }
+
+// ============================================================================
+// albums_by_artist — #60, ArtistDetailView Discography
+// ============================================================================
+
+/// Covers the artist-scoped Discography endpoint. Asserts the query is
+/// scoped by `AlbumArtistIds` (not `ArtistIds` — compilations the artist
+/// only appears on should NOT show up in Discography), that the response
+/// is parsed, and that `total_count` carries the server's total.
+#[tokio::test]
+async fn albums_by_artist_scopes_by_album_artist_ids() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "al1", "Name": "Debut", "Type": "MusicAlbum",
+                    "AlbumArtist": "Solo",
+                    "AlbumArtistId": "artist-xyz",
+                    "AlbumArtists": [{"Id": "artist-xyz", "Name": "Solo"}],
+                    "ArtistItems": [{"Id": "artist-xyz", "Name": "Solo"}],
+                    "ProductionYear": 2020, "RunTimeTicks": 1800000000000u64,
+                    "ChildCount": 11, "Genres": ["Indie"],
+                    "ImageTags": { "Primary": "imgA" }
+                },
+                {
+                    "Id": "al2", "Name": "Sophomore Slump", "Type": "MusicAlbum",
+                    "AlbumArtist": "Solo",
+                    "AlbumArtistId": "artist-xyz",
+                    "AlbumArtists": [{"Id": "artist-xyz", "Name": "Solo"}],
+                    "ArtistItems": [{"Id": "artist-xyz", "Name": "Solo"}],
+                    "ProductionYear": 2022, "RunTimeTicks": 2400000000000u64,
+                    "ChildCount": 14, "Genres": ["Indie"],
+                    "ImageTags": { "Primary": "imgB" }
+                }
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .albums_by_artist("artist-xyz", crate::Paging::new(0, 20))
+        .await
+        .unwrap();
+
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total_count, 2);
+    assert_eq!(page.items[0].name, "Debut");
+    assert_eq!(page.items[0].artist_id.as_deref(), Some("artist-xyz"));
+    assert_eq!(page.items[1].name, "Sophomore Slump");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(
+        q.contains("AlbumArtistIds=artist-xyz"),
+        "should scope by AlbumArtistIds, got: {q}"
+    );
+    // "AlbumArtistIds=" contains "ArtistIds=" as a substring, so check
+    // for the broader filter either as the first param or after an `&`.
+    assert!(
+        !q.starts_with("ArtistIds=") && !q.contains("&ArtistIds="),
+        "should NOT use the broader ArtistIds filter (would include compilations), got: {q}"
+    );
+    assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("Limit=20"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+}
+
+/// `albums_by_artist` with `limit = 0` should clamp to 1, matching the
+/// other `Paging`-taking endpoints (`albums`, `artists`, `list_tracks`,
+/// `albums_by_artist`, ...). The server treats `Limit=0` as "no limit"
+/// which would blow response size on an artist with a deep back
+/// catalogue; clamping keeps the contract uniform.
+#[tokio::test]
+async fn albums_by_artist_clamps_zero_limit_to_one() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client
+        .albums_by_artist("artist-xyz", crate::Paging::new(0, 0))
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("Limit=1"), "zero limit should clamp to 1, got: {q}");
+}

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -753,6 +753,7 @@ final class AppModel {
         sidebarCopyingPlaylistIds = []
         playlistPendingDelete = nil
         artistTopTracks = [:]
+        artistAlbumsCache = [:]
         recentlyPlayed = []
         forYou = []
         jumpBackIn = []
@@ -812,6 +813,7 @@ final class AppModel {
         sidebarCopyingPlaylistIds = []
         playlistPendingDelete = nil
         artistTopTracks = [:]
+        artistAlbumsCache = [:]
         recentlyPlayed = []
         forYou = []
         jumpBackIn = []
@@ -1869,6 +1871,38 @@ final class AppModel {
             imageTag: imageTag
         )
     }
+
+    /// Every album where the given artist is the primary (album) artist.
+    /// Server-scoped via `AlbumArtistIds`, so compilations / guest-spots
+    /// don't leak into the Discography section. Drives
+    /// `ArtistDetailView.artistAlbums` — replaces the stale
+    /// `model.albums.filter { $0.artistId == artistID }` pattern that
+    /// only searched the first page of 100 cached albums (#60).
+    ///
+    /// Results are cached per-artist for the session since the data is
+    /// stable for the duration of the user's browsing session and the
+    /// detail screen may be entered / left repeatedly.
+    @discardableResult
+    func loadArtistAlbums(artistId: String, limit: UInt32 = 100) async -> [Album] {
+        if let cached = artistAlbumsCache[artistId] { return cached }
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.albumsByArtist(artistId: artistId, offset: 0, limit: limit)
+            }.value
+            artistAlbumsCache[artistId] = page.items
+            serverReachability.noteSuccess()
+            return page.items
+        } catch {
+            if handleAuthError(error) { return [] }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            return []
+        }
+    }
+
+    /// Per-session cache for `loadArtistAlbums`. Cleared on `logout()`.
+    private var artistAlbumsCache: [String: [Album]] = [:]
 
     /// Fetch the top 5 most-played tracks for an artist, driving the
     /// "Top Tracks" section on the artist detail screen (#229). Backed by

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -68,7 +68,11 @@ struct ArtistDetailView: View {
             if model.artists.first(where: { $0.id == artistID }) == nil {
                 fetchedArtist = await model.resolveArtist(id: artistID)
             }
-            artistAlbums = model.albums.filter { $0.artistId == artistID }
+            // Server-scoped fetch via `AlbumArtistIds`. The prior
+            // `model.albums.filter { ... }` only looked at the cached
+            // first page of 100 library-wide albums, so Discography
+            // rendered empty for most artists on a large library (#60).
+            artistAlbums = await model.loadArtistAlbums(artistId: artistID)
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
             isLoadingTopTracks = false
         }


### PR DESCRIPTION
## Problem (verified live)

\`ArtistDetailView\` Discography resolved via \`model.albums.filter { \$0.artistId == artistID }\` — a filter over the paged first 100 cached albums. On a 20k-album library that's 0.5% coverage; nearly every artist renders an empty Discography.

Verified against music.skalthoff.com: Ed Sheeran has **24 albums** on the server, the old path returned **0** because his catalog didn't sit in the library's first SortName page.

## Fix

- **\`core.albums_by_artist(artist_id, offset, limit)\`** — new FFI hitting \`GET /Users/{user_id}/Items?AlbumArtistIds=<id>&IncludeItemTypes=MusicAlbum&Recursive=true\`. Scoped via \`AlbumArtistIds\` (not the broader \`ArtistIds\`) so compilations / guest-tracks don't leak into the artist's Discography — the conventional "artist's own work" rule.
- **\`AppModel.loadArtistAlbums(artistId:)\`** — wraps the FFI on \`Task.detached\`, caches per-artist for the session.
- **\`ArtistDetailView.task\`** — awaits \`loadArtistAlbums\` instead of filtering \`model.albums\`.

## Tests

- \`albums_by_artist_scopes_by_album_artist_ids\` — asserts \`AlbumArtistIds=<id>\` and NOT the broader \`ArtistIds=<id>\` (substring overlap guarded via \`starts_with\` / \`&\`-prefix check).
- \`albums_by_artist_clamps_zero_limit_to_one\` — matches the \`albums\` / \`artists\` / \`list_tracks\` clamping convention.

164 lib tests pass; clippy + rustdoc clean.

Partial fix for #60 (the "Appears On" / real \`AlbumType\` work still requires MusicBrainz plugin metadata on the server side).