### PR TITLE
core+macos: wire mark_played / mark_unplayed (#133)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1526,6 +1526,121 @@ impl JellyfinClient {
         }
     }
 
+    /// Mark an item (track / album / playlist) as played for the current user.
+    ///
+    /// Uses the preferred `POST /UserPlayedItems/{itemId}` endpoint (user
+    /// inferred from the authentication token). Older Jellyfin builds that
+    /// answer 404 / 405 to that route fall back to the legacy
+    /// `POST /Users/{userId}/PlayedItems/{itemId}` endpoint.
+    ///
+    /// Returns the full updated [`UserItemData`] so the UI can update both
+    /// its `played` glyph and the `play_count` text without refetching the
+    /// item. Server-side this bumps `PlayCount` by one and stamps a fresh
+    /// `LastPlayedDate` (Jellyfin does NOT cascade to children — calling
+    /// this on an album does not increment per-track play counts).
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set. See #133.
+    pub async fn mark_played(&self, item_id: &str) -> Result<UserItemData> {
+        self.require_token()?;
+
+        let url = self.endpoint(&format!("UserPlayedItems/{item_id}"))?;
+        let resp = self
+            .send_with_retry_raw(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
+            .await?;
+
+        if resp.status().is_success() {
+            let raw: RawUserData = resp.json().await?;
+            return Ok(raw.into());
+        }
+
+        if matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            if let Some(user_id) = self.user_id.as_ref() {
+                let legacy_url =
+                    self.endpoint(&format!("Users/{user_id}/PlayedItems/{item_id}"))?;
+                let legacy_resp = self
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .post(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
+                    .await?;
+                let raw: RawUserData = legacy_resp.json().await?;
+                return Ok(raw.into());
+            }
+        }
+
+        let raw: RawUserData = Self::check(resp).await?.json().await?;
+        Ok(raw.into())
+    }
+
+    /// Clear the played flag from an item for the current user.
+    ///
+    /// Uses the preferred `DELETE /UserPlayedItems/{itemId}` endpoint, with
+    /// a fallback to `DELETE /Users/{userId}/PlayedItems/{itemId}` for
+    /// older Jellyfin builds that answer 404 / 405.
+    ///
+    /// Server-side this resets `PlayCount` to zero and clears
+    /// `LastPlayedDate`. Returns the updated [`UserItemData`] for the same
+    /// no-refetch UI refresh as [`Self::mark_played`].
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set. See #133.
+    pub async fn mark_unplayed(&self, item_id: &str) -> Result<UserItemData> {
+        self.require_token()?;
+
+        let url = self.endpoint(&format!("UserPlayedItems/{item_id}"))?;
+        let resp = self
+            .send_with_retry_raw(|| {
+                Ok(self.http.delete(url.clone()).headers(self.build_headers()?))
+            })
+            .await?;
+
+        if resp.status().is_success() {
+            let raw: RawUserData = resp.json().await?;
+            return Ok(raw.into());
+        }
+
+        if matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            if let Some(user_id) = self.user_id.as_ref() {
+                let legacy_url =
+                    self.endpoint(&format!("Users/{user_id}/PlayedItems/{item_id}"))?;
+                let legacy_resp = self
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .delete(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
+                    .await?;
+                let raw: RawUserData = legacy_resp.json().await?;
+                return Ok(raw.into());
+            }
+        }
+
+        let raw: RawUserData = Self::check(resp).await?.json().await?;
+        Ok(raw.into())
+    }
+
+    /// Convenience dispatcher: route to [`Self::mark_played`] when `played`
+    /// is `true` and [`Self::mark_unplayed`] otherwise. Mirrors the shape
+    /// of [`Self::toggle_favorite`] for callers that only know the desired
+    /// target state. See #133.
+    pub async fn set_played(&self, item_id: &str, played: bool) -> Result<UserItemData> {
+        if played {
+            self.mark_played(item_id).await
+        } else {
+            self.mark_unplayed(item_id).await
+        }
+    }
+
     /// Create a new playlist for the current user via `POST /Playlists`.
     ///
     /// The request body uses Jellyfin's PascalCase keys:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -693,6 +693,42 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.toggle_favorite(&item_id, favorite)))
     }
 
