### PR TITLE
fix(release): match case patterns against relative path so Autoupdate signs

### DIFF
--- a/macos/Scripts/sign.sh
+++ b/macos/Scripts/sign.sh
@@ -133,11 +133,19 @@ if [[ -d "$APP/Contents/Frameworks" ]]; then
         if [[ -d "$fw/Versions" ]]; then
             fw_basename="$(basename "$fw" .framework)"
             while IFS= read -r -d '' bin; do
-                # Skip files that live inside a nested bundle (already
-                # signed in 1a/1b) or in a known non-binary subdir.
-                case "$bin" in
+                # Path RELATIVE to this framework — used for the case
+                # patterns below so they match nested bundles inside
+                # this framework without spuriously matching the outer
+                # `.framework/` path component itself (the bug rc8
+                # tripped: `*/*.framework/*` matched every file inside
+                # Sparkle.framework and skipped them all, including
+                # Autoupdate).
+                rel="${bin#"$fw/"}"
+                case "$rel" in
                     */*.app/*|*/*.xpc/*|*/*.framework/*) continue ;;
                     */Headers/*|*/Resources/*|*/Modules/*) continue ;;
+                    *.app/*|*.xpc/*|*.framework/*) continue ;;
+                    Headers/*|Resources/*|Modules/*|_CodeSignature/*) continue ;;
                 esac
                 [[ -f "$bin" && -x "$bin" ]] || continue
                 file -b "$bin" 2>/dev/null | grep -q "Mach-O" || continue


### PR DESCRIPTION
## Summary

[v0.2.0-rc8](https://github.com/skalthoff/jellify-desktop/actions/runs/24929079241) cleared the `Updater.app` + XPC services from #671 but notary still rejected Sparkle's loose `Autoupdate` Mach-O:

```
path: Sparkle.framework/Versions/B/Autoupdate
message: The binary is not signed with a valid Developer ID certificate.
message: The signature does not include a secure timestamp.
```

(4 errors total — Developer ID + timestamp × x86_64 + arm64 slices.)

Cause: the `case` statement in step 1c that's supposed to skip files inside nested bundles ran against the absolute `$bin` path, and pattern `*/*.framework/*` matched the **outer** `Sparkle.framework/` component itself. Every file under the framework therefore got skipped — including the loose `Autoupdate` the loop was specifically meant to find.

Fix: compute `$rel` (path relative to the current framework) and match the case patterns against `$rel`. `Versions/B/Autoupdate` now passes through, while `Versions/B/Updater.app/Contents/MacOS/Updater` correctly trips `*/*.app/*` (already covered by step 1b).

Also added belt-and-braces patterns for top-level `Headers / Resources / Modules / _CodeSignature / *.app / *.xpc / *.framework` directly under `Versions/X/` (all currently filtered later by the Mach-O / exec checks anyway).

## Test plan

- [x] `bash -n macos/Scripts/sign.sh` — syntax ok.
- [ ] Tag `v0.2.0-rc9` after merge → notary should now accept.