### PR TITLE
core+macos: artist play/shuffle via tracks_by_artist (#156)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1014,6 +1014,86 @@ impl JellyfinClient {
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
+    /// Fetch every audio track in an artist's catalog, ordered for "play all"
+    /// — albums alphabetised, each album in disc + track order. Filters by
+    /// `AlbumArtistIds` (not `ArtistIds`) so guest features on other artists'
+    /// albums don't leak in; matches [`Self::albums_by_artist`]'s scope.
+    ///
+    /// Backed by `GET /Users/{id}/Items?AlbumArtistIds={id}&IncludeItemTypes=Audio
+    /// &Recursive=true&SortBy=Album,ParentIndexNumber,IndexNumber
+    /// &SortOrder=Ascending,Ascending,Ascending`. The three-column sort matches
+    /// `album_tracks` (#571 fix) — `ItemSortBy` doesn't expose
+    /// ParentIndexNumber / IndexNumber so the URL is hand-rolled. `paging`
+    /// drives the standard `Limit` / `StartIndex` pair; callers wanting the
+    /// full discography pass a generous `limit` (e.g. 500) and accept the
+    /// soft cap. See #156.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
+    pub async fn tracks_by_artist(
+        &self,
+        artist_id: &str,
+        paging: Paging,
+    ) -> Result<PaginatedTracks> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("AlbumArtistIds", artist_id);
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            // Three-field sort gives proper catalog order: album name,
+            // then disc, then track. Hand-rolled because ItemSortBy doesn't
+            // expose ParentIndexNumber / IndexNumber.
+            q.append_pair("SortBy", "Album,ParentIndexNumber,IndexNumber");
+            q.append_pair(
+                "SortOrder",
+                &enums::csv(
+                    &[
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                    ],
+                    SortOrder::as_str,
+                ),
+            );
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::AlbumId,
+                        ItemField::AlbumArtist,
+                        ItemField::Artists,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                        ItemField::RunTimeTicks,
+                    ],
+                    ItemField::as_str,
+                ),
+            );
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        let items: Vec<Track> = raw.items.into_iter().map(Track::from).collect();
+        Ok(PaginatedTracks {
+            items,
+            total_count: raw.total_record_count,
+        })
+    }
+
     /// Fetch an artist's "top tracks" — audio items credited to the given
     /// artist, sorted by the user's `PlayCount` descending with `SortName` as
     /// a stable tiebreaker. Backed by

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -393,6 +393,22 @@ impl JellifyCore {
         })
     }
 
+    /// Every audio track in an artist's catalog, paginated, in catalog order
+    /// (album name → disc → track). Filters by `AlbumArtistIds` so guest
+    /// features on other artists' albums don't leak in. Powers the artist
+    /// page "Play All" / "Shuffle" affordances — see #156.
+    pub fn tracks_by_artist(
+        &self,
+        artist_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.tracks_by_artist(&artist_id, Paging::new(offset, limit)))
+        })
+    }
+
     /// Seed a station around any item (track, album, artist, playlist,
     /// genre) via Jellyfin's polymorphic `/Items/{id}/InstantMix`. Returns a
     /// freshly generated queue of audio tracks the caller drops into the

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7246,3 +7246,101 @@ async fn mark_played_without_session_returns_not_authenticated() {
         requests
     );
 }
