### PR TITLE
fix(release): drop SPM resource processing, copy resources to Contents/Resources/

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -48,9 +48,18 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/Jellify",
-            resources: [
-                .process("Resources")
-            ],
+            // Resources are NOT processed by SwiftPM. SwiftPM's generated
+            // `resource_bundle_accessor.swift` resolves the bundle via
+            // `Bundle.main.bundleURL.appendingPathComponent("<Pkg>_<Target>.bundle")`,
+            // so the bundle has to live at the .app's TOP LEVEL — but
+            // macOS .app structure forbids any top-level entry other
+            // than `Contents/` (`codesign` rejects with "unsealed contents
+            // present in the bundle root"). Instead, `make-bundle.sh`
+            // copies `Sources/Jellify/Resources/` contents straight into
+            // `Contents/Resources/`, and code that needs them reads via
+            // `Bundle.main.url(forResource:withExtension:)` (the
+            // standard macOS .app pattern).
+            // resources: [.process("Resources")],
             linkerSettings: [
                 .linkedFramework("AudioToolbox"),
                 .linkedFramework("AudioUnit"),

--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -104,24 +104,33 @@ mkdir -p "$APP/Contents/Resources"
 
 cp "$EXE" "$APP/Contents/MacOS/Jellify"
 
-# Copy SPM-processed resources (fonts + Localizable.xcstrings) into the
-# .app. SwiftPM's generated `resource_bundle_accessor.swift` resolves
-# the bundle via
-#   Bundle.main.bundleURL.appendingPathComponent("Jellify_Jellify.bundle")
-# For a .app, `Bundle.main.bundleURL` IS the .app directory itself, so
-# the resource bundle has to sit at the .app's TOP LEVEL — not inside
-# Contents/Resources/, which is the normal macOS convention. SwiftPM's
-# only fallback is the build-time location (e.g.
-# /Users/runner/.../Jellify_Jellify.bundle), which exists on the build
-# machine but not on any user's machine. Without the top-level copy the
-# app boots, hits resource_bundle_accessor.swift, and crashes with
-#   Fatal error: could not load resource bundle: from
-#   /Applications/Jellify.app/Jellify_Jellify.bundle or <runner path>
-# Keep AppIcon.icns under Contents/Resources/ (the macOS convention is
-# fine for that); only the SPM-generated bundle has to live at the root.
-BUNDLE="$BUILD_DIR/Jellify_Jellify.bundle"
-if [[ -d "$BUNDLE" ]]; then
-    cp -R "$BUNDLE" "$APP/"
+# Copy our resources straight into Contents/Resources/. We deliberately
+# do NOT use SPM's resource processing (`resources: [.process(...)]` in
+# Package.swift) because its generated accessor expects the bundle at
+# the .app top level, which violates macOS .app structure rules:
+#
+#   codesign refuses with "unsealed contents present in the bundle root"
+#   when anything other than Contents/ sits at the .app root.
+#
+# So `Sources/Jellify/Resources/{Fonts,Localizable.xcstrings,...}` ends
+# up under `Contents/Resources/` directly. Code that needs them reads
+# via `Bundle.main.url(forResource:withExtension:)` — see
+# `FontRegistration.register()` in Theme.swift. SwiftUI's
+# `LocalizedStringKey` auto-discovers Localizable.xcstrings in
+# Bundle.main, so no Swift-side change for the i18n path.
+RES_SRC="$MACOS/Sources/Jellify/Resources"
+if [[ -d "$RES_SRC" ]]; then
+    # Localizable.xcstrings sits at the root of Resources/.
+    if [[ -f "$RES_SRC/Localizable.xcstrings" ]]; then
+        cp "$RES_SRC/Localizable.xcstrings" "$APP/Contents/Resources/"
+    fi
+    # Fonts/*.otf — flatten into Contents/Resources/ so Bundle.main
+    # finds them with `url(forResource: "Figtree-Bold", withExtension:
+    # "otf")`. The pattern matches our existing CTFontManager call site
+    # which doesn't hunt subdirectories.
+    if [[ -d "$RES_SRC/Fonts" ]]; then
+        find "$RES_SRC/Fonts" -type f -name "*.otf" -exec cp {} "$APP/Contents/Resources/" \;
+    fi
 fi
 
 # Copy the app icon if it has been produced. This is intentionally soft:
@@ -150,6 +159,7 @@ if [[ -d "$SPARKLE_SRC" ]]; then
     # and kills the process on launch with "CODESIGNING Invalid Page" before
     # main runs. Re-seal ad-hoc here so dev builds launch; sign.sh supersedes
     # this with a real Developer ID signature for distribution.
+    #
     codesign --force --sign - "$APP/Contents/MacOS/Jellify"
 fi
 

--- a/macos/Sources/Jellify/Theme/Theme.swift
+++ b/macos/Sources/Jellify/Theme/Theme.swift
@@ -110,7 +110,12 @@ enum FontRegistration {
     static func register() {
         guard !registered else { return }
         registered = true
-        let bundle = Bundle.module
+        // Fonts live in Contents/Resources/ of the .app rather than an
+        // SPM-generated sub-bundle (see Package.swift on the `Jellify`
+        // target). Bundle.main IS the .app, and `make-bundle.sh` copies
+        // Sources/Jellify/Resources/Fonts/*.otf straight into
+        // Contents/Resources/.
+        let bundle = Bundle.main
         for name in [
             "Figtree-Regular", "Figtree-Italic", "Figtree-Medium",
             "Figtree-SemiBold", "Figtree-Bold", "Figtree-ExtraBold",


### PR DESCRIPTION
## Summary

[v0.2.0-rc9](https://github.com/skalthoff/jellify-desktop/releases/tag/v0.2.0-rc9) built + notarized clean but the `.app` crashed on first launch on any non-build machine. [v0.2.0-rc10](https://github.com/skalthoff/jellify-desktop/actions/runs/24930158799) tried to fix that by moving the SPM resource bundle to the `.app` top level (where SwiftPM's accessor expects it). codesign refused with `unsealed contents present in the bundle root` — macOS `.app` structure rules forbid any top-level entry other than `Contents/`.

The conflict is fundamental:
- SwiftPM's generated `resource_bundle_accessor.swift` resolves `Bundle.main.bundleURL.appendingPathComponent("Pkg_Target.bundle")` — for a `.app`, `Bundle.main.bundleURL` IS the `.app`, so the bundle must sit at the `.app` root.
- macOS `.app` rules require everything under `Contents/` — codesign refuses anything else at the root.

## Fix

Drop SPM resource processing entirely:

- **`Package.swift`** — remove `resources: [.process("Resources")]` from the Jellify target. No more `Bundle.module` is generated.
- **`Theme.swift`** — `Bundle.module` → `Bundle.main`. Fonts now resolve via the standard macOS resource path.
- **`make-bundle.sh`** — drop the deep-bundle conversion + ad-hoc seal of the top-level bundle. Copy `Sources/Jellify/Resources/Localizable.xcstrings` and `Fonts/*.otf` straight into `Contents/Resources/`.
- **`sign.sh`** — drop the top-level `*.bundle` pre-seal step (added in #673's follow-on attempt). `.app` structure is back to a single `Contents/` tree, so the standard framework → binary → `.app` order suffices.

SwiftUI's `LocalizedStringKey` auto-discovers `Localizable.xcstrings` in `Bundle.main`, so the i18n path doesn't need any change.

## Test plan

- [x] Local fresh build:
  - `rm -rf macos/.build macos/Jellify.xcframework macos/build`
  - `./macos/Scripts/build-core.sh --release --arm64-only` ✓
  - `swift build -c release` ✓
  - `./macos/Scripts/make-bundle.sh --release` — no codesign warning, app structure has only `Contents/` at the root, all 8 Figtree fonts + `Localizable.xcstrings` in `Contents/Resources/`.
  - `Jellify.app/Contents/MacOS/Jellify` runs and survives past 3s (previously crashed in `resource_bundle_accessor.swift`'s `fatalError`).
- [ ] Tag `v0.2.0-rc11` after merge → expect a working signed/notarized DMG that actually launches on user machines.

## RC trail context (release pipeline)

| RC | Change | Result |
|---|---|---|
| 9 | initial pipeline working | Built + signed + notarized + stapled — but `.app` crashes at launch (this PR's bug) |
| 10 | bundle at .app root ([#673](https://github.com/skalthoff/jellify-desktop/pull/673)) | codesign rejects (top-level entries forbidden) |
| 11 | this PR | aims to ship |