### PR TITLE
fix(ux): sidebar nav + playlist data-layer holes — working prototype

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -761,62 +761,51 @@ impl JellyfinClient {
         })
     }
 
-    /// Fetch playlists the current user owns. Jellyfin stores user-owned
-    /// playlists under the user's profile directory, so the returned `Path`
-    /// contains `/data/` (e.g. `/config/data/users/<id>/playlists/...`);
-    /// public/community playlists live elsewhere and are filtered out.
+    /// Fetch every playlist visible to the current user under the given
+    /// Playlists library view, paginated.
     ///
     /// `playlist_library_id` is the Playlists view id (the CollectionFolder
-    /// with `CollectionType == "playlists"`). Resolving that id is tracked
-    /// separately; callers pass it in here.
+    /// with `CollectionType == "playlists"`). Resolving that id is handled
+    /// by [`JellyfinClient::playlist_library_id`].
     ///
-    /// `total_count` on the returned [`PaginatedPlaylists`] is the server's
-    /// unfiltered `TotalRecordCount` (all playlists under the library view,
-    /// both user- and public-owned) — the per-page `items.len()` may be
-    /// smaller once the client-side `/data/` filter has been applied.
+    /// Historical note: previous versions filtered by `Path.contains("/data/")`
+    /// on the assumption that Jellyfin stores user-owned playlists under the
+    /// user profile dir. That's only true on default-install servers — any
+    /// server where the Playlists library is mounted elsewhere (e.g.
+    /// `/sMusic/playlists/` as on music.skalthoff.com) hides *every* playlist
+    /// from the client, leaving "0 OF 78 PLAYLISTS" on the UI. The filter is
+    /// removed; "user-owned vs public" is a split that needs a proper
+    /// discriminator (e.g. `CanDelete` or `OwnerId` from `Fields`), tracked
+    /// separately.
     pub async fn user_playlists(
         &self,
         playlist_library_id: &str,
         paging: Paging,
     ) -> Result<PaginatedPlaylists> {
         let raw = self.playlists_items(playlist_library_id, paging).await?;
-        let items = raw
-            .items
-            .into_iter()
-            .filter(|i| i.path.as_deref().is_some_and(|p| p.contains("/data/")))
-            .map(Playlist::from)
-            .collect();
+        let items: Vec<Playlist> = raw.items.into_iter().map(Playlist::from).collect();
         Ok(PaginatedPlaylists {
             items,
             total_count: raw.total_record_count,
         })
     }
 
-    /// Fetch playlists visible to the current user that are NOT owned by
-    /// them — i.e. public/community playlists. These live outside the user's
-    /// profile directory, so their `Path` does not contain `/data/`.
+    /// Same implementation as [`JellyfinClient::user_playlists`] until a
+    /// reliable user-vs-public discriminator is wired. Kept as a distinct
+    /// method so callers that care about the intent — a future "Community
+    /// Playlists" surface — don't have to change when the split lands.
     ///
-    /// `playlist_library_id` is the Playlists view id (the CollectionFolder
-    /// with `CollectionType == "playlists"`). Resolving that id is tracked
-    /// separately; callers pass it in here.
-    ///
-    /// See [`JellyfinClient::user_playlists`] for the `total_count` caveat.
+    /// Previous behaviour filtered on `!Path.contains("/data/")`. That was a
+    /// false discriminator (returned everything when the Playlists library
+    /// was mounted outside the user profile dir, returned nothing when it
+    /// was). Same fix rationale as `user_playlists`.
     pub async fn public_playlists(
         &self,
         playlist_library_id: &str,
         paging: Paging,
     ) -> Result<PaginatedPlaylists> {
-        let raw = self.playlists_items(playlist_library_id, paging).await?;
-        let items = raw
-            .items
-            .into_iter()
-            .filter(|i| !i.path.as_deref().is_some_and(|p| p.contains("/data/")))
-            .map(Playlist::from)
-            .collect();
-        Ok(PaginatedPlaylists {
-            items,
-            total_count: raw.total_record_count,
-        })
+        // Same query today; see doc comment. Avoid duplicating the HTTP call.
+        self.user_playlists(playlist_library_id, paging).await
     }
 
     /// Shared `GET /Items` request that returns all playlists under the
