### PR TITLE
fix(release): compile Localizable.xcstrings to .lproj/.strings for SwiftUI

### DIFF
--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -120,9 +120,16 @@ cp "$EXE" "$APP/Contents/MacOS/Jellify"
 # Bundle.main, so no Swift-side change for the i18n path.
 RES_SRC="$MACOS/Sources/Jellify/Resources"
 if [[ -d "$RES_SRC" ]]; then
-    # Localizable.xcstrings sits at the root of Resources/.
-    if [[ -f "$RES_SRC/Localizable.xcstrings" ]]; then
-        cp "$RES_SRC/Localizable.xcstrings" "$APP/Contents/Resources/"
+    # Localizable.xcstrings is the source format. SwiftUI's
+    # LocalizedStringKey can't read xcstrings directly — it looks for
+    # compiled `<lang>.lproj/Localizable.strings` files. Compile via
+    # xcstringstool so the .app gets the runtime layout SwiftUI expects.
+    # Without this step, every LocalizedStringKey site falls through to
+    # rendering its lookup key (`auth.sign_in`, `app.name`, etc.).
+    if [[ -f "$RES_SRC/Localizable.xcstrings" ]] && command -v xcrun >/dev/null 2>&1; then
+        xcrun xcstringstool compile "$RES_SRC/Localizable.xcstrings" \
+            -o "$APP/Contents/Resources/" 2>/dev/null || \
+            cp "$RES_SRC/Localizable.xcstrings" "$APP/Contents/Resources/"
     fi
     # Fonts/*.otf — flatten into Contents/Resources/ so Bundle.main
     # finds them with `url(forResource: "Figtree-Bold", withExtension:


### PR DESCRIPTION
## Summary

The [v0.2.0-rc11](https://github.com/skalthoff/jellify-desktop/releases/tag/v0.2.0-rc11) DMG launches but every `LocalizedStringKey` site renders its **lookup key** verbatim instead of the localized string:

```
app.name
app.subtitle.desktop
login.field.url
login.field.username
login.field.password
auth.sign_in
menu.playback
...
```

Cause: [#674](https://github.com/skalthoff/jellify-desktop/pull/674) dropped SwiftPM resource processing and replaced it with `cp Localizable.xcstrings → Contents/Resources/`. SwiftUI's `LocalizedStringKey` resolver doesn't read `.xcstrings` (the Xcode 15+ source format) — it looks for compiled `<lang>.lproj/Localizable.strings` files at the standard CFBundle path. SwiftPM's resource processing ran that compile step under the hood; the manual `cp` didn't.

## Fix

Invoke `xcrun xcstringstool compile` in `make-bundle.sh` before the bundle is finalised. Output lands at `Contents/Resources/en.lproj/Localizable.strings` (plus any other locales as they're added), which is exactly where SwiftUI looks. Falls back to a plain `cp` if `xcrun` isn't on `PATH` so non-Xcode build environments don't break entirely.

## Test plan

Verified locally on Apple Silicon (rc11-equivalent local build with this fix applied):

- [x] **Login screen renders English text** — `Jellify` / `SERVER URL` / `USERNAME` / `PASSWORD` / `Sign in` (was raw lookup keys).
- [x] **Sign-in to `https://music.skalthoff.com`** (test/test) succeeds: library populates with `100 OF 20060 ALBUMS` (matches the test server), 78 playlists in sidebar.
- [x] **Hidden affordances confirmed** ([#663](https://github.com/skalthoff/jellify-desktop/pull/663)) — album context menu shows Play / Shuffle / Play Next / Add to Queue / Album Radio / Add to Playlist / Go to Artist / Go to Album / Favorite / Copy Link. **Mark All as Played**, **Download**, **Edit Album** are all gone as designed.
- [x] **Playback works** — clicking Play on an Ed Sheeran album starts streaming via AVQueuePlayer; transport bar shows position counter advancing in real time (0:07 → 0:54), audio routes to MacBook Pro Speakers.
- [x] **Queue mutation works** ([#662](https://github.com/skalthoff/jellify-desktop/pull/662)) — Add to Queue context-menu action completes cleanly while another track is playing.
- [ ] Tag `v0.2.0-rc12` after merge → verify the CI-built DMG carries the compiled `.strings` and matches the local-build behaviour.
- [ ] Once rc12 is verified, tag `v0.2.0`.