### PR TITLE
fix(release): pin Xcode 16.4 in macos-release.yml so deps build clean

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -45,7 +45,15 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          # Pin to Xcode 16.x (Swift 5.10 default) rather than `latest-stable`.
+          # Xcode 26 defaults dependency builds to Swift 6 strict concurrency,
+          # which Nuke 13.0.2 (and other transitive deps in this generation)
+          # do not yet compile under. Our own targets opt in to Swift 5 via
+          # `swiftLanguageVersions: [.v5]` in Package.swift, but that doesn't
+          # propagate to dependencies built by xcodebuild during the
+          # multi-arch `swift build --arch arm64 --arch x86_64`.
+          # Revisit when the wider Swift 6 / Sendable cleanup lands.
+          xcode-version: '16.4'
 
       - name: Install Rust (universal)
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

[v0.2.0-rc2](https://github.com/skalthoff/jellify-desktop/actions/runs/24926013303) cleared the per-target Swift language version error from [#665](https://github.com/skalthoff/jellify-desktop/pull/665) but tripped over a downstream wall — Nuke 13.0.2 (and other transitive deps in the same generation) don't compile under Xcode 26's Swift 6 strict-concurrency default:

```
.../Nuke/Sources/Nuke/Encoding/ImageEncoding.swift:38:16: error: stored property 'image' of 'Sendable'-conforming struct 'ImageEncodingContext' has non-sendable type 'PlatformImage' (aka 'NSImage')
.../Nuke/Sources/Nuke/Pipeline/ImagePipeline.swift:68:5: error: 'nonisolated' modifier cannot be applied to this declaration
.../Nuke/Sources/Nuke/Pipeline/ImagePipeline.swift:123:13: error: call can throw, but it is not marked with 'try' and the error is not handled
```

Our own targets opt in to Swift 5 via `swiftLanguageVersions: [.v5]` at the package level (#665), but that doesn't propagate to dependencies built by xcodebuild during the multi-arch `swift build --arch arm64 --arch x86_64` path used by the release workflow.

Pin to Xcode 16.4 (Swift 5.10 default) so dependencies compile under their intended language mode. The wider Swift 6 / Sendable cleanup is tracked separately and out of scope for 0.2.

## Test plan

- [ ] Tag `v0.2.0-rc3` after merge → verify `macos-release.yml` makes it past Swift build into sign / notarize / DMG.