### PR TITLE
core: fix artists and playlist_library_id endpoints (both returned 0 live)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -490,7 +490,14 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("userId", user_id);
             q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicArtist");
+            // Deliberate: no `IncludeItemTypes=MusicArtist`. Verified live
+            // against music.skalthoff.com — Jellyfin 10.11 returns 0 items
+            // from `/Artists/AlbumArtists` when `IncludeItemTypes=MusicArtist`
+            // is supplied (the endpoint already scopes to MusicArtist by
+            // path, and the server's query builder AND-intersects against
+            // the type list, which apparently excludes the endpoint's own
+            // inherent type on some configs). Without the filter the
+            // endpoint returns the full artist list.
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
             q.append_pair("SortBy", "SortName");
@@ -1828,44 +1835,38 @@ impl JellyfinClient {
         Ok(id)
     }
 
-    /// Resolve the playlists library's id — the ManualPlaylistsFolder with
-    /// `CollectionType == "playlists"`. Backed by
-    /// `GET /Items?userId={id}&includeItemTypes=ManualPlaylistsFolder&excludeItemTypes=CollectionFolder`
-    /// (the view's own id isn't surfaced by `/UserViews`). Cached on the
-    /// client after the first call; invalidated on
-    /// [`JellyfinClient::set_session`].
+    /// Resolve the playlists library's id — the `UserView` with
+    /// `CollectionType == "playlists"`. Cached on the client after the
+    /// first call; invalidated on [`JellyfinClient::set_session`].
+    ///
+    /// Uses the same `/UserViews` endpoint as [`Self::music_library_id`].
+    /// An earlier implementation hit
+    /// `/Items?includeItemTypes=ManualPlaylistsFolder` on the (documented-
+    /// but-wrong) assumption that the UserView wasn't surfaced. That
+    /// endpoint does surface a playlists-typed item — but with a
+    /// `ManualPlaylistsFolder` id that is **not a valid `ParentId`** for
+    /// `/Items?ParentId=…&IncludeItemTypes=Playlist`. The UserView id is
+    /// the one `/Items` actually scopes to, so that's what callers need.
+    /// Verified live against Jellyfin 10.11.8: `/UserViews` surfaces
+    /// `{ Type: "UserView", CollectionType: "playlists", Id: <viewId> }`
+    /// and that id returns the 78 user playlists when used as `ParentId`.
     ///
     /// Errors with [`JellifyError::NotAuthenticated`] if no session is
     /// active, or [`JellifyError::Server`] with status 404 when the