+    /// Mark an item (track / album / playlist) as played for the current
+    /// user. Returns the full updated [`UserItemData`] so the UI can update
+    /// `played` + `play_count` + `last_played_at` without refetching. Errors
+    /// with [`JellifyError::NotAuthenticated`] if no session is active.
+    /// See issue #133.
+    pub fn mark_played(
+        &self,
+        item_id: String,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.mark_played(&item_id)))
+    }
+
+    /// Clear the played flag from an item for the current user. Returns the
+    /// updated [`UserItemData`] (with `play_count = 0` and `last_played_at =
+    /// None`). Errors with [`JellifyError::NotAuthenticated`] if no session
+    /// is active. See issue #133.
+    pub fn mark_unplayed(
+        &self,
+        item_id: String,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.mark_unplayed(&item_id)))
+    }
+
+    /// Set or clear an item's played flag in a single call. `played=true`
+    /// dispatches to [`Self::mark_played`], `false` dispatches to
+    /// [`Self::mark_unplayed`]. Mirrors the shape of [`Self::toggle_favorite`]
+    /// for multi-select callers that compute the target state from the
+    /// majority current state of the selection. See issue #133.
+    pub fn set_played(
+        &self,
+        item_id: String,
+        played: bool,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.set_played(&item_id, played)))
+    }
+
     /// Create a new playlist for the current user. Returns the new
     /// playlist id — callers refetch the full [`Playlist`] via
     /// [`JellifyCore::fetch_item`] if they need the populated record.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -698,10 +698,7 @@ impl JellifyCore {
     /// `played` + `play_count` + `last_played_at` without refetching. Errors
     /// with [`JellifyError::NotAuthenticated`] if no session is active.
     /// See issue #133.
