### PR TITLE
release 0.2: playback reporting + queue primitives + #555/#560 rebases

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1,5 +1,7 @@
+use crate::enums::{self, ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 use crate::error::{JellifyError, Result};
 use crate::models::*;
+use crate::query::ItemsQuery;
 use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client as HttpClient, RequestBuilder, Response, StatusCode};
@@ -8,6 +10,17 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use url::Url;
+
+/// A generic paginated wrapper used by [`ItemsQuery`] before the raw items
+/// are mapped to a concrete model type. Mirrors the shape of the per-model
+/// `PaginatedAlbums` / `PaginatedArtists` / etc. records, but generic over
+/// the element type so the query layer doesn't need to know which model
+/// the caller wants.
+#[derive(Clone, Debug)]
+pub struct PaginatedItems<T> {
+    pub items: Vec<T>,
+    pub total_count: u32,
+}
 
 const CLIENT_NAME: &str = "Jellify Desktop";
 const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -176,7 +189,7 @@ impl JellyfinClient {
         Ok(headers)
     }
 
-    fn endpoint(&self, path: &str) -> Result<Url> {
+    pub(crate) fn endpoint(&self, path: &str) -> Result<Url> {
         let trimmed = path.trim_start_matches('/');
         self.base_url.join(trimmed).map_err(Into::into)
     }
@@ -193,16 +206,15 @@ impl JellyfinClient {
     }
 
     async fn check(resp: Response) -> Result<Response> {
-        let status = resp.status();
-        if status.is_success() {
-            Ok(resp)
-        } else {
-            let message = resp.text().await.unwrap_or_default();
-            Err(JellifyError::Server {
-                status: status.as_u16(),
-                message,
-            })
-        }
+        check_response(resp).await
+    }
+
+    /// Build and issue a raw [`ItemsQuery`] against this client. Convenience
+    /// passthrough for [`ItemsQuery::execute`] so callers can write
+    /// `client.query().item_types(...).limit(...).execute().await` without
+    /// importing the query module directly.
+    pub fn query(&self) -> ItemsQuery {
+        ItemsQuery::new()
     }
 
     /// Is the HTTP status worth retrying?
@@ -395,6 +407,15 @@ impl JellyfinClient {
         Self::check(resp).await
     }
 
+    /// GET the given URL through the retry + silent re-auth pipeline, returning
+    /// the successful response. Used by [`crate::query::ItemsQuery::execute`]
+    /// so builder-driven calls participate in the same 401 refresh and backoff
+    /// semantics as the per-endpoint methods in this file.
+    pub(crate) async fn send_get(&self, url: Url) -> Result<Response> {
+        self.send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await
+    }
+
     /// Silent re-auth hook. Invokes the registered [`RefreshTokenFn`] (if
     /// any) and, on success, swaps the client's in-memory token so the
     /// next attempt picks it up via [`Self::auth_header`].
@@ -485,6 +506,11 @@ impl JellyfinClient {
             .user_id
             .as_ref()
             .ok_or(JellifyError::NotAuthenticated)?;
+        // `Artists/AlbumArtists` is a dedicated endpoint, not a standard
+        // `/Items` query, so we issue the request directly rather than
+        // going through [`ItemsQuery::execute`]. We still format the params
+        // via the typed enum helpers so the set of allowed values lives in
+        // one place.
         let mut url = self.endpoint("Artists/AlbumArtists")?;
         {
             let mut q = url.query_pairs_mut();
@@ -500,9 +526,15 @@ impl JellyfinClient {
             // endpoint returns the full artist list.
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
+            q.append_pair("SortBy", ItemSortBy::SortName.as_str());
+            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::Genres, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
             q.append_pair("EnableUserData", "true");
             q.append_pair("EnableImages", "true");
             q.append_pair("ImageTypeLimit", "1");
@@ -518,35 +550,24 @@ impl JellyfinClient {
     }
 
     pub async fn albums(&self, paging: Paging) -> Result<PaginatedAlbums> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
-            );
-            q.append_pair("EnableUserData", "true");
-            q.append_pair("EnableImages", "true");
-            q.append_pair("ImageTypeLimit", "1");
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(PaginatedAlbums {
-            items: raw.items.into_iter().map(Album::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        // Thin wrapper over the typed `ItemsQuery` builder — kept for
+        // backwards compatibility with existing call sites. New code should
+        // prefer `client.query().item_types(...).fetch_albums(...)` directly.
+        ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_albums(self)
+            .await
     }
 
     /// Every album where the given artist is the primary (album) artist,
@@ -568,36 +589,22 @@ impl JellyfinClient {
         artist_id: &str,
         paging: Paging,
     ) -> Result<PaginatedAlbums> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("AlbumArtistIds", artist_id);
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
-            );
-            q.append_pair("EnableUserData", "true");
-            q.append_pair("EnableImages", "true");
-            q.append_pair("ImageTypeLimit", "1");
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(PaginatedAlbums {
-            items: raw.items.into_iter().map(Album::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        ItemsQuery::new()
+            .recursive()
+            .album_artist(artist_id)
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_albums(self)
+            .await
     }
 
     /// Fetch the most recently added albums in a library, respecting the
@@ -641,12 +648,20 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("ParentId", library_id);
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
+            q.append_pair("IncludeItemTypes", ItemKind::MusicAlbum.as_str());
             q.append_pair("Limit", &server_limit.to_string());
             q.append_pair("GroupItems", "true");
             q.append_pair(
                 "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Genres,
+                        ItemField::ProductionYear,
+                        ItemField::ChildCount,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
             q.append_pair("EnableUserData", "true");
             q.append_pair("EnableImages", "true");
@@ -687,38 +702,25 @@ impl JellyfinClient {
         music_library_id: Option<&str>,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            if let Some(parent) = music_library_id {
-                q.append_pair("ParentId", parent);
-            }
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "ParentId,AlbumId,AlbumArtist,Artists,ProductionYear,RunTimeTicks",
-            );
-            q.append_pair("EnableUserData", "true");
-            q.append_pair("EnableImages", "true");
-            q.append_pair("ImageTypeLimit", "1");
+        let mut q = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::ParentId,
+                ItemField::AlbumId,
+                ItemField::AlbumArtist,
+                ItemField::Artists,
+                ItemField::ProductionYear,
+                ItemField::RunTimeTicks,
+            ])
+            .enable_user_data();
+        if let Some(parent) = music_library_id {
+            q = q.parent(parent);
         }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(PaginatedTracks {
-            items: raw.items.into_iter().map(Track::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        q.fetch_tracks(self).await
     }
 
     /// Recently played audio tracks for the current user, sorted by
@@ -734,38 +736,24 @@ impl JellyfinClient {
         music_library_id: Option<&str>,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            if let Some(parent) = music_library_id {
-                q.append_pair("ParentId", parent);
-            }
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "DatePlayed");
-            q.append_pair("SortOrder", "Descending");
-            q.append_pair(
-                "Fields",
-                "ParentId,MediaSources,UserData,ProductionYear,PrimaryImageAspectRatio",
-            );
-            q.append_pair("EnableUserData", "true");
-            q.append_pair("EnableImages", "true");
-            q.append_pair("ImageTypeLimit", "1");
+        let mut q = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::DatePlayed, SortOrder::Descending)
+            .fields(vec![
+                ItemField::ParentId,
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data();
+        if let Some(parent) = music_library_id {
+            q = q.parent(parent);
         }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(PaginatedTracks {
-            items: raw.items.into_iter().map(Track::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        q.fetch_tracks(self).await
     }
 
     /// Fetch every playlist visible to the current user under the given
@@ -825,6 +813,11 @@ impl JellyfinClient {
         playlist_library_id: &str,
         paging: Paging,
     ) -> Result<RawItems<RawItem>> {
+        // Like `playlist_tracks`, this endpoint pins the bare `/Items` path
+        // with an explicit `UserId` query param (rather than
+        // `/Users/{id}/Items`) so we issue the request directly rather than
+        // through `ItemsQuery::execute`. Field names still come from the
+        // typed enums.
         let user_id = self
             .user_id
             .as_ref()
@@ -834,10 +827,13 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("ParentId", playlist_library_id);
             q.append_pair("UserId", user_id);
-            q.append_pair("IncludeItemTypes", "Playlist");
+            q.append_pair("IncludeItemTypes", ItemKind::Playlist.as_str());
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("Fields", "ChildCount,Path");
+            q.append_pair(
+                "Fields",
+                &enums::csv(&[ItemField::ChildCount, ItemField::Path], ItemField::as_str),
+            );
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
@@ -870,6 +866,17 @@ impl JellyfinClient {
         playlist_id: &str,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
+        // Note: we intentionally do NOT pass `SortBy`/`SortOrder` here —
+        // playlists are ordered collections and Jellyfin returns items in
+        // their stored order when no sort is specified. The test asserts on
+        // the absence of those params.
+        //
+        // Also note: the original call site used the bare `/Items` endpoint
+        // with an explicit `UserId=...` query param rather than the
+        // `/Users/{id}/Items` form `ItemsQuery::execute` dispatches to.
+        // We preserve that by hand-rolling the URL here so the test that
+        // pins `query_param("ParentId", ...)` against the bare `/Items`
+        // path keeps matching.
         let user_id = self
             .user_id
             .as_ref()
@@ -879,12 +886,21 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("ParentId", playlist_id);
             q.append_pair("UserId", user_id);
-            q.append_pair("IncludeItemTypes", "Audio");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
             q.append_pair(
                 "Fields",
-                "MediaSources,ParentId,Path,PlaylistItemId,SortName",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::ParentId,
+                        ItemField::Path,
+                        ItemField::PlaylistItemId,
+                        ItemField::SortName,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -945,6 +961,13 @@ impl JellyfinClient {
     }
 
     pub async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {
+        // `album_tracks` returns the flat `Vec<Track>` the callers expect
+        // (no total count — album children fit in a single page), so we
+        // don't use `fetch_tracks`. `SortBy=ParentIndexNumber,IndexNumber,
+        // SortName` is hand-built because `ItemSortBy` doesn't have a
+        // `ParentIndexNumber`/`IndexNumber` variant — those are shape-less
+        // numeric index fields specific to albums, not general `ItemFields`
+        // the server advertises as sort columns.
         let user_id = self
             .user_id
             .as_ref()
@@ -959,10 +982,29 @@ impl JellyfinClient {
             // requires SortBy and SortOrder to be comma-separated arrays of
             // equal length).  Fixes #571.
             q.append_pair("SortBy", "ParentIndexNumber,IndexNumber,SortName");
-            q.append_pair("SortOrder", "Ascending,Ascending,Ascending");
+            // Three sort fields → three parallel SortOrder values. Fixes #571.
+            q.append_pair(
+                "SortOrder",
+                &enums::csv(
+                    &[
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                    ],
+                    SortOrder::as_str,
+                ),
+            );
             q.append_pair(
                 "Fields",
-                "MediaSources,UserData,ProductionYear,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -986,29 +1028,24 @@ impl JellyfinClient {
     /// Requires an authenticated session; returns
     /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
     pub async fn artist_top_tracks(&self, artist_id: &str, limit: u32) -> Result<Vec<Track>> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("ArtistIds", artist_id);
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("SortBy", "PlayCount,SortName");
-            q.append_pair("SortOrder", "Descending,Ascending");
-            q.append_pair(
-                "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+        let page = ItemsQuery::new()
+            .artist(artist_id)
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(limit)
+            .sort_by(vec![ItemSortBy::PlayCount, ItemSortBy::SortName])
+            .sort_order(vec![SortOrder::Descending, SortOrder::Ascending])
+            .fields(vec![
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ParentId,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_tracks(self)
             .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(page.items)
     }
 
     /// Seed a station around any item — track, album, artist, playlist, or
@@ -1035,7 +1072,16 @@ impl JellyfinClient {
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair(
                 "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
             q.append_pair("EnableUserData", "true");
         }
@@ -1065,7 +1111,10 @@ impl JellyfinClient {
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
-            q.append_pair("IncludeItemTypes", "Audio,MusicAlbum");
+            q.append_pair(
+                "IncludeItemTypes",
+                &enums::csv(&[ItemKind::Audio, ItemKind::MusicAlbum], ItemKind::as_str),
+            );
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair("EnableUserData", "true");
         }
@@ -1090,7 +1139,13 @@ impl JellyfinClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
             q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("Fields", "Genres,PrimaryImageAspectRatio");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::Genres, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
@@ -1113,7 +1168,15 @@ impl JellyfinClient {
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair(
                 "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Genres,
+                        ItemField::ProductionYear,
+                        ItemField::ChildCount,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -1162,28 +1225,23 @@ impl JellyfinClient {
     /// with no play history will fall back to the server's `SortName`
     /// tiebreaker (every row at `PlayCount = 0`).
     pub async fn frequently_played_tracks(&self, limit: u32) -> Result<Vec<Track>> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "Audio");
-            q.append_pair("Limit", &limit.max(1).to_string());
-            q.append_pair("SortBy", "PlayCount,SortName");
-            q.append_pair("SortOrder", "Descending,Ascending");
-            q.append_pair(
-                "Fields",
-                "MediaSources,UserData,ParentId,ProductionYear,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+        let page = ItemsQuery::new()
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(limit)
+            .sort_by(vec![ItemSortBy::PlayCount, ItemSortBy::SortName])
+            .sort_order(vec![SortOrder::Descending, SortOrder::Ascending])
+            .fields(vec![
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ParentId,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_tracks(self)
             .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(page.items)
     }
 
     /// All music genres in the user's library, paginated. Backed by
@@ -1202,9 +1260,15 @@ impl JellyfinClient {
             q.append_pair("IncludeItemTypes", "Audio,MusicAlbum,MusicArtist");
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair("Fields", "ItemCounts,PrimaryImageAspectRatio");
+            q.append_pair("SortBy", ItemSortBy::SortName.as_str());
+            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[ItemField::ItemCounts, ItemField::PrimaryImageAspectRatio],
+                    ItemField::as_str,
+                ),
+            );
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
@@ -1224,33 +1288,22 @@ impl JellyfinClient {
     /// [`JellyfinClient::albums`] / `artists` / `list_tracks` using
     /// `GenreIds` (a future refactor; see Issue 38).
     pub async fn items_by_genre(&self, genre_id: &str, paging: Paging) -> Result<PaginatedAlbums> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("GenreIds", genre_id);
-            q.append_pair("Recursive", "true");
-            q.append_pair("IncludeItemTypes", "MusicAlbum");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", "SortName");
-            q.append_pair("SortOrder", "Ascending");
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,ChildCount,PrimaryImageAspectRatio",
-            );
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
-            .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(PaginatedAlbums {
-            items: raw.items.into_iter().map(Album::from).collect(),
-            total_count: raw.total_record_count,
-        })
+        ItemsQuery::new()
+            .genre(genre_id)
+            .recursive()
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::SortName, SortOrder::Ascending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_albums(self)
+            .await
     }
 
     /// Full artist record with biography, backdrops, and external links —
@@ -1272,7 +1325,18 @@ impl JellyfinClient {
             q.append_pair("userId", user_id);
             q.append_pair(
                 "Fields",
-                "Overview,Genres,Tags,ProviderIds,ExternalUrls,BackdropImageTags,PrimaryImageAspectRatio",
+                &enums::csv(
+                    &[
+                        ItemField::Overview,
+                        ItemField::Genres,
+                        ItemField::Tags,
+                        ItemField::ProviderIds,
+                        ItemField::ExternalUrls,
+                        ItemField::BackdropImageTags,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
+                    ItemField::as_str,
+                ),
             );
         }
         let resp = self
@@ -1283,10 +1347,7 @@ impl JellyfinClient {
             .items
             .into_iter()
             .next()
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: format!("artist not found: {artist_id}"),
-            })?;
+            .ok_or_else(|| JellifyError::NotFound(format!("artist not found: {artist_id}")))?;
         Ok(ArtistDetail::from(first))
     }
 
@@ -1351,10 +1412,7 @@ impl JellyfinClient {
                 JellifyError::Decode("fetch_item: response missing Items array".into())
             })?;
         if items.is_empty() {
-            return Err(JellifyError::Server {
-                status: 404,
-                message: format!("item not found: {item_id}"),
-            });
+            return Err(JellifyError::NotFound(format!("item not found: {item_id}")));
         }
         Ok(items.swap_remove(0))
     }
@@ -1552,37 +1610,36 @@ impl JellyfinClient {
     /// requests via [`JellyfinClient::albums`] / `artists` etc. with
     /// `SearchTerm` — a follow-up once the UI grows that affordance.
     pub async fn search(&self, query: &str, paging: Paging) -> Result<SearchResults> {
-        let user_id = self
-            .user_id
-            .as_ref()
-            .ok_or(JellifyError::NotAuthenticated)?;
-        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
-        {
-            let mut q = url.query_pairs_mut();
-            q.append_pair("Recursive", "true");
-            q.append_pair("SearchTerm", query);
-            q.append_pair("IncludeItemTypes", "MusicArtist,MusicAlbum,Audio");
-            q.append_pair("Limit", &paging.limit.max(1).to_string());
-            q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair(
-                "Fields",
-                "Genres,ProductionYear,PrimaryImageAspectRatio,UserData,MediaSources,AlbumId",
-            );
-            q.append_pair("EnableUserData", "true");
-        }
-        let resp = self
-            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+        let page = ItemsQuery::new()
+            .recursive()
+            .search(query)
+            .item_types(vec![
+                ItemKind::MusicArtist,
+                ItemKind::MusicAlbum,
+                ItemKind::Audio,
+            ])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+                ItemField::UserData,
+                ItemField::MediaSources,
+                ItemField::AlbumId,
+            ])
+            .enable_user_data()
+            .execute(self)
             .await?;
-        let raw: RawItems<RawItem> = resp.json().await?;
 
         let mut artists = Vec::new();
         let mut albums = Vec::new();
         let mut tracks = Vec::new();
-        for item in raw.items {
+        for item in page.items {
             match item.kind.as_deref() {
-                Some("MusicArtist") => artists.push(Artist::from(item)),
-                Some("MusicAlbum") => albums.push(Album::from(item)),
-                Some("Audio") => tracks.push(Track::from(item)),
+                Some(s) if s == ItemKind::MusicArtist.as_str() => artists.push(Artist::from(item)),
+                Some(s) if s == ItemKind::MusicAlbum.as_str() => albums.push(Album::from(item)),
+                Some(s) if s == ItemKind::Audio.as_str() => tracks.push(Track::from(item)),
                 _ => {}
             }
         }
@@ -1590,7 +1647,7 @@ impl JellyfinClient {
             artists,
             albums,
             tracks,
-            total_record_count: raw.total_record_count,
+            total_record_count: page.total_count,
         })
     }
 
@@ -1827,10 +1884,7 @@ impl JellyfinClient {
             .into_iter()
             .find(|v| v.collection_type.as_deref() == Some("music"))
             .map(|v| v.id)
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: "no music library found in user views".into(),
-            })?;
+            .ok_or_else(|| JellifyError::NotFound("no music library found in user views".into()))?;
         self.library_cache.lock().music = Some(id.clone());
         Ok(id)
     }
@@ -1864,9 +1918,8 @@ impl JellyfinClient {
             .into_iter()
             .find(|v| v.collection_type.as_deref() == Some("playlists"))
             .map(|v| v.id)
-            .ok_or_else(|| JellifyError::Server {
-                status: 404,
-                message: "no playlists library found in user views".into(),
+            .ok_or_else(|| {
+                JellifyError::NotFound("no playlists library found in user views".into())
             })?;
         self.library_cache.lock().playlist = Some(id.clone());
         Ok(id)
@@ -2104,6 +2157,32 @@ impl JellyfinClient {
     }
 }
 
+/// Classify a [`reqwest::Response`] as success or a structured
+/// [`JellifyError`] variant. Shared between [`JellyfinClient::check`] and
+/// the query-layer helpers in [`crate::query`].
+///
+/// On non-2xx responses this reads the `Retry-After` header (for 429
+/// rate-limit responses) and the body text (for the general `Server`
+/// variant), and dispatches via [`JellifyError::from_status`] so the caller
+/// can match on the narrow error kind rather than parsing a message.
+pub(crate) async fn check_response(resp: Response) -> Result<Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let retry_after = resp
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok());
+    let body = resp.text().await.unwrap_or_default();
+    Err(JellifyError::from_status(
+        status.as_u16(),
+        body,
+        retry_after,
+    ))
+}
+
 // ============================================================================
 // Wire types (Jellyfin's JSON shapes)
 // ============================================================================
@@ -2176,11 +2255,11 @@ struct RawUser {
 }
 
 #[derive(Debug, Deserialize)]
-struct RawItems<T> {
+pub(crate) struct RawItems<T> {
     #[serde(rename = "Items", default)]
-    items: Vec<T>,
+    pub(crate) items: Vec<T>,
     #[serde(rename = "TotalRecordCount", default)]
-    total_record_count: u32,
+    pub(crate) total_record_count: u32,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -2264,8 +2343,32 @@ impl From<RawLibrary> for Library {
 pub struct RawUserData {
     #[serde(rename = "IsFavorite", default)]
     pub is_favorite: bool,
+    #[serde(rename = "Played", default)]
+    pub played: bool,
     #[serde(rename = "PlayCount", default)]
     pub play_count: u32,
+    #[serde(rename = "PlaybackPositionTicks", default)]
+    pub playback_position_ticks: i64,
+    #[serde(rename = "LastPlayedDate", default)]
+    pub last_played_date: Option<String>,
+    #[serde(rename = "Likes", default)]
+    pub likes: Option<bool>,
+    #[serde(rename = "Rating", default)]
+    pub rating: Option<f64>,
+}
+
+impl From<RawUserData> for UserItemData {
+    fn from(r: RawUserData) -> Self {
+        UserItemData {
+            is_favorite: r.is_favorite,
+            played: r.played,
+            play_count: r.play_count,
+            playback_position_ticks: r.playback_position_ticks,
+            last_played_at: r.last_played_date,
+            likes: r.likes,
+            rating: r.rating,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2347,6 +2450,7 @@ impl From<RawSearchHint> for SearchHint {
 
 impl From<RawItem> for Artist {
     fn from(r: RawItem) -> Self {
+        let user_data = r.user_data.map(UserItemData::from);
         Artist {
             id: r.id,
             name: r.name,
@@ -2354,6 +2458,7 @@ impl From<RawItem> for Artist {
             song_count: 0,
             genres: r.genres,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }
@@ -2369,6 +2474,7 @@ impl From<RawItem> for Album {
             .album_artist_id
             .clone()
             .or_else(|| r.artist_items.first().map(|a| a.id.clone()));
+        let user_data = r.user_data.map(UserItemData::from);
         Album {
             id: r.id,
             name: r.name,
@@ -2379,6 +2485,7 @@ impl From<RawItem> for Album {
             runtime_ticks: r.runtime_ticks,
             genres: r.genres,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }
@@ -2406,7 +2513,18 @@ impl From<RawItem> for Track {
             .album_artist_id
             .clone()
             .or_else(|| r.artist_items.first().map(|a| a.id.clone()));
-        let user_data = r.user_data.unwrap_or_default();
+        // Preserve the pre-refactor convenience fields on Track even when
+        // the server didn't send `UserData` — `is_favorite`/`play_count`
+        // default to `false`/`0` the same way they did before the
+        // `user_data: Option<UserItemData>` field landed. Callers that need
+        // the full payload (including last-played-at, position ticks,
+        // thumbs rating) read `user_data`.
+        let raw_user = r.user_data;
+        let (is_fav, play_count) = raw_user
+            .as_ref()
+            .map(|u| (u.is_favorite, u.play_count))
+            .unwrap_or((false, 0));
+        let user_data = raw_user.map(UserItemData::from);
         Track {
             id: r.id,
             name: r.name,
@@ -2418,12 +2536,13 @@ impl From<RawItem> for Track {
             disc_number: r.parent_index_number,
             year: r.production_year,
             runtime_ticks: r.runtime_ticks,
-            is_favorite: user_data.is_favorite,
-            play_count: user_data.play_count,
+            is_favorite: is_fav,
+            play_count,
             container: r.container,
             bitrate: r.bitrate,
             image_tag: r.image_tags.get("Primary").cloned(),
             playlist_item_id: r.playlist_item_id,
+            user_data,
         }
     }
 }

--- a/core/src/enums.rs
+++ b/core/src/enums.rs
@@ -22,7 +22,8 @@
 //! Every enum derives `Serialize` / `Deserialize` with
 //! `#[serde(rename_all = "PascalCase")]`, so building query strings is a
 //! plain `serde_json::to_value` away (or, when writing query strings
-//! directly, [`Self::as_str`] yields the exact server-facing token).
+//! directly, each enum exposes an `as_str(&self) -> &'static str` helper
+//! that yields the exact server-facing token — see [`ItemKind::as_str`]).
 
 use serde::{Deserialize, Serialize};
 

--- a/core/src/enums.rs
+++ b/core/src/enums.rs
@@ -1,0 +1,340 @@
+//! Typed enums for Jellyfin API query parameters.
+//!
+//! Historically the client crate built query strings with string literals
+//! sprinkled through [`crate::client`] (`IncludeItemTypes=MusicAlbum`,
+//! `SortBy=PlayCount,SortName`, ...). That was quick to land but scattered
+//! the allowed values across the call sites — a typo in a call site would
+//! silently fail server-side, and consumers of the Swift FFI had no way to
+//! discover the accepted values short of reading the Rust source.
+//!
+//! The enums here centralise those allowed values as `PascalCase`-
+//! serialising Rust enums:
+//!
+//! - [`ItemKind`] mirrors Jellyfin's `BaseItemKind` (the subset a music app
+//!   hits).
+//! - [`ImageType`] mirrors the `ImageController` routes served from
+//!   `/Items/{id}/Images/{type}`.
+//! - [`ItemSortBy`] mirrors the `ItemSortBy` strings accepted by the `/Items`
+//!   family of endpoints.
+//! - [`SortOrder`] is the two-value direction (Ascending / Descending).
+//! - [`ItemField`] mirrors the `Fields` projection parameter.
+//!
+//! Every enum derives `Serialize` / `Deserialize` with
+//! `#[serde(rename_all = "PascalCase")]`, so building query strings is a
+//! plain `serde_json::to_value` away (or, when writing query strings
+//! directly, [`Self::as_str`] yields the exact server-facing token).
+
+use serde::{Deserialize, Serialize};
+
+/// The item-type subset Jellify Desktop cares about.
+///
+/// Mirrors Jellyfin's `BaseItemKind` — we only expose the variants that can
+/// land in music-scoped queries (tracks, albums, artists, playlists,
+/// genres). Variants serialise in PascalCase so the enum is drop-in for
+/// `IncludeItemTypes` / `ExcludeItemTypes` query params.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemKind {
+    /// An audio track — Jellyfin's `Audio` item kind.
+    Audio,
+    /// A music album grouping several `Audio` children — `MusicAlbum`.
+    MusicAlbum,
+    /// A music artist — `MusicArtist`. Jellyfin distinguishes AlbumArtist
+    /// vs. Artist at the field level; this kind covers both for query purposes.
+    MusicArtist,
+    /// A user or public playlist — `Playlist`.
+    Playlist,
+    /// A music genre bucket — `MusicGenre`.
+    MusicGenre,
+    /// A music video — rare in Jellify Desktop but accepted by the server
+    /// and included so `ItemKind` round-trips without loss for generic
+    /// queries.
+    MusicVideo,
+    /// A manual-playlists folder (the playlists library view itself).
+    ManualPlaylistsFolder,
+    /// A standard library collection folder — returned by `/UserViews` for
+    /// Music / Movies / TV Shows / etc. Rarely set by our own queries but
+    /// needed for `ExcludeItemTypes` filters that target the library folder
+    /// vs. its children.
+    CollectionFolder,
+}
+
+impl ItemKind {
+    /// The exact server-facing token (e.g. `"MusicAlbum"`). Useful when
+    /// building URL query strings by hand rather than via `serde_json`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemKind::Audio => "Audio",
+            ItemKind::MusicAlbum => "MusicAlbum",
+            ItemKind::MusicArtist => "MusicArtist",
+            ItemKind::Playlist => "Playlist",
+            ItemKind::MusicGenre => "MusicGenre",
+            ItemKind::MusicVideo => "MusicVideo",
+            ItemKind::ManualPlaylistsFolder => "ManualPlaylistsFolder",
+            ItemKind::CollectionFolder => "CollectionFolder",
+        }
+    }
+}
+
+/// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
+/// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ImageType {
+    Primary,
+    Backdrop,
+    Thumb,
+    Logo,
+    Art,
+    Banner,
+    Disc,
+    Box,
+    Screenshot,
+    Menu,
+    Chapter,
+    BoxRear,
+    Profile,
+}
+
+impl ImageType {
+    /// Path segment as Jellyfin expects it in the URL
+    /// (`/Items/{id}/Images/{segment}`). Distinct from [`Self::as_str`] only
+    /// in spirit — they happen to coincide today.
+    pub fn as_path(&self) -> &'static str {
+        self.as_str()
+    }
+
+    /// The exact server-facing token (e.g. `"Primary"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ImageType::Primary => "Primary",
+            ImageType::Backdrop => "Backdrop",
+            ImageType::Thumb => "Thumb",
+            ImageType::Logo => "Logo",
+            ImageType::Art => "Art",
+            ImageType::Banner => "Banner",
+            ImageType::Disc => "Disc",
+            ImageType::Box => "Box",
+            ImageType::Screenshot => "Screenshot",
+            ImageType::Menu => "Menu",
+            ImageType::Chapter => "Chapter",
+            ImageType::BoxRear => "BoxRear",
+            ImageType::Profile => "Profile",
+        }
+    }
+}
+
+/// The `SortBy` values accepted by `/Items`-family endpoints. Mirrors
+/// Jellyfin's `ItemSortBy` — only the fields meaningful to a music library
+/// are represented.
+///
+/// Callers pass a `Vec<ItemSortBy>` to [`crate::query::ItemsQuery::sort_by`];
+/// the builder joins them into the CSV the server expects (e.g.
+/// `PlayCount,SortName`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemSortBy {
+    Name,
+    SortName,
+    DateCreated,
+    DatePlayed,
+    PlayCount,
+    PremiereDate,
+    ProductionYear,
+    Album,
+    AlbumArtist,
+    Artist,
+    Runtime,
+    IsFavoriteOrLiked,
+    CommunityRating,
+    CriticRating,
+    Random,
+}
+
+impl ItemSortBy {
+    /// The exact server-facing token (e.g. `"PlayCount"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemSortBy::Name => "Name",
+            ItemSortBy::SortName => "SortName",
+            ItemSortBy::DateCreated => "DateCreated",
+            ItemSortBy::DatePlayed => "DatePlayed",
+            ItemSortBy::PlayCount => "PlayCount",
+            ItemSortBy::PremiereDate => "PremiereDate",
+            ItemSortBy::ProductionYear => "ProductionYear",
+            ItemSortBy::Album => "Album",
+            ItemSortBy::AlbumArtist => "AlbumArtist",
+            ItemSortBy::Artist => "Artist",
+            ItemSortBy::Runtime => "Runtime",
+            ItemSortBy::IsFavoriteOrLiked => "IsFavoriteOrLiked",
+            ItemSortBy::CommunityRating => "CommunityRating",
+            ItemSortBy::CriticRating => "CriticRating",
+            ItemSortBy::Random => "Random",
+        }
+    }
+}
+
+/// Sort direction for [`ItemSortBy`]. Two variants with `Asc` / `Desc`
+/// aliases for consumers that prefer the short form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl SortOrder {
+    /// Short alias for `Ascending` so callers can write
+    /// `SortOrder::Asc` where the full word reads clunky.
+    #[allow(non_upper_case_globals)]
+    pub const Asc: SortOrder = SortOrder::Ascending;
+    /// Short alias for `Descending`.
+    #[allow(non_upper_case_globals)]
+    pub const Desc: SortOrder = SortOrder::Descending;
+
+    /// The exact server-facing token (`"Ascending"` / `"Descending"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "Ascending",
+            SortOrder::Descending => "Descending",
+        }
+    }
+}
+
+/// The `Fields` projection values accepted by `/Items`-family endpoints.
+/// Mirrors Jellyfin's `ItemFields` — only the fields the music UI pulls are
+/// represented.
+///
+/// Callers pass a `Vec<ItemField>` to
+/// [`crate::query::ItemsQuery::fields`]; the builder joins them into the CSV
+/// the server expects (e.g. `Genres,ProductionYear,ChildCount`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "PascalCase")]
+pub enum ItemField {
+    Overview,
+    Genres,
+    ChildCount,
+    People,
+    MediaStreams,
+    MediaSources,
+    DateCreated,
+    Studios,
+    PrimaryImageAspectRatio,
+    ExternalUrls,
+    Path,
+    Tags,
+    ProductionYear,
+    ParentId,
+    AlbumId,
+    AlbumArtist,
+    Artists,
+    RunTimeTicks,
+    UserData,
+    SortName,
+    ItemCounts,
+    BackdropImageTags,
+    ProviderIds,
+    PlaylistItemId,
+}
+
+impl ItemField {
+    /// The exact server-facing token (e.g. `"Overview"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ItemField::Overview => "Overview",
+            ItemField::Genres => "Genres",
+            ItemField::ChildCount => "ChildCount",
+            ItemField::People => "People",
+            ItemField::MediaStreams => "MediaStreams",
+            ItemField::MediaSources => "MediaSources",
+            ItemField::DateCreated => "DateCreated",
+            ItemField::Studios => "Studios",
+            ItemField::PrimaryImageAspectRatio => "PrimaryImageAspectRatio",
+            ItemField::ExternalUrls => "ExternalUrls",
+            ItemField::Path => "Path",
+            ItemField::Tags => "Tags",
+            ItemField::ProductionYear => "ProductionYear",
+            ItemField::ParentId => "ParentId",
+            ItemField::AlbumId => "AlbumId",
+            ItemField::AlbumArtist => "AlbumArtist",
+            ItemField::Artists => "Artists",
+            ItemField::RunTimeTicks => "RunTimeTicks",
+            ItemField::UserData => "UserData",
+            ItemField::SortName => "SortName",
+            ItemField::ItemCounts => "ItemCounts",
+            ItemField::BackdropImageTags => "BackdropImageTags",
+            ItemField::ProviderIds => "ProviderIds",
+            ItemField::PlaylistItemId => "PlaylistItemId",
+        }
+    }
+}
+
+/// Join a slice of enum tokens into the CSV Jellyfin accepts on its `/Items`
+/// endpoints (e.g. `"MusicAlbum,MusicArtist"`).
+pub(crate) fn csv<T, F>(values: &[T], render: F) -> String
+where
+    F: Fn(&T) -> &'static str,
+{
+    let mut out = String::new();
+    let mut first = true;
+    for value in values {
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push_str(render(value));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn item_kind_serialises_pascal_case() {
+        assert_eq!(ItemKind::MusicAlbum.as_str(), "MusicAlbum");
+        assert_eq!(
+            serde_json::to_value(ItemKind::MusicArtist).unwrap(),
+            serde_json::json!("MusicArtist")
+        );
+    }
+
+    #[test]
+    fn sort_order_aliases_match_canonical() {
+        assert_eq!(SortOrder::Asc, SortOrder::Ascending);
+        assert_eq!(SortOrder::Desc, SortOrder::Descending);
+    }
+
+    #[test]
+    fn csv_joins_tokens_with_commas() {
+        let kinds = [ItemKind::MusicAlbum, ItemKind::MusicArtist, ItemKind::Audio];
+        assert_eq!(
+            csv(&kinds, ItemKind::as_str),
+            "MusicAlbum,MusicArtist,Audio"
+        );
+    }
+
+    #[test]
+    fn image_type_round_trips() {
+        for it in [
+            ImageType::Primary,
+            ImageType::Backdrop,
+            ImageType::Thumb,
+            ImageType::Logo,
+            ImageType::Art,
+            ImageType::Banner,
+            ImageType::Disc,
+            ImageType::Box,
+            ImageType::Screenshot,
+            ImageType::Menu,
+            ImageType::Chapter,
+            ImageType::BoxRear,
+            ImageType::Profile,
+        ] {
+            let s = it.as_str();
+            let back: ImageType = serde_json::from_value(serde_json::json!(s)).unwrap();
+            assert_eq!(back, it, "round trip {s}");
+        }
+    }
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,5 +1,22 @@
 use thiserror::Error;
 
+/// Canonical error type for the Jellify core. Structured so callers can
+/// match on the concrete failure class without parsing error messages.
+///
+/// The coarse `Server { status, message }` that preceded this rework has
+/// been split by HTTP status so Swift / Rust callers can act on meaningful
+/// subclasses:
+///
+/// - [`Self::Auth`] — 401 from the server (bad / expired credentials).
+/// - [`Self::Forbidden`] — 403 (user lacks permission for the item).
+/// - [`Self::NotFound`] — 404 (item / user view does not exist).
+/// - [`Self::RateLimit`] — 429 with an optional `Retry-After` hint.
+/// - [`Self::Network`] — transport-level failure (DNS, TLS, timeout).
+/// - [`Self::Server`] — any other HTTP failure (5xx or unclassified 4xx).
+///
+/// [`Self::is_retryable`] is the single source of truth for "should I
+/// exponentially back off and try again?"; it returns `true` for 5xx
+/// `Server`, `RateLimit`, and `Network`.
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum JellifyError {
@@ -16,8 +33,17 @@ pub enum JellifyError {
     #[error("authentication failed: {0}")]
     Auth(String),
 
-    #[error("server returned an error: {status} {message}")]
-    Server { status: u16, message: String },
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("rate limited (retry after {retry_after:?}s)")]
+    RateLimit { retry_after: Option<u64> },
+
+    #[error("server returned an error: {status} {body}")]
+    Server { status: u16, body: String },
 
     #[error("not logged in")]
     NotAuthenticated,
@@ -61,6 +87,49 @@ pub enum JellifyError {
 
     #[error("{0}")]
     Other(String),
+}
+
+impl JellifyError {
+    /// Should the caller retry the request after an exponential backoff?
+    ///
+    /// Returns `true` for:
+    /// - [`Self::RateLimit`] — the server asked us to slow down; the
+    ///   `retry_after` (when set) is an upper bound on the wait.
+    /// - [`Self::Server`] with a 5xx status — transient server-side issue.
+    /// - [`Self::Network`] — transport fault (DNS, TLS, timeout); usually
+    ///   resolves on its own.
+    ///
+    /// Returns `false` for `Auth`, `Forbidden`, `NotFound`, `Decode`,
+    /// `InvalidInput`, `NotAuthenticated`, `NoSession`, `Storage`,
+    /// `Credentials`, `Audio`, `Other` — those need user or code action, not
+    /// a retry.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            JellifyError::RateLimit { .. } => true,
+            JellifyError::Network(_) => true,
+            JellifyError::Server { status, .. } => (500..600).contains(status),
+            _ => false,
+        }
+    }
+
+    /// Build a JellifyError from an HTTP response's status code, body text,
+    /// and optional `Retry-After` header. Dispatches to the narrowest
+    /// variant that matches the status:
+    ///
+    /// - 401 → [`Self::Auth`]
+    /// - 403 → [`Self::Forbidden`]
+    /// - 404 → [`Self::NotFound`]
+    /// - 429 → [`Self::RateLimit`]
+    /// - else → [`Self::Server`]
+    pub fn from_status(status: u16, body: String, retry_after: Option<u64>) -> Self {
+        match status {
+            401 => JellifyError::Auth(body),
+            403 => JellifyError::Forbidden(body),
+            404 => JellifyError::NotFound(body),
+            429 => JellifyError::RateLimit { retry_after },
+            _ => JellifyError::Server { status, body },
+        }
+    }
 }
 
 impl From<reqwest::Error> for JellifyError {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -813,6 +813,30 @@ impl JellifyCore {
         Ok(self.player.current_in_queue())
     }
 
+    /// Insert `tracks` immediately after the currently-playing entry.
+    /// "Play Next" semantics, per #282. Returns the new queue length.
+    ///
+    /// No-op when either the queue is empty or `tracks` is empty — callers
+    /// that want to prime the queue with the new tracks should fall back to
+    /// [`Self::set_queue`] when the queue length stays at zero.
+    pub fn play_next(&self, tracks: Vec<Track>) -> u32 {
+        self.player.insert_next(tracks)
+    }
+
+    /// Append `tracks` to the end of the queue. "Add to Queue" semantics,
+    /// per #282. Returns the new queue length. No-op when `tracks` is empty.
+    pub fn add_to_queue(&self, tracks: Vec<Track>) -> u32 {
+        self.player.append_to_queue(tracks)
+    }
+
+    /// Remove every entry from the queue except the currently playing track
+    /// (which stays as a single-item queue so skip_next correctly reports
+    /// `None`). Exposed so the UI's "Clear Up Next" action doesn't require
+    /// stopping playback to reset the queue.
+    pub fn clear_queue(&self) {
+        self.player.clear_queue();
+    }
+
     pub fn mark_track_started(&self, track: Track) {
         self.player.set_current(track.clone());
         let now = chrono::Utc::now().timestamp();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,14 +11,18 @@
 //! play them and calls back with status updates.
 
 pub mod client;
+pub mod enums;
 pub mod error;
 pub mod models;
 pub mod player;
+pub mod query;
 pub mod storage;
 
+pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 pub use error::{JellifyError, Result};
 pub use models::*;
 pub use player::{PlaybackState, Player, PlayerStatus, RepeatMode};
+pub use query::ItemsQuery;
 
 use crate::client::{JellyfinClient, PublicSystemInfo};
 use crate::storage::{CredentialStore, Database};

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -32,6 +32,10 @@ pub struct Artist {
     pub song_count: u32,
     pub genres: Vec<String>,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this artist — carries the
+    /// favorite flag, play count, last-played date, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
@@ -45,6 +49,10 @@ pub struct Album {
     pub runtime_ticks: u64,
     pub genres: Vec<String>,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this album — carries the
+    /// favorite flag, play count, last-played date, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
@@ -59,7 +67,13 @@ pub struct Track {
     pub disc_number: Option<u32>,
     pub year: Option<i32>,
     pub runtime_ticks: u64,
+    /// Convenience mirror of `user_data.as_ref().map(|u| u.is_favorite)`
+    /// for call sites that only need the favorite flag. Kept for backwards
+    /// compatibility with pre-[`UserItemData`] code; new code should read
+    /// `user_data.is_favorite` so the full payload is available.
     pub is_favorite: bool,
+    /// Convenience mirror of `user_data.as_ref().map(|u| u.play_count)`.
+    /// See [`Self::is_favorite`].
     pub play_count: u32,
     pub container: Option<String>,
     pub bitrate: Option<u32>,
@@ -70,6 +84,10 @@ pub struct Track {
     /// specific entry rather than the underlying item, so duplicate tracks in
     /// the same playlist can be operated on independently.
     pub playlist_item_id: Option<String>,
+    /// The server's `UserData` projection for this track — carries the
+    /// favorite flag, play count, playback position, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 impl Track {
@@ -288,6 +306,30 @@ pub struct FavoriteState {
     pub play_count: Option<u32>,
     #[serde(rename = "LastPlayedDate", default)]
     pub last_played: Option<String>,
+}
+
+/// Full `UserItemData` projection as returned by Jellyfin for each user /
+/// item pair. When callers request `Fields=UserData` on a library endpoint,
+/// the server embeds this struct on every returned item; [`Album`],
+/// [`Artist`], and [`Track`] surface it via their optional `user_data` field.
+///
+/// `playback_position_ticks` is in Jellyfin's 100-ns tick units
+/// (`seconds * 10_000_000`). `last_played_at` is the raw ISO-8601 string the
+/// server returns, or `None` when the item has never been played.
+///
+/// `likes` / `rating` are Jellyfin's optional thumbs / numeric-rating fields;
+/// the Jellyfin Web UI surfaces them independently from the star-based
+/// `CommunityRating` and they round-trip here so a future ratings UI can
+/// read them without another round-trip.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, uniffi::Record)]
+pub struct UserItemData {
+    pub is_favorite: bool,
+    pub played: bool,
+    pub play_count: u32,
+    pub playback_position_ticks: i64,
+    pub last_played_at: Option<String>,
+    pub likes: Option<bool>,
+    pub rating: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug, Default, uniffi::Record)]
@@ -643,32 +685,6 @@ pub struct PlaybackStopInfo {
     pub session_id: Option<String>,
 }
 
-/// Jellyfin image variants served from `GET /Items/{id}/Images/{type}`.
-/// Mirrors the `ImageType` routes defined by the Jellyfin `ImageController`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
-pub enum ImageType {
-    Primary,
-    Backdrop,
-    Thumb,
-    Disc,
-    Logo,
-    Banner,
-    Art,
-    Box,
-}
-
-impl ImageType {
-    /// Path segment as Jellyfin expects it in the URL.
-    pub fn as_path(&self) -> &'static str {
-        match self {
-            ImageType::Primary => "Primary",
-            ImageType::Backdrop => "Backdrop",
-            ImageType::Thumb => "Thumb",
-            ImageType::Disc => "Disc",
-            ImageType::Logo => "Logo",
-            ImageType::Banner => "Banner",
-            ImageType::Art => "Art",
-            ImageType::Box => "Box",
-        }
-    }
-}
+// `ImageType` now lives in `crate::enums` alongside the other typed query
+// enums (`ItemKind`, `ItemSortBy`, `SortOrder`, `ItemField`). It is
+// re-exported from the crate root for backwards-compatible imports.

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -214,7 +214,7 @@ pub struct ArtistDetail {
     pub overview: Option<String>,
     /// `BackdropImageTags` from the server — one entry per backdrop image.
     /// Pass the index to [`crate::JellyfinClient::image_url_of_type`] with
-    /// [`ImageType::Backdrop`] to build per-backdrop URLs.
+    /// [`crate::ImageType::Backdrop`] to build per-backdrop URLs.
     pub backdrop_image_tags: Vec<String>,
     /// Parallel to `BackdropImageTags`: the underlying item ids that carry
     /// the backdrop tags. When empty, callers should use `id` directly.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -183,6 +183,57 @@ impl Player {
         }
     }
 
+    /// Insert `tracks` into the queue immediately after the currently-playing
+    /// entry without disturbing what's already playing. "Play Next" semantics,
+    /// matching Apple Music / Spotify. No-op when the queue is empty — the
+    /// caller should fall back to [`Player::set_queue`] for that case so the
+    /// playhead actually starts.
+    ///
+    /// Returns the new queue length. Closes #282 for the Play Next flows
+    /// (album / playlist / track context menu, Up Next panel drag-drop).
+    pub fn insert_next(&self, tracks: Vec<Track>) -> u32 {
+        let mut s = self.shared.lock();
+        if s.queue.is_empty() || tracks.is_empty() {
+            // Nothing currently playing — the caller is better served by
+            // `set_queue` which also primes `current`. Return the queue's
+            // untouched length so the caller can detect the no-op.
+            return s.queue.len() as u32;
+        }
+        let insert_at = (s.queue_index + 1).min(s.queue.len());
+        s.queue.splice(insert_at..insert_at, tracks);
+        s.queue.len() as u32
+    }
+
+    /// Append `tracks` to the end of the queue without touching the playhead.
+    /// "Add to Queue" semantics. No-op when `tracks` is empty.
+    ///
+    /// Returns the new queue length. Closes #282 for Add-to-Queue flows.
+    pub fn append_to_queue(&self, tracks: Vec<Track>) -> u32 {
+        let mut s = self.shared.lock();
+        if tracks.is_empty() {
+            return s.queue.len() as u32;
+        }
+        s.queue.extend(tracks);
+        s.queue.len() as u32
+    }
+
+    /// Replace the queue with an empty vec. Distinct from [`Player::clear`]
+    /// (which only wipes the active-playback bookkeeping) so the UI can offer
+    /// a "Clear Up Next" action without stopping playback of the current
+    /// track. Leaves the currently playing track intact as a single-item
+    /// queue so subsequent `skip_next` correctly reports `None` rather than
+    /// falling off a zero-length vec.
+    pub fn clear_queue(&self) {
+        let mut s = self.shared.lock();
+        if let Some(current) = s.current.clone() {
+            s.queue = vec![current];
+            s.queue_index = 0;
+        } else {
+            s.queue.clear();
+            s.queue_index = 0;
+        }
+    }
+
     pub fn set_current(&self, track: Track) {
         let mut s = self.shared.lock();
         s.current = Some(track);
@@ -412,5 +463,106 @@ mod tests {
             "skip_previous at start should return None"
         );
         assert_eq!(player.status().current_track.unwrap().id, "a");
+    }
+
+    // ---- #282: insert_next / append_to_queue / clear_queue ----
+
+    #[test]
+    fn insert_next_puts_tracks_right_after_current() {
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+
+        let new_len = player.insert_next(vec![track("x"), track("y")]);
+
+        assert_eq!(new_len, 5, "queue length after insert_next");
+        // Current stays on "a"; skip_next should now land on "x", then "y",
+        // then the original "b".
+        assert_eq!(player.status().current_track.unwrap().id, "a");
+        assert_eq!(player.skip_next().unwrap().id, "x");
+        assert_eq!(player.skip_next().unwrap().id, "y");
+        assert_eq!(player.skip_next().unwrap().id, "b");
+    }
+
+    #[test]
+    fn insert_next_at_end_appends_after_current_and_allows_skip_next() {
+        let player = Player::new();
+        player.set_queue(vec![track("a")], 0).unwrap();
+        let new_len = player.insert_next(vec![track("x")]);
+        assert_eq!(new_len, 2);
+        assert_eq!(player.skip_next().unwrap().id, "x");
+    }
+
+    #[test]
+    fn insert_next_on_empty_queue_is_noop() {
+        let player = Player::new();
+        let new_len = player.insert_next(vec![track("x")]);
+        assert_eq!(new_len, 0, "no current track => insert_next must no-op");
+        assert!(player.status().current_track.is_none());
+    }
+
+    #[test]
+    fn insert_next_with_empty_tracks_is_noop() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 0).unwrap();
+        let new_len = player.insert_next(vec![]);
+        assert_eq!(new_len, 2);
+        assert_eq!(player.skip_next().unwrap().id, "b");
+    }
+
+    #[test]
+    fn append_to_queue_adds_at_end_without_disturbing_current() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 0).unwrap();
+
+        let new_len = player.append_to_queue(vec![track("x"), track("y")]);
+
+        assert_eq!(new_len, 4);
+        assert_eq!(player.status().current_track.unwrap().id, "a");
+        assert_eq!(player.skip_next().unwrap().id, "b");
+        assert_eq!(player.skip_next().unwrap().id, "x");
+        assert_eq!(player.skip_next().unwrap().id, "y");
+    }
+
+    #[test]
+    fn append_to_queue_on_empty_queue_just_extends() {
+        let player = Player::new();
+        let new_len = player.append_to_queue(vec![track("x"), track("y")]);
+        // `append_to_queue` does not prime `current`; that's `set_queue`'s job.
+        assert_eq!(new_len, 2);
+        assert!(player.status().current_track.is_none());
+    }
+
+    #[test]
+    fn append_to_queue_with_empty_tracks_is_noop() {
+        let player = Player::new();
+        player.set_queue(vec![track("a")], 0).unwrap();
+        let new_len = player.append_to_queue(vec![]);
+        assert_eq!(new_len, 1);
+    }
+
+    #[test]
+    fn clear_queue_keeps_current_track_as_single_entry() {
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 1)
+            .unwrap();
+        player.clear_queue();
+
+        let status = player.status();
+        assert_eq!(status.current_track.unwrap().id, "b");
+        assert_eq!(status.queue_length, 1);
+        assert_eq!(status.queue_position, 0);
+        // skip_next should now return None — nothing left after "b".
+        assert!(player.skip_next().is_none());
+    }
+
+    #[test]
+    fn clear_queue_on_empty_player_stays_empty() {
+        let player = Player::new();
+        player.clear_queue();
+        assert_eq!(player.status().queue_length, 0);
+        assert!(player.status().current_track.is_none());
     }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -266,6 +266,7 @@ mod tests {
             bitrate: None,
             image_tag: None,
             playlist_item_id: None,
+            user_data: None,
         }
     }
 

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -11,7 +11,7 @@
 //! [`ItemsQuery`] centralises the builder into a single typed fluent
 //! interface. The typed query-parameter enums ([`ItemKind`], [`ItemSortBy`],
 //! [`SortOrder`], [`ItemField`]) replace the string literals, and the
-//! builder's [`Self::execute`] method dispatches to either
+//! builder's [`ItemsQuery::execute`] method dispatches to either
 //! `/Users/{id}/Items` (when `user_id` is set) or `/Items` (when not).
 //!
 //! Existing per-endpoint methods on [`JellyfinClient`] (e.g.

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -1,0 +1,419 @@
+//! Fluent `ItemsQuery` builder for Jellyfin's `/Items` family of endpoints.
+//!
+//! The `JellyfinClient::albums`, `::artists`, `::list_tracks`, `::search`,
+//! `::album_tracks`, and friends all ultimately issue a `GET /Items` (or
+//! `GET /Users/{id}/Items`) request with some permutation of the same set of
+//! query parameters (`IncludeItemTypes`, `SortBy`, `Fields`, `ParentId`,
+//! ...). Historically each method hand-rolled its own query string with
+//! string literals, which meant the set of "allowed values" was scattered
+//! across the call sites and a typo at one site was a silent server error.
+//!
+//! [`ItemsQuery`] centralises the builder into a single typed fluent
+//! interface. The typed query-parameter enums ([`ItemKind`], [`ItemSortBy`],
+//! [`SortOrder`], [`ItemField`]) replace the string literals, and the
+//! builder's [`Self::execute`] method dispatches to either
+//! `/Users/{id}/Items` (when `user_id` is set) or `/Items` (when not).
+//!
+//! Existing per-endpoint methods on [`JellyfinClient`] (e.g.
+//! [`JellyfinClient::albums`]) are retained for backwards compatibility and
+//! now delegate to `ItemsQuery` internally; new call sites should prefer
+//! the builder directly.
+
+use crate::client::{JellyfinClient, PaginatedItems, RawItem, RawItems};
+use crate::enums::{self, ItemField, ItemKind, ItemSortBy, SortOrder};
+use crate::error::{JellifyError, Result};
+use url::Url;
+
+/// Fluent builder for a Jellyfin `GET /Items`-family request.
+///
+/// Construct with [`ItemsQuery::new`], set the parameters you need with the
+/// fluent setters, and finish with [`Self::execute`] (returns a raw
+/// [`PaginatedItems`] wrapping [`RawItem`]s) or one of the typed helpers
+/// [`Self::fetch_albums`] / [`Self::fetch_artists`] / [`Self::fetch_tracks`]
+/// / [`Self::fetch_playlists`].
+///
+/// Unset fields are simply omitted from the outbound query string; the
+/// server's defaults apply. `limit = 0` is clamped to `1` before issuing the
+/// request, matching the legacy behaviour of the per-endpoint methods.
+#[derive(Clone, Debug, Default)]
+pub struct ItemsQuery {
+    pub(crate) parent_id: Option<String>,
+    pub(crate) user_id: Option<String>,
+    pub(crate) types: Vec<ItemKind>,
+    pub(crate) sort_by: Vec<ItemSortBy>,
+    pub(crate) sort_order: Vec<SortOrder>,
+    pub(crate) limit: u32,
+    pub(crate) offset: u32,
+    pub(crate) is_favorite: Option<bool>,
+    pub(crate) genre_ids: Vec<String>,
+    pub(crate) artist_ids: Vec<String>,
+    pub(crate) album_artist_ids: Vec<String>,
+    pub(crate) years: Vec<u32>,
+    pub(crate) search_term: Option<String>,
+    pub(crate) fields: Vec<ItemField>,
+    pub(crate) recursive: bool,
+    pub(crate) enable_user_data: bool,
+    pub(crate) ids: Vec<String>,
+    pub(crate) exclude_types: Vec<ItemKind>,
+}
+
+impl ItemsQuery {
+    /// Start with an empty query. Every field defaults to `None`, empty
+    /// vec, or `0` as appropriate.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set `ParentId` — scopes the query to items parented under `id` (a
+    /// library collection folder, an album, a playlist, ...).
+    pub fn parent<S: Into<String>>(mut self, id: S) -> Self {
+        self.parent_id = Some(id.into());
+        self
+    }
+
+    /// Override the `UserId` routing. When set, [`Self::execute`] sends the
+    /// request to `/Users/{user_id}/Items`; when unset, [`Self::execute`]
+    /// uses the client's authenticated user id for the same route. Pass
+    /// `None` explicitly to force the bare `/Items` route (rarely needed).
+    pub fn user<S: Into<String>>(mut self, id: S) -> Self {
+        self.user_id = Some(id.into());
+        self
+    }
+
+    /// Restrict the result set to a list of [`ItemKind`]s — serialised as
+    /// `IncludeItemTypes=Audio,MusicAlbum,...`.
+    pub fn item_types(mut self, kinds: Vec<ItemKind>) -> Self {
+        self.types = kinds;
+        self
+    }
+
+    /// Exclude items of the given [`ItemKind`]s — `ExcludeItemTypes=...`.
+    pub fn exclude_item_types(mut self, kinds: Vec<ItemKind>) -> Self {
+        self.exclude_types = kinds;
+        self
+    }
+
+    /// Set the sort order columns — serialised as
+    /// `SortBy=PlayCount,SortName`. The `SortOrder` vec (see
+    /// [`Self::sort_order`]) should be parallel to this list; when the two
+    /// vecs differ in length, Jellyfin reuses the last `SortOrder` entry for
+    /// the remaining `SortBy` columns.
+    pub fn sort_by(mut self, by: Vec<ItemSortBy>) -> Self {
+        self.sort_by = by;
+        self
+    }
+
+    /// Set the sort direction(s). See [`Self::sort_by`].
+    pub fn sort_order(mut self, order: Vec<SortOrder>) -> Self {
+        self.sort_order = order;
+        self
+    }
+
+    /// Convenience for the single-column case — equivalent to
+    /// `.sort_by(vec![column]).sort_order(vec![order])`.
+    pub fn sort(mut self, column: ItemSortBy, order: SortOrder) -> Self {
+        self.sort_by = vec![column];
+        self.sort_order = vec![order];
+        self
+    }
+
+    /// Maximum number of items to return — `Limit=...`. Clamped to `1`
+    /// before the request is sent.
+    pub fn limit(mut self, n: u32) -> Self {
+        self.limit = n;
+        self
+    }
+
+    /// Starting offset — `StartIndex=...`.
+    pub fn offset(mut self, n: u32) -> Self {
+        self.offset = n;
+        self
+    }
+
+    /// Set `IsFavorite=true` (restrict to favorited items). Short-hand for
+    /// `self.is_favorite(true)`.
+    pub fn favorites_only(mut self) -> Self {
+        self.is_favorite = Some(true);
+        self
+    }
+
+    /// Set `IsFavorite=...` explicitly (e.g. `false` to suppress favorites).
+    pub fn is_favorite(mut self, v: bool) -> Self {
+        self.is_favorite = Some(v);
+        self
+    }
+
+    /// Add a genre id — sent as `GenreIds=a,b,c`. Can be called repeatedly.
+    pub fn genre<S: Into<String>>(mut self, id: S) -> Self {
+        self.genre_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of genre ids.
+    pub fn genres<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.genre_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add an artist id — sent as `ArtistIds=a,b,c` (matches any credited
+    /// artist). Can be called repeatedly.
+    pub fn artist<S: Into<String>>(mut self, id: S) -> Self {
+        self.artist_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of artist ids.
+    pub fn artists<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.artist_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add an album-artist id — sent as `AlbumArtistIds=a,b,c` (matches
+    /// items whose `AlbumArtist` credit is the given artist).
+    pub fn album_artist<S: Into<String>>(mut self, id: S) -> Self {
+        self.album_artist_ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of album-artist ids.
+    pub fn album_artists<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.album_artist_ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add a production year — sent as `Years=1999,2001`.
+    pub fn year(mut self, y: u32) -> Self {
+        self.years.push(y);
+        self
+    }
+
+    /// Set the full list of production years.
+    pub fn years<I>(mut self, years: I) -> Self
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        self.years = years.into_iter().collect();
+        self
+    }
+
+    /// Full-text search term — `SearchTerm=...`.
+    pub fn search<S: Into<String>>(mut self, q: S) -> Self {
+        self.search_term = Some(q.into());
+        self
+    }
+
+    /// Set the `Fields` projection — e.g. `[Genres, ProductionYear,
+    /// ChildCount]`. Serialised as a comma-separated list.
+    pub fn fields(mut self, fs: Vec<ItemField>) -> Self {
+        self.fields = fs;
+        self
+    }
+
+    /// Append a single `Fields` entry.
+    pub fn field(mut self, f: ItemField) -> Self {
+        self.fields.push(f);
+        self
+    }
+
+    /// Set `Recursive=true` so the query walks child collections.
+    pub fn recursive(mut self) -> Self {
+        self.recursive = true;
+        self
+    }
+
+    /// Set `Recursive=...` explicitly (`true` → recursive, `false` →
+    /// omit the param so the server default applies).
+    pub fn with_recursive(mut self, v: bool) -> Self {
+        self.recursive = v;
+        self
+    }
+
+    /// Set `EnableUserData=true` so the server includes the per-user
+    /// `UserData` payload on each item. Implied by `Fields=UserData`, but
+    /// exposed here for endpoints that accept the standalone switch.
+    pub fn enable_user_data(mut self) -> Self {
+        self.enable_user_data = true;
+        self
+    }
+
+    /// Add an explicit item id — sent as `Ids=a,b,c`.
+    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
+        self.ids.push(id.into());
+        self
+    }
+
+    /// Set the full list of explicit item ids.
+    pub fn ids<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.ids = ids.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Apply every set parameter onto the given URL. Shared between
+    /// [`Self::execute`] and the callers (in `client.rs`) that need to
+    /// embed the query onto an existing URL.
+    pub(crate) fn apply(&self, url: &mut Url) {
+        let mut q = url.query_pairs_mut();
+        let limit = self.limit.max(1);
+        q.append_pair("Limit", &limit.to_string());
+        q.append_pair("StartIndex", &self.offset.to_string());
+        if let Some(parent) = &self.parent_id {
+            q.append_pair("ParentId", parent);
+        }
+        if self.recursive {
+            q.append_pair("Recursive", "true");
+        }
+        if !self.types.is_empty() {
+            q.append_pair(
+                "IncludeItemTypes",
+                &enums::csv(&self.types, ItemKind::as_str),
+            );
+        }
+        if !self.exclude_types.is_empty() {
+            q.append_pair(
+                "ExcludeItemTypes",
+                &enums::csv(&self.exclude_types, ItemKind::as_str),
+            );
+        }
+        if !self.sort_by.is_empty() {
+            q.append_pair("SortBy", &enums::csv(&self.sort_by, ItemSortBy::as_str));
+        }
+        if !self.sort_order.is_empty() {
+            q.append_pair(
+                "SortOrder",
+                &enums::csv(&self.sort_order, SortOrder::as_str),
+            );
+        }
+        if let Some(fav) = self.is_favorite {
+            q.append_pair("IsFavorite", if fav { "true" } else { "false" });
+        }
+        if !self.genre_ids.is_empty() {
+            q.append_pair("GenreIds", &self.genre_ids.join(","));
+        }
+        if !self.artist_ids.is_empty() {
+            q.append_pair("ArtistIds", &self.artist_ids.join(","));
+        }
+        if !self.album_artist_ids.is_empty() {
+            q.append_pair("AlbumArtistIds", &self.album_artist_ids.join(","));
+        }
+        if !self.years.is_empty() {
+            let joined = self
+                .years
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            q.append_pair("Years", &joined);
+        }
+        if let Some(term) = &self.search_term {
+            q.append_pair("SearchTerm", term);
+        }
+        if !self.fields.is_empty() {
+            q.append_pair("Fields", &enums::csv(&self.fields, ItemField::as_str));
+        }
+        if self.enable_user_data {
+            q.append_pair("EnableUserData", "true");
+        }
+        if !self.ids.is_empty() {
+            q.append_pair("Ids", &self.ids.join(","));
+        }
+        // Image flags: every UI-facing call site wants primary-image metadata,
+        // and every pre-refactor endpoint set these explicitly. Emitted by the
+        // builder so migrated endpoints keep shipping behavior.
+        q.append_pair("EnableImages", "true");
+        q.append_pair("ImageTypeLimit", "1");
+    }
+
+    /// Issue the request and return the raw server response as
+    /// [`PaginatedItems<RawItem>`]. Chooses between `/Users/{id}/Items` and
+    /// `/Items` based on `self.user_id` (or the client's authenticated user
+    /// id when the caller did not override it).
+    ///
+    /// This is the low-level entry point — prefer the typed helpers
+    /// [`Self::fetch_albums`] / `fetch_artists` / `fetch_tracks` /
+    /// `fetch_playlists` when the caller knows which model type to expect.
+    pub async fn execute(self, client: &JellyfinClient) -> Result<PaginatedItems<RawItem>> {
+        let effective_user = self
+            .user_id
+            .clone()
+            .or_else(|| client.user_id().map(ToOwned::to_owned))
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let path = format!("Users/{effective_user}/Items");
+        let mut url = client.endpoint(&path)?;
+        self.apply(&mut url);
+        let raw: RawItems<RawItem> = client.send_get(url).await?.json().await?;
+        Ok(PaginatedItems {
+            items: raw.items,
+            total_count: raw.total_record_count,
+        })
+    }
+
+    /// Thin convenience alias for [`Self::execute`] — matches the
+    /// `fetch(self, client) -> Page<Item>` shape requested on the issue.
+    pub async fn fetch(self, client: &JellyfinClient) -> Result<PaginatedItems<RawItem>> {
+        self.execute(client).await
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Album`].
+    pub async fn fetch_albums(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedAlbums> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedAlbums {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Artist`].
+    pub async fn fetch_artists(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedArtists> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedArtists {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Track`].
+    pub async fn fetch_tracks(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedTracks> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedTracks {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+
+    /// Execute, then map the raw items to [`crate::models::Playlist`].
+    pub async fn fetch_playlists(
+        self,
+        client: &JellyfinClient,
+    ) -> Result<crate::models::PaginatedPlaylists> {
+        let page = self.execute(client).await?;
+        Ok(crate::models::PaginatedPlaylists {
+            items: page.items.into_iter().map(Into::into).collect(),
+            total_count: page.total_count,
+        })
+    }
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::client::JellyfinClient;
+use crate::enums::ImageType;
 use crate::error::JellifyError;
-use crate::models::{ImageType, Paging};
+use crate::models::Paging;
 use crate::storage::{CredentialStore, Database};
 use crate::{CoreConfig, JellifyCore};
 use serde_json::json;
@@ -1332,9 +1333,11 @@ async fn artist_detail_returns_server_404_on_empty_items() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.artist_detail("missing").await.unwrap_err();
+    // Post-refactor: the 404 local-miss case uses the dedicated
+    // `NotFound` variant rather than the coarse `Server { status: 404 }`.
     assert!(
-        matches!(err, crate::error::JellifyError::Server { status: 404, .. }),
-        "expected 404 Server error, got {err:?}"
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
     );
 }
 
@@ -2148,10 +2151,12 @@ async fn fetch_item_empty_items_returns_not_found() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.fetch_item("missing-id", &[]).await.unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
-        other => panic!("expected Server 404, got {other:?}"),
-    }
+    // Post-refactor: the local empty-items miss raises `NotFound` rather
+    // than the coarse `Server { status: 404 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -3990,10 +3995,12 @@ async fn music_library_id_returns_404_when_no_music_view() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let err = client.music_library_id().await.unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 404),
-        other => panic!("expected Server 404, got {other:?}"),
-    }
+    // Post-refactor: a missing "music" collection view surfaces as
+    // `NotFound` rather than the coarse `Server { status: 404 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -4204,10 +4211,12 @@ async fn remove_from_playlist_propagates_server_errors() {
         .remove_from_playlist("pl-1", &["entry-1".into()])
         .await
         .unwrap_err();
-    match err {
-        crate::error::JellifyError::Server { status, .. } => assert_eq!(status, 403),
-        other => panic!("expected Server 403, got {other:?}"),
-    }
+    // Post-refactor: 403 responses surface as the dedicated `Forbidden`
+    // variant rather than the coarse `Server { status: 403 }`.
+    assert!(
+        matches!(err, crate::error::JellifyError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -6564,4 +6573,410 @@ async fn with_client_releases_inner_lock_before_http() {
     })
     .await
     .expect("spawn_blocking panicked");
+}
+
+// ---------------------------------------------------------------------------
+// BATCH-24: typed enums / ItemsQuery / structured errors / UserItemData
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn items_query_builder_round_trips_through_server() {
+    // End-to-end: a hand-built `ItemsQuery` should produce the same
+    // server-facing request as the legacy per-endpoint methods. We check
+    // for the critical query params and confirm the response maps to the
+    // expected `PaginatedAlbums`.
+    use crate::enums::{ItemField, ItemKind, ItemSortBy, SortOrder};
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "a1", "Name": "Test Album", "Type": "MusicAlbum",
+                    "AlbumArtist": "Test Artist",
+                    "ProductionYear": 2024, "ChildCount": 10,
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = ItemsQuery::new()
+        .recursive()
+        .item_types(vec![ItemKind::MusicAlbum])
+        .sort(ItemSortBy::SortName, SortOrder::Ascending)
+        .limit(50)
+        .offset(0)
+        .fields(vec![ItemField::Genres, ItemField::ProductionYear])
+        .fetch_albums(&client)
+        .await
+        .unwrap();
+
+    assert_eq!(page.total_count, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].name, "Test Album");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
+    assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+    assert!(q.contains("Limit=50"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+}
+
+#[tokio::test]
+async fn items_query_builder_clamps_zero_limit_to_one() {
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = ItemsQuery::new().limit(0).execute(&client).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("query");
+    assert!(q.contains("Limit=1"), "expected clamped limit: {q}");
+}
+
+#[tokio::test]
+async fn items_query_builder_requires_user_id() {
+    // With no session AND no explicit `user_id`, `execute` must short-circuit
+    // before any HTTP call with `NotAuthenticated`.
+    use crate::query::ItemsQuery;
+
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = ItemsQuery::new().execute(&client).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_auth_maps_401() {
+    // A 401 on an authenticated library call goes through the silent
+    // re-auth path in `send_with_retry_raw`; with no refresh callback
+    // wired (and therefore no fresh keyring token to grab), the caller
+    // sees [`JellifyError::AuthExpired`] rather than the raw `Auth(body)`.
+    // The raw `Auth(_)` variant is still the target of `from_status` for
+    // endpoints that bypass the retry layer — verified separately on
+    // `from_status` directly.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::AuthExpired),
+        "expected AuthExpired for 401 on authenticated call, got {err:?}"
+    );
+
+    // And the raw mapping (`from_status`) still lands on `Auth(body)` —
+    // which is what endpoints that bypass the retry layer will see.
+    let raw = crate::error::JellifyError::from_status(401, "unauthorized".into(), None);
+    assert!(
+        matches!(raw, crate::error::JellifyError::Auth(_)),
+        "from_status(401) must be Auth, got {raw:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_forbidden_maps_403() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::Forbidden(_)),
+        "expected Forbidden for 403, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn structured_error_rate_limit_parses_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "42")
+                .set_body_string("slow down"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    match err {
+        crate::error::JellifyError::RateLimit { retry_after } => {
+            assert_eq!(retry_after, Some(42));
+        }
+        other => panic!("expected RateLimit, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn structured_error_server_5xx_is_retryable() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    match &err {
+        crate::error::JellifyError::Server { status, .. } => assert_eq!(*status, 503),
+        other => panic!("expected Server, got {other:?}"),
+    }
+    assert!(err.is_retryable(), "5xx must be retryable");
+}
+
+#[test]
+fn structured_error_is_retryable_classification() {
+    use crate::error::JellifyError;
+
+    // Retryable: RateLimit, Network, Server 5xx.
+    assert!(JellifyError::RateLimit { retry_after: None }.is_retryable());
+    assert!(JellifyError::Network("boom".into()).is_retryable());
+    assert!(JellifyError::Server {
+        status: 500,
+        body: "".into(),
+    }
+    .is_retryable());
+    assert!(JellifyError::Server {
+        status: 599,
+        body: "".into(),
+    }
+    .is_retryable());
+
+    // Not retryable: Auth, Forbidden, NotFound, Decode, InvalidInput,
+    // NotAuthenticated, NoSession.
+    assert!(!JellifyError::Auth("".into()).is_retryable());
+    assert!(!JellifyError::Forbidden("".into()).is_retryable());
+    assert!(!JellifyError::NotFound("".into()).is_retryable());
+    assert!(!JellifyError::Decode("".into()).is_retryable());
+    assert!(!JellifyError::InvalidInput("".into()).is_retryable());
+    assert!(!JellifyError::NotAuthenticated.is_retryable());
+    assert!(!JellifyError::NoSession.is_retryable());
+    // A 4xx `Server` (unclassified) is NOT retryable — only 5xx is.
+    assert!(!JellifyError::Server {
+        status: 418,
+        body: "".into(),
+    }
+    .is_retryable());
+}
+
+#[test]
+fn structured_error_from_status_dispatches_variants() {
+    use crate::error::JellifyError;
+    assert!(matches!(
+        JellifyError::from_status(401, "".into(), None),
+        JellifyError::Auth(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(403, "".into(), None),
+        JellifyError::Forbidden(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(404, "".into(), None),
+        JellifyError::NotFound(_)
+    ));
+    assert!(matches!(
+        JellifyError::from_status(429, "".into(), Some(5)),
+        JellifyError::RateLimit {
+            retry_after: Some(5)
+        }
+    ));
+    assert!(matches!(
+        JellifyError::from_status(500, "".into(), None),
+        JellifyError::Server { status: 500, .. }
+    ));
+    assert!(matches!(
+        JellifyError::from_status(418, "".into(), None),
+        JellifyError::Server { status: 418, .. }
+    ));
+}
+
+#[tokio::test]
+async fn user_item_data_round_trips_on_track() {
+    // `Fields=UserData` on a `/Items` query should populate every field of
+    // `Track::user_data` — this is the end-to-end path that feeds the Home
+    // "Play It Again" row and the player's "resume from position" UI.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Alb",
+                    "AlbumArtist": "Ar", "Artists": ["Ar"],
+                    "RunTimeTicks": 3000000000u64,
+                    "UserData": {
+                        "IsFavorite": true,
+                        "Played": true,
+                        "PlayCount": 9,
+                        "PlaybackPositionTicks": 500000000i64,
+                        "LastPlayedDate": "2025-02-03T04:05:06Z",
+                        "Likes": true,
+                        "Rating": 4.5
+                    },
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client.album_tracks("a1").await.unwrap();
+    assert_eq!(tracks.len(), 1);
+    let t = &tracks[0];
+    let ud = t.user_data.as_ref().expect("user_data must be populated");
+    assert!(ud.is_favorite);
+    assert!(ud.played);
+    assert_eq!(ud.play_count, 9);
+    assert_eq!(ud.playback_position_ticks, 500_000_000);
+    assert_eq!(ud.last_played_at.as_deref(), Some("2025-02-03T04:05:06Z"));
+    assert_eq!(ud.likes, Some(true));
+    assert_eq!(ud.rating, Some(4.5));
+
+    // Legacy convenience fields on `Track` mirror the payload.
+    assert!(t.is_favorite);
+    assert_eq!(t.play_count, 9);
+}
+
+#[tokio::test]
+async fn user_item_data_is_none_when_server_omits_it() {
+    // When the server does not include `UserData` on the payload, the
+    // track's `user_data` field should be `None` (not `Some(default)`).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Alb",
+                    "RunTimeTicks": 1000000000u64,
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client.album_tracks("a1").await.unwrap();
+    assert!(tracks[0].user_data.is_none(), "no UserData => no user_data");
+    assert!(!tracks[0].is_favorite);
+    assert_eq!(tracks[0].play_count, 0);
 }

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -597,9 +597,13 @@ final class AppModel {
             id: "queue.clear",
             title: "Clear Queue",
             symbol: "trash",
-            run: {
-                // TODO(#282): wire to a core `clear_queue` primitive.
-                print("[AppModel] Clear Queue — not yet wired (see #282)")
+            run: { [weak self] in
+                // #282: wipe the queue but keep the currently playing track
+                // as a single-item queue so playback doesn't stop.
+                self?.core.clearQueue()
+                if let core = self?.core {
+                    self?.status = core.status()
+                }
             }
         ))
         actions.append(PaletteAction(
@@ -2718,26 +2722,41 @@ final class AppModel {
     }
 
     /// Insert an album's tracks immediately after the currently-playing track.
-    /// TODO: #282 — proper Up Next vs Auto Queue separation. For now, the core
-    /// queue is replaced on every `setQueue`, so until we grow an `insertNext`
-    /// primitive this falls back to appending behaviour.
+    /// Uses the `core.playNext` primitive wired in for #282. When nothing is
+    /// currently playing, falls back to `play(album:)` so the album actually
+    /// starts instead of silently queueing into an empty player.
     func playNext(album: Album) {
-        // TODO: #282 — queue "Up Next" insertion; for now, surface a log.
-        print("[AppModel] playNext(album:) not yet wired — see #282")
         Task {
             let tracks = await loadTracks(forAlbum: album.id)
             guard !tracks.isEmpty else { return }
-            play(tracks: tracks, startIndex: 0)
+            if status.currentTrack == nil {
+                play(tracks: tracks, startIndex: 0)
+                return
+            }
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.playNext(tracks: tracks)
+            }.value
+            self.status = core.status()
         }
     }
 
-    /// Append an album's tracks to the end of the queue.
-    /// TODO: #282 — the core lacks an `appendToQueue` primitive, so this is a
-    /// stub that plays the album outright for now.
+    /// Append an album's tracks to the end of the queue. Uses the
+    /// `core.addToQueue` primitive wired in for #282; when nothing is playing
+    /// falls back to `play(album:)` so we don't end up with a loaded queue
+    /// but no playhead.
     func addToQueue(album: Album) {
-        // TODO: #282 — queue append. Currently behaves like `play`.
-        print("[AppModel] addToQueue(album:) not yet wired — see #282")
-        play(album: album)
+        Task {
+            let tracks = await loadTracks(forAlbum: album.id)
+            guard !tracks.isEmpty else { return }
+            if status.currentTrack == nil {
+                play(tracks: tracks, startIndex: 0)
+                return
+            }
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.addToQueue(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
     /// In-memory favorite flag keyed by item id (album/track/artist/playlist).
@@ -3144,22 +3163,40 @@ final class AppModel {
     }
 
     /// Insert a playlist's tracks immediately after the currently-playing track.
-    /// TODO: #282 — proper Up Next vs Auto Queue separation. For now, the core
-    /// queue is replaced on every `setQueue`, so until we grow an `insertNext`
-    /// primitive this falls back to replace-and-play behaviour.
+    /// Wired to `core.playNext` for #282. Falls back to `play(playlist:)`
+    /// when nothing is currently playing so the menu item still does the
+    /// obvious thing.
     func playNext(playlist: Playlist) {
-        // TODO: #282 — queue "Up Next" insertion; for now, replace-and-play.
-        print("[AppModel] playNext(playlist:) not yet wired — see #282")
-        play(playlist: playlist)
+        Task {
+            let tracks = await loadPlaylistTracks(playlist: playlist)
+            guard !tracks.isEmpty else { return }
+            if status.currentTrack == nil {
+                play(tracks: tracks, startIndex: 0)
+                return
+            }
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.playNext(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
-    /// Append a playlist's tracks to the end of the queue.
-    /// TODO: #282 — the core lacks an `appendToQueue` primitive, so this is a
-    /// stub that plays the playlist outright for now.
+    /// Append a playlist's tracks to the end of the queue. Wired to
+    /// `core.addToQueue` for #282. Falls back to `play(playlist:)` when
+    /// nothing is currently playing.
     func addToQueue(playlist: Playlist) {
-        // TODO: #282 — queue append. Currently behaves like `play`.
-        print("[AppModel] addToQueue(playlist:) not yet wired — see #282")
-        play(playlist: playlist)
+        Task {
+            let tracks = await loadPlaylistTracks(playlist: playlist)
+            guard !tracks.isEmpty else { return }
+            if status.currentTrack == nil {
+                play(tracks: tracks, startIndex: 0)
+                return
+            }
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.addToQueue(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
     /// Toggle the favorite flag for a playlist on the Jellyfin server.
@@ -3550,24 +3587,37 @@ final class AppModel {
     // editor #96).
 
     /// Insert a selection of tracks immediately after the currently-playing
-    /// track.
-    /// TODO(#282): queue "Up Next" insertion primitive. For now, behaves
-    /// like `play(tracks:)` so the menu item does something.
+    /// track. Wired to `core.playNext` for #282; when nothing is playing
+    /// falls back to `play(tracks:)` so the menu item always does something.
     func playNext(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
-        // TODO(#282): queue "Up Next" insertion not yet wired.
-        print("[AppModel] playNext(tracks:) not yet wired — see #282")
-        play(tracks: tracks, startIndex: 0)
+        if status.currentTrack == nil {
+            play(tracks: tracks, startIndex: 0)
+            return
+        }
+        Task {
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.playNext(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
-    /// Append a selection of tracks to the end of the queue.
-    /// TODO(#282): queue append primitive. For now, replaces the queue via
-    /// `play(tracks:)` so the menu item has a landing pad.
+    /// Append a selection of tracks to the end of the queue. Wired to
+    /// `core.addToQueue` for #282; when nothing is playing falls back to
+    /// `play(tracks:)`.
     func addToQueue(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
-        // TODO(#282): queue append not yet wired.
-        print("[AppModel] addToQueue(tracks:) not yet wired — see #282")
-        play(tracks: tracks, startIndex: 0)
+        if status.currentTrack == nil {
+            play(tracks: tracks, startIndex: 0)
+            return
+        }
+        Task {
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.addToQueue(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
     /// Kick off an Instant Mix ("song radio") seeded by a single track.

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -684,7 +684,7 @@ final class AppModel {
             startPolling()
             await refreshLibrary()
         } catch {
-            self.errorMessage = "Login failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .login)
         }
     }
 
@@ -887,6 +887,10 @@ final class AppModel {
     /// class — 401 responses surface as `Auth`, the retry-layer fallback is
     /// `AuthExpired`, and a missing token is `NotAuthenticated` — so we can
     /// match variants directly instead of parsing the Display message.
+    ///
+    /// Call-sites that do NOT match auth go on to call
+    /// `JellifyErrorPresenter.message(for:context:)` (see #351) to turn the
+    /// raw Display string into localized banner copy.
     private func handleAuthError(_ error: Error) -> Bool {
         guard let err = error as? JellifyError else { return false }
         switch err {
@@ -942,7 +946,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Albums load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
         do {
             let artists = try await artistsPage
@@ -954,7 +958,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Artists load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
         do {
             let tracks = try await tracksPage
@@ -966,7 +970,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Tracks load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
         if anySucceeded {
             serverReachability.noteSuccess()
@@ -1006,7 +1010,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -1030,7 +1034,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -1051,7 +1055,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -1075,7 +1079,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Library load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
         }
     }
 
@@ -1169,7 +1173,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            self.errorMessage = "Playlists load failed: \(error.localizedDescription)"
+            self.errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistsLoad)
         }
     }
 
@@ -1229,7 +1233,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist load failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistLoad)
         }
         return all
     }
@@ -1687,6 +1691,10 @@ final class AppModel {
             runtimeTicks: runtimeTicks,
             genres: genres,
             imageTag: imageTag,
+            // DTO parser doesn't request `Fields=UserData`, so the
+            // server-authoritative projection is absent here. Favourite /
+            // play-count consumers read the legacy convenience mirrors
+            // (`isFavorite` / `playCount`) where those are set.
             userData: nil
         )
     }
@@ -1777,6 +1785,10 @@ final class AppModel {
             bitrate: bitrate,
             imageTag: imageTag,
             playlistItemId: nil,
+            // DTO parser doesn't request `Fields=UserData`, so the
+            // server-authoritative projection is absent. Legacy mirrors
+            // `isFavorite` / `playCount` are populated above from whatever
+            // the BaseItemDto carried.
             userData: nil
         )
     }
@@ -1795,7 +1807,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Album tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .albumTracks)
             return []
         }
     }
@@ -2025,7 +2037,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistTracks)
             return []
         }
     }
@@ -2063,7 +2075,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Playlist tracks failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistTracks)
         }
     }
 
@@ -2303,7 +2315,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2353,7 +2365,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2520,7 +2532,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2562,7 +2574,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Search failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .search)
         }
     }
 
@@ -2684,7 +2696,7 @@ final class AppModel {
             errorMessage = nil
         } catch {
             if handleAuthError(error) { return }
-            errorMessage = "Couldn't start playback: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playback)
         }
     }
 
@@ -2787,7 +2799,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Favorite failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .favorite)
         }
     }
 
@@ -2835,7 +2847,7 @@ final class AppModel {
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
             }
-            errorMessage = "Add to playlist failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playlistAdd)
             return false
         }
     }
@@ -3758,7 +3770,7 @@ final class AppModel {
             try audio.play(track: track)
         } catch {
             if handleAuthError(error) { return }
-            errorMessage = "Playback failed: \(error.localizedDescription)"
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .playback)
         }
     }
 

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -878,26 +878,24 @@ final class AppModel {
         authExpired = true
     }
 
-    /// Inspect an error from a core call and, if it looks like a 401 or the
-    /// core's `NotAuthenticated` variant, mark the session expired and return
-    /// `true` so the caller knows to skip its generic error surfacing.
+    /// Inspect an error from a core call and, if it's the core's
+    /// `NotAuthenticated` / `Auth` variant (both meaning the token's dead
+    /// or never existed), mark the session expired and return `true` so the
+    /// caller knows to skip its generic error surfacing.
     ///
-    /// `JellifyError` is a `flat_error` in uniffi, so on the Swift side we
-    /// only get the `thiserror` Display string. The variants we care about
-    /// are:
-    /// - `NotAuthenticated` → `"not logged in"`
-    /// - `AuthExpired` → `"authentication expired — please sign in again"`
-    /// - `Auth(...)` → `"authentication failed: ..."`
-    /// - `Server { status: 401, .. }` → `"server returned an error: 401 ..."`
+    /// Post-BATCH-24 the Rust `JellifyError` is a typed enum split by HTTP
+    /// class — 401 responses surface as `Auth`, the retry-layer fallback is
+    /// `AuthExpired`, and a missing token is `NotAuthenticated` — so we can
+    /// match variants directly instead of parsing the Display message.
     private func handleAuthError(_ error: Error) -> Bool {
-        let description = error.localizedDescription
-        let isNotAuthenticated = description.contains("not logged in")
-        let isAuthExpired = description.contains("authentication expired")
-        let isAuthFailed = description.contains("authentication failed")
-        let isServer401 = description.contains("server returned an error: 401")
-        guard isNotAuthenticated || isAuthExpired || isAuthFailed || isServer401 else { return false }
-        markAuthExpired()
-        return true
+        guard let err = error as? JellifyError else { return false }
+        switch err {
+        case .NotAuthenticated, .Auth, .AuthExpired:
+            markAuthExpired()
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: - Library
@@ -1675,6 +1673,10 @@ final class AppModel {
                let primary = tags["Primary"], !primary.isEmpty { return primary }
             return nil
         }()
+        // `user_data` landed on `Album` in BATCH-24 — clients that build
+        // Albums from a local `BaseItemDto` can pass `nil` to reproduce the
+        // old behaviour; callers that have a richer `UserData` projection
+        // should populate the struct directly.
         return Album(
             id: id,
             name: name,
@@ -1684,7 +1686,8 @@ final class AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             genres: genres,
-            imageTag: imageTag
+            imageTag: imageTag,
+            userData: nil
         )
     }
 
@@ -1755,6 +1758,8 @@ final class AppModel {
                let primary = tags["Primary"], !primary.isEmpty { return primary }
             return nil
         }()
+        // `user_data` landed on `Track` in BATCH-24 — see `albumFromDTO`
+        // above for the same pattern.
         return Track(
             id: id,
             name: name,
@@ -1771,7 +1776,8 @@ final class AppModel {
             container: container,
             bitrate: bitrate,
             imageTag: imageTag,
-            playlistItemId: nil
+            playlistItemId: nil,
+            userData: nil
         )
     }
 
@@ -1814,7 +1820,8 @@ final class AppModel {
                 albumCount: 0,
                 songCount: 0,
                 genres: detail.genres,
-                imageTag: detail.imageTag
+                imageTag: detail.imageTag,
+                userData: nil
             )
         } catch {
             _ = handleAuthError(error)
@@ -1875,7 +1882,8 @@ final class AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             genres: genres,
-            imageTag: imageTag
+            imageTag: imageTag,
+            userData: nil
         )
     }
 

--- a/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
+++ b/macos/Sources/Jellify/Components/AuthExpiredSheet.swift
@@ -19,11 +19,11 @@ struct AuthExpiredSheet: View {
                 .padding(.top, 8)
 
             VStack(spacing: 8) {
-                Text("Your session expired")
+                Text("auth.session.expired.title")
                     .font(Theme.font(18, weight: .bold))
                     .foregroundStyle(Theme.ink)
 
-                Text("Please sign in again to continue listening.")
+                Text("auth.session.expired.body")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .multilineTextAlignment(.center)
@@ -31,7 +31,7 @@ struct AuthExpiredSheet: View {
             }
 
             Button(action: onSignIn) {
-                Text("Sign in")
+                Text("auth.sign_in")
                     .font(Theme.font(14, weight: .bold))
                     .frame(width: 260, height: 40)
                     .foregroundStyle(Theme.bg)
@@ -40,7 +40,7 @@ struct AuthExpiredSheet: View {
             }
             .buttonStyle(.plain)
             .keyboardShortcut(.defaultAction)
-            .accessibilityLabel("Sign in again")
+            .accessibilityLabel("auth.sign_in.again.a11y")
         }
         .padding(32)
         .frame(width: 360)

--- a/macos/Sources/Jellify/Components/EmptyLibraryState.swift
+++ b/macos/Sources/Jellify/Components/EmptyLibraryState.swift
@@ -11,10 +11,11 @@ import AppKit
 struct EmptyLibraryState: View {
     let serverUrl: URL?
 
-    private let headline = "No music yet"
-    private let subtitle =
-        "Your Jellyfin server doesn't have any music in its library, " +
-        "or it's still being indexed. Add a library on the server, then refresh."
+    /// Resolved copy for the a11y-combine label. We pull the catalog values
+    /// once here so the composite `Text` uses the same phrasing the rest of
+    /// the view renders.
+    private var headline: String { String(localized: "empty.library.title", bundle: .main) }
+    private var subtitle: String { String(localized: "empty.library.subtitle", bundle: .main) }
 
     var body: some View {
         VStack(spacing: 18) {
@@ -27,10 +28,10 @@ struct EmptyLibraryState: View {
                 .accessibilityHidden(true)
 
             VStack(spacing: 6) {
-                Text(headline)
+                Text("empty.library.title")
                     .font(Theme.font(22, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
-                Text(subtitle)
+                Text("empty.library.subtitle")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink2)
                     .multilineTextAlignment(.center)
@@ -43,7 +44,7 @@ struct EmptyLibraryState: View {
                     NSWorkspace.shared.open(serverUrl)
                 } label: {
                     HStack(spacing: 8) {
-                        Text("Open Jellyfin web")
+                        Text("empty.library.open_web")
                             .font(Theme.font(13, weight: .bold))
                         Image(systemName: "arrow.up.right.square")
                             .font(.system(size: 12, weight: .bold))
@@ -61,7 +62,7 @@ struct EmptyLibraryState: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Open Jellyfin web")
+                .accessibilityLabel("empty.library.open_web")
             }
         }
         .padding(.vertical, 56)

--- a/macos/Sources/Jellify/Components/EmptyQueueState.swift
+++ b/macos/Sources/Jellify/Components/EmptyQueueState.swift
@@ -9,8 +9,18 @@ import SwiftUI
 struct EmptyQueueState: View {
     /// SF Symbol rendered above the headline.
     var systemImage: String = "text.line.first.and.arrowtriangle.forward"
-    var title: String = "Queue is empty"
-    var subtitle: String = "Play something to start a queue."
+    /// Optional overrides — when `nil`, the catalog-backed defaults load from
+    /// `Localizable.xcstrings`. Passing explicit copy is still supported for
+    /// places that want a surface-specific phrasing.
+    var title: String? = nil
+    var subtitle: String? = nil
+
+    private var resolvedTitle: String {
+        title ?? String(localized: "empty.queue.title", bundle: .main)
+    }
+    private var resolvedSubtitle: String {
+        subtitle ?? String(localized: "empty.queue.subtitle", bundle: .main)
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -20,12 +30,12 @@ struct EmptyQueueState: View {
                 .accessibilityHidden(true)
 
             VStack(spacing: 4) {
-                Text(title)
+                Text(resolvedTitle)
                     .font(Theme.font(18, weight: .bold))
                     .foregroundStyle(Theme.ink2)
                     .multilineTextAlignment(.center)
 
-                Text(subtitle)
+                Text(resolvedSubtitle)
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .multilineTextAlignment(.center)
@@ -35,7 +45,7 @@ struct EmptyQueueState: View {
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(title). \(subtitle)")
+        .accessibilityLabel("\(resolvedTitle). \(resolvedSubtitle)")
         .accessibilityAddTraits(.isStaticText)
     }
 }

--- a/macos/Sources/Jellify/Components/OfflineBanner.swift
+++ b/macos/Sources/Jellify/Components/OfflineBanner.swift
@@ -26,11 +26,16 @@ struct OfflineBanner: View {
         self.onRetry = onRetry
     }
 
+    /// Resolved copy for the banner. The named-server variant interpolates
+    /// the user-supplied host verbatim — it's user data, not a translatable
+    /// phrase, so only the surrounding scaffolding comes from the catalog.
+    /// The generic fallback goes through `Localizable.xcstrings` via the
+    /// `offline.generic` key.
     private var message: String {
         if let host, !host.isEmpty {
             return "Can't reach \(host). Trying again\u{2026}"
         }
-        return "You're offline. Playing from downloaded tracks only."
+        return String(localized: "offline.generic", bundle: .main)
     }
 
     var body: some View {
@@ -49,7 +54,7 @@ struct OfflineBanner: View {
             Spacer(minLength: 12)
 
             Button(action: onRetry) {
-                Text("Retry")
+                Text("common.retry")
                     .font(Theme.font(12, weight: .bold))
                     .foregroundStyle(Theme.ink)
                     .padding(.horizontal, 12)
@@ -64,7 +69,7 @@ struct OfflineBanner: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Retry network connection")
+            .accessibilityLabel("offline.retry.a11y")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -91,7 +91,7 @@ struct PlayerBar: View {
             .accessibilityLabel("Now Playing: \(track.name) by \(track.artistName)")
             .accessibilityHint("Shows track details")
         } else {
-            Text("Nothing playing")
+            Text("player.nothing_playing")
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -25,12 +25,14 @@ struct Sidebar: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(LinearGradient(colors: [Theme.teal, Theme.primary], startPoint: .topLeading, endPoint: .bottomTrailing))
                     .frame(width: 30, height: 30)
-                    .overlay(Text("🪼").font(.system(size: 16)))
+                    // Emoji rendered verbatim — a jellyfish is a jellyfish in
+                    // every locale; no catalog entry needed.
+                    .overlay(Text(verbatim: "🪼").font(.system(size: 16)))
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("Jellify")
+                    Text("app.name")
                         .font(Theme.font(15, weight: .black, italic: true))
                         .foregroundStyle(Theme.ink)
-                    Text("DESKTOP")
+                    Text("app.subtitle.desktop")
                         .font(Theme.font(9, weight: .bold))
                         .foregroundStyle(Theme.ink3)
                         .tracking(1.5)
@@ -43,24 +45,24 @@ struct Sidebar: View {
 
             // Primary nav
             VStack(alignment: .leading, spacing: 2) {
-                navItem("house", label: "Home", screen: .home)
-                navItem("music.note.list", label: "Library", screen: .library)
-                navItem("magnifyingglass", label: "Search", screen: .search)
+                navItem("house", label: "sidebar.nav.home", screen: .home)
+                navItem("music.note.list", label: "sidebar.nav.library", screen: .library)
+                navItem("magnifyingglass", label: "sidebar.nav.search", screen: .search)
             }
             .padding(.horizontal, 10)
 
             // Stats header. Keep the aggregate "Albums / Artists / Playlists"
             // summary rows above the playlist list so the count glance stays
             // in place; the playlist list lives as its own section below.
-            sectionHeader("Your Library")
+            sectionHeader("sidebar.section.your_library")
             VStack(alignment: .leading, spacing: 2) {
                 // "Favorites" has no dedicated surface yet — route to the
                 // library's default tab for now so the row isn't a dead
                 // click (follow-up: dedicated favorites tab, #133).
-                libRow("heart", label: "Favorites", count: nil, tab: .albums)
-                libRow("square.stack", label: "Albums", count: UInt32(model.albums.count), tab: .albums)
-                libRow("person.crop.circle", label: "Artists", count: UInt32(model.artists.count), tab: .artists)
-                libRow("music.note.list", label: "Playlists", count: UInt32(model.playlists.count), tab: .playlists)
+                libRow("heart", label: "sidebar.stats.favorites", count: nil, tab: .albums)
+                libRow("square.stack", label: "sidebar.stats.albums", count: UInt32(model.albums.count), tab: .albums)
+                libRow("person.crop.circle", label: "sidebar.stats.artists", count: UInt32(model.artists.count), tab: .artists)
+                libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count), tab: .playlists)
             }
             .padding(.horizontal, 10)
 
@@ -253,7 +255,7 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func navItem(_ icon: String, label: String, screen: AppModel.Screen) -> some View {
+    private func navItem(_ icon: String, label: LocalizedStringKey, screen: AppModel.Screen) -> some View {
         let active = model.screen == screen
         Button { model.screen = screen } label: {
             HStack(spacing: 10) {
@@ -292,7 +294,12 @@ struct Sidebar: View {
     }
 
     @ViewBuilder
-    private func libRow(_ icon: String, label: String, count: UInt32?, tab: LibraryTab) -> some View {
+    private func libRow(
+        _ icon: String,
+        label: LocalizedStringKey,
+        count: UInt32?,
+        tab: LibraryTab
+    ) -> some View {
         Button {
             // Set the requested library tab before flipping the screen so the
             // Library view reads the right chip on its first render. See
@@ -323,13 +330,18 @@ struct Sidebar: View {
         // Combine icon + label + count into one VoiceOver utterance so the
         // row reads as "Albums, 42" rather than three separate fragments.
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(count.map { "\(label), \($0)" } ?? label)
+        .accessibilityLabel(label)
         .accessibilityAddTraits(.isButton)
     }
 
     @ViewBuilder
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
+    private func sectionHeader(_ title: LocalizedStringKey) -> some View {
+        // The header reads as uppercase in the rendered frame via the heavy
+        // tracking + smallcap feel; we no longer force `.uppercased()` here
+        // because doing so would mangle non-Latin scripts (Arabic, CJK)
+        // that have no case distinction. The catalog entries already ship
+        // the English label in uppercase.
+        Text(title)
             .font(Theme.font(10, weight: .bold))
             .foregroundStyle(Theme.ink3)
             .tracking(1.5)

--- a/macos/Sources/Jellify/Components/StreamErrorToast.swift
+++ b/macos/Sources/Jellify/Components/StreamErrorToast.swift
@@ -62,7 +62,7 @@ struct StreamErrorToast: View {
             Spacer(minLength: 12)
 
             Button(action: onRetry) {
-                Text("Retry")
+                Text("common.retry")
                     .font(Theme.font(12, weight: .bold))
                     .foregroundStyle(Theme.ink)
                     .padding(.horizontal, 12)
@@ -77,17 +77,17 @@ struct StreamErrorToast: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Retry playing \(trackName)")
+            .accessibilityLabel("stream.error.retry.a11y")
 
             Button(action: onGoToTrack) {
-                Text("Go to track")
+                Text("stream.error.go_to_track")
                     .font(Theme.font(12, weight: .semibold))
                     .foregroundStyle(Theme.ink2)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Go to \(trackName)")
+            .accessibilityLabel(Text("stream.error.go_to_track"))
 
             if let onDismiss {
                 Button(action: onDismiss) {
@@ -97,7 +97,7 @@ struct StreamErrorToast: View {
                         .frame(width: 20, height: 20)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss")
+                .accessibilityLabel("common.dismiss.a11y")
             }
         }
         .padding(.horizontal, 16)

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -116,7 +116,7 @@ struct JellifyCommands: Commands {
         // `AppModel.beginNewPlaylist`, which flips the sidebar into edit
         // mode on a fresh placeholder row. See BATCH-06b / #71.
         CommandGroup(replacing: .newItem) {
-            Button("New Playlist") {
+            Button("menu.file.new_playlist") {
                 model.screen = .library
                 model.beginNewPlaylist()
             }
@@ -133,7 +133,7 @@ struct JellifyCommands: Commands {
         CommandGroup(after: .sidebar) {
             Divider()
 
-            Button("Show Sidebar") {
+            Button("menu.view.show_sidebar") {
                 // TODO(#5): bind to a published `isSidebarVisible` flag on
                 // AppModel and have `MainShell` conditionally mount `Sidebar()`.
                 // The menu item is reserved now so the shortcut exists.
@@ -141,7 +141,7 @@ struct JellifyCommands: Commands {
             .keyboardShortcut("s", modifiers: [.command, .option])
             .disabled(true)
 
-            Button("Show Queue Inspector") {
+            Button("menu.view.show_queue") {
                 // TODO(#272): the queue drawer lands with BATCH-07's rich
                 // inspector. Menu item reserved so ⌘⌥Q resolves to something
                 // discoverable once the panel exists.
@@ -157,19 +157,19 @@ struct JellifyCommands: Commands {
             // Home, Library, Search. `model.screen` is the source of truth
             // and re-assigning it triggers the same `MainShell` animation
             // as clicking the sidebar.
-            Button("Home") {
+            Button("menu.nav.home") {
                 model.screen = .home
             }
             .keyboardShortcut("1", modifiers: .command)
             .disabled(model.session == nil)
 
-            Button("Library") {
+            Button("menu.nav.library") {
                 model.screen = .library
             }
             .keyboardShortcut("2", modifiers: .command)
             .disabled(model.session == nil)
 
-            Button("Search") {
+            Button("menu.nav.search") {
                 model.screen = .search
             }
             .keyboardShortcut("3", modifiers: .command)
@@ -181,7 +181,7 @@ struct JellifyCommands: Commands {
             // `requestSearchFocus` one-shot and the new `isSearchFieldFocused`
             // mirror so any field binding a `@FocusState` to either will
             // receive focus. See #7 / #104.
-            Button("Find…") {
+            Button("menu.nav.find") {
                 model.focusSearch()
             }
             .keyboardShortcut("f", modifiers: .command)
@@ -190,7 +190,7 @@ struct JellifyCommands: Commands {
             // ⌘L jumps to the full Now Playing view and toggles back to the
             // previous screen when pressed again (matches Music.app feel).
             // See #89 / #6 and the Playback menu's mirror shortcut.
-            Button("Go to Now Playing") {
+            Button("menu.nav.now_playing") {
                 toggleNowPlaying()
             }
             .keyboardShortcut("l", modifiers: .command)
@@ -200,7 +200,7 @@ struct JellifyCommands: Commands {
             // search + static action verbs. Toggling the flag here and
             // letting `RootView` mount the overlay keeps the palette
             // independent of whichever screen is currently focused.
-            Button("Command Palette\u{2026}") {
+            Button("menu.nav.command_palette") {
                 model.isCommandPaletteOpen.toggle()
             }
             .keyboardShortcut("k", modifiers: .command)
@@ -213,8 +213,8 @@ struct JellifyCommands: Commands {
         // whole app is usable from the home row. Media keys (F7/F8/F9) and
         // Bluetooth AVRCP events hit the same `AppModel` methods via
         // `MediaSession` — see file header for why they aren't re-registered.
-        CommandMenu("Playback") {
-            Button(playPauseLabel) {
+        CommandMenu("menu.playback") {
+            Button(playPauseLabelKey) {
                 model.togglePlayPause()
             }
             .keyboardShortcut(.space, modifiers: [])
@@ -222,13 +222,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Next Track") {
+            Button("menu.playback.next") {
                 model.skipNext()
             }
             .keyboardShortcut(.rightArrow, modifiers: .command)
             .disabled(model.status.currentTrack == nil)
 
-            Button("Previous Track") {
+            Button("menu.playback.previous") {
                 model.skipPrevious()
             }
             .keyboardShortcut(.leftArrow, modifiers: .command)
@@ -236,13 +236,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Volume Up") {
+            Button("menu.playback.volume_up") {
                 let next = min(1.0, model.status.volume + 0.05)
                 model.setVolume(next)
             }
             .keyboardShortcut(.upArrow, modifiers: .command)
 
-            Button("Volume Down") {
+            Button("menu.playback.volume_down") {
                 let next = max(0.0, model.status.volume - 0.05)
                 model.setVolume(next)
             }
@@ -250,13 +250,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Seek Forward 10s") {
+            Button("menu.playback.seek_forward") {
                 model.seek(by: 10)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.command, .shift])
             .disabled(model.status.currentTrack == nil)
 
-            Button("Seek Back 10s") {
+            Button("menu.playback.seek_back") {
                 model.seek(by: -10)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.command, .shift])
@@ -264,13 +264,13 @@ struct JellifyCommands: Commands {
 
             Divider()
 
-            Button("Stop") {
+            Button("menu.playback.stop") {
                 model.stop()
             }
             .keyboardShortcut(".", modifiers: .command)
             .disabled(model.status.currentTrack == nil)
 
-            Button("Go to Now Playing") {
+            Button("menu.nav.now_playing") {
                 toggleNowPlaying()
             }
             .keyboardShortcut("l", modifiers: .command)
@@ -284,13 +284,13 @@ struct JellifyCommands: Commands {
         // an explicit Tile Window action so the command is discoverable
         // even when the system hasn't surfaced the OS-level tiling item.
         CommandGroup(after: .windowArrangement) {
-            Button("Tile Window to Left of Screen") {
+            Button("menu.window.tile_left") {
                 tileCurrentWindow(edge: .left)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.control, .option, .command])
             .disabled(NSApp.keyWindow == nil)
 
-            Button("Tile Window to Right of Screen") {
+            Button("menu.window.tile_right") {
                 tileCurrentWindow(edge: .right)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.control, .option, .command])
@@ -303,7 +303,7 @@ struct JellifyCommands: Commands {
         // We redirect it to the repo's issue tracker so the menu item
         // actually leads somewhere useful.
         CommandGroup(replacing: .help) {
-            Button("Jellify Help") {
+            Button("menu.help.jellify") {
                 if let url = URL(string: "https://github.com/skalthoff/jellify-desktop") {
                     NSWorkspace.shared.open(url)
                 }
@@ -320,8 +320,11 @@ struct JellifyCommands: Commands {
         // behavior (e.g. AppKit's responder-chain text editing actions).
     }
 
-    private var playPauseLabel: String {
-        model.status.state == .playing ? "Pause" : "Play"
+    /// Catalog key for the Play / Pause toggle in the Playback menu. Returned
+    /// as `LocalizedStringKey` so SwiftUI looks up the translation from
+    /// `Localizable.xcstrings` rather than rendering the literal key.
+    private var playPauseLabelKey: LocalizedStringKey {
+        model.status.state == .playing ? "menu.playback.pause" : "menu.playback.play"
     }
 
     /// Toggle behaviour for the "Go to Now Playing" menu item: first press
@@ -427,7 +430,7 @@ private struct RestoreLoadingView: View {
         ZStack {
             Theme.bg.ignoresSafeArea()
             VStack(spacing: 16) {
-                Text("Jellify")
+                Text("app.name")
                     .font(Theme.font(40, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
                 ProgressView()

--- a/macos/Sources/Jellify/JellifyErrorPresenter.swift
+++ b/macos/Sources/Jellify/JellifyErrorPresenter.swift
@@ -1,0 +1,149 @@
+import Foundation
+import SwiftUI
+
+/// Maps a `JellifyError` surfaced by the core (via UniFFI) into a
+/// presentation-quality localized message.
+///
+/// Issue #351. The core declares `JellifyError` as a UniFFI `flat_error`, so on
+/// the Swift side we only receive the rendered `thiserror` Display string —
+/// there is no Swift enum with associated values to pattern-match on. The
+/// presenter therefore works by substring-matching the Display text against the
+/// known variant prefixes. The mapping is intentionally conservative: anything
+/// we can't place with confidence falls through to `error.other`, which reads
+/// as "Something went wrong." rather than leaking low-level jargon.
+///
+/// ### Why a dedicated presenter?
+///
+/// Prior to this module, error call-sites stuffed `"<prefix>: \(error.localizedDescription)"`
+/// into `AppModel.errorMessage`, which meant the banner string carried
+/// technical detail (`"network error: error sending request"`, etc.) and was
+/// impossible to localize — the Display string is hardcoded English from the
+/// Rust side. The presenter funnels every surfacing path through a single
+/// `String(localized:)` lookup so translators see a small, stable key set in
+/// `Localizable.xcstrings`.
+///
+/// ### Usage
+///
+/// ```swift
+/// do { try core.listAlbums(...) } catch {
+///     if handleAuthError(error) { return }
+///     errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
+/// }
+/// ```
+///
+/// `context` is an optional hint used to pick a more specific banner when the
+/// error itself is generic (e.g. a search failure vs. a library load failure,
+/// both of which might be `JellifyError::Server`). When the mapped variant
+/// already carries enough context (Auth, NotFound, RateLimit) the `context`
+/// parameter is ignored.
+enum JellifyErrorPresenter {
+    /// Surfaces the user-facing banner copy for `error`, honouring the
+    /// provided `context` for generic failures. Always returns a non-empty
+    /// string — the default is `error.other` → "Something went wrong."
+    static func message(for error: Error, context: Context = .generic) -> String {
+        let key = key(for: error, context: context)
+        // `String(localized:)` wants `String.LocalizationValue`, whose `init(_:)`
+        // treats the argument as the catalog key. Wrapping explicitly keeps
+        // the compiler from misreading the String as an already-rendered
+        // value.
+        return String(localized: String.LocalizationValue(key), bundle: .main)
+    }
+
+    /// Returns the stable semantic key we'd surface for `error`. Exposed so
+    /// callers that want a `Text(LocalizedStringKey(...))` binding can skip the
+    /// bundle-lookup round-trip and still share the mapping.
+    static func key(for error: Error, context: Context = .generic) -> String {
+        let description = error.localizedDescription.lowercased()
+
+        // Auth family has the highest priority — a 401 dressed as
+        // `JellifyError::Server` still means "credentials are bad", and
+        // treating it as a transport error would leak a stale token into
+        // the UI. `handleAuthError` on `AppModel` already intercepts most
+        // of these; this branch covers the fall-through cases (e.g. an
+        // error bubbled from an async task that bypassed the helper).
+        if description.contains("not logged in")
+            || description.contains("authentication expired")
+            || description.contains("authentication failed")
+            || description.contains("401")
+        {
+            return "error.auth.expired"
+        }
+
+        // `JellifyError::Server` renders as "server returned an error:
+        // {status} {message}". Pattern-match the status digits embedded
+        // in the Display so 403/404/429 get specialised banners even
+        // though the Rust side lumps them under one variant.
+        if description.contains("server returned an error:") {
+            if description.contains(" 403") || description.contains("forbidden") {
+                return "error.forbidden"
+            }
+            if description.contains(" 404") || description.contains("not found") {
+                return "error.not_found"
+            }
+            if description.contains(" 429") || description.contains("rate limit") {
+                return "error.rate_limit"
+            }
+            // Any other status (500s, gateway errors, etc.) — prefer the
+            // caller's context banner if it was supplied; otherwise the
+            // generic "server ran into a problem" fallback.
+            return context.fallbackKey ?? "error.server"
+        }
+
+        // Non-server variants, keyed off the `thiserror` Display prefix
+        // declared in `core/src/error.rs`. Order mirrors the enum to keep
+        // this readable.
+        if description.contains("network error") {
+            return "error.network"
+        }
+        if description.contains("decode error") {
+            return "error.decode"
+        }
+        if description.contains("storage error") {
+            return "error.storage"
+        }
+        if description.contains("credential store") {
+            return "error.credentials"
+        }
+        if description.contains("audio error") {
+            return "error.audio"
+        }
+        if description.contains("invalid input") {
+            return "error.invalid_input"
+        }
+
+        return context.fallbackKey ?? "error.other"
+    }
+
+    /// Hint the call-site can pass so generic failures get a more specific
+    /// banner. Each case maps to a key in `Localizable.xcstrings`. `generic`
+    /// is the catch-all and flows to `error.other` / `error.server`.
+    enum Context {
+        case generic
+        case login
+        case libraryLoad
+        case playlistsLoad
+        case playlistLoad
+        case albumTracks
+        case playlistTracks
+        case search
+        case playback
+        case favorite
+        case playlistAdd
+
+        fileprivate var fallbackKey: String? {
+            switch self {
+            case .generic: return nil
+            case .login: return "error.login.failed"
+            case .libraryLoad: return "error.library.load"
+            case .playlistsLoad: return "error.playlists.load"
+            case .playlistLoad: return "error.playlist.load"
+            case .albumTracks: return "error.album.tracks"
+            case .playlistTracks: return "error.playlist.tracks"
+            case .search: return "error.search"
+            case .playback: return "error.playback"
+            case .favorite: return "error.favorite"
+            case .playlistAdd: return "error.playlist.add"
+            }
+        }
+    }
+}

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -1,0 +1,1086 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "app.name" : {
+      "comment" : "Brand name shown in the sidebar header and splash screens.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jellify"
+          }
+        }
+      }
+    },
+    "app.subtitle.desktop" : {
+      "comment" : "Small tracking-uppercase label shown below the wordmark on brand lockups.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DESKTOP"
+          }
+        }
+      }
+    },
+    "auth.session.expired.title" : {
+      "comment" : "Modal sheet title when the server rejects a stored access token (HTTP 401).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session expired"
+          }
+        }
+      }
+    },
+    "auth.session.expired.body" : {
+      "comment" : "Modal sheet body message explaining the user needs to re-authenticate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please sign in again to continue listening."
+          }
+        }
+      }
+    },
+    "auth.sign_in" : {
+      "comment" : "Primary sign-in button on LoginView and the auth-expired sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in"
+          }
+        }
+      }
+    },
+    "auth.sign_in.again.a11y" : {
+      "comment" : "Accessibility label for the sign-in button on the auth-expired sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in again"
+          }
+        }
+      }
+    },
+    "auth.signing_in" : {
+      "comment" : "Button label shown while a sign-in request is in flight.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signing in\u2026"
+          }
+        }
+      }
+    },
+    "breadcrumb.album.fallback" : {
+      "comment" : "Breadcrumb segment when the current album hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
+          }
+        }
+      }
+    },
+    "breadcrumb.artist.fallback" : {
+      "comment" : "Breadcrumb segment when the current artist hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artist"
+          }
+        }
+      }
+    },
+    "breadcrumb.playlist.fallback" : {
+      "comment" : "Breadcrumb segment when the current playlist hasn't resolved its name yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playlist"
+          }
+        }
+      }
+    },
+    "common.cancel" : {
+      "comment" : "Generic Cancel action label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "common.delete" : {
+      "comment" : "Generic Delete action label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "common.dismiss.a11y" : {
+      "comment" : "Accessibility label for a close/dismiss button on toasts and banners.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
+          }
+        }
+      }
+    },
+    "common.retry" : {
+      "comment" : "Retry action label — shared between offline and stream-error toasts/banners.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        }
+      }
+    },
+    "empty.library.title" : {
+      "comment" : "Headline on the empty-library state shown when the server has no music yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No music yet"
+          }
+        }
+      }
+    },
+    "empty.library.subtitle" : {
+      "comment" : "Body copy on the empty-library state explaining that the server is empty or still indexing.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Jellyfin server doesn't have any music in its library, or it's still being indexed. Add a library on the server, then refresh."
+          }
+        }
+      }
+    },
+    "empty.library.open_web" : {
+      "comment" : "CTA on the empty-library state that opens the Jellyfin web admin UI.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Jellyfin web"
+          }
+        }
+      }
+    },
+    "empty.queue.title" : {
+      "comment" : "Empty state title inside the queue inspector panel.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queue is empty"
+          }
+        }
+      }
+    },
+    "empty.queue.subtitle" : {
+      "comment" : "Empty state subtitle inside the queue inspector panel.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play something to start a queue."
+          }
+        }
+      }
+    },
+    "error.auth.expired" : {
+      "comment" : "Banner copy for JellifyError.AuthExpired / Auth — surfaced by JellifyErrorPresenter.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please sign in again."
+          }
+        }
+      }
+    },
+    "error.forbidden" : {
+      "comment" : "Banner copy when a core call returns HTTP 403.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You don't have permission to do that."
+          }
+        }
+      }
+    },
+    "error.not_found" : {
+      "comment" : "Banner copy when a core call returns HTTP 404.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That item couldn't be found."
+          }
+        }
+      }
+    },
+    "error.rate_limit" : {
+      "comment" : "Banner copy when the server throttles us (HTTP 429).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Too many requests. Please try again in a moment."
+          }
+        }
+      }
+    },
+    "error.network" : {
+      "comment" : "Banner copy for transport-level failures (JellifyError.Network).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network error. Check your connection and try again."
+          }
+        }
+      }
+    },
+    "error.server" : {
+      "comment" : "Banner copy for HTTP 5xx responses (JellifyError.Server non-auth).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server ran into a problem. Please try again."
+          }
+        }
+      }
+    },
+    "error.decode" : {
+      "comment" : "Banner copy for JellifyError.Decode — the server response couldn't be parsed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't read the server's response."
+          }
+        }
+      }
+    },
+    "error.storage" : {
+      "comment" : "Banner copy for JellifyError.Storage — local SQLite or cache failure.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local storage error. Please try again."
+          }
+        }
+      }
+    },
+    "error.credentials" : {
+      "comment" : "Banner copy for JellifyError.Credentials — keychain access failed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't access the system keychain."
+          }
+        }
+      }
+    },
+    "error.audio" : {
+      "comment" : "Banner copy for JellifyError.Audio — the audio engine failed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio playback error."
+          }
+        }
+      }
+    },
+    "error.invalid_input" : {
+      "comment" : "Banner copy for JellifyError.InvalidInput — user-supplied value was rejected.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That value isn't valid."
+          }
+        }
+      }
+    },
+    "error.other" : {
+      "comment" : "Banner copy for JellifyError.Other — catch-all fallback.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong."
+          }
+        }
+      }
+    },
+    "error.playback" : {
+      "comment" : "Banner copy when the audio engine fails to start a track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't start playback."
+          }
+        }
+      }
+    },
+    "error.library.load" : {
+      "comment" : "Banner prefix when the library refresh pipeline fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load your library."
+          }
+        }
+      }
+    },
+    "error.playlists.load" : {
+      "comment" : "Banner copy when refreshing playlists fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load playlists."
+          }
+        }
+      }
+    },
+    "error.playlist.load" : {
+      "comment" : "Banner copy when loading a single playlist fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load this playlist."
+          }
+        }
+      }
+    },
+    "error.album.tracks" : {
+      "comment" : "Banner copy when loading album tracks fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load album tracks."
+          }
+        }
+      }
+    },
+    "error.playlist.tracks" : {
+      "comment" : "Banner copy when loading playlist tracks fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load playlist tracks."
+          }
+        }
+      }
+    },
+    "error.search" : {
+      "comment" : "Banner copy when a search query fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search failed."
+          }
+        }
+      }
+    },
+    "error.favorite" : {
+      "comment" : "Banner copy when toggling a favorite fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't update favorite."
+          }
+        }
+      }
+    },
+    "error.playlist.add" : {
+      "comment" : "Banner copy when adding a track to a playlist fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't add to playlist."
+          }
+        }
+      }
+    },
+    "error.login.failed" : {
+      "comment" : "Banner copy when login fails for a generic reason.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in failed."
+          }
+        }
+      }
+    },
+    "error.wrong_credentials" : {
+      "comment" : "Inline error on LoginView when the server returns 401 on submit.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wrong username or password"
+          }
+        }
+      }
+    },
+    "login.placeholder.not_wired" : {
+      "comment" : "Placeholder banner when a menu action hasn't been wired to the core yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creating playlists isn't wired yet \u2014 see #131."
+          }
+        }
+      }
+    },
+    "login.network_banner" : {
+      "comment" : "Top-of-column banner on LoginView when the system is offline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No network. Check your connection."
+          }
+        }
+      }
+    },
+    "login.probe.checking" : {
+      "comment" : "Status row under the server URL field while probing.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking\u2026"
+          }
+        }
+      }
+    },
+    "login.field.url" : {
+      "comment" : "Uppercase field label above the server URL input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SERVER URL"
+          }
+        }
+      }
+    },
+    "login.field.username" : {
+      "comment" : "Uppercase field label above the username input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USERNAME"
+          }
+        }
+      }
+    },
+    "login.field.password" : {
+      "comment" : "Uppercase field label above the password input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PASSWORD"
+          }
+        }
+      }
+    },
+    "login.username.placeholder" : {
+      "comment" : "TextField prompt for the username input.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you"
+          }
+        }
+      }
+    },
+    "login.discovered_servers" : {
+      "comment" : "Heading above the LAN-discovered server chip row.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FOUND ON THIS NETWORK"
+          }
+        }
+      }
+    },
+    "login.a11y.server_url" : {
+      "comment" : "Accessibility label for the server URL field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server URL"
+          }
+        }
+      }
+    },
+    "login.a11y.username" : {
+      "comment" : "Accessibility label for the username field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Username"
+          }
+        }
+      }
+    },
+    "login.a11y.password" : {
+      "comment" : "Accessibility label for the password field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        }
+      }
+    },
+    "menu.file.new_playlist" : {
+      "comment" : "File > New > New Playlist\u2026 menu item.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Playlist\u2026"
+          }
+        }
+      }
+    },
+    "menu.view.show_sidebar" : {
+      "comment" : "View menu item to toggle the sidebar visibility (placeholder until #5 lands).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Sidebar"
+          }
+        }
+      }
+    },
+    "menu.view.show_queue" : {
+      "comment" : "View menu item to toggle the queue inspector.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Queue Inspector"
+          }
+        }
+      }
+    },
+    "menu.nav.home" : {
+      "comment" : "View menu navigation entry for the Home screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
+    },
+    "menu.nav.library" : {
+      "comment" : "View menu navigation entry for the Library screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        }
+      }
+    },
+    "menu.nav.search" : {
+      "comment" : "View menu navigation entry for the Search screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        }
+      }
+    },
+    "menu.nav.find" : {
+      "comment" : "View > Find\u2026 menu item (\u2318F).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find\u2026"
+          }
+        }
+      }
+    },
+    "menu.nav.now_playing" : {
+      "comment" : "View menu item: \"Go to Now Playing\" (\u2318L).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to Now Playing"
+          }
+        }
+      }
+    },
+    "menu.nav.command_palette" : {
+      "comment" : "View menu item that opens the \u2318K Command Palette.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Command Palette\u2026"
+          }
+        }
+      }
+    },
+    "menu.playback" : {
+      "comment" : "Top-level Playback menu name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playback"
+          }
+        }
+      }
+    },
+    "menu.playback.play" : {
+      "comment" : "Playback menu item: Play.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play"
+          }
+        }
+      }
+    },
+    "menu.playback.pause" : {
+      "comment" : "Playback menu item: Pause.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        }
+      }
+    },
+    "menu.playback.next" : {
+      "comment" : "Playback menu item: Next Track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next Track"
+          }
+        }
+      }
+    },
+    "menu.playback.previous" : {
+      "comment" : "Playback menu item: Previous Track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Track"
+          }
+        }
+      }
+    },
+    "menu.playback.volume_up" : {
+      "comment" : "Playback menu item: Volume Up.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volume Up"
+          }
+        }
+      }
+    },
+    "menu.playback.volume_down" : {
+      "comment" : "Playback menu item: Volume Down.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volume Down"
+          }
+        }
+      }
+    },
+    "menu.playback.seek_forward" : {
+      "comment" : "Playback menu item: Seek Forward 10s.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seek Forward 10s"
+          }
+        }
+      }
+    },
+    "menu.playback.seek_back" : {
+      "comment" : "Playback menu item: Seek Back 10s.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seek Back 10s"
+          }
+        }
+      }
+    },
+    "menu.playback.stop" : {
+      "comment" : "Playback menu item: Stop.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
+          }
+        }
+      }
+    },
+    "menu.window.tile_left" : {
+      "comment" : "Window menu item: tile current window to left half of screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tile Window to Left of Screen"
+          }
+        }
+      }
+    },
+    "menu.window.tile_right" : {
+      "comment" : "Window menu item: tile current window to right half of screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tile Window to Right of Screen"
+          }
+        }
+      }
+    },
+    "menu.help.jellify" : {
+      "comment" : "Help menu entry that opens the repo in a browser.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jellify Help"
+          }
+        }
+      }
+    },
+    "menu.view.toggle_queue" : {
+      "comment" : "Invisible \u2318\u2325Q button label used to register the Queue Inspector shortcut inside MainShell.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Queue Inspector"
+          }
+        }
+      }
+    },
+    "player.nothing_playing" : {
+      "comment" : "PlayerBar left-meta label when no track is loaded.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing playing"
+          }
+        }
+      }
+    },
+    "sidebar.nav.home" : {
+      "comment" : "Sidebar primary nav item: Home.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
+    },
+    "sidebar.nav.library" : {
+      "comment" : "Sidebar primary nav item: Library.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        }
+      }
+    },
+    "sidebar.nav.search" : {
+      "comment" : "Sidebar primary nav item: Search.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        }
+      }
+    },
+    "sidebar.section.your_library" : {
+      "comment" : "Sidebar section header above the stats rows.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Library"
+          }
+        }
+      }
+    },
+    "sidebar.stats.favorites" : {
+      "comment" : "Sidebar stats row: Favorites.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        }
+      }
+    },
+    "sidebar.stats.albums" : {
+      "comment" : "Sidebar stats row: Albums.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albums"
+          }
+        }
+      }
+    },
+    "sidebar.stats.artists" : {
+      "comment" : "Sidebar stats row: Artists.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artists"
+          }
+        }
+      }
+    },
+    "sidebar.stats.playlists" : {
+      "comment" : "Sidebar stats row: Playlists.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playlists"
+          }
+        }
+      }
+    },
+    "stream.error.retry.a11y" : {
+      "comment" : "Accessibility label on the Retry button inside StreamErrorToast.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry playing the failed track"
+          }
+        }
+      }
+    },
+    "stream.error.go_to_track" : {
+      "comment" : "Secondary CTA on StreamErrorToast that routes to the failed track.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to track"
+          }
+        }
+      }
+    },
+    "offline.retry.a11y" : {
+      "comment" : "Accessibility label on the Retry button inside OfflineBanner.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry network connection"
+          }
+        }
+      }
+    },
+    "offline.generic" : {
+      "comment" : "OfflineBanner message when the system reports no network.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're offline. Playing from downloaded tracks only."
+          }
+        }
+      }
+    },
+    "playlist.delete.message" : {
+      "comment" : "Body of the delete-playlist confirmation dialog.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will permanently delete this playlist. This action cannot be undone."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/macos/Sources/Jellify/Screens/LoginView.swift
+++ b/macos/Sources/Jellify/Screens/LoginView.swift
@@ -145,10 +145,10 @@ struct LoginView: View {
         VStack(spacing: 4) {
             JellyfishMark(size: 72)
                 .padding(.bottom, 4)
-            Text("Jellify")
+            Text("app.name")
                 .font(Theme.font(40, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("DESKTOP")
+            Text("app.subtitle.desktop")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(3)
@@ -158,7 +158,7 @@ struct LoginView: View {
     @ViewBuilder
     private var discoveredServersRow: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("FOUND ON THIS NETWORK")
+            Text("login.discovered_servers")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
@@ -193,11 +193,12 @@ struct LoginView: View {
     @ViewBuilder
     private var urlField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("SERVER URL")
+            Text("login.field.url")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            TextField("https://jellyfin.example.com", text: $url)
+            // URL placeholder is a sample host, not a translatable phrase.
+            TextField(String("https://jellyfin.example.com"), text: $url)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -212,7 +213,7 @@ struct LoginView: View {
                 .focused($focusedField, equals: .url)
                 .submitLabel(.next)
                 .onSubmit { focusedField = .username }
-                .accessibilityLabel("Server URL")
+                .accessibilityLabel("login.a11y.server_url")
         }
     }
 
@@ -228,7 +229,7 @@ struct LoginView: View {
             case .checking:
                 HStack(spacing: 6) {
                     ProgressView().controlSize(.mini)
-                    Text("Checking…")
+                    Text("login.probe.checking")
                         .font(Theme.font(12, weight: .medium))
                         .foregroundStyle(Theme.teal)
                 }
@@ -254,11 +255,11 @@ struct LoginView: View {
     @ViewBuilder
     private var usernameField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("USERNAME")
+            Text("login.field.username")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            TextField("you", text: $username)
+            TextField(LocalizedStringKey("login.username.placeholder"), text: $username)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -273,18 +274,19 @@ struct LoginView: View {
                 .focused($focusedField, equals: .username)
                 .submitLabel(.next)
                 .onSubmit { focusedField = .password }
-                .accessibilityLabel("Username")
+                .accessibilityLabel("login.a11y.username")
         }
     }
 
     @ViewBuilder
     private var passwordField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("PASSWORD")
+            Text("login.field.password")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            SecureField("••••••••", text: $password)
+            // Bullet glyphs are the masked-input affordance; not a phrase.
+            SecureField(String("••••••••"), text: $password)
                 .textFieldStyle(.plain)
                 .font(Theme.font(14, weight: .medium))
                 .foregroundStyle(Theme.ink)
@@ -301,7 +303,7 @@ struct LoginView: View {
                 .onSubmit(submit)
                 .modifier(ShakeEffect(animatableData: CGFloat(shakeAttempts)))
                 .animation(.interpolatingSpring(stiffness: 800, damping: 10), value: shakeAttempts)
-                .accessibilityLabel("Password")
+                .accessibilityLabel("login.a11y.password")
         }
     }
 
@@ -314,7 +316,10 @@ struct LoginView: View {
                         .scaleEffect(0.7)
                         .tint(Theme.ink)
                 }
-                Text(model.isLoggingIn ? "Signing in…" : "Sign in")
+                // Toggle between the two catalog keys rather than the raw
+                // literals so translators never see "Signing in…" in a
+                // ternary — each shows up as its own extractable row.
+                Text(model.isLoggingIn ? LocalizedStringKey("auth.signing_in") : LocalizedStringKey("auth.sign_in"))
                     .font(Theme.font(14, weight: .bold))
             }
             .frame(maxWidth: .infinity)
@@ -328,7 +333,7 @@ struct LoginView: View {
         .disabled(model.isLoggingIn || !canSubmit)
         .opacity(canSubmit ? 1 : 0.5)
         .keyboardShortcut(.defaultAction)
-        .accessibilityLabel("Sign in")
+        .accessibilityLabel("auth.sign_in")
     }
 
     // MARK: - Actions
@@ -336,17 +341,21 @@ struct LoginView: View {
     private func submit() {
         guard canSubmit, !model.isLoggingIn else { return }
         let previousError = model.errorMessage
+        // Snapshot the localized copy that `JellifyErrorPresenter` emits for
+        // auth failures (401 / NotAuthenticated / AuthExpired). When the
+        // model surfaces this exact string we're dealing with a credential
+        // problem at submit-time, so replace it with the friendlier shake +
+        // wrong-credentials copy. See `JellifyErrorPresenter.key(for:)`.
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
         Task {
             await model.login(url: url, username: username, password: password)
-            // `AppModel.login` stuffs `"Login failed: <localized>"` into
-            // `errorMessage` on failure. Treat a 401 specially so we can
-            // shake the password field.
             if let err = model.errorMessage, err != previousError {
-                if err.contains("401") {
+                if err == authExpiredCopy {
                     shakeAttempts += 1
-                    // Overwrite the raw server error with a friendlier copy
-                    // so the row under the fields reads cleanly.
-                    model.errorMessage = "Wrong username or password"
+                    // Overwrite the generic "Please sign in again." with the
+                    // form-specific "Wrong username or password" so the row
+                    // under the fields reads cleanly.
+                    model.errorMessage = String(localized: "error.wrong_credentials", bundle: .main)
                 }
             }
         }
@@ -376,7 +385,10 @@ struct LoginView: View {
     }
 
     private var passwordBorderColor: Color {
-        if let err = model.errorMessage, err == "Wrong username or password" {
+        // Compare against the localized `error.wrong_credentials` copy so the
+        // border-tint heuristic continues to work regardless of language.
+        let wrongCreds = String(localized: "error.wrong_credentials", bundle: .main)
+        if let err = model.errorMessage, err == wrongCreds {
             return Theme.accentHot
         }
         return Theme.border
@@ -444,7 +456,7 @@ struct LoginNetworkBanner: View {
             Image(systemName: "wifi.slash")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Theme.danger)
-            Text("No network. Check your connection.")
+            Text("login.network_banner")
                 .font(Theme.font(12, weight: .semibold))
                 .foregroundStyle(Theme.ink)
             Spacer()

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -45,7 +45,7 @@ struct MainShell: View {
         // (SwiftUI elides hidden buttons from the responder chain), so the
         // button has a 1×1 clear frame that stays non-interactive.
         .background(
-            Button("Toggle Queue Inspector") { model.toggleQueueInspector() }
+            Button("menu.view.toggle_queue") { model.toggleQueueInspector() }
                 .keyboardShortcut("q", modifiers: [.command, .option])
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -73,10 +73,17 @@ struct MainShell: View {
             titleVisibility: .visible,
             presenting: model.playlistPendingDelete
         ) { _ in
-            Button("Delete", role: .destructive) { model.performDeletePending() }
-            Button("Cancel", role: .cancel) { model.cancelDeletePending() }
+            Button("common.delete", role: .destructive) { model.performDeletePending() }
+            Button("common.cancel", role: .cancel) { model.cancelDeletePending() }
         } message: { playlist in
-            Text("This will permanently delete \"\(playlist.name)\". This action cannot be undone.")
+            // Playlist name is user data — interpolate without attempting to
+            // localize it. The surrounding "This will permanently delete … "
+            // scaffolding lives in the catalog under `playlist.delete.message`;
+            // we prepend the name in quotes so the dialog still echoes which
+            // playlist is about to be deleted, then show the localized
+            // explainer on the next line.
+            Text(verbatim: "\u{201C}\(playlist.name)\u{201D}\n")
+                + Text("playlist.delete.message")
         }
     }
 

--- a/macos/Sources/Jellify/Screens/OnboardingView.swift
+++ b/macos/Sources/Jellify/Screens/OnboardingView.swift
@@ -291,10 +291,16 @@ private struct ConnectStep: View {
             && !password.isEmpty
     }
 
+    /// Generic error banner. Since `AppModel.login` now surfaces errors
+    /// through `JellifyErrorPresenter`, any 401 is already translated to
+    /// the shared `error.auth.expired` copy. We still want the onboarding
+    /// flow to replace that specific message with the form-specific
+    /// "Wrong username or password" hint.
     private var visibleError: String? {
         guard let err = model.errorMessage else { return nil }
-        if err.contains("401") {
-            return "Wrong username or password"
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
+        if err == authExpiredCopy {
+            return String(localized: "error.wrong_credentials", bundle: .main)
         }
         return err
     }
@@ -302,11 +308,12 @@ private struct ConnectStep: View {
     private func submit() {
         guard canSubmit, !model.isLoggingIn else { return }
         let previous = model.errorMessage
+        let authExpiredCopy = String(localized: "error.auth.expired", bundle: .main)
         Task {
             await model.login(url: url, username: username, password: password)
-            if let err = model.errorMessage, err != previous, err.contains("401") {
+            if let err = model.errorMessage, err != previous, err == authExpiredCopy {
                 shakeAttempts += 1
-                model.errorMessage = "Wrong username or password"
+                model.errorMessage = String(localized: "error.wrong_credentials", bundle: .main)
             }
         }
     }

--- a/macos/Sources/Jellify/ServerReachability.swift
+++ b/macos/Sources/Jellify/ServerReachability.swift
@@ -73,36 +73,24 @@ final class ServerReachability {
 
     /// Decide whether a thrown error should be treated as a server-reachability
     /// failure. Returns `true` for network-level errors (connection refused,
-    /// timeout) and for HTTP 5xx responses from the server. 4xx responses are
-    /// *not* treated as reachability failures — they signal a client/auth
-    /// problem, not that the endpoint is down.
+    /// timeout), HTTP 5xx responses from the server, and 429 rate-limit
+    /// responses. 401/403/404 responses are *not* treated as reachability
+    /// failures — they signal a client/auth problem, not that the endpoint
+    /// is down.
+    ///
+    /// Post-BATCH-24 the Rust `JellifyError` is a typed enum split by HTTP
+    /// class, so we no longer need to parse the legacy
+    /// `"server returned an error: <status> <body>"` message to recover the
+    /// status code. `Server` now carries only 5xx / unclassified failures
+    /// (401/403/404/429 have their own variants).
     static func shouldCount(error: Error) -> Bool {
         guard let err = error as? JellifyError else { return false }
         switch err {
-        case .Network:
+        case .Network, .Server, .RateLimit:
             return true
-        case .Server(let message):
-            return is5xx(message: message)
         default:
             return false
         }
-    }
-
-    /// Parse a server error message of the form
-    /// `"server returned an error: <status> <body>"` and return `true` when
-    /// `<status>` is in the 500–599 range.
-    private static func is5xx(message: String) -> Bool {
-        // The Rust side formats `Server` via
-        // `#[error("server returned an error: {status} {message}")]`, so the
-        // status lives as the first token after the fixed prefix.
-        let prefix = "server returned an error: "
-        guard let range = message.range(of: prefix) else {
-            return false
-        }
-        let tail = message[range.upperBound...]
-        let statusToken = tail.prefix { !$0.isWhitespace }
-        guard let status = Int(statusToken) else { return false }
-        return (500...599).contains(status)
     }
 }
 

--- a/macos/Sources/Jellify/Theme/Theme.swift
+++ b/macos/Sources/Jellify/Theme/Theme.swift
@@ -41,6 +41,32 @@ enum Theme {
     /// sizes ride `.body`; headline sizes ride `.title3` / `.title2` /
     /// `.largeTitle` depending on scale so they keep their relative rank
     /// when the user cranks text size up.
+    ///
+    /// ## Glyph fallback (#347)
+    ///
+    /// `Font.custom(name:size:)` ultimately resolves to a `CTFont` via Core
+    /// Text, which keeps a per-font cascade list. When a run contains a code
+    /// point the primary face (Figtree) doesn't cover — CJK ideographs,
+    /// Cyrillic, Arabic, Hebrew, Thai, Devanagari, emoji, etc. — Core Text
+    /// consults that cascade and substitutes from the system cascade list
+    /// (fall-back: `.AppleSystemUIFont` / `.SFNS-Regular`). The substitution
+    /// happens at the glyph layer, so a line that mixes Latin and CJK renders
+    /// Latin in Figtree and CJK in whichever system face covers those code
+    /// points — without the app having to detect the script itself.
+    ///
+    /// We verified this behaviour on macOS 14 with Figtree's published OTF
+    /// glyph set (Latin-1, Latin Extended-A/B, a handful of European
+    /// diacritics). The first non-covered run in a sentence switches to the
+    /// system default and the metrics stay compatible enough that line height
+    /// doesn't visibly jump. If a future Figtree release ships additional
+    /// scripts the cascade simply starts picking them up from the primary
+    /// face; nothing in this helper needs updating.
+    ///
+    /// SwiftUI also exposes `.font(_:)` modifiers that compose (e.g. a parent
+    /// `.font(.system)` scope would supply the fallback directly), but our
+    /// views set the Figtree font at the leaf and rely on Core Text's
+    /// per-glyph substitution here. Keeping the comment colocated with the
+    /// helper so future maintainers don't wire a redundant script detector.
     static func font(_ size: CGFloat, weight: Font.Weight = .regular, italic: Bool = false) -> Font {
         let name: String
         switch weight {

--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -173,7 +173,14 @@ public final class AudioEngine: NSObject {
             audioStreamIndex: nil,
             playSessionId: playSessionId,
             playMethod: playMethod,
-            positionTicks: 0
+            positionTicks: 0,
+            playbackStartTimeTicks: nil,
+            volumeLevel: nil,
+            playlistIndex: nil,
+            playlistLength: nil,
+            canSeek: true,
+            isPaused: false,
+            isMuted: false
         )
         try? core.reportPlaybackStarted(info: info)
         reportingItemId = trackId

--- a/macos/Sources/JellifyAudio/AudioEngine.swift
+++ b/macos/Sources/JellifyAudio/AudioEngine.swift
@@ -141,6 +141,88 @@ public final class AudioEngine: NSObject {
         return (info.mediaSources.first?.id, info.playSessionId)
     }
 
+    /// The currently-reporting session, captured at the last
+    /// `reportPlaybackStarted` call. Held so `stop` / track-change can emit a
+    /// matching `reportPlaybackStopped` with the same `itemId` + source +
+    /// session triple — Jellyfin requires those to line up server-side.
+    private var reportingItemId: String?
+    private var reportingMediaSourceId: String?
+    private var reportingPlaySessionId: String?
+
+    private func positionTicks() -> Int64 {
+        guard let player, let item = player.currentItem else { return 0 }
+        let seconds = CMTimeGetSeconds(item.currentTime())
+        guard seconds.isFinite, seconds >= 0 else { return 0 }
+        return Int64(seconds * 10_000_000)
+    }
+
+    /// Fire `POST /Sessions/Playing` for the track that just became the
+    /// AVQueuePlayer's `currentItem`. Best-effort — Jellyfin accepts the
+    /// stream regardless of whether the session-begin report landed, so we
+    /// swallow errors rather than surfacing them to the UI.
+    private func reportStarted(
+        trackId: String,
+        mediaSourceId: String?,
+        playSessionId: String?,
+        playMethod: String?
+    ) {
+        let info = PlaybackStartInfo(
+            itemId: trackId,
+            sessionId: nil,
+            mediaSourceId: mediaSourceId,
+            audioStreamIndex: nil,
+            playSessionId: playSessionId,
+            playMethod: playMethod,
+            positionTicks: 0
+        )
+        try? core.reportPlaybackStarted(info: info)
+        reportingItemId = trackId
+        reportingMediaSourceId = mediaSourceId
+        reportingPlaySessionId = playSessionId
+    }
+
+    /// Fire `POST /Sessions/Playing/Stopped` for the previously-reported
+    /// session, then clear the reporting triple. Safe to call when nothing
+    /// is active — it no-ops when `reportingItemId` is `nil`.
+    private func reportStopped() {
+        guard let itemId = reportingItemId else { return }
+        let info = PlaybackStopInfo(
+            itemId: itemId,
+            failed: false,
+            positionTicks: positionTicks(),
+            mediaSourceId: reportingMediaSourceId,
+            playSessionId: reportingPlaySessionId,
+            sessionId: nil
+        )
+        try? core.reportPlaybackStopped(info: info)
+        reportingItemId = nil
+        reportingMediaSourceId = nil
+        reportingPlaySessionId = nil
+    }
+
+    /// Fire a single `PlaybackProgressInfo` report — used on pause / resume /
+    /// seek transitions so the server sees state changes promptly rather
+    /// than waiting for the next heartbeat tick. Best-effort: swallow
+    /// errors, the periodic heartbeat (if running) will catch up.
+    private func reportProgressSnapshot(isPaused: Bool) {
+        guard let itemId = reportingItemId else { return }
+        let info = PlaybackProgressInfo(
+            itemId: itemId,
+            failed: false,
+            isPaused: isPaused,
+            isMuted: false,
+            positionTicks: positionTicks(),
+            mediaSourceId: reportingMediaSourceId,
+            playSessionId: reportingPlaySessionId,
+            playMethod: nil,
+            volumeLevel: nil,
+            playbackRate: nil,
+            audioStreamIndex: nil,
+            sessionId: nil
+        )
+        try? core.reportPlaybackProgress(info: info)
+    }
+
     // MARK: - Public
 
     public func play(track: Track) throws {
@@ -189,6 +271,11 @@ public final class AudioEngine: NSObject {
 
         attachPlayerObservers(to: newPlayer, item: item)
 
+        // Any previous session needs a matching Stopped report before we
+        // start the new one — Jellyfin keys sessions by PlaySessionId and
+        // leaks a transcode job otherwise.
+        reportStopped()
+
         core.markTrackStarted(track: track)
         core.markState(state: .playing)
         newPlayer.play()
@@ -196,6 +283,22 @@ public final class AudioEngine: NSObject {
         // reads the current position via its delegate, so `core.markState`
         // must run first so the snapshot is up to date. See issue #29.
         mediaSession?.trackChanged(track)
+
+        // POST /Sessions/Playing so Jellyfin shows "Now Playing on macOS"
+        // on other clients and the heartbeat has a session to report against.
+        reportStarted(
+            trackId: track.id,
+            mediaSourceId: mediaSourceId,
+            playSessionId: playSessionId,
+            playMethod: nil
+        )
+
+        // (Re)start the 5s heartbeat against the new PlaySessionId so
+        // Jellyfin's "last seen" timer for this session stays fresh and the
+        // server's resume-from-position store follows playback. Calling
+        // start_heartbeat on every play is intentional — the core cancels
+        // any prior interval before installing the new one.
+        core.startHeartbeat(intervalSecs: 5, playSessionId: playSessionId)
     }
 
     public func pause() {
@@ -206,16 +309,22 @@ public final class AudioEngine: NSObject {
         // sync within the same run loop turn for responsiveness. Duplicate
         // calls are cheap: MediaSession.rateChanged is idempotent.
         mediaSession?.rateChanged(isPlaying: false)
+        reportProgressSnapshot(isPaused: true)
     }
 
     public func resume() {
         player?.play()
         core.markState(state: .playing)
         mediaSession?.rateChanged(isPlaying: true)
+        reportProgressSnapshot(isPaused: false)
     }
 
     public func stop() {
         cancelStallWatchdog()
+        // Emit Stopped BEFORE draining the queue so positionTicks still
+        // reflects the last known playback position.
+        reportStopped()
+        core.stopHeartbeat()
         player?.pause()
         // removeAllItems() drains the AVQueuePlayer's item list (including any
         // pre-loaded next-track entry) and implicitly nulls currentItem — the
@@ -251,6 +360,12 @@ public final class AudioEngine: NSObject {
             Task { @MainActor in
                 guard let self, self.seekGeneration == generation else { return }
                 self.mediaSession?.seeked(to: seconds)
+                // Fire a PlaybackProgressInfo post-seek so the server's
+                // "last position" reflects the scrub immediately rather
+                // than waiting for the next heartbeat tick — this is what
+                // powers resume-from-position on other clients.
+                let paused = self.player?.rate == 0
+                self.reportProgressSnapshot(isPaused: paused)
             }
         }
     }


### PR DESCRIPTION
## Summary

Foundation work for the 0.2 release. Four self-contained commits — each has a detailed message; this PR description summarizes the milestone they land together.

- **`693369f`** — rebase of #555 (typed enums + `ItemsQuery` builder + structured `JellifyError` + `UserItemData`) onto post-#655 main. 181/182 lib tests pass; preserves all main-side changes that landed during the 65-commit divergence (artists 10.11 fix, albums_by_artist, three-column SortOrder, playlist_library_id NotFound, etc.).
- **`ef7adfe`** — rebase of #560 (i18n String Catalog + font fallback + localized error presenter) on top of #555. Localizable.xcstrings (English baseline), `JellifyErrorPresenter` for catalog-keyed errors, and component/screen migration to `LocalizedStringKey`.
- **`007f218`** — wires `Play Next` / `Add to Queue` / `Clear Queue` (#282). Adds `Player::insert_next`, `Player::append_to_queue`, `Player::clear_queue` in core (with 8 tests), exposes them via `JellifyCore`, and replaces the print-stub bodies in `AppModel.playNext(...)` / `addToQueue(...)` for albums, playlists, and track-lists. Command-palette `Clear Queue` action wired.
- **`b00bc0e`** — wires `/Sessions/Playing*` reporting in `AudioEngine`. `report_started` on track load, `report_progress` snapshots on pause/resume/seek (plus 5s heartbeat), `report_stopped` on track change/stop. Server now increments `PlayCount`, resume-from-position works across clients, and Jellyfin Web/iOS show "Now Playing on macOS" with the matching `PlaySessionId`.

Together these close the four big runtime gaps that were blocking a 0.2 cut: the data-layer foundation (#555), localization baseline (#560), real queue semantics, and server-side playback visibility.

## Test plan

- [ ] CI green — `core` clippy + lib tests, macOS swift build (the FFI-relevant-files clean-build gate added in #651 will catch xcframework/binding drift).
- [ ] `./macos/Scripts/build-core.sh --release && rm -rf macos/.build && swift build --package-path macos` clean locally.
- [ ] Real-server smoke against `music.skalthoff.com`: library populates (20060 albums / 3839 artists / 78 playlists / 254 genres), navigation works, error toasts localize.
- [ ] Playback against `music.skalthoff.com`:
  - [ ] Start a track — Jellyfin Web Dashboard → Active Devices shows the macOS session as Now Playing with the correct title and progress.
  - [ ] Pause / resume / seek — Web reflects the state change within ~1s (progress snapshot), not 5s (heartbeat).
  - [ ] Track end — `PlayCount` on the track increments by 1 server-side.
  - [ ] Skip mid-track — Stopped fires for the prior `PlaySessionId` so the transcode job is cleaned up.
- [ ] Queue ops:
  - [ ] From an album/playlist context menu, `Play Next` inserts after the currently-playing track without disturbing it.
  - [ ] `Add to Queue` appends.
  - [ ] Command-palette `Clear Queue` empties Up Next + Auto Queue, leaves the current track playing, and `skip_next` reports `None` after.

## Follow-ups for 0.2 (separate PRs)

1. Hide remaining "not yet wired" UI affordances (downloads, mark_played, Instant Mix, artist play/shuffle, similar artists, playlist add/edit/export, track info, browse genre).
2. Bump `core/Cargo.toml` to `0.2.0`.
3. Tag `v0.2.0-rc1` to exercise `macos-release.yml`, smoke-test the signed DMG, then tag `v0.2.0`.