+
+// ============================================================================
+// tracks_by_artist (#156)
+// ============================================================================
+
+#[tokio::test]
+async fn tracks_by_artist_filters_by_album_artist_with_catalog_sort() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("AlbumArtistIds", "artist-77"))
+        .and(query_param("Recursive", "true"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(query_param("SortBy", "Album,ParentIndexNumber,IndexNumber"))
+        .and(query_param("SortOrder", "Ascending,Ascending,Ascending"))
+        .and(query_param("EnableUserData", "true"))
+        .and(query_param("Limit", "500"))
+        .and(query_param("StartIndex", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "t1", "Name": "Track One", "Type": "Audio", "AlbumId": "a1", "AlbumArtist": "X" },
+                { "Id": "t2", "Name": "Track Two", "Type": "Audio", "AlbumId": "a1", "AlbumArtist": "X" }
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_artist("artist-77", Paging::new(0, 500))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 2);
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.items[0].id, "t1");
+    assert_eq!(page.items[1].id, "t2");
+}
+
+#[tokio::test]
+async fn tracks_by_artist_propagates_pagination_offset() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("AlbumArtistIds", "artist-77"))
+        .and(query_param("Limit", "50"))
+        .and(query_param("StartIndex", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 250
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_artist("artist-77", Paging::new(100, 50))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 250, "server-reported total wins over page len");
+    assert!(page.items.is_empty());
+}
+
+#[tokio::test]
+async fn tracks_by_artist_without_session_returns_not_authenticated() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .tracks_by_artist("artist-77", Paging::new(0, 500))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "guard must short-circuit before any HTTP call"
+    );
+}

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -3152,19 +3152,49 @@ final class AppModel {
 
     // MARK: - Artist actions
 
-    /// Play every track by an artist in catalog order.
-    /// TODO: #156 / #465 — artist-tracks FFI (and an ItemsQuery filter for
-    /// `artist_id`) isn't wired yet, so this is a logging stub.
+    /// Play every track in an artist's catalog (album → disc → track order).
+    /// Caps at the soft 500-track ceiling — prolific artists may have more,
+    /// but the player gets a deterministic prefix that matches what
+    /// `tracks_by_artist` returned. See #156.
     func playAll(artist: Artist) {
-        // TODO: #156 / #465 — artist-tracks FFI not yet wired.
-        print("[AppModel] playAll(artist:) not yet wired — see #156 / #465")
+        Task {
+            let tracks = await loadTracks(forArtist: artist.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks, startIndex: 0)
+        }
     }
 
-    /// Shuffle every track by an artist.
-    /// TODO: #156 / #465 — same artist-tracks FFI dependency as `playAll`.
+    /// Shuffle every track in an artist's catalog. Loads in catalog order,
+    /// shuffles client-side, plays from the head. Same 500-track soft cap
+    /// as `playAll(artist:)`. See #156.
     func shuffle(artist: Artist) {
-        // TODO: #156 / #465 — artist-tracks FFI not yet wired.
-        print("[AppModel] shuffle(artist:) not yet wired — see #156 / #465")
+        Task {
+            let tracks = await loadTracks(forArtist: artist.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks.shuffled(), startIndex: 0)
+        }
+    }
+
+    /// Internal helper — fetch the first page of an artist's catalog via the
+    /// `tracks_by_artist` FFI. Mirrors `loadTracks(forAlbum:)` in shape so
+    /// `playAll(artist:)` / `shuffle(artist:)` collapse to a one-liner. The
+    /// 500-row limit is a deliberate soft cap to keep the FFI / queue under
+    /// a single round-trip. See #156.
+    private func loadTracks(forArtist artistId: String) async -> [Track] {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.tracksByArtist(artistId: artistId, offset: 0, limit: 500)
+            }.value
+            return page.items
+        } catch {
+            if !handleAuthError(error) {
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
+            }
+            return []
+        }
     }
 
     /// Play the artist's top tracks (play-count-weighted). Fetches the

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -22,7 +22,7 @@ extension AppModel {
     /// on artist surfaces. Top-track-driven actions (Play Next via
     /// top-tracks fallback, Start Artist Radio) remain available because
     /// they route through wired FFIs.
-    var supportsArtistPlayShuffle: Bool { false }
+    var supportsArtistPlayShuffle: Bool { true }
 
     /// New-playlist picker (#72, #126). Gates the "New Playlist…" entry
     /// at the bottom of Add to Playlist submenus on album and track


### PR DESCRIPTION
## Summary

Closes #156. Replaces two \`print(\"…not yet wired…\")\` stubs in \`AppModel.swift\` (\`playAll(artist:)\` and \`shuffle(artist:)\`) with real FFI calls.

**Stacked on #678** (mark_played) — base will rebase onto \`main\` after #678 lands.

## Core

- \`client.rs\` — \`tracks_by_artist(artist_id, paging) → PaginatedTracks\` filtered by \`AlbumArtistIds\` so guest features on other artists' albums don't leak in (matches \`albums_by_artist\` scope). Three-field sort \`Album,ParentIndexNumber,IndexNumber\` for proper catalog order — hand-rolled URL because \`ItemSortBy\` doesn't expose \`ParentIndexNumber\`/\`IndexNumber\`, same pattern as \`album_tracks\` (#571 fix).
- \`lib.rs\` — thin uniffi export.
- \`tests.rs\` — 3 tests at EOF: preferred-route happy path verifying every query param, pagination offset/limit propagation with server total preserved, and \`NotAuthenticated\` guard before any HTTP traffic.

## macOS

- \`playAll(artist:)\` — loads catalog, plays from index 0
- \`shuffle(artist:)\` — loads catalog, \`.shuffled()\` locally, plays from index 0 (mirrors \`shuffle(album:)\`)
- \`loadTracks(forArtist:)\` — private helper dispatching FFI call via \`Task.detached\` (mirrors \`loadTracks(forAlbum:)\`). Soft-caps at 500 tracks per call

## Verification

- [x] \`cargo test -p jellify_core --lib\` — **199 passed** (3 new tracks_by_artist tests on top of #678's 196)
- [x] \`rm -rf macos/.build && swift build -c release\` — clean cold build (30s)
- [x] xcframework regenerated via \`build-core.sh --release --arm64-only\`; \`tracksByArtist\` visible on the Swift facade
- [ ] CI passes
- [ ] Manual smoke: artist context-menu "Play All" → queue populates with full catalog in album/disc/track order
- [ ] Manual smoke: artist context-menu "Shuffle" → queue populates with shuffled catalog