-    /// server has no playlist library (rare — Jellyfin synthesises one
+    /// server has no playlists library (rare — Jellyfin synthesises one
     /// the first time a playlist is created).
     pub async fn playlist_library_id(&self) -> Result<String> {
         if let Some(id) = self.library_cache.lock().playlist.clone() {
             return Ok(id);
         }
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint("Items")?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("userId", user_id);
-            q.append_pair("includeItemTypes", "ManualPlaylistsFolder");
-            q.append_pair("excludeItemTypes", "CollectionFolder");
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawLibrary> = resp.json().await?;
-        let id = raw
-            .items
+        let views = self.user_views().await?;
+        let id = views
             .into_iter()
-            .find(|item| item.collection_type.as_deref() == Some("playlists"))
-            .map(|item| item.id)
+            .find(|v| v.collection_type.as_deref() == Some("playlists"))
+            .map(|v| v.id)
             .ok_or_else(|| JellifyError::Server {
                 status: 404,
-                message: "no playlist library found".into(),
+                message: "no playlists library found in user views".into(),
             })?;
         self.library_cache.lock().playlist = Some(id.clone());
         Ok(id)

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1561,7 +1561,14 @@ async fn artists_exposes_total_record_count_and_paging() {
     let q = get.url.query().expect("expected a query string");
     assert!(q.contains("Limit=100"), "query: {q}");
     assert!(q.contains("StartIndex=25"), "query: {q}");
-    assert!(q.contains("IncludeItemTypes=MusicArtist"), "query: {q}");
+    // Deliberately absent: `IncludeItemTypes=MusicArtist`. Live Jellyfin
+    // 10.11 servers return 0 items from this endpoint when the filter is
+    // present (see artists_does_not_send_include_item_types_music_artist
+    // for the regression assertion).
+    assert!(
+        !q.contains("IncludeItemTypes=MusicArtist"),
+        "artists() must NOT send IncludeItemTypes=MusicArtist, got: {q}"
+    );
 }
 
 #[tokio::test]
@@ -3982,7 +3989,14 @@ async fn music_library_id_returns_404_when_no_music_view() {
 }
 
 #[tokio::test]
-async fn playlist_library_id_finds_manual_playlists_folder() {
+async fn playlist_library_id_finds_playlists_user_view() {
+    // Rationale: an earlier implementation hit
+    // `/Items?includeItemTypes=ManualPlaylistsFolder` which returned the
+    // ManualPlaylistsFolder entity's id — but that id is NOT a valid
+    // `ParentId` for `/Items?ParentId=…&IncludeItemTypes=Playlist` on
+    // real servers. The UserView id (the one surfaced by /UserViews) is.
+    // So the canonical resolution goes through /UserViews + CollectionType
+    // filter, same as music_library_id.
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -3993,15 +4007,14 @@ async fn playlist_library_id_finds_manual_playlists_folder() {
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(path("/Items"))
+        .and(path("/UserViews"))
         .and(query_param("userId", "u1"))
-        .and(query_param("includeItemTypes", "ManualPlaylistsFolder"))
-        .and(query_param("excludeItemTypes", "CollectionFolder"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "Items": [
-                { "Id": "lib-pl", "Name": "Playlists", "CollectionType": "playlists" }
+                { "Id": "lib-music", "Name": "Music", "CollectionType": "music", "Type": "CollectionFolder" },
+                { "Id": "lib-pl", "Name": "Playlists", "CollectionType": "playlists", "Type": "UserView" }
             ],
-            "TotalRecordCount": 1
+            "TotalRecordCount": 2
         })))
         .mount(&server)
         .await;
@@ -4011,7 +4024,7 @@ async fn playlist_library_id_finds_manual_playlists_folder() {
     let id = client.playlist_library_id().await.unwrap();
     assert_eq!(id, "lib-pl");
 
-    // Second call is served from the cache.
+    // Second call is served from the cache (no additional /UserViews hit).
     let again = client.playlist_library_id().await.unwrap();
     assert_eq!(again, "lib-pl");
     let get_count = server
@@ -4019,7 +4032,7 @@ async fn playlist_library_id_finds_manual_playlists_folder() {
         .await
         .unwrap()
         .iter()
-        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/Items")
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/UserViews")
         .count();
     assert_eq!(
         get_count, 1,
@@ -6392,4 +6405,56 @@ async fn playlist_tracks_rejects_non_audio_items() {
     assert_eq!(page.items.len(), 1, "non-Audio rows must be dropped");
     assert_eq!(page.items[0].id, "t1");
     assert_eq!(page.items[0].name, "Real Track");
+}
+
+// ============================================================================
+// artists endpoint — MusicArtist filter regression (UX fix)
+// ============================================================================
+
+/// Regression for the "0 artists" bug. Some Jellyfin 10.11 builds return
+/// zero items from `/Artists/AlbumArtists` when `IncludeItemTypes=MusicArtist`
+/// is supplied — verified live against music.skalthoff.com. The endpoint
+/// already scopes to MusicArtist by path, so the filter is redundant *and*
+/// breaks the server-side query builder's AND-intersection on some configs.
+/// Assert the query no longer carries that parameter.
+#[tokio::test]
+async fn artists_does_not_send_include_item_types_music_artist() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "a1", "Name": "Solo", "Type": "MusicArtist" }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client.artists(crate::Paging::new(0, 50)).await.unwrap();
+    assert_eq!(page.items.len(), 1);
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(
+        !q.contains("IncludeItemTypes=MusicArtist"),
+        "artists() must NOT send IncludeItemTypes=MusicArtist (breaks live Jellyfin 10.11), got: {q}"
+    );
+    // Sanity: all the other fields we depend on are still present.
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
 }


### PR DESCRIPTION
**Two independent data-layer bugs** found via live probe against music.skalthoff.com. Both made an entire Library tab render empty even after #654's path-filter fix.

## Bug 1 — \`artists\` sent \`IncludeItemTypes=MusicArtist\` which breaks the endpoint

\`/Artists/AlbumArtists?IncludeItemTypes=MusicArtist\` returns **0** on Jellyfin 10.11.8. Drop the filter and the same endpoint returns the full 2,367-row artist list. The path already scopes to MusicArtist by design — the filter caused the server's query builder to AND-intersect against a narrower set some configs return as empty.

Result: Library's Artists chip read "0 of 3839" regardless of library size.

## Bug 2 — \`playlist_library_id\` returned the wrong entity's id

\`playlist_library_id()\` hit \`/Items?includeItemTypes=ManualPlaylistsFolder\`. That returns a playlists-typed row but its \`Id\` is the **ManualPlaylistsFolder** entity — **not a valid \`ParentId\`** for \`/Items?ParentId=…&IncludeItemTypes=Playlist\`. The UserView id (surfaced by \`/UserViews\`) is.

On music.skalthoff.com:
- ManualPlaylistsFolder id: \`1071671e…\` → \`/Items?ParentId=…\` returns empty
- UserView id:              \`1f61a42b…\` → \`/Items?ParentId=…\` returns 79

Mirror \`music_library_id\`'s pattern: query \`/UserViews\`, pick \`collectionType == "playlists"\`. Same contract, same cache, same error semantics.

This is why the user saw "0 playlists beyond the folder" even after #654 — the path filter was correctly removed, but the upstream \`ParentId\` was the wrong id.

## Tests

- \`artists_does_not_send_include_item_types_music_artist\` — regression for bug 1
- \`artists_exposes_total_record_count_and_paging\` — updated from the old assertion
- \`playlist_library_id_finds_playlists_user_view\` — replaces \`_finds_manual_playlists_folder\`; mocks \`/UserViews\` and asserts cached resolution

166 lib tests pass; clippy clean; clean swift build passes (#651 gate).

## Ops

The xcframework + generated Swift bindings are gitignored, so anyone pulling main and running only \`swift build\` (without \`./macos/Scripts/build-core.sh\` first) still needs to regenerate. Separate hardening.

Run after pulling:
\`\`\`bash
./macos/Scripts/build-core.sh --arm64-only
rm -rf macos/.build && swift build --package-path macos
\`\`\`