### PR TITLE
fix(release): swift-tools-version 6.0 -> 5.10 to match Xcode 15.4

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary

[v0.2.0-rc4](https://github.com/skalthoff/jellify-desktop/actions/runs/24927003054) failed at Swift build:

```
error: 'macos': package 'macos' is using Swift tools version 6.0.0 but the installed version is 5.10.0
```

Xcode 15.4 (pinned in [#667](https://github.com/skalthoff/jellify-desktop/pull/667), the last Swift 5.10 stable on the macos-14 runner) ships Swift 5.10, but `Package.swift` declared `swift-tools-version: 6.0`.

The `6.0` declaration was originally needed for the per-target `.swiftLanguageMode(.v5)` API (PackageDescription 6.0). Since [#665](https://github.com/skalthoff/jellify-desktop/pull/665) replaced those with package-level `swiftLanguageVersions: [.v5]` (available since pre-6.0 manifests), we don't use any 6.0-specific manifest features.

Drop to `5.10` so the manifest parses on the pinned 15.4 toolchain. The newer Swift toolchain on dev machines processes a 5.10-tools manifest in compatibility mode without restricting any features the package uses.

## Test plan

- [x] `./macos/Scripts/build-core.sh --arm64-only && swift build`: Build complete! (20.49s)
- [ ] Tag `v0.2.0-rc5` after merge → expect Swift build to clear and reach sign / notarize / DMG.