### PR TITLE
release: bump workspace version to 0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -31,7 +31,7 @@ body:
     id: version
     attributes:
       label: Jellify version
-      placeholder: e.g., 0.1.0 (commit abc123)
+      placeholder: e.g., 0.2.0 (commit abc123)
     validations:
       required: true
   - type: dropdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jellify-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "jellify_core",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "jellify-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "jellify_core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-only"

--- a/macos/Scripts/make-dmg.sh
+++ b/macos/Scripts/make-dmg.sh
@@ -16,7 +16,7 @@
 #     drops the arguments.
 #
 # Usage:
-#   VERSION=0.1.0 DEVELOPER_ID="Developer ID Application: Jane (TEAMID)" \
+#   VERSION=0.2.0 DEVELOPER_ID="Developer ID Application: Jane (TEAMID)" \
 #     ./macos/Scripts/make-dmg.sh                      # uses build/Jellify.app
 #   ./macos/Scripts/make-dmg.sh path/to/Jellify.app
 set -euo pipefail

--- a/macos/Scripts/notarize.sh
+++ b/macos/Scripts/notarize.sh
@@ -17,7 +17,7 @@
 # page in the developer portal.
 #
 # Usage:
-#   ./macos/Scripts/notarize.sh path/to/Jellify-0.1.0.dmg
+#   ./macos/Scripts/notarize.sh path/to/Jellify-0.2.0.dmg
 #   NOTARY_PROFILE=other-profile ./macos/Scripts/notarize.sh some.dmg
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

First named release after 0.1.0. Lands the four 0.2 blockers ([#662](https://github.com/skalthoff/jellify-desktop/pull/662)) and the affordance-gating capability flags ([#663](https://github.com/skalthoff/jellify-desktop/pull/663)) on top of the signed-DMG release pipeline ([#657](https://github.com/skalthoff/jellify-desktop/pull/657)).

- `Cargo.toml` `workspace.package` version `0.1.0` → `0.2.0`
- `Cargo.lock` updated for `jellify_core`, `jellify-cli`, `jellify-desktop` workspace members
- Example version refs in `make-dmg.sh`, `notarize.sh`, and the bug-report issue template placeholder bumped to match

After this merges I'll tag `v0.2.0-rc1` to exercise `macos-release.yml` end-to-end (signed DMG + Sparkle appcast on gh-pages), smoke-test against `music.skalthoff.com`, then tag `v0.2.0` for the public cut.

## Test plan

- [ ] CI green — `cargo build` / `cargo test` / `swift build` all pass with the bumped version.
- [ ] Tag a `v0.2.0-rc1` after merge → verify `macos-release.yml` produces a signed `Jellify-0.2.0-rc1.dmg` in the GitHub Release and an appcast.xml entry in `gh-pages`.