### PR TITLE
chore: open v0.3.0 — bump workspace + roadmap snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jellify-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "jellify_core",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "jellify-desktop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "jellify_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-only"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Ship a **native desktop Jellyfin client** — no Electron, no webview — that f
 - **M1 — Rust core foundation** ✅ Completed. Jellyfin REST client, SQLite cache, keyring credential store, queue state, UniFFI bindings. `cargo test --workspace` passes.
 - **M2 — macOS app MVP** ✅ Completed. SwiftUI shell (Login, Library grid, Album detail, Search, PlayerBar), AVPlayer-backed streaming, headless `SmokeTest` integration verifier. End-to-end playback validated against a real Jellyfin server.
 - **M3 — macOS polish** 🔵 In progress. Driven by the research sprint captured in [/tmp/jellify-research](../..//tmp/jellify-research) and the issues filed under the `M3 — macOS polish` milestone.
-- **M4 — macOS distribution** 🟢 Operational. v0.2.0 shipped 2026-04-25 (Apple Silicon DMG, Sparkle appcast live). Universal binary + Intel slice deferred to v0.3.0.
+- **M4 — macOS distribution** 🟢 Operational. v0.2.0 shipped 2026-04-25 (Apple Silicon DMG, Sparkle appcast live). Apple Silicon only — Intel is out of scope; the install base no longer justifies the multi-arch build complexity.
 - **M5 — Windows port** ⚪ Scoped. WinUI 3 + UniFFI .NET bindings + SMTC + MSIX.
 - **M6 — Linux port** ⚪ Scoped. GTK4 + libadwaita + GStreamer + MPRIS2 + Flathub.
 
@@ -19,8 +19,7 @@ Ship a **native desktop Jellyfin client** — no Electron, no webview — that f
 
 Wires the visible "not yet wired" stubs in `AppModel.swift` as real FFI calls
 (downloads, add-to-playlist, mark-as-played, artist play/shuffle, genre browse,
-similar artists, Instant Mix everywhere) and ships the deferred Intel slice so
-the DMG runs on every Mac.
+similar artists, Instant Mix everywhere).
 
 Out of scope for 0.3 (deferred to 0.4): lyrics, mini-player, crossfade/EQ
 wiring, perf refactors, Swift 6 / Sendable migration, the P1/P2 sweep from
@@ -48,7 +47,7 @@ Deliverable: `gh release create vX.Y.Z` produces a signed, notarized, stapled `J
 Key work:
 - Developer ID signing + hardened runtime entitlements.
 - `notarytool` CI pipeline with Keychain-stored credentials.
-- `create-dmg` packaging, universal binary via `lipo`.
+- `create-dmg` packaging, Apple Silicon only (Intel out of scope).
 - Sparkle 2 via SPM, EdDSA-signed appcast hosted on GitHub Pages.
 - Crash reporting (opt-in Sentry-Cocoa).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,9 +11,20 @@ Ship a **native desktop Jellyfin client** — no Electron, no webview — that f
 - **M1 — Rust core foundation** ✅ Completed. Jellyfin REST client, SQLite cache, keyring credential store, queue state, UniFFI bindings. `cargo test --workspace` passes.
 - **M2 — macOS app MVP** ✅ Completed. SwiftUI shell (Login, Library grid, Album detail, Search, PlayerBar), AVPlayer-backed streaming, headless `SmokeTest` integration verifier. End-to-end playback validated against a real Jellyfin server.
 - **M3 — macOS polish** 🔵 In progress. Driven by the research sprint captured in [/tmp/jellify-research](../..//tmp/jellify-research) and the issues filed under the `M3 — macOS polish` milestone.
-- **M4 — macOS distribution** 🟡 Scoped. Signing, notarization, DMG, Sparkle auto-update, GitHub Release CI.
+- **M4 — macOS distribution** 🟢 Operational. v0.2.0 shipped 2026-04-25 (Apple Silicon DMG, Sparkle appcast live). Universal binary + Intel slice deferred to v0.3.0.
 - **M5 — Windows port** ⚪ Scoped. WinUI 3 + UniFFI .NET bindings + SMTC + MSIX.
 - **M6 — Linux port** ⚪ Scoped. GTK4 + libadwaita + GStreamer + MPRIS2 + Flathub.
+
+### Active release: v0.3.0 — "Feature-gap closure" 🔵 In progress
+
+Wires the visible "not yet wired" stubs in `AppModel.swift` as real FFI calls
+(downloads, add-to-playlist, mark-as-played, artist play/shuffle, genre browse,
+similar artists, Instant Mix everywhere) and ships the deferred Intel slice so
+the DMG runs on every Mac.
+
+Out of scope for 0.3 (deferred to 0.4): lyrics, mini-player, crossfade/EQ
+wiring, perf refactors, Swift 6 / Sendable migration, the P1/P2 sweep from
+audit issue #610.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

Opens the **v0.3.0 "Feature-gap closure"** milestone now that v0.2.0 has shipped (Apple Silicon DMG, Sparkle appcast live, 12-RC pipeline cleared).

- `Cargo.toml` workspace version `0.2.0 → 0.3.0`. `Cargo.lock` regenerated via `cargo check --workspace`; `jellify_core`, `jellify-cli`, `jellify-desktop` follow.
- `ROADMAP.md` marks M4 distribution **operational** and adds an "Active release: v0.3.0" section describing the in-flight scope.
- macOS `Info.plist` is untouched — `CFBundleShortVersionString` is templated at build-time by `make-bundle.sh` from the git tag, so the version flows through whenever `v0.3.0-rc1` (or later) is tagged.

## What 0.3 closes

The plan: wire the 14+ visible `print("…not yet wired…")` stubs in `AppModel.swift` as real FFI calls — downloads, add-to-playlist, mark-as-played, artist play/shuffle, genre browse, similar artists, Instant Mix everywhere — and ship the deferred Intel slice so the DMG runs on every Mac. Audit issue #610 P1/P2 sweep, lyrics, mini-player, crossfade/EQ, and Swift 6 migration are explicitly out of scope and defer to 0.4.

## Test plan

- [x] `cargo check --workspace --offline` — clean compile at 0.3.0
- [ ] CI passes
- [ ] Tag `v0.3.0-rc1` later in 0.3 cycle — confirm `make-bundle.sh` injects 0.3.0 into the bundle plist