### PR TITLE
fix(release): switch macos-release.yml runner to macos-15

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -28,7 +28,12 @@ permissions:
 jobs:
   build:
     name: Build, sign, notarize, publish
-    runs-on: macos-14
+    # macos-15 (Sequoia) ships Xcode 26.x which compiles Nuke 13.0.2
+    # cleanly. macos-14 only has up to Xcode 16.2, where dependency
+    # builds trip Sendable errors in Nuke 13. Regular CI's macOS job
+    # already runs on macos-15, so this keeps the release path on the
+    # same image as PR builds.
+    runs-on: macos-15
     env:
       # Resolve the tag from either push or workflow_dispatch. `github.ref_name`
       # for a tag push is the tag; for dispatch we take the input.


### PR DESCRIPTION
## Summary

[v0.2.0-rc6](https://github.com/skalthoff/jellify-desktop/actions/runs/24928066476) still failed compiling Nuke 13.0.2 even after dropping the multi-arch path in [#669](https://github.com/skalthoff/jellify-desktop/pull/669). The actual variable was the **runner image**, not the build flags.

- `macos-14` only exposes Xcode up to 16.2, where dependency builds trip Sendable errors in Nuke 13.0.2 even via single-arch `swift build`.
- `macos-15` ships Xcode 26.x, which compiles Nuke 13 cleanly.
- Regular CI's `macOS app` job already runs on `macos-15` and passes on every merged PR (the [comment on the runs-on line](https://github.com/skalthoff/jellify-desktop/blob/main/.github/workflows/ci.yml) calls this out).

Switching the release workflow's runner aligns it with PR CI — same toolchain, same outcome.

## Test plan

- [ ] Tag `v0.2.0-rc7` after merge → expect single-arch `swift build` to compile cleanly, then sign / notarize / DMG / appcast.