### PR TITLE
fix(release): place SPM resource bundle at .app root, not Contents/Resources/

### DIFF
--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -104,10 +104,24 @@ mkdir -p "$APP/Contents/Resources"
 
 cp "$EXE" "$APP/Contents/MacOS/Jellify"
 
-# Copy SPM-processed resources (fonts bundle) next to the executable.
+# Copy SPM-processed resources (fonts + Localizable.xcstrings) into the
+# .app. SwiftPM's generated `resource_bundle_accessor.swift` resolves
+# the bundle via
+#   Bundle.main.bundleURL.appendingPathComponent("Jellify_Jellify.bundle")
+# For a .app, `Bundle.main.bundleURL` IS the .app directory itself, so
+# the resource bundle has to sit at the .app's TOP LEVEL — not inside
+# Contents/Resources/, which is the normal macOS convention. SwiftPM's
+# only fallback is the build-time location (e.g.
+# /Users/runner/.../Jellify_Jellify.bundle), which exists on the build
+# machine but not on any user's machine. Without the top-level copy the
+# app boots, hits resource_bundle_accessor.swift, and crashes with
+#   Fatal error: could not load resource bundle: from
+#   /Applications/Jellify.app/Jellify_Jellify.bundle or <runner path>
+# Keep AppIcon.icns under Contents/Resources/ (the macOS convention is
+# fine for that); only the SPM-generated bundle has to live at the root.
 BUNDLE="$BUILD_DIR/Jellify_Jellify.bundle"
 if [[ -d "$BUNDLE" ]]; then
-    cp -R "$BUNDLE" "$APP/Contents/Resources/"
+    cp -R "$BUNDLE" "$APP/"
 fi
 
 # Copy the app icon if it has been produced. This is intentionally soft:


### PR DESCRIPTION
## Summary

[v0.2.0-rc9](https://github.com/skalthoff/jellify-desktop/releases/tag/v0.2.0-rc9) built, signed, notarized, and stapled cleanly. The DMG mounts. The `.app` then crashes on first launch:

```
Fatal error: could not load resource bundle: from
  /Applications/Jellify.app/Jellify_Jellify.bundle or
  /Users/runner/work/jellify-desktop/jellify-desktop/macos/.build/
    arm64-apple-macosx/release/Jellify_Jellify.bundle
```

SwiftPM generates `resource_bundle_accessor.swift` with this lookup:

```swift
Bundle.main.bundleURL.appendingPathComponent("Jellify_Jellify.bundle")
```

For a `.app`, `Bundle.main.bundleURL` IS the `.app` directory itself — so the SPM resource bundle has to sit at the **`.app` top level**, not inside `Contents/Resources/`. The accessor's fallback path is the build-time location (`/Users/runner/.../Jellify_Jellify.bundle`), which exists on the build machine but never on a user's machine.

CI's smoke-launch step runs the binary on the build machine where the fallback resolves, so this bug was latent ever since SPM resources landed. The release dry-run (download + open DMG on a clean machine) is the first time it surfaces.

## Fix

`make-bundle.sh`: copy `$BUILD_DIR/Jellify_Jellify.bundle` to `$APP/` instead of `$APP/Contents/Resources/`. `AppIcon.icns` stays in `Contents/Resources/` — the macOS convention applies to it; only the SPM-generated bundle is constrained by SwiftPM's accessor path.

## Test plan

- [x] Local ad-hoc rebuild + launch: `./macos/Scripts/build-core.sh --arm64-only && swift build -c release && ./macos/Scripts/make-bundle.sh --release` then `Jellify.app/Contents/MacOS/Jellify` stays running past the resource_bundle_accessor's fatalError (previously crashed in <1s).
- [ ] Tag `v0.2.0-rc10` after merge → expect a working DMG.

Local codesign emits `Jellify.app: unsealed contents present in the bundle root` — benign for ad-hoc, but if the Developer ID identity on the runner rejects it the follow-up is to teach `sign.sh` to seal the top-level bundle before sealing the outer `.app`.