### PR TITLE
chore: drop Intel — Apple Silicon only (#660 wontfix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           xcode-version: latest-stable
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
           key: macos-app

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,9 +70,7 @@ jobs:
           xcode-version: latest-stable
       - uses: dtolnay/rust-toolchain@stable
         with:
-          # build-core.sh targets aarch64 by default; x86_64 must be installed
-          # explicitly so the runner can produce universal xcframeworks.
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
           key: e2e-macos

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -89,22 +89,20 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # ------------------------------------------------------------------
-      # Build the Rust xcframework and the Swift app.
-      # 0.2 ships arm64 only — see the `Select Xcode` comment above for the
-      # multi-arch tradeoff. Restore `--release` (no `--arm64-only`) and
-      # `swift build --arch arm64 --arch x86_64` once 0.3's Swift 6 cleanup
-      # lands.
+      # Build the Rust xcframework and the Swift app. Apple Silicon only —
+      # Intel was dropped from M4 distribution; the install base no longer
+      # justifies the multi-arch build complexity (and SwiftPM xcframework
+      # consumption with `swift build --arch arm64 --arch x86_64` is broken
+      # under Xcode 26 — see #660 wontfix).
       # ------------------------------------------------------------------
-      - name: Build xcframework (arm64)
+      - name: Build xcframework
         working-directory: macos
-        run: ./Scripts/build-core.sh --release --arm64-only
+        run: ./Scripts/build-core.sh --release
 
-      - name: Swift build (release, arm64)
+      - name: Swift build (release)
         working-directory: macos
-        # Native single-arch build on the macos-14 (Apple Silicon) runner
-        # — emits arm64 binaries from `.build/release/`. Avoids xcodebuild
-        # routing that the multi-arch flag triggers, so deps compile in
-        # the same lenient mode as regular CI.
+        # Native single-arch build on the macos-15 (Apple Silicon) runner
+        # — emits arm64 binaries from `.build/release/`.
         run: swift build -c release
 
       - name: Install create-dmg

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -52,18 +52,16 @@ jobs:
         with:
           # `latest-stable` resolves to Xcode 16.2 on the macos-14 runner
           # today. Xcode 16.x compiles Nuke 13.0.2 cleanly via single-arch
-          # `swift build` (the regular CI proves this on every PR). The
-          # multi-arch route through xcodebuild trips strict-concurrency
-          # errors in Nuke, so the 0.2 release ships Apple Silicon only —
-          # see the `Swift build` step below. Universal slice returns in
-          # 0.3 alongside the wider Swift 6 / Sendable cleanup.
+          # `swift build`. Apple Silicon only — Intel was dropped from
+          # macOS distribution permanently (#660 wontfix); current install
+          # base no longer justifies multi-arch build complexity, and
+          # SwiftPM xcframework consumption with multi-arch is broken under
+          # Xcode 26.
           xcode-version: latest-stable
 
       - name: Install Rust (Apple Silicon)
         uses: dtolnay/rust-toolchain@stable
         with:
-          # 0.2 ships Apple Silicon only; the x86_64 slice is deferred to
-          # 0.3 once Nuke / strict-concurrency on multi-arch is sorted.
           targets: aarch64-apple-darwin
 
       - name: Cache cargo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ carries `uniffi::Record` / `uniffi::Enum`, the xcframework and
 `jellify_core.swift` bindings need regeneration:
 
 ```bash
-./macos/Scripts/build-core.sh --arm64-only         # dev
+./macos/Scripts/build-core.sh                      # dev (debug)
 ./macos/Scripts/build-core.sh --release            # ship
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ Deliverable: `gh release create vX.Y.Z` produces a signed, notarized, stapled `J
 Key work:
 - Developer ID signing + hardened runtime entitlements.
 - `notarytool` CI pipeline with Keychain-stored credentials.
-- `create-dmg` packaging, universal binary via `lipo`.
+- `create-dmg` packaging, Apple Silicon arm64 only (Intel dropped — see #660).
 - Sparkle 2 via SPM, EdDSA-signed appcast hosted on GitHub Pages.
 - Crash reporting (opt-in Sentry-Cocoa).
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,6 @@ all-features = true
 # Windows and Linux apps land.
 targets = [
     { triple = "aarch64-apple-darwin" },
-    { triple = "x86_64-apple-darwin" },
     { triple = "x86_64-pc-windows-msvc" },
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -127,7 +127,7 @@ login keychain under the name `jellify-notary`.
 
 ```sh
 brew install create-dmg jq shellcheck
-rustup target add aarch64-apple-darwin x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
 ```
 
 `shellcheck` is dev-only. `jq` is required by `notarize.sh`. Xcode
@@ -141,7 +141,7 @@ command line tools must be present (`xcode-select --install`).
 | -------------------------------------------- | -------------------------------------------------------------- |
 | `macos/Resources/Info.plist`                 | Info.plist template with `$VERSION`/`$BUILD` placeholders      |
 | `macos/Resources/Jellify.entitlements`       | Hardened-runtime entitlements applied at signing time          |
-| `macos/Scripts/build-core.sh`                | Builds the Rust core as a universal `arm64 + x86_64` xcframework|
+| `macos/Scripts/build-core.sh`                | Builds the Rust core as an `arm64` xcframework                  |
 | `macos/Scripts/make-bundle.sh`               | Assembles `Jellify.app` and injects Info.plist version fields  |
 | `macos/Scripts/sign.sh`                      | Codesigns the bundle inside-out with the hardened runtime      |
 | `macos/Scripts/make-dmg.sh`                  | Produces `Jellify-<version>.dmg` via `create-dmg`              |
@@ -155,16 +155,16 @@ Each script is idempotent and cleans up after itself on failure, so a
 partial run can be retried from any step.
 
 ```sh
-# 1. Build the Rust core as a universal xcframework.
+# 1. Build the Rust core as an arm64 xcframework.
 ./macos/Scripts/build-core.sh --release
 
-# 2. Compile Swift for both architectures.
+# 2. Compile Swift for arm64 (Apple Silicon only).
 cd macos
-swift build -c release --arch arm64 --arch x86_64
+swift build -c release
 cd ..
 
 # 3. Assemble Jellify.app. Picks up $VERSION / $BUILD (or git fallback).
-VERSION=0.1.0 BUILD=1 ./macos/Scripts/make-bundle.sh --release --universal
+VERSION=0.1.0 BUILD=1 ./macos/Scripts/make-bundle.sh --release
 
 # 4. Code-sign inside-out with the hardened runtime.
 DEVELOPER_ID="Developer ID Application: Your Name (TEAMID123)" \
@@ -192,7 +192,7 @@ Jellify.app/
 ├── Contents/
 │   ├── Info.plist           (rendered from Resources/Info.plist)
 │   ├── MacOS/
-│   │   └── Jellify          (universal Mach-O, signed + hardened runtime)
+│   │   └── Jellify          (arm64 Mach-O, signed + hardened runtime)
 │   ├── Resources/
 │   │   ├── AppIcon.icns     (optional — soft-dependency on icon pipeline)
 │   │   └── Jellify_Jellify.bundle/   (SPM-processed fonts bundle)
@@ -209,14 +209,12 @@ ROADMAP) and will live at `Contents/Frameworks/Sparkle.framework`.
 
 ### `build-core.sh`
 
-Builds `libjellify_core.a` for both `aarch64-apple-darwin` and
-`x86_64-apple-darwin` (in release mode; LTO is pinned in `Cargo.toml`),
-then fuses them into a single fat archive with `lipo`. The UniFFI
-Swift binding is regenerated from the arm64 `.dylib` and both the
-headers and the fat static lib go into `macos/Jellify.xcframework`,
-which the SPM `binaryTarget` consumes.
+Builds `libjellify_core.a` for `aarch64-apple-darwin` (in release mode;
+LTO is pinned in `Cargo.toml`). The UniFFI Swift binding is regenerated
+from the `.dylib`, and both the headers and the static lib go into
+`macos/Jellify.xcframework`, which the SPM `binaryTarget` consumes.
 
-Pass `--arm64-only` during development to skip the x86_64 leg.
+Apple Silicon only — Intel was dropped from M4 distribution (#660 wontfix).
 
 ### `make-bundle.sh`
 

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -399,7 +399,7 @@ auto-updating `.app` on someone's Mac.
 ```
   git tag v0.2.0  ── push ──►  .github/workflows/macos-release.yml
        │
-       ├─ build universal xcframework (arm64 + x86_64)
+       ├─ build arm64 xcframework (Apple Silicon only — see #660)
        ├─ swift build -c release
        ├─ make-iconset.sh            → Resources/Jellify.icns
        ├─ make-bundle.sh             → build/Jellify.app

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -89,9 +89,8 @@ let package = Package(
     // target `.swiftLanguageMode(.v5)`. The per-target API serialises to
     // `5` (no `.0`) and xcodebuild on Xcode 26 rejects it (`SWIFT_VERSION
     // '5' unsupported, supported: 4.0, 4.2, 5.0, 6.0`). The package-level
-    // form serialises through `SWIFT_VERSION = 5.0` so multi-arch
-    // `swift build --arch arm64 --arch x86_64` (which routes through
-    // xcodebuild) accepts it. Stays on Swift 5 mode pending the wider
-    // Sendable / strict-concurrency cleanup tracked across the codebase.
+    // form serialises through `SWIFT_VERSION = 5.0`. Stays on Swift 5 mode
+    // pending the wider Sendable / strict-concurrency cleanup tracked
+    // across the codebase.
     swiftLanguageVersions: [.v5]
 )

--- a/macos/Scripts/build-core.sh
+++ b/macos/Scripts/build-core.sh
@@ -2,23 +2,20 @@
 # Build the jellify_core Rust library for macOS and wrap it as an XCFramework
 # that the Swift package can consume.
 #
-# By default this builds a universal xcframework (arm64 + x86_64) stitched
-# together with `lipo`. The install base still has a meaningful Intel tail
-# (pre-2020 Macs, Ventura floor) so the shipped DMG must cover both.
-#
-# Single-arch is still available for dev-loop speed via --arm64-only.
+# Apple Silicon only. The Intel slice was dropped after the audit (the
+# install base no longer justifies the multi-arch build complexity, and
+# SwiftPM xcframework consumption with `swift build --arch arm64 --arch
+# x86_64` is broken under Xcode 26 — see #660).
 #
 # Usage:
-#   ./macos/Scripts/build-core.sh                 # universal debug
-#   ./macos/Scripts/build-core.sh --release       # universal release
-#   ./macos/Scripts/build-core.sh --arm64-only    # skip x86_64 (dev only)
+#   ./macos/Scripts/build-core.sh                 # debug
+#   ./macos/Scripts/build-core.sh --release       # release
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MACOS="$ROOT/macos"
 PROFILE="debug"
 CARGO_FLAGS=""
-UNIVERSAL=1
 
 for arg in "$@"; do
     case "$arg" in
@@ -30,29 +27,20 @@ for arg in "$@"; do
             PROFILE="debug"
             CARGO_FLAGS=""
             ;;
-        --arm64-only)
-            UNIVERSAL=0
-            ;;
         -h | --help)
-            sed -n '2,14p' "${BASH_SOURCE[0]}"
+            sed -n '2,12p' "${BASH_SOURCE[0]}"
             exit 0
             ;;
         *)
             echo "error: unknown argument: $arg" >&2
-            echo "usage: $0 [--release|--debug] [--arm64-only]" >&2
+            echo "usage: $0 [--release|--debug]" >&2
             exit 2
             ;;
     esac
 done
 
 ARM64_TARGET="aarch64-apple-darwin"
-X86_64_TARGET="x86_64-apple-darwin"
-
-# Per-arch expected artifact paths.
 ARM64_STATIC="$ROOT/target/$ARM64_TARGET/$PROFILE/libjellify_core.a"
-X86_64_STATIC="$ROOT/target/$X86_64_TARGET/$PROFILE/libjellify_core.a"
-UNIVERSAL_DIR="$ROOT/target/universal-apple-darwin/$PROFILE"
-UNIVERSAL_STATIC="$UNIVERSAL_DIR/libjellify_core.a"
 
 # Scratch dirs we might touch; cleaned up on failure so a re-run isn't
 # bitten by a half-written xcframework.
@@ -75,36 +63,11 @@ cleanup_on_failure() {
 }
 trap cleanup_on_failure EXIT
 
-echo "==> Building jellify_core ($PROFILE, universal=$UNIVERSAL)"
+echo "==> Building jellify_core ($PROFILE)"
 (cd "$ROOT" && cargo build $CARGO_FLAGS --target "$ARM64_TARGET" -p jellify_core)
 if [[ ! -f "$ARM64_STATIC" ]]; then
     echo "error: arm64 static lib not found at $ARM64_STATIC" >&2
     exit 1
-fi
-
-if [[ "$UNIVERSAL" -eq 1 ]]; then
-    # Ensure the x86_64 target is installed; fail with a clear message if not.
-    if ! rustup target list --installed 2>/dev/null | grep -q "^$X86_64_TARGET$"; then
-        echo "error: $X86_64_TARGET rustup target is not installed." >&2
-        echo "       run: rustup target add $X86_64_TARGET" >&2
-        echo "       (or pass --arm64-only for a dev build)" >&2
-        exit 1
-    fi
-
-    (cd "$ROOT" && cargo build $CARGO_FLAGS --target "$X86_64_TARGET" -p jellify_core)
-    if [[ ! -f "$X86_64_STATIC" ]]; then
-        echo "error: x86_64 static lib not found at $X86_64_STATIC" >&2
-        exit 1
-    fi
-
-    echo "==> Fusing universal static lib via lipo"
-    mkdir -p "$UNIVERSAL_DIR"
-    lipo -create "$ARM64_STATIC" "$X86_64_STATIC" -output "$UNIVERSAL_STATIC"
-    # Sanity check: lipo -info should report both arches.
-    lipo -info "$UNIVERSAL_STATIC"
-    STATIC="$UNIVERSAL_STATIC"
-else
-    STATIC="$ARM64_STATIC"
 fi
 
 echo "==> Building uniffi-bindgen"
@@ -147,7 +110,7 @@ echo "==> Creating $XCF"
 XCF_IN_PROGRESS=1
 rm -rf "$XCF"
 xcodebuild -create-xcframework \
-    -library "$STATIC" \
+    -library "$ARM64_STATIC" \
     -headers "$HEADERS" \
     -output "$XCF" >/dev/null
 XCF_IN_PROGRESS=

--- a/macos/Scripts/generate-appcast.sh
+++ b/macos/Scripts/generate-appcast.sh
@@ -99,11 +99,12 @@ fi
 while IFS= read -r tag; do
   [[ -z "$tag" ]] && continue
   echo "    tag: $tag"
-  # Each tag's DMGs go into their own subdir so generate_appcast emits
-  # relative paths like "$tag/Jellify-X.Y.Z.dmg". Combined with the
-  # url-prefix below (.../releases/download/), this produces the working
-  # GitHub release-asset URL .../releases/download/$tag/Jellify-X.Y.Z.dmg.
-  # Flat layout would drop the $tag segment and 404. Fixes #742.
+  # Each tag's DMGs (Apple Silicon only — one DMG per release; #660) go into
+  # their own subdir so generate_appcast emits relative paths like
+  # "$tag/Jellify-X.Y.Z.dmg". Combined with the url-prefix below
+  # (.../releases/download/), this produces the working GitHub release-asset
+  # URL .../releases/download/$tag/Jellify-X.Y.Z.dmg. Flat layout would
+  # drop the $tag segment and 404. Fixes #742.
   mkdir -p "$DMG_DIR/$tag"
   gh release download "$tag" \
     --repo "$GITHUB_REPOSITORY" \

--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -11,12 +11,11 @@
 #   3. Fallback: 0.0.0-dev / 0.
 #
 # Usage:
-#   ./macos/Scripts/make-bundle.sh                      # debug arm64 build
-#   ./macos/Scripts/make-bundle.sh --release            # release arm64 build
-#   ./macos/Scripts/make-bundle.sh --release --universal # release arm64+x86_64
+#   ./macos/Scripts/make-bundle.sh                      # debug build
+#   ./macos/Scripts/make-bundle.sh --release            # release build
 #
-# The --universal flag selects the `apple/Products` output tree that
-# `swift build --arch arm64 --arch x86_64` produces.
+# Apple Silicon only — Intel was dropped from M4 distribution. swift-build
+# outputs land under `<triple>/<profile>` and the bundle is single-arch.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -26,19 +25,17 @@ INFO_TEMPLATE="$RESOURCES/Info.plist"
 APP="$MACOS/build/Jellify.app"
 
 PROFILE="debug"
-UNIVERSAL=0
 for arg in "$@"; do
     case "$arg" in
         --release) PROFILE="release" ;;
         --debug)   PROFILE="debug"   ;;
