### PR TITLE
fix(release): drop pinned Xcode to 15.4 (16.4 not on macos-14 runner)

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -45,15 +45,17 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          # Pin to Xcode 16.x (Swift 5.10 default) rather than `latest-stable`.
-          # Xcode 26 defaults dependency builds to Swift 6 strict concurrency,
-          # which Nuke 13.0.2 (and other transitive deps in this generation)
-          # do not yet compile under. Our own targets opt in to Swift 5 via
-          # `swiftLanguageVersions: [.v5]` in Package.swift, but that doesn't
-          # propagate to dependencies built by xcodebuild during the
-          # multi-arch `swift build --arch arm64 --arch x86_64`.
+          # Pin to Xcode 15.4 — last stable in the Swift 5.10 line that
+          # accepts Nuke 13.0.2 without forcing strict-concurrency
+          # checking. The macos-14 runner currently exposes 15.0.1 /
+          # 15.1 / 15.2 / 15.3 / 15.4 / 16.1 / 16.2; on Xcode 16.x the
+          # multi-arch xcodebuild path fails compiling Nuke with
+          # Sendable errors even though the toolchain default is still
+          # Swift 5. Our own targets opt in via `swiftLanguageVersions:
+          # [.v5]` in Package.swift, but that pin doesn't propagate to
+          # dependencies built through the multi-arch path.
           # Revisit when the wider Swift 6 / Sendable cleanup lands.
-          xcode-version: '16.4'
+          xcode-version: '15.4'
 
       - name: Install Rust (universal)
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

[#666](https://github.com/skalthoff/jellify-desktop/pull/666) pinned to `16.4`, but the macos-14 GH runner errored:

```
##[error]Could not find Xcode version that satisfied version spec: '16.4'
```

Available on the runner: `15.0.1 / 15.1 / 15.2 / 15.3 / 15.4 / 16.1 / 16.2` (no 16.4, no 16.3).

The 16.x line still trips Nuke 13.0.2 compile errors during the multi-arch `swift build --arch arm64 --arch x86_64` path (Sendable-conforming struct holds non-sendable `PlatformImage`, etc. — visible in the [v0.2.0-rc2 log](https://github.com/skalthoff/jellify-desktop/actions/runs/24926013303)). 15.4 is the last stable Swift 5.10 release where Nuke 13 compiles cleanly without strict-concurrency gates.

## Test plan

- [ ] Tag `v0.2.0-rc4` after merge → verify `macos-release.yml` makes it past Swift build into sign / notarize / DMG.