### PR TITLE
macos: hide UI affordances whose FFI hasn't landed for 0.2

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -589,10 +589,7 @@ final class AppModel {
             }
         ))
 
-        // Queue + download verbs. Both are placeholders today — the core
-        // lacks a `clear_queue` primitive and the download engine hasn't
-        // landed (#70). Kept in the roster so the discovery affordance
-        // surfaces them; the closures are no-ops for now.
+        // Queue verb — wired via core.clearQueue (#282).
         actions.append(PaletteAction(
             id: "queue.clear",
             title: "Clear Queue",
@@ -606,16 +603,18 @@ final class AppModel {
                 }
             }
         ))
-        actions.append(PaletteAction(
-            id: "download.current",
-            title: "Download Current",
-            symbol: "arrow.down.circle",
-            run: { [weak self] in
-                guard self?.status.currentTrack != nil else { return }
-                // TODO(#70): wire to the download engine once it lands.
-                print("[AppModel] Download Current — not yet wired (see #70)")
-            }
-        ))
+        if supportsDownloads {
+            actions.append(PaletteAction(
+                id: "download.current",
+                title: "Download Current",
+                symbol: "arrow.down.circle",
+                run: { [weak self] in
+                    guard self?.status.currentTrack != nil else { return }
+                    // TODO(#70): wire to the download engine once it lands.
+                    print("[AppModel] Download Current — not yet wired (see #70)")
+                }
+            ))
+        }
 
         return actions
     }

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Capability flags that gate UI affordances whose backing FFI hasn't
+/// landed yet. Each flag is `false` for the 0.2 release; flip to `true`
+/// per-feature once the named issue closes.
+///
+/// Why a flag instead of just deleting the call site: keeping the menu
+/// entry, button, and `AppModel` method around — but hidden — means the
+/// FFI work that enables it can flip a single flag rather than re-wiring
+/// every surface.
+extension AppModel {
+    /// Download engine (#70, #222). Gates "Download Current" in the
+    /// command palette plus per-album / per-playlist / per-track Download
+    /// affordances.
+    var supportsDownloads: Bool { false }
+
+    /// `mark_played` / `mark_unplayed` FFIs (#133, #222). Gates
+    /// "Mark All as Played" on albums and "Mark as Played" on tracks.
+    var supportsMarkPlayed: Bool { false }
+
+    /// Artist-tracks FFI (#156, #465). Gates "Play All" / "Shuffle All"
+    /// on artist surfaces. Top-track-driven actions (Play Next via
+    /// top-tracks fallback, Start Artist Radio) remain available because
+    /// they route through wired FFIs.
+    var supportsArtistPlayShuffle: Bool { false }
+
+    /// New-playlist picker (#72, #126). Gates the "New Playlist…" entry
+    /// at the bottom of Add to Playlist submenus on album and track
+    /// surfaces. The route-through helpers `addAlbumToPlaylist` /
+    /// `addTracksToPlaylist` remain available — only the picker sheet
+    /// is the missing piece.
+    var supportsNewPlaylistPicker: Bool { false }
+
+    /// Album metadata editor (#96, #222). Gates "Edit Album…".
+    var supportsEditAlbum: Bool { false }
+
+    /// Playlist M3U8 export (#98, #125). Gates "Export as .m3u8…".
+    var supportsExportPlaylist: Bool { false }
+
+    /// Track-info sheet (#95). Gates "Show Track Info" on track
+    /// context menus.
+    var supportsTrackInfo: Bool { false }
+
+    /// Genre actions (#144, #248, #318). Gates the entire genre context
+    /// menu — browse landing, genre radio, genre shuffle, and pin-to-home
+    /// are all stubs today.
+    var supportsGenreActions: Bool { false }
+}