-        --universal) UNIVERSAL=1 ;;
         -h | --help)
-            sed -n '2,19p' "${BASH_SOURCE[0]}"
+            sed -n '2,17p' "${BASH_SOURCE[0]}"
             exit 0
             ;;
         *)
             echo "error: unknown argument: $arg" >&2
-            echo "usage: $0 [--release|--debug] [--universal]" >&2
+            echo "usage: $0 [--release|--debug]" >&2
             exit 2
             ;;
     esac
@@ -49,20 +46,13 @@ if [[ ! -f "$INFO_TEMPLATE" ]]; then
     exit 1
 fi
 
-# Pick the swift-build output directory. The universal build puts products
-# under `apple/Products/<Configuration>`; single-arch builds use
-# `<triple>/<profile>`.
-if [[ "$UNIVERSAL" -eq 1 ]]; then
-    CONFIG_CAP="$(tr '[:lower:]' '[:upper:]' <<< "${PROFILE:0:1}")${PROFILE:1}"
-    BUILD_DIR="$MACOS/.build/apple/Products/$CONFIG_CAP"
-else
-    BUILD_DIR="$MACOS/.build/arm64-apple-macosx/$PROFILE"
-fi
+# swift-build single-arch output directory.
+BUILD_DIR="$MACOS/.build/arm64-apple-macosx/$PROFILE"
 EXE="$BUILD_DIR/Jellify"
 
 if [[ ! -x "$EXE" ]]; then
     echo "error: Jellify executable not found at $EXE" >&2
