### PR TITLE
fix(release): Package.swift Swift 5 mode rejected by xcodebuild on Xcode 26

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -31,18 +31,12 @@ let package = Package(
         .target(
             name: "JellifyCore",
             dependencies: ["JellifyCoreFFI"],
-            path: "Sources/JellifyCore",
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
-            ]
+            path: "Sources/JellifyCore"
         ),
         .target(
             name: "JellifyAudio",
             dependencies: ["JellifyCore"],
-            path: "Sources/JellifyAudio",
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
-            ]
+            path: "Sources/JellifyAudio"
         ),
         .executableTarget(
             name: "Jellify",
@@ -56,9 +50,6 @@ let package = Package(
             path: "Sources/Jellify",
             resources: [
                 .process("Resources")
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
             ],
             linkerSettings: [
                 .linkedFramework("AudioToolbox"),
@@ -74,9 +65,6 @@ let package = Package(
             name: "SmokeTest",
             dependencies: ["JellifyCore", "JellifyAudio"],
             path: "Sources/SmokeTest",
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
-            ],
             linkerSettings: [
                 .linkedFramework("AudioToolbox"),
                 .linkedFramework("AudioUnit"),
@@ -87,5 +75,14 @@ let package = Package(
                 .linkedFramework("SystemConfiguration"),
             ]
         ),
-    ]
+    ],
+    // Pin Swift 5 language mode at the package level rather than via per-
+    // target `.swiftLanguageMode(.v5)`. The per-target API serialises to
+    // `5` (no `.0`) and xcodebuild on Xcode 26 rejects it (`SWIFT_VERSION
+    // '5' unsupported, supported: 4.0, 4.2, 5.0, 6.0`). The package-level
+    // form serialises through `SWIFT_VERSION = 5.0` so multi-arch
+    // `swift build --arch arm64 --arch x86_64` (which routes through
+    // xcodebuild) accepts it. Stays on Swift 5 mode pending the wider
+    // Sendable / strict-concurrency cleanup tracked across the codebase.
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
## Summary

The `macos-release.yml` workflow's `Swift build (release, universal)` step (multi-arch via `swift build --arch arm64 --arch x86_64`, which routes through xcodebuild) has been failing on **both** the prior `v0.1.0` attempt and just now on `v0.2.0-rc1`:

```
error: 'macos': Some of the Swift language versions used in target 'Jellify' settings are supported. (given: [5], supported: [4.0, 4.2, 5.0, 6.0])
SWIFT_VERSION '' is unsupported, supported versions are: 4.0, 4.2, 5.0, 6.0.
```

The modern per-target `.swiftLanguageMode(.v5)` API (PackageDescription 6.0) serialises as a bare `5` — xcodebuild on the runner's Xcode 26 normalises that to `''` and rejects it because its supported list is `4.0, 4.2, 5.0, 6.0`.

Fix: hoist Swift 5 mode to the package level via `swiftLanguageVersions: [.v5]`. The package-level setting is the older API — supported by every Xcode toolchain since Swift 3 — and serialises through `SWIFT_VERSION=5.0` cleanly. All four targets had `.v5` already, so the move is behaviour-equivalent.

The wider strict-concurrency / Sendable cleanup needed to actually adopt Swift 6 mode is out of scope for the 0.2 cut.

## Test plan

- [x] `./macos/Scripts/build-core.sh --arm64-only && swift build -c debug` — Build complete!
- [ ] CI: regular swift build still green
- [ ] Tag `v0.2.0-rc2` after merge → verify `macos-release.yml` makes it past the Swift build step into Sign / Notarize / DMG.