### PR TITLE
ci: wire macos-release.yml end-to-end for signed DMG releases

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -82,16 +82,21 @@ jobs:
       # ------------------------------------------------------------------
       - name: Build universal xcframework
         working-directory: macos
-        env:
-          # The existing build-core.sh builds arm64-only. For release we
-          # want a universal static library; the flag is picked up by the
-          # M4 universal build work landing alongside this workflow.
-          JELLIFY_UNIVERSAL: "1"
+        # build-core.sh produces an arm64 + x86_64 lipo-fused static lib by
+        # default; --release selects the release profile.
         run: ./Scripts/build-core.sh --release
 
-      - name: Swift build (release)
+      - name: Swift build (release, universal)
         working-directory: macos
-        run: swift build -c release
+        # --arch arm64 --arch x86_64 routes the build through
+        # .build/apple/Products/Release/, which make-bundle.sh --universal
+        # consumes. A bare `swift build` on macos-14 (Apple Silicon) emits
+        # arm64-only binaries and silently breaks Intel users.
+        run: swift build -c release --arch arm64 --arch x86_64
+
+      - name: Install create-dmg
+        # Required by make-dmg.sh. Not preinstalled on macos-14.
+        run: brew install create-dmg
 
       - name: Make app icon
         working-directory: macos
@@ -100,11 +105,12 @@ jobs:
       - name: Bundle .app
         working-directory: macos
         env:
-          JELLIFY_BUILD_CONFIG: "release"
-          JELLIFY_VERSION: ${{ steps.version.outputs.version }}
-          JELLIFY_BUILD: ${{ steps.version.outputs.build }}
+          # make-bundle.sh reads $VERSION and $BUILD directly; $SPARKLE_PUBLIC_ED_KEY
+          # is substituted into Info.plist via plutil -replace SUPublicEDKey.
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD: ${{ steps.version.outputs.build }}
           SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
-        run: ./Scripts/make-bundle.sh
+        run: ./Scripts/make-bundle.sh --release --universal
 
       # ------------------------------------------------------------------
       # Sign + notarize. The individual scripts (sign.sh, notarize.sh,
@@ -146,24 +152,42 @@ jobs:
       - name: Sign .app
         working-directory: macos
         env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_DEVELOPER_ID_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_IDENTITY }}
-        run: ./Scripts/sign.sh
+          # sign.sh reads $DEVELOPER_ID (the cert's common name).
+          DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID_IDENTITY }}
+        run: ./Scripts/sign.sh build/Jellify.app
 
       - name: Make DMG
         working-directory: macos
         env:
-          JELLIFY_VERSION: ${{ steps.version.outputs.version }}
+          # make-dmg.sh reads $VERSION and $DEVELOPER_ID. Without the
+          # identity the DMG ships unsigned and notarization rejects it.
+          VERSION: ${{ steps.version.outputs.version }}
+          DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID_IDENTITY }}
         run: ./Scripts/make-dmg.sh
 