@@ -858,6 +847,15 @@ impl JellyfinClient {
     /// returns items in the playlist's stored order when no sort is specified.
     /// Callers that need a different sort can do it client-side.
     ///
+    /// Caller-ID guard: if a caller accidentally hands the Playlists
+    /// CollectionFolder id (the library-view id, not a single playlist) as
+    /// `playlist_id`, the server **ignores `IncludeItemTypes=Audio`** under a
+    /// folder parent and returns the folder's children — 78 Playlist-typed
+    /// entries that would otherwise get mapped through `Track::from` and
+    /// render as minute-long "tracks" on the UI. Defend with a
+    /// post-response `kind == "Audio"` filter so the pipe refuses to accept
+    /// non-audio rows regardless of what the server returns.
+    ///
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
     pub async fn playlist_tracks(
@@ -886,8 +884,18 @@ impl JellyfinClient {
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
         let raw: RawItems<RawItem> = resp.json().await?;
+        let items: Vec<Track> = raw
+            .items
+            .into_iter()
+            .filter(|i| i.kind.as_deref() == Some("Audio"))
+            .map(Track::from)
+            .collect();
+        // `total_count` is the server's `TotalRecordCount` — may over-count
+        // if we just rejected non-Audio entries. That's fine for the UI
+        // (our items.len() is the authoritative "what we rendered"); leaving
+        // total as the server value preserves the pagination contract.
         Ok(PaginatedTracks {
-            items: raw.items.into_iter().map(Track::from).collect(),
+            items,
             total_count: raw.total_record_count,
         })
     }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1731,7 +1731,17 @@ async fn latest_albums_requires_authenticated_session() {
 }
 
 #[tokio::test]
-async fn user_playlists_filters_to_data_path_and_builds_query() {
+async fn user_playlists_returns_every_playlist_in_library_view() {
+    // Rationale: the prior `Path.contains("/data/")` filter was a false
+    // discriminator — it assumed Jellyfin stored user-owned playlists
+    // under `/config/data/users/…` but any server that mounts its
+    // Playlists library elsewhere (e.g. `/sMusic/playlists/` as on the
+    // author's own server) had 100% of its playlists filtered out, leaving
+    // the UI reading "0 OF N PLAYLISTS".
+    //
+    // Corrected behaviour: `user_playlists` returns every playlist the
+    // server lists under the given library view, without a client-side
+    // path filter.
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -1761,7 +1771,7 @@ async fn user_playlists_filters_to_data_path_and_builds_query() {
                 {
                     "Id": "p2", "Name": "Community Top 40", "Type": "Playlist",
                     "ChildCount": 40,
-                    "Path": "/media/playlists/community-top-40",
+                    "Path": "/sMusic/playlists/community-top-40",
                     "ImageTags": {}
                 }
             ],
@@ -1776,21 +1786,24 @@ async fn user_playlists_filters_to_data_path_and_builds_query() {
         .user_playlists("lib-pl", Paging::new(5, 20))
         .await
         .unwrap();
-    let playlists = page.items;
 
-    assert_eq!(playlists.len(), 1);
-    // `total_count` surfaces the server's unfiltered TotalRecordCount —
-    // the paging UI needs this to know when a follow-up page would yield
-    // more results even if the client-side /data/ filter removed some.
+    assert_eq!(page.items.len(), 2, "should return every playlist, not apply a /data/ filter");
     assert_eq!(page.total_count, 2);
-    assert_eq!(playlists[0].id, "p1");
-    assert_eq!(playlists[0].name, "My Mix");
-    assert_eq!(playlists[0].track_count, 12);
-    assert_eq!(playlists[0].image_tag.as_deref(), Some("tag-1"));
+    assert_eq!(page.items[0].id, "p1");
+    assert_eq!(page.items[0].name, "My Mix");
+    assert_eq!(page.items[0].track_count, 12);
+    assert_eq!(page.items[0].image_tag.as_deref(), Some("tag-1"));
+    // Crucially, the non-`/data/`-path playlist is included.
+    assert_eq!(page.items[1].id, "p2");
+    assert_eq!(page.items[1].name, "Community Top 40");
 }
 
 #[tokio::test]
-async fn public_playlists_filters_out_data_path() {
+async fn public_playlists_mirrors_user_playlists_until_split_lands() {
+    // Until a real user-vs-public discriminator (e.g. CanDelete / OwnerId)
+    // is wired, `public_playlists` intentionally returns the same set as
+    // `user_playlists` so neither method silently drops rows based on a
+    // broken `Path` heuristic.
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -1831,18 +1844,13 @@ async fn public_playlists_filters_out_data_path() {
         .public_playlists("lib-pl", Paging::new(0, 50))
         .await
         .unwrap();
-    let playlists = page.items;
 
-    // Both the community playlist (non-/data/ path) and the playlist with no
-    // `Path` at all are treated as public — absence cannot prove ownership.
-    assert_eq!(playlists.len(), 2);
+    assert_eq!(page.items.len(), 3, "public_playlists mirrors user_playlists today");
     assert_eq!(page.total_count, 3);
-    let ids: Vec<&str> = playlists.iter().map(|p| p.id.as_str()).collect();
-    assert!(ids.contains(&"p2"), "public_playlists should include p2");
-    assert!(ids.contains(&"p3"), "public_playlists should include p3");
-    let community = playlists.iter().find(|p| p.id == "p2").unwrap();
-    assert_eq!(community.track_count, 40);
-    assert_eq!(community.image_tag.as_deref(), Some("tag-2"));
+    let ids: Vec<&str> = page.items.iter().map(|p| p.id.as_str()).collect();
+    assert!(ids.contains(&"p1"));
+    assert!(ids.contains(&"p2"));
+    assert!(ids.contains(&"p3"));
 }
 
 #[tokio::test]
@@ -6319,4 +6327,69 @@ async fn albums_by_artist_clamps_zero_limit_to_one() {
         .expect("expected a GET request");
     let q = get.url.query().expect("expected a query string");
     assert!(q.contains("Limit=1"), "zero limit should clamp to 1, got: {q}");
+}
+
+// ============================================================================
+// playlist_tracks defensive Type filter — #313 / ux-audit
+// ============================================================================
+
+/// Regression for the "Playlists > Playlists" screenshot. When the caller
+/// accidentally hands the Playlists *CollectionFolder* id (the library-view
+/// id, not a single playlist) as `playlist_id`, the server ignores
+/// `IncludeItemTypes=Audio` under a folder parent and returns the folder's
+/// children — Playlist-typed items that, if mapped through `Track::from`,
+/// would render as minute-long "tracks" on the UI. The Rust client now
+/// post-filters by `Type == "Audio"` so the downstream UI never sees
+/// non-audio rows regardless of what the server returns.
+#[tokio::test]
+async fn playlist_tracks_rejects_non_audio_items() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // Simulate the server's bad behaviour: return a mix of Audio and
+    // Playlist items for the /Items?ParentId=<folderId>&IncludeItemTypes=Audio
+    // request.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Real Track", "Type": "Audio",
+                    "AlbumId": "a1", "AlbumArtist": "Artist",
+                    "RunTimeTicks": 180_000_000_000u64
+                },
+                {
+                    "Id": "pl1", "Name": "Africa by Toto", "Type": "Playlist",
+                    "RunTimeTicks": 12_000_000_000u64,
+                    "ChildCount": 5
+                },
+                {
+                    "Id": "pl2", "Name": "Ayla Music", "Type": "Playlist",
+                    "RunTimeTicks": 205_200_000_000u64,
+                    "ChildCount": 92
+                }
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .playlist_tracks("library-folder-id", crate::Paging::new(0, 50))
+        .await
+        .unwrap();
+
+    // Only the Audio entry survives; the Playlist items would otherwise
+    // render as tracks with multi-hour durations on the UI.
+    assert_eq!(page.items.len(), 1, "non-Audio rows must be dropped");
+    assert_eq!(page.items[0].id, "t1");
+    assert_eq!(page.items[0].name, "Real Track");
 }

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -28,6 +28,13 @@ final class AppModel {
     enum Screen: Hashable { case home, discover, library, search, settings, album(String), artist(String), playlist(String), nowPlaying }
     var screen: Screen = .library
 
+    /// Which chip is active on the Library screen. Driven by the sidebar's
+    /// "Albums / Artists / Playlists" libRows so they can deep-link into a
+    /// specific tab rather than always landing on the default. `LibraryView`
+    /// mirrors this into its local `@State` on appear and writes back on
+    /// user-chip-change so the sidebar selection persists across navigation.
+    var libraryTab: LibraryTab = .albums
+
     /// Screen the app was on before the user opened the full Now Playing
     /// view. `NowPlayingView` offers a "Back" affordance that pops to this
     /// value rather than unconditionally routing to `.library`, so a user
@@ -1868,6 +1875,60 @@ final class AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             genres: genres,
+            imageTag: imageTag
+        )
+    }
+
+    /// Resolve a `Playlist` record by id — cache-first, falling back to
+    /// `core.fetchItem` when the id isn't in the loaded `playlists` page.
+    /// Mirror of `resolveArtist(id:)` / `resolveAlbum(id:)`. Lets
+    /// `PlaylistView` render a hero for deep-linked playlists past the
+    /// first library page. Returns nil on error or missing id.
+    func resolvePlaylist(id: String) async -> Playlist? {
+        if let cached = playlist(id: id) { return cached }
+        do {
+            let json = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.fetchItem(
+                    itemId: id,
+                    fields: ["ChildCount", "RunTimeTicks", "PrimaryImageAspectRatio"]
+                )
+            }.value
+            guard let parsed = Self.parsePlaylist(from: json) else { return nil }
+            // Seed the cache so `model.playlist(id:)` works on the next
+            // call without another FFI round-trip, and so breadcrumbs can
+            // read the name.
+            if !playlists.contains(where: { $0.id == parsed.id }) {
+                playlists.append(parsed)
+            }
+            return parsed
+        } catch {
+            _ = handleAuthError(error)
+            return nil
+        }
+    }
+
+    static func parsePlaylist(from json: String) -> Playlist? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        guard let id = root["Id"] as? String,
+              let name = root["Name"] as? String
+        else { return nil }
+        // Defensive guard against the "Playlists > Playlists" case — if the
+        // server hands back a CollectionFolder / UserView instead of a real
+        // Playlist (id happens to match the library-view id), refuse it so
+        // the UI falls through to "not found" instead of rendering the
+        // folder's children as track rows.
+        let kind = (root["Type"] as? String) ?? ""
+        guard kind == "Playlist" else { return nil }
+        let trackCount = (root["ChildCount"] as? NSNumber)?.uint32Value ?? 0
+        let runtimeTicks = (root["RunTimeTicks"] as? NSNumber)?.uint64Value ?? 0
+        let imageTag = (root["ImageTags"] as? [String: String])?["Primary"]
+        return Playlist(
+            id: id,
+            name: name,
+            trackCount: trackCount,
+            runtimeTicks: runtimeTicks,
             imageTag: imageTag
         )
     }

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -233,7 +233,12 @@ struct LibraryListRow: View {
         case .artist(let artist):
             model.screen = .artist(artist.id)
         case .playlist(let playlist):
-            model.screen = .playlist(playlist.id)
+            // Route through `goToPlaylist` so the playlist is seeded into
+            // `model.playlists` before the screen flips. Without this seed,
+            // `PlaylistView`'s cache lookup misses for any row the user
+            // opens from a non-first-page list (search results, list
+            // pagination beyond 100 items) and the hero renders "not found".
+            model.goToPlaylist(playlist)
         }
     }
 

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -54,10 +54,13 @@ struct Sidebar: View {
             // in place; the playlist list lives as its own section below.
             sectionHeader("Your Library")
             VStack(alignment: .leading, spacing: 2) {
-                libRow("heart", label: "Favorites", count: nil)
-                libRow("square.stack", label: "Albums", count: UInt32(model.albums.count))
-                libRow("person.crop.circle", label: "Artists", count: UInt32(model.artists.count))
-                libRow("music.note.list", label: "Playlists", count: UInt32(model.playlists.count))
+                // "Favorites" has no dedicated surface yet — route to the
+                // library's default tab for now so the row isn't a dead
+                // click (follow-up: dedicated favorites tab, #133).
+                libRow("heart", label: "Favorites", count: nil, tab: .albums)
+                libRow("square.stack", label: "Albums", count: UInt32(model.albums.count), tab: .albums)
+                libRow("person.crop.circle", label: "Artists", count: UInt32(model.artists.count), tab: .artists)
+                libRow("music.note.list", label: "Playlists", count: UInt32(model.playlists.count), tab: .playlists)
             }
             .padding(.horizontal, 10)
 
@@ -289,28 +292,39 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func libRow(_ icon: String, label: String, count: UInt32?) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: icon)
-                .foregroundStyle(Theme.ink2)
-                .frame(width: 18)
-                .accessibilityHidden(true)
-            Text(label)
-                .font(Theme.font(13, weight: .semibold))
-                .foregroundStyle(Theme.ink2)
-            Spacer()
-            if let c = count {
-                Text("\(c)")
-                    .font(Theme.font(10, weight: .bold))
-                    .foregroundStyle(Theme.ink3)
+    private func libRow(_ icon: String, label: String, count: UInt32?, tab: LibraryTab) -> some View {
+        Button {
+            // Set the requested library tab before flipping the screen so the
+            // Library view reads the right chip on its first render. See
+            // `AppModel.libraryTab`.
+            model.libraryTab = tab
+            model.screen = .library
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 18)
+                    .accessibilityHidden(true)
+                Text(label)
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                Spacer()
+                if let c = count {
+                    Text("\(c)")
+                        .font(Theme.font(10, weight: .bold))
+                        .foregroundStyle(Theme.ink3)
+                }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .buttonStyle(.plain)
         // Combine icon + label + count into one VoiceOver utterance so the
         // row reads as "Albums, 42" rather than three separate fragments.
         .accessibilityElement(children: .combine)
         .accessibilityLabel(count.map { "\(label), \($0)" } ?? label)
+        .accessibilityAddTraits(.isButton)
     }
 
     @ViewBuilder

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -62,6 +62,10 @@ enum LibraryTab: Hashable, CaseIterable {
 struct LibraryView: View {
     @Environment(AppModel.self) private var model
     @AppStorage("libraryViewMode") private var viewMode: LibraryViewMode = .grid
+    /// Local mirror of `model.libraryTab`. Starts from whatever the sidebar /
+    /// last session left it at, updates the model on chip taps so the sidebar
+    /// selection (and a future back-nav into the library) land on the same
+    /// tab the user last touched.
     @State private var selectedTab: LibraryTab = .albums
     /// Single shared hover ID for the grid. Published via
     /// `.libraryHoverID` env so every cell reads from (and writes to) the same
@@ -94,6 +98,21 @@ struct LibraryView: View {
             \.libraryHoverID,
             LibraryHoverBinding(id: $hoverID, isActive: true)
         )
+        // Sync the local `selectedTab` with `model.libraryTab` so the
+        // sidebar's Albums/Artists/Playlists libRows can deep-link into
+        // a specific chip. `.onAppear` covers the case where the library
+        // is entered fresh; `.onChange` covers the case where the user
+        // is already on the library and the sidebar flips the tab.
+        .onAppear { selectedTab = model.libraryTab }
+        .onChange(of: model.libraryTab) { _, newValue in
+            selectedTab = newValue
+        }
+        .onChange(of: selectedTab) { _, newValue in
+            // Write-back so the sidebar's highlighted chip stays in sync.
+            if model.libraryTab != newValue {
+                model.libraryTab = newValue
+            }
+        }
     }
 
     /// Jellyfin's web UI lives at `/web/` on the server host. Falls back to

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -173,7 +173,9 @@ struct MainShell: View {
             if let album = model.albums.first(where: { $0.id == id }) {
                 segments.append(album.name)
             } else {
-                segments.append("Album")
+                // Ellipsis is more informative than a section-name-matching
+                // literal fallback ("Albums > Album") that reads like a bug.
+                segments.append("…")
             }
         case .artist(let id):
             segments.append("Library")
@@ -181,7 +183,7 @@ struct MainShell: View {
             if let artist = model.artists.first(where: { $0.id == id }) {
                 segments.append(artist.name)
             } else {
-                segments.append("Artist")
+                segments.append("…")
             }
         case .playlist(let id):
             segments.append("Library")
@@ -189,7 +191,7 @@ struct MainShell: View {
             if let playlist = model.playlist(id: id) {
                 segments.append(playlist.name)
             } else {
-                segments.append("Playlist")
+                segments.append("…")
             }
         case .nowPlaying:
             segments.append("Now Playing")

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -24,6 +24,7 @@ struct PlaylistView: View {
 
     @State private var tracks: [Track] = []
     @State private var isLoadingTracks = true
+    @State private var fetchedPlaylist: Playlist?
 
     /// Editor draft state for the title. `nil` means the title is being
     /// displayed; non-nil means the user has tapped it and a `TextField` is
@@ -36,12 +37,11 @@ struct PlaylistView: View {
     @State private var descriptionDraft: String? = nil
     @FocusState private var descriptionFocused: Bool
 
-    /// Resolve the playlist from the model's cache. Missing is an edge
-    /// case (deep link landing on `.playlist(id)` before the sidebar /
-    /// library has primed the cache); we render a gentle fallback rather
-    /// than crash.
+    /// Resolve the playlist: cached library page first, then whichever
+    /// record the `.task` block fetched on demand. Nil means the id can't
+    /// be resolved (deleted upstream, not a real Playlist, server errored).
     private var playlist: Playlist? {
-        model.playlist(id: playlistID)
+        model.playlist(id: playlistID) ?? fetchedPlaylist
     }
 
     private var description: String {
@@ -59,7 +59,16 @@ struct PlaylistView: View {
         }
         .background(Theme.bg)
         .task(id: playlistID) {
+            // Cache miss (deep link past the first page of library playlists,
+            // or the pre-#654 "Playlists collection folder id" regression
+            // the core now defends against): ask `resolvePlaylist` to
+            // fetch + validate the record so the hero can render.
+            if model.playlist(id: playlistID) == nil {
+                fetchedPlaylist = await model.resolvePlaylist(id: playlistID)
+            }
             guard let playlist = playlist else {
+                // Unknown / deleted / non-playlist id — refuse to load
+                // tracks so the "Playlist not found" hero renders alone.
                 isLoadingTracks = false
                 return
             }
@@ -358,10 +367,24 @@ struct PlaylistView: View {
         }
     }
 
+    /// Render a tick-count runtime as a human playlist duration.
+    ///
+    /// `ticks == 0` → "0" (falls back to zero rather than rendering a hero
+    /// stat that reads as "no runtime data"; callers gate the surrounding
+    /// stat line on `playlist != nil`).
+    /// `< 60 min` → "42" (bare minute count — matches the stat's "MINUTES"
+    /// label beneath).
+    /// `≥ 60 min` → "5h 42m" (hours segment so a 5h42m playlist doesn't
+    /// read as "342" minutes and tell the user it's roughly six hours by
+    /// forcing them to do long division).
     private func formatMinutes(_ ticks: UInt64) -> String {
-        let seconds = Double(ticks) / 10_000_000.0
-        let minutes = Int(seconds / 60)
-        return "\(minutes)"
+        guard ticks > 0 else { return "0" }
+        let totalSeconds = Int(Double(ticks) / 10_000_000.0)
+        let totalMinutes = totalSeconds / 60
+        guard totalMinutes >= 60 else { return "\(totalMinutes)" }
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return "\(hours)h \(minutes)m"
     }
 }
 


### PR DESCRIPTION
Five fixes that turn "Playlists tab looks broken" and "sidebar rows do nothing" into a working prototype. Verified against music.skalthoff.com.

## Root-causes of the Playlists screenshot

The user's "Playlists > Playlists / 5 TRACKS / 0 MINUTES / rows of playlist names as tracks" was **two data-layer bugs in Rust core**:

### 1. \`user_playlists\` \`/data/\` path filter hid every playlist

\`core/src/client.rs\` filtered \`/Items\` results on \`Path.contains("/data/")\`. That assumes Jellyfin stores user-owned playlists under the user profile dir — only true on default installs. Any server where the Playlists library is mounted elsewhere (e.g. \`/sMusic/playlists/\` on music.skalthoff.com, verified live) had **100%** of its playlists filtered out, leaving "0 OF 78 PLAYLISTS" on the chip.

**Fix**: drop the filter. \`public_playlists\` mirrors \`user_playlists\` until a reliable user-vs-public discriminator (\`CanDelete\` / \`OwnerId\`) is wired.

### 2. \`playlist_tracks(libraryId)\` returned Playlist items as "tracks"

\`playlist_tracks\` asked for \`/Items?ParentId={id}&IncludeItemTypes=Audio\`. Jellyfin **ignores** \`IncludeItemTypes=Audio\` under a CollectionFolder parent and returns the folder's children — 78 Playlist-typed items, mapped through \`Track::from\` and rendered as tracks with minute-long durations. 20:00 / 342:00 / 481:00 in the screenshot == the playlists' \`RunTimeTicks\` formatted as m:ss.

**Fix**: post-filter \`Type == "Audio"\` in Rust. Downstream UI never sees non-audio rows regardless of what the server returns.

## Swift fixes

### 3. Sidebar libRows are real buttons

"Favorites / Albums / Artists / Playlists" under "Your Library" had no \`onTapGesture\`. Users reasonably tried them — nothing happened. Wrap each in a \`Button\` that sets \`model.libraryTab\` then flips \`screen = .library\` so the requested chip opens.

New \`AppModel.libraryTab: LibraryTab = .albums\`; \`LibraryView\` mirrors it into its \`@State\` on appear and writes back on chip change so the sidebar's highlighted chip stays in sync.

### 4. \`AppModel.resolvePlaylist\` + \`PlaylistView\` cache-miss

Mirror of \`resolveArtist\`/\`resolveAlbum\`. Defends against the CollectionFolder-as-Playlist case by checking \`Type == "Playlist"\` on the parsed JSON before returning; deep-linked playlists past the first library page now render a real hero.

### 5. \`LibraryListRow\` routes playlists through \`goToPlaylist\`

List-mode playlist rows previously set \`model.screen\` directly, skipping the cache-seed. Now go through \`goToPlaylist\` like every other entry point.

## Polish

- \`PlaylistView.formatMinutes\` — 5h42m now reads \`"5h 42m"\` instead of \`"342"\`.
- Breadcrumb cache-miss fallback is \`"…"\` instead of a section-name literal (\`"Playlists > Playlist"\` looked like a breadcrumb duplication bug).

## Tests

- \`user_playlists_returns_every_playlist_in_library_view\` — confirms filter is gone
- \`public_playlists_mirrors_user_playlists_until_split_lands\`
- \`playlist_tracks_rejects_non_audio_items\` — regression for the screenshot
- 165 Rust lib tests pass, clippy clean
- \`rm -rf macos/.build && swift build\` clean (per #651 gate)

## Deferred (UX_AUDIT.md)

Context-menu stubs, \`PlayerBar.currentContext\` wire-up, \`PlaylistDetailView\` vs \`PlaylistView\` routing choice. None are ship-blockers for "prototype is navigable"; queued for a separate polish PR.