-    pub fn mark_played(
-        &self,
-        item_id: String,
-    ) -> std::result::Result<UserItemData, JellifyError> {
+    pub fn mark_played(&self, item_id: String) -> std::result::Result<UserItemData, JellifyError> {
         self.with_client(|c| self.runtime.block_on(c.mark_played(&item_id)))
     }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7020,3 +7020,220 @@ fn player_clear_drops_queue() {
     assert_eq!(status.queue_position, 0, "clear() must reset queue_index");
     assert!(player.current_in_queue().is_none());
 }
+
+// ============================================================================
+// mark_played / mark_unplayed (#133)
+// Mirrors the favorite-endpoint test shape: preferred /UserPlayedItems route
+// for new servers, legacy /Users/{userId}/PlayedItems fallback for old ones,
+// and an auth-required guard before any HTTP traffic.
+// ============================================================================
+
+#[tokio::test]
+async fn mark_played_uses_preferred_endpoint_and_returns_user_data() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": true,
+            "PlayCount": 3,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": "2026-04-25T18:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_played("track-abc").await.unwrap();
+    assert!(state.played);
+    assert_eq!(state.play_count, 3);
+    assert_eq!(state.last_played_at.as_deref(), Some("2026-04-25T18:00:00Z"));
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/UserPlayedItems/track-abc")
+        .expect("expected POST to preferred played endpoint");
+    assert!(post.body.is_empty(), "expected empty body, got {:?}", post.body);
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().starts_with("/Users/u1/PlayedItems/")),
+        "unexpected fallback to legacy route"
+    );
+}
+
+#[tokio::test]
+async fn mark_unplayed_uses_preferred_endpoint_and_returns_user_data() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": false,
+            "PlayCount": 0,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_unplayed("track-abc").await.unwrap();
+    assert!(!state.played);
+    assert_eq!(state.play_count, 0);
+    assert!(state.last_played_at.is_none());
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "DELETE"
+            && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected DELETE to /UserPlayedItems/track-abc"
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().starts_with("/Users/u1/PlayedItems/")),
+        "unexpected fallback to legacy route"
+    );
+}
+
+#[tokio::test]
+async fn mark_played_falls_back_to_legacy_route_on_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Users/u1/PlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": true,
+            "PlayCount": 1,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": "2026-04-25T18:30:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_played("track-abc").await.unwrap();
+    assert!(state.played);
+    assert_eq!(state.play_count, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST" && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected preferred route to be tried first"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST"
+                && r.url.path() == "/Users/u1/PlayedItems/track-abc"),
+        "expected fallback to legacy route after 404"
+    );
+}
+
+#[tokio::test]
+async fn mark_unplayed_falls_back_to_legacy_route_on_405() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/Users/u1/PlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": false,
+            "PlayCount": 0,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_unplayed("track-abc").await.unwrap();
+    assert!(!state.played);
+    assert_eq!(state.play_count, 0);
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "DELETE"
+            && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected preferred route to be tried first"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE"
+                && r.url.path() == "/Users/u1/PlayedItems/track-abc"),
+        "expected fallback to legacy route after 405"
+    );
+}
+
+#[tokio::test]
+async fn mark_played_without_session_returns_not_authenticated() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.mark_played("anything").await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    let err = client.mark_unplayed("anything").await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    // No HTTP traffic should have escaped the guard.
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "guard should short-circuit before any HTTP call, got {:?}",
+        requests
+    );
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7056,14 +7056,21 @@ async fn mark_played_uses_preferred_endpoint_and_returns_user_data() {
     let state = client.mark_played("track-abc").await.unwrap();
     assert!(state.played);
     assert_eq!(state.play_count, 3);
-    assert_eq!(state.last_played_at.as_deref(), Some("2026-04-25T18:00:00Z"));
+    assert_eq!(
+        state.last_played_at.as_deref(),
+        Some("2026-04-25T18:00:00Z")
+    );
 
     let requests = server.received_requests().await.unwrap();
     let post = requests
         .iter()
         .find(|r| r.method.as_str() == "POST" && r.url.path() == "/UserPlayedItems/track-abc")
         .expect("expected POST to preferred played endpoint");
-    assert!(post.body.is_empty(), "expected empty body, got {:?}", post.body);
+    assert!(
+        post.body.is_empty(),
+        "expected empty body, got {:?}",
+        post.body
+    );
     assert!(
         !requests
             .iter()
@@ -7104,8 +7111,9 @@ async fn mark_unplayed_uses_preferred_endpoint_and_returns_user_data() {
 
     let requests = server.received_requests().await.unwrap();
     assert!(
-        requests.iter().any(|r| r.method.as_str() == "DELETE"
-            && r.url.path() == "/UserPlayedItems/track-abc"),
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE" && r.url.path() == "/UserPlayedItems/track-abc"),
         "expected DELETE to /UserPlayedItems/track-abc"
     );
     assert!(
@@ -7202,8 +7210,9 @@ async fn mark_unplayed_falls_back_to_legacy_route_on_405() {
 
     let requests = server.received_requests().await.unwrap();
     assert!(
-        requests.iter().any(|r| r.method.as_str() == "DELETE"
-            && r.url.path() == "/UserPlayedItems/track-abc"),
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE" && r.url.path() == "/UserPlayedItems/track-abc"),
         "expected preferred route to be tried first"
     );
     assert!(

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -2863,6 +2863,14 @@ final class AppModel {
     /// round-trip.
     var favoriteById: [String: Bool] = [:]
 
+    /// In-memory played flag keyed by item id (track / album / playlist).
+    /// Mirrors `favoriteById` — populated lazily from
+    /// `track.userData?.played` and stamped with the server's authoritative
+    /// answer after every `mark_played` / `mark_unplayed` call. Used to
+    /// drive the "played" glyph in track rows and to compute the toggle
+    /// target state in `toggleMarkPlayed(tracks:)`. See #133.
+    var playedById: [String: Bool] = [:]
+
     /// Toggle the favorite flag for an album on the Jellyfin server. Reads
     /// the current state from `favoriteById` (falling back to `false` on a
     /// cold start) and calls the opposite side of `set_favorite` /
@@ -2912,6 +2920,33 @@ final class AppModel {
                 serverReachability.noteFailure()
             }
             errorMessage = JellifyErrorPresenter.message(for: error, context: .favorite)
+        }
+    }
+
+    /// Read the locally-cached played state for an item id. Mirrors
+    /// `isFavorite(id:)`; used by row views + `toggleMarkPlayed(tracks:)`
+    /// to compute the target state for a multi-select toggle. See #133.
+    func isPlayed(id: String) -> Bool {
+        playedById[id] ?? false
+    }
+
+    /// Internal helper — hits `mark_played` / `mark_unplayed` on the core
+    /// and mirrors the server's answer (full `UserItemData`) into
+    /// `playedById`. Mirrors `setFavorite(itemId:enabled:)` in shape so a
+    /// single-item toggle has a single failure path. See #133.
+    private func setPlayed(itemId: String, played: Bool) async {
+        do {
+            let state = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.setPlayed(itemId: itemId, played: played)
+            }.value
+            playedById[itemId] = state.played
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .markPlayed)
         }
     }
 
@@ -3061,11 +3096,16 @@ final class AppModel {
         playInstantMix(seedId: album.id)
     }
 
-    /// Mark every track on the album as played.
-    /// TODO: #133 / #222 — `mark_played` FFI not yet wired.
+    /// Mark the album as played server-side. Matches Jellyfin web's
+    /// "Mark Played" affordance: the album's `UserData.Played` flips and
+    /// `LastPlayedDate` stamps, but per-track `PlayCount` is **not**
+    /// incremented (Jellyfin doesn't cascade the operation to children).
+    /// `playedById[album.id]` flips immediately for the optimistic glyph
+    /// flip, then reconciles with the server's authoritative response. See #133.
     func markAllAsPlayed(album: Album) {
-        // TODO(#133): mark_played FFI not yet wired.
-        print("[AppModel] markAllAsPlayed(album:) not yet wired — see #133 / #222")
+        let target = !isPlayed(id: album.id)
+        playedById[album.id] = target
+        Task { await setPlayed(itemId: album.id, played: target) }
     }
 
     /// Present the album metadata editor. Admin-only once the sheet lands.
@@ -3833,12 +3873,30 @@ final class AppModel {
         print("[AppModel] toggleDownload(tracks: \(tracks.count)) not yet wired — see #70")
     }
 
-    /// Mark or unmark every track in the selection as played.
-    /// TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
+    /// Toggle the played flag across a multi-select of tracks. Target
+    /// state is "everyone unplayed" if **all** selected tracks are
+    /// currently played; otherwise "everyone played". This matches the
+    /// menubar / context-menu convention where a single click on a
+    /// mixed selection commits to one direction. Each track's flip is
+    /// optimistic locally and reconciled against the server's response;
+    /// failures don't abort the rest of the batch. See #133.
     func toggleMarkPlayed(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
-        // TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
-        print("[AppModel] toggleMarkPlayed(tracks: \(tracks.count)) not yet wired — see #133")
+        // Decide target: prefer the cached value, fall back to the track's
+        // embedded user_data, finally `false` if nothing is known. Mark
+        // played unless every track is *already* played.
+        let allPlayed = tracks.allSatisfy { track in
+            if let cached = playedById[track.id] { return cached }
+            return track.userData?.played ?? false
+        }
+        let target = !allPlayed
+        // Optimistic flip on the whole selection so the glyph updates instantly.
+        for track in tracks { playedById[track.id] = target }
+        Task {
+            for track in tracks {
+                await setPlayed(itemId: track.id, played: target)
+            }
+        }
     }
 
     // MARK: - Track sharing

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -16,7 +16,7 @@ extension AppModel {
 
     /// `mark_played` / `mark_unplayed` FFIs (#133, #222). Gates
     /// "Mark All as Played" on albums and "Mark as Played" on tracks.
-    var supportsMarkPlayed: Bool { false }
+    var supportsMarkPlayed: Bool { true }
 
     /// Artist-tracks FFI (#156, #465). Gates "Play All" / "Shuffle All"
     /// on artist surfaces. Top-track-driven actions (Play Next via

--- a/macos/Sources/Jellify/JellifyErrorPresenter.swift
+++ b/macos/Sources/Jellify/JellifyErrorPresenter.swift
@@ -128,6 +128,7 @@ enum JellifyErrorPresenter {
         case search
         case playback
         case favorite
+        case markPlayed
         case playlistAdd
 
         fileprivate var fallbackKey: String? {
@@ -142,6 +143,7 @@ enum JellifyErrorPresenter {
             case .search: return "error.search"
             case .playback: return "error.playback"
             case .favorite: return "error.favorite"
+            case .markPlayed: return "error.markPlayed"
             case .playlistAdd: return "error.playlist.add"
             }
         }

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -469,6 +469,18 @@
         }
       }
     },
+    "error.markPlayed" : {
+      "comment" : "Banner copy when marking an item played / unplayed fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't update played status."
+          }
+        }
+      }
+    },
     "error.playlist.add" : {
       "comment" : "Banner copy when adding a track to a playlist fails.",
       "extractionState" : "manual",


### PR DESCRIPTION
## Summary

Closes #133. Wires two visible \`print(\"…not yet wired…\")\` stubs in \`AppModel.swift\` (\`markAllAsPlayed(album:)\` and \`toggleMarkPlayed(tracks:)\`) into real FFI calls.

## Core

- **\`client.rs\`** — adds \`mark_played\` / \`mark_unplayed\` / \`set_played\` dispatcher.
  - Preferred: \`POST/DELETE /UserPlayedItems/{itemId}\` (user inferred from token)
  - Fallback: \`POST/DELETE /Users/{userId}/PlayedItems/{itemId}\` on 404/405 for older Jellyfin builds
  - Mirrors the favorite-endpoint shape from #35
  - Returns the full \`UserItemData\` so callers can refresh \`played\` + \`play_count\` + \`last_played_at\` without refetching
- **\`lib.rs\`** — thin uniffi exports wrapping the three client methods
- **\`tests.rs\`** — 5 tests at EOF: preferred-route happy path for played + unplayed, legacy-route fallback on 404/405, and \`NotAuthenticated\` guard short-circuits before any HTTP traffic

## macOS

- \`AppModel.playedById\` — in-memory cache mirroring \`favoriteById\`, populated with the server's authoritative response after each FFI call
- \`AppModel.isPlayed(id:)\` — cache lookup helper, mirrors \`isFavorite(id:)\`
- \`AppModel.setPlayed(itemId:played:)\` — private helper hitting \`core.setPlayed\` via \`Task.detached\`, mirrors server answer into \`playedById\`, surfaces banner via \`JellifyErrorPresenter\` on failure
- \`markAllAsPlayed(album:)\` — optimistic flip on \`album.id\`, then \`setPlayed\`. Matches Jellyfin web's "Mark Played" — flips the album's UserData but does NOT cascade to per-track play counts (Jellyfin server-side doesn't either)
- \`toggleMarkPlayed(tracks:)\` — multi-select toggle. Computes target as "everyone played" unless every track is already played (then unmark all). Optimistic flip on the whole selection, sequential FFI calls
- \`JellifyErrorPresenter.Context.markPlayed\` → \`error.markPlayed\` localization key
- \`Localizable.xcstrings\` — \"Couldn't update played status.\" English entry

## Verification

- [x] \`cargo test -p jellify_core --lib\` — **196 passed** (including 5 new mark_played tests)
- [x] \`rm -rf macos/.build && swift build -c release\` — clean cold build (30s linker complete)
- [x] xcframework + bindings regenerated via \`build-core.sh\`; \`markPlayed\` / \`markUnplayed\` / \`setPlayed\` visible on the Swift \`JellifyCore\` facade
- [ ] CI passes
- [ ] Manual smoke: track context-menu "Mark as Played" → confirm play_count bumps via curl \`GET /Users/{uid}/Items/{tid}\`
- [ ] Manual smoke: album context-menu "Mark Played" → album shows played glyph; per-track play_count unchanged