-      - name: Notarize DMG
-        working-directory: macos
+      - name: Bootstrap notarytool keychain profile
+        # notarize.sh calls `xcrun notarytool submit --keychain-profile`,
+        # which requires the profile to already exist in a keychain on
+        # the default search list. We write it into the ephemeral
+        # keychain imported above; the runner is disposable so no cleanup.
         env:
           APPLE_NOTARY_PROFILE: ${{ secrets.APPLE_NOTARY_PROFILE }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: ./Scripts/notarize.sh
+        run: |
+          xcrun notarytool store-credentials "$APPLE_NOTARY_PROFILE" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --keychain "$KEYCHAIN"
+
+      - name: Notarize DMG
+        working-directory: macos
+        env:
+          # notarize.sh reads $NOTARY_PROFILE and takes the DMG path as $1.
+          NOTARY_PROFILE: ${{ secrets.APPLE_NOTARY_PROFILE }}
+        run: ./Scripts/notarize.sh "build/Jellify-${{ steps.version.outputs.version }}.dmg"
 
       # ------------------------------------------------------------------
       # Publish the release.

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -5,6 +5,51 @@ that passes Gatekeeper and launches cleanly on a fresh Mac.
 
 ---
 
+## First-release operator checklist
+
+The rest of this doc is reference material. If you're setting things up
+for the first time, work through this list top to bottom — every step is
+mandatory for a tag push to produce a signed, notarized DMG.
+
+- [ ] **Apple Developer Program enrolled** (below → "Apple Developer
+      Program enrollment"). Individual enrollment is $99/yr; can take
+      ~24h to approve.
+- [ ] **Developer ID Application certificate** in your Mac's login
+      keychain (same section). Verify with
+      `security find-identity -v -p codesigning | grep "Developer ID Application"`.
+- [ ] **Team ID recorded** (10 chars, from the Membership page).
+- [ ] **`.p12` exported** (cert + private key together) and
+      `base64 -i cert.p12 | pbcopy`'d for the `APPLE_DEVELOPER_ID_CERT_P12`
+      secret.
+- [ ] **App-specific password** created at <https://appleid.apple.com>
+      → Sign-In and Security → App-Specific Passwords. Label it
+      "Jellify notarization".
+- [ ] **Sparkle keypair generated** (below → "Sparkle key generation").
+      Store both halves in your password manager before closing the
+      terminal.
+- [ ] **All 9 GitHub secrets set** under Settings → Secrets and
+      variables → Actions (below → "Required GitHub Actions secrets").
+      The workflow fails fast on the first missing one.
+- [ ] **`gh-pages` branch bootstrapped** (below → "First-ever gh-pages
+      bootstrap"). Skipping this makes the appcast publish step blow up
+      on the first tag.
+- [ ] **Local dry run done** (optional but strongly recommended — below
+      → "Running the first release manually"). Confirms your secrets
+      are shaped right before committing to a tag.
+- [ ] **First tag pushed**:
+      ```bash
+      git tag -s v0.1.0 -m "Jellify 0.1.0"
+      git push origin v0.1.0
+      ```
+      `.github/workflows/macos-release.yml` picks it up, builds for
+      ~20 min on macos-14, uploads the DMG to the release, and
+      regenerates the appcast on `gh-pages`.
+
+If a step fails, the "Troubleshooting" section at the bottom covers the
+usual suspects.
+
+---
+
 ## **MANUAL PREREQUISITE — Apple Developer Program enrollment (issue #175)**
 
 **This step is a multi-day, non-engineering task. The engineering pipeline

--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -146,6 +146,14 @@ cp "$INFO_TEMPLATE" "$TMP_PLIST"
 plutil -replace CFBundleShortVersionString -string "$VERSION" "$TMP_PLIST"
 plutil -replace CFBundleVersion            -string "$BUILD"   "$TMP_PLIST"
 
+# Substitute Sparkle's public Ed25519 key. The template ships the literal
+# placeholder `@@SPARKLE_PUBLIC_ED_KEY@@`; release builds replace it with
+# the real key from $SPARKLE_PUBLIC_ED_KEY. Local dev runs typically leave
+# it unset — we replace with an empty string so Sparkle silently disables
+# auto-update at launch instead of failing its key-length check and taking
+# the app down before main runs.
+plutil -replace SUPublicEDKey -string "${SPARKLE_PUBLIC_ED_KEY:-}" "$TMP_PLIST"
+
 # Fail loudly if the template drifted into something Core Foundation can't
 # parse — this is the check issue #177 asks for.
 plutil -lint "$TMP_PLIST" >/dev/null


### PR DESCRIPTION
Fixes the macOS release workflow so a tag push actually produces a signed, notarized DMG with a working Sparkle auto-update feed. The scaffolding (scripts, docs, workflow file) all existed but had drifted: nothing had ever run end-to-end because zero tags / releases / secrets were configured on the repo, and several env/arg mismatches would have failed the first tag push regardless.

## Why

First step toward distributing the Mac app — the user has an Apple Developer account and wants signed releases on GitHub.

## What changed

- **`.github/workflows/macos-release.yml`** — fixed env-name mismatches (`JELLIFY_VERSION` → `VERSION`, `APPLE_DEVELOPER_ID_IDENTITY` → `DEVELOPER_ID`, `APPLE_NOTARY_PROFILE` → `NOTARY_PROFILE`), passed the positional args `sign.sh` and `notarize.sh` require, installed `create-dmg` via brew (not preinstalled on `macos-14`), added `--arch arm64 --arch x86_64` to the swift build step (was arm64-only, would have broken Intel users despite the universal xcframework), and added a `xcrun notarytool store-credentials` bootstrap step so the keychain profile exists before `notarize.sh` needs it.
- **`macos/Scripts/make-bundle.sh`** — added `plutil -replace SUPublicEDKey` to substitute `$SPARKLE_PUBLIC_ED_KEY` into Info.plist. The template ships `@@SPARKLE_PUBLIC_ED_KEY@@` as a placeholder and nothing was rewriting it, so Sparkle would have failed its key-length check at launch. Missing env replaces to an empty string (Sparkle treats as "auto-update disabled") so local dev builds don't break.
- **`macos/DISTRIBUTION.md`** — added a first-release operator checklist at the top (Apple enrollment → cert → p12 → app-specific password → Sparkle keypair → 9 GitHub secrets → gh-pages bootstrap → tag push) so the manual setup is a single pane of glass.

## Verification

- [x] `shellcheck macos/Scripts/*.sh` — clean on modified scripts
- [x] `bash -n macos/Scripts/make-bundle.sh` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/macos-release.yml'))"` — parses
- [x] `actionlint .github/workflows/macos-release.yml` — only pre-existing SC2046 on the cert-import step (unchanged)
- [ ] End-to-end tag push — gated on the operator checklist in DISTRIBUTION.md being worked through (Apple cert, Sparkle keys, 9 secrets, gh-pages branch). No way to exercise the workflow without those.

## Out of scope

- Actually running the release (requires credentials + a tag push).
- Fixing the pre-existing SC2046 shellcheck warning on the cert-import step (unrelated to this change).
- Any rework of the Sparkle integration in Swift — this PR only wires the build-time public-key injection.