--- a/macos/Sources/Jellify/Components/AddToPlaylistSubmenu.swift
+++ b/macos/Sources/Jellify/Components/AddToPlaylistSubmenu.swift
@@ -25,9 +25,11 @@ struct AddToPlaylistSubmenu: View {
     private let maxPlaylists = 50
 
     var body: some View {
-        Button("New Playlist…", systemImage: "plus") { onNewPlaylist() }
+        if model.supportsNewPlaylistPicker {
+            Button("New Playlist…", systemImage: "plus") { onNewPlaylist() }
+            if !model.playlists.isEmpty { Divider() }
+        }
         if !model.playlists.isEmpty {
-            Divider()
             ForEach(model.playlists.prefix(maxPlaylists), id: \.id) { playlist in
                 Button(playlist.name) { onPick(playlist) }
             }

--- a/macos/Sources/Jellify/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Jellify/Components/AlbumContextMenu.swift
@@ -60,17 +60,23 @@ struct AlbumContextMenu: View {
         Divider()
 
         Button("Favorite Album", systemImage: "heart") { model.toggleFavorite(album: album) }
-        Button("Mark All as Played", systemImage: "checkmark.circle") {
-            model.markAllAsPlayed(album: album)
+        if model.supportsMarkPlayed {
+            Button("Mark All as Played", systemImage: "checkmark.circle") {
+                model.markAllAsPlayed(album: album)
+            }
         }
 
         Divider()
 
-        Button("Download", systemImage: "arrow.down.circle") {
-            model.enqueueDownload(album: album)
+        if model.supportsDownloads {
+            Button("Download", systemImage: "arrow.down.circle") {
+                model.enqueueDownload(album: album)
+            }
         }
-        Button("Edit Album…", systemImage: "pencil") {
-            model.requestEditAlbum(album: album)
+        if model.supportsEditAlbum {
+            Button("Edit Album…", systemImage: "pencil") {
+                model.requestEditAlbum(album: album)
+            }
         }
         Button("Copy Link", systemImage: "link") { model.copyShareLink(album: album) }
             .disabled(model.webURL(for: album) == nil)

--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -51,23 +51,25 @@ struct ArtistCard: View {
                     .frame(maxWidth: .infinity)
                     .aspectRatio(1, contentMode: .fit)
 
-                    Button { model.playAll(artist: artist) } label: {
-                        Image(systemName: "play.fill")
-                            .foregroundStyle(.white)
-                            .font(.system(size: 16))
-                            .frame(width: 40, height: 40)
-                            .background(Circle().fill(Theme.primary))
-                            .shadow(color: Theme.primary.opacity(0.5), radius: 10, y: 4)
+                    if model.supportsArtistPlayShuffle {
+                        Button { model.playAll(artist: artist) } label: {
+                            Image(systemName: "play.fill")
+                                .foregroundStyle(.white)
+                                .font(.system(size: 16))
+                                .frame(width: 40, height: 40)
+                                .background(Circle().fill(Theme.primary))
+                                .shadow(color: Theme.primary.opacity(0.5), radius: 10, y: 4)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(8)
+                        .opacity(isHovering ? 1 : 0)
+                        .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+                        .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                        // Hover overlay doesn't show for a non-mouse user, so
+                        // make sure VoiceOver can find the play affordance by
+                        // name. See #331.
+                        .accessibilityLabel("Play all tracks by \(artist.name)")
                     }
-                    .buttonStyle(.plain)
-                    .padding(8)
-                    .opacity(isHovering ? 1 : 0)
-                    .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
-                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
-                    // Hover overlay doesn't show for a non-mouse user, so
-                    // make sure VoiceOver can find the play affordance by
-                    // name. See #331.
-                    .accessibilityLabel("Play all tracks by \(artist.name)")
                 }
 
                 VStack(alignment: .leading, spacing: 2) {

--- a/macos/Sources/Jellify/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/ArtistContextMenu.swift
@@ -27,8 +27,12 @@ struct ArtistContextMenu: View {
     var showGoToArtist: Bool = true
 
     var body: some View {
-        Button("Play All", systemImage: "play.fill") { model.playAll(artist: artist) }
-        Button("Shuffle All", systemImage: "shuffle") { model.shuffle(artist: artist) }
+        if model.supportsArtistPlayShuffle {
+            Button("Play All", systemImage: "play.fill") { model.playAll(artist: artist) }
+            Button("Shuffle All", systemImage: "shuffle") { model.shuffle(artist: artist) }
+        }
+        // Play Next falls through to top-tracks playback today, so it works
+        // without the artist-tracks FFI.
         Button("Play Next", systemImage: "text.insert") { model.playNextArtist(artist: artist) }
 
         Divider()

--- a/macos/Sources/Jellify/Components/GenreContextMenu.swift
+++ b/macos/Sources/Jellify/Components/GenreContextMenu.swift
@@ -23,20 +23,25 @@ struct GenreContextMenu: View {
     let genre: String
 
     var body: some View {
-        Button("Browse genre", systemImage: "square.grid.2x2") {
-            model.browseGenre(genre: genre)
-        }
-        Button("Start genre radio", systemImage: "dot.radiowaves.left.and.right") {
-            model.startGenreRadio(genre: genre)
-        }
-        Button("Shuffle genre", systemImage: "shuffle") {
-            model.shuffleGenre(genre: genre)
-        }
+        // Every entry in this menu is gated on FFIs that don't ship in 0.2
+        // (#144 / #248 / #318). When `supportsGenreActions` flips on per
+        // feature these will come back individually.
+        if model.supportsGenreActions {
+            Button("Browse genre", systemImage: "square.grid.2x2") {
+                model.browseGenre(genre: genre)
+            }
+            Button("Start genre radio", systemImage: "dot.radiowaves.left.and.right") {
+                model.startGenreRadio(genre: genre)
+            }
+            Button("Shuffle genre", systemImage: "shuffle") {
+                model.shuffleGenre(genre: genre)
+            }
 
-        Divider()
+            Divider()
 
-        Button("Pin to Home", systemImage: "pin") {
-            model.pinGenreToHome(genre: genre)
+            Button("Pin to Home", systemImage: "pin") {
+                model.pinGenreToHome(genre: genre)
+            }
         }
     }
 }

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -45,7 +45,7 @@ struct LibraryListRow: View {
                         size: 40,
                         radius: artworkRadius
                     )
-                    if isHovering {
+                    if isHovering, showPlayHover {
                         Button(action: playPrimary) {
                             Image(systemName: "play.fill")
                                 .foregroundStyle(.white)
@@ -250,6 +250,16 @@ struct LibraryListRow: View {
             model.playAll(artist: artist)
         case .playlist(let playlist):
             model.play(playlist: playlist)
+        }
+    }
+
+    /// Hide the inline hover-play button when the row's primary action would
+    /// hit a stub (artist rows depend on `supportsArtistPlayShuffle`).
+    /// Album / Playlist rows always show it.
+    private var showPlayHover: Bool {
+        switch payload {
+        case .album, .playlist: return true
+        case .artist: return model.supportsArtistPlayShuffle
         }
     }
 

--- a/macos/Sources/Jellify/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/PlaylistContextMenu.swift
@@ -60,8 +60,10 @@ struct PlaylistContextMenu: View {
 
         Divider()
 
-        Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
-            model.exportPlaylist(playlist: playlist)
+        if model.supportsExportPlaylist {
+            Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
+                model.exportPlaylist(playlist: playlist)
+            }
         }
         Button("Copy Link", systemImage: "link") { model.copyShareLink(playlist: playlist) }
             .disabled(model.webURL(for: playlist) == nil)

--- a/macos/Sources/Jellify/Components/TrackContextMenu.swift
+++ b/macos/Sources/Jellify/Components/TrackContextMenu.swift
@@ -87,10 +87,12 @@ struct TrackContextMenu: View {
                 model.goToArtist(track: track)
             }
             .disabled(track.artistId == nil)
-            Button("Show Track Info", systemImage: "info.circle") {
-                model.showTrackInfo(track: track)
+            if model.supportsTrackInfo {
+                Button("Show Track Info", systemImage: "info.circle") {
+                    model.showTrackInfo(track: track)
+                }
+                .keyboardShortcut("i", modifiers: .command)
             }
-            .keyboardShortcut("i", modifiers: .command)
         }
 
         if let scope = playlistScope {
@@ -105,14 +107,18 @@ struct TrackContextMenu: View {
             favoriteLabel,
             systemImage: allFavorited ? "heart.slash" : "heart"
         ) { model.toggleFavorite(tracks: selection) }
-        Button(
-            downloadLabel,
-            systemImage: "arrow.down.circle"
-        ) { model.toggleDownload(tracks: selection) }
-        Button(
-            markPlayedLabel,
-            systemImage: "checkmark.circle"
-        ) { model.toggleMarkPlayed(tracks: selection) }
+        if model.supportsDownloads {
+            Button(
+                downloadLabel,
+                systemImage: "arrow.down.circle"
+            ) { model.toggleDownload(tracks: selection) }
+        }
+        if model.supportsMarkPlayed {
+            Button(
+                markPlayedLabel,
+                systemImage: "checkmark.circle"
+            ) { model.toggleMarkPlayed(tracks: selection) }
+        }
 
         Divider()
 

--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -220,11 +220,14 @@ struct AlbumDetailView: View {
         .accessibilityLabel("Start album radio")
     }
 
+    @ViewBuilder
     private var downloadButton: some View {
-        secondaryCTA(icon: "arrow.down.circle", label: "Download") {
-            if let album = album { model.enqueueDownload(album: album) }
+        if model.supportsDownloads {
+            secondaryCTA(icon: "arrow.down.circle", label: "Download") {
+                if let album = album { model.enqueueDownload(album: album) }
+            }
+            .accessibilityLabel("Download album")
         }
-        .accessibilityLabel("Download album")
     }
 
     private var favouriteButton: some View {

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -313,10 +313,12 @@ struct ArtistDetailView: View {
                 .help("Play all tracks")
                 .accessibilityLabel("Play all tracks by \(artist.name)")
 
-                transportSecondary(
-                    icon: "shuffle",
-                    help: "Shuffle all"
-                ) { model.shuffle(artist: artist) }
+                if model.supportsArtistPlayShuffle {
+                    transportSecondary(
+                        icon: "shuffle",
+                        help: "Shuffle all"
+                    ) { model.shuffle(artist: artist) }
+                }
 
                 // Follow — today toggles favorite. The "Follow" vocabulary
                 // is Jellify's; server-side it's `IsFavorite` on the artist

--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -162,7 +162,7 @@ struct SearchView: View {
     private var scopeRow: some View {
         @Bindable var model = model
         HStack(spacing: 8) {
-            ForEach(SearchScope.allCases, id: \.self) { scope in
+            ForEach(visibleScopes, id: \.self) { scope in
                 Chip(
                     label: scope.label,
                     isActive: model.activeSearchScope == scope,
@@ -282,8 +282,11 @@ struct SearchView: View {
     @ViewBuilder
     private var sectionedResults: some View {
         VStack(alignment: .leading, spacing: 28) {
+            let allScopes: [SearchScope] = model.supportsGenreActions
+                ? [.artists, .albums, .tracks, .playlists, .genres]
+                : [.artists, .albums, .tracks, .playlists]
             let scopes = model.activeSearchScope == .all
-                ? [SearchScope.artists, .albums, .tracks, .playlists, .genres]
+                ? allScopes
                 : [model.activeSearchScope]
             ForEach(scopes, id: \.self) { scope in
                 SectionView(
@@ -296,6 +299,16 @@ struct SearchView: View {
                 )
             }
         }
+    }
+
+    /// Scope chips to render in the chip row. Drops `.genres` when the
+    /// genre actions feature is hidden so users can't navigate to a scope
+    /// where every action is a stub.
+    private var visibleScopes: [SearchScope] {
+        if model.supportsGenreActions {
+            return SearchScope.allCases
+        }
+        return SearchScope.allCases.filter { $0 != .genres }
     }
 
     private func bucket(for scope: SearchScope) -> [SearchItem] {


### PR DESCRIPTION
## Summary

Closes the "broken buttons that silently no-op" pattern flagged in CLAUDE.md. Each `print("[AppModel] X not yet wired")` site previously shipped as a visible menu item or button; clicking did nothing, which read as a bug. With these gates the affordance is hidden until the corresponding capability flag flips on per-PR when each FFI lands.

Follow-up to [jellify-desktop#662](https://github.com/skalthoff/jellify-desktop/pull/662) — the third of the named 0.2 blockers (queue primitives + playback reporting landed in #662; this hides the remainder until 0.3).

## What's new

`macos/Sources/Jellify/Capabilities.swift` — per-feature `Bool` flags as `extension AppModel` computed properties, all `false` for 0.2:

- `supportsDownloads` (#70 / #222) — Download Current palette action; album / playlist / track / AlbumDetailView download affordances.
- `supportsMarkPlayed` (#133 / #222) — "Mark All as Played" on albums, "Mark as Played" on tracks.
- `supportsArtistPlayShuffle` (#156 / #465) — "Play All" / "Shuffle All" in `ArtistContextMenu`, the inline hover-play button on `ArtistCard`, the hover-play button on `LibraryListRow` for artist payloads, the Shuffle CTA in `ArtistDetailView`'s transport bar.
- `supportsNewPlaylistPicker` (#72 / #126) — "New Playlist…" entry at the top of `AddToPlaylistSubmenu`. The route-through helpers `addAlbumToPlaylist` / `addTracksToPlaylist` stay live.
- `supportsEditAlbum` (#96 / #222) — "Edit Album…" on the album context menu.
- `supportsExportPlaylist` (#98 / #125) — "Export as .m3u8…" on the playlist context menu.
- `supportsTrackInfo` (#95) — "Show Track Info" on the track context menu.
- `supportsGenreActions` (#144 / #248 / #318) — entire `GenreContextMenu`, plus the `.genres` scope chip + section in `SearchView`.

## Deliberately kept visible

- `ArtistContextMenu` "Play Next" — `playNextArtist` falls through to `playTopTracks` which is wired.
- `ArtistDetailView` Play button — uses top-tracks fallback when `playAll(artist:)` would no-op.
- HomeView / DiscoverView Instant Mix CTAs — `startInstantMix` is wired via `core.instantMix`.
- All `play` / `shuffle` / `playNext` / `addToQueue` / `playRadio` / `Add to Playlist` (with picker hidden) on album / playlist / track surfaces — all wired post-#282.

Effect: 0.2 ships UI surfaces that all do what they say. The print-stub methods on `AppModel` stay in place behind the flags so flipping a single Bool re-enables every affordance the FFI unlocks.

## Test plan

- [ ] CI green — `swift build` clean, no diagnostics from the gated call sites.
- [ ] Right-click an album → context menu does NOT show: Mark All as Played, Download, Edit Album.
- [ ] Right-click an artist → context menu does NOT show: Play All, Shuffle All. (Play Next stays.)
- [ ] Right-click a track → context menu does NOT show: Show Track Info, Download, Mark as Played.
- [ ] Right-click a playlist → context menu does NOT show: Export as .m3u8…
- [ ] Right-click a genre → no items render at all.
- [ ] Search → Genres scope chip is hidden, no Genres section in the All view.
- [ ] Album / Playlist / Track Add-to-Playlist submenu shows existing playlists but no "New Playlist…" entry.
- [ ] Hover over an artist row in the library list → no inline play button.
- [ ] Artist detail transport bar → Shuffle button is hidden.
- [ ] Album detail CTA row → no Download button.
- [ ] Command palette → no "Download Current" entry.

## Follow-ups for 0.2

1. Bump `core/Cargo.toml` to `0.2.0`.
2. Tag `v0.2.0-rc1` to exercise `macos-release.yml`, smoke-test the signed DMG, then tag `v0.2.0`.