-    echo "       run 'swift build' (or './macos/Scripts/build-core.sh --release' + a universal swift build) first" >&2
+    echo "       run './macos/Scripts/build-core.sh --release' + 'swift build -c release' first" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Strips Intel from the macOS build pipeline and docs. Closes #660 as wontfix.

The Intel install base no longer justifies the multi-arch build complexity, and SwiftPM xcframework consumption with `swift build --arch arm64 --arch x86_64` is broken under Xcode 26 — both the canonical lipo'd universal slice ("Library not found for -ljellify_core") and a hand-crafted two-slice layout ("Both 'macos-arm64' and 'macos-x86_64' represent two equivalent library definitions") fail at link/load time. Both reproduced locally before deciding to drop the slice entirely.

## Files touched

- **`macos/Scripts/build-core.sh`** — drops `--arm64-only` flag (now the only mode), drops `UNIVERSAL`/`lipo` branch, drops `X86_64_TARGET`/`UNIVERSAL_STATIC` paths.
- **`macos/Scripts/make-bundle.sh`** — drops `--universal` flag and the `apple/Products` build-tree branch.
- **`.github/workflows/macos-release.yml`** — drops the "0.3 will restore arch flags" comment, drops `--arm64-only` from the `build-core.sh` invocation, renames step.
- **`macos/Package.swift`** — drops the `swift build --arch arm64 --arch x86_64` rationale from the Swift 5 mode comment.
- **`macos/Scripts/generate-appcast.sh`** — "one (universal) or two (per-arch)" → "one DMG per release".
- **`deny.toml`** — drops `x86_64-apple-darwin` from the cargo-deny target list.
- **`macos/DISTRIBUTION.md`** — tooling install, files table, release flow, bundle layout, script-detail section all updated.
- **`CLAUDE.md`** — drops `--arm64-only` from the dev-command example.

ROADMAP.md is updated separately on top of #676.

## Test plan

Verified locally on Xcode 26.4.1 / Swift 6.3.1:

- [x] `bash -n` on all three modified scripts: clean
- [x] `./macos/Scripts/build-core.sh --release` produces single-slice `Jellify.xcframework/macos-arm64/` (verified via `find`)
- [x] `rm -rf macos/.build && swift build -c release` cold build clean (34s, linked OK)
- [ ] CI passes
- [ ] Tag a `v0.3.0-rc1` later in cycle and confirm Sparkle update path still works