### PR TITLE
macos: wire similar_artists into ArtistDetailView + showSimilar (#146)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1014,6 +1014,86 @@ impl JellyfinClient {
         Ok(raw.items.into_iter().map(Track::from).collect())
     }
 
+    /// Fetch every audio track in an artist's catalog, ordered for "play all"
+    /// — albums alphabetised, each album in disc + track order. Filters by
+    /// `AlbumArtistIds` (not `ArtistIds`) so guest features on other artists'
+    /// albums don't leak in; matches [`Self::albums_by_artist`]'s scope.
+    ///
+    /// Backed by `GET /Users/{id}/Items?AlbumArtistIds={id}&IncludeItemTypes=Audio
+    /// &Recursive=true&SortBy=Album,ParentIndexNumber,IndexNumber
+    /// &SortOrder=Ascending,Ascending,Ascending`. The three-column sort matches
+    /// `album_tracks` (#571 fix) — `ItemSortBy` doesn't expose
+    /// ParentIndexNumber / IndexNumber so the URL is hand-rolled. `paging`
+    /// drives the standard `Limit` / `StartIndex` pair; callers wanting the
+    /// full discography pass a generous `limit` (e.g. 500) and accept the
+    /// soft cap. See #156.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no `user_id` is set.
+    pub async fn tracks_by_artist(
+        &self,
+        artist_id: &str,
+        paging: Paging,
+    ) -> Result<PaginatedTracks> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(JellifyError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("AlbumArtistIds", artist_id);
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            // Three-field sort gives proper catalog order: album name,
+            // then disc, then track. Hand-rolled because ItemSortBy doesn't
+            // expose ParentIndexNumber / IndexNumber.
+            q.append_pair("SortBy", "Album,ParentIndexNumber,IndexNumber");
+            q.append_pair(
+                "SortOrder",
+                &enums::csv(
+                    &[
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                        SortOrder::Ascending,
+                    ],
+                    SortOrder::as_str,
+                ),
+            );
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::AlbumId,
+                        ItemField::AlbumArtist,
+                        ItemField::Artists,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                        ItemField::RunTimeTicks,
+                    ],
+                    ItemField::as_str,
+                ),
+            );
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        let items: Vec<Track> = raw.items.into_iter().map(Track::from).collect();
+        Ok(PaginatedTracks {
+            items,
+            total_count: raw.total_record_count,
+        })
+    }
+
     /// Fetch an artist's "top tracks" — audio items credited to the given
     /// artist, sorted by the user's `PlayCount` descending with `SortName` as
     /// a stable tiebreaker. Backed by

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1526,6 +1526,121 @@ impl JellyfinClient {
         }
     }
 
+    /// Mark an item (track / album / playlist) as played for the current user.
+    ///
+    /// Uses the preferred `POST /UserPlayedItems/{itemId}` endpoint (user
+    /// inferred from the authentication token). Older Jellyfin builds that
+    /// answer 404 / 405 to that route fall back to the legacy
+    /// `POST /Users/{userId}/PlayedItems/{itemId}` endpoint.
+    ///
+    /// Returns the full updated [`UserItemData`] so the UI can update both
+    /// its `played` glyph and the `play_count` text without refetching the
+    /// item. Server-side this bumps `PlayCount` by one and stamps a fresh
+    /// `LastPlayedDate` (Jellyfin does NOT cascade to children — calling
+    /// this on an album does not increment per-track play counts).
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set. See #133.
+    pub async fn mark_played(&self, item_id: &str) -> Result<UserItemData> {
+        self.require_token()?;
+
+        let url = self.endpoint(&format!("UserPlayedItems/{item_id}"))?;
+        let resp = self
+            .send_with_retry_raw(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
+            .await?;
+
+        if resp.status().is_success() {
+            let raw: RawUserData = resp.json().await?;
+            return Ok(raw.into());
+        }
+
+        if matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            if let Some(user_id) = self.user_id.as_ref() {
+                let legacy_url =
+                    self.endpoint(&format!("Users/{user_id}/PlayedItems/{item_id}"))?;
+                let legacy_resp = self
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .post(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
+                    .await?;
+                let raw: RawUserData = legacy_resp.json().await?;
+                return Ok(raw.into());
+            }
+        }
+
+        let raw: RawUserData = Self::check(resp).await?.json().await?;
+        Ok(raw.into())
+    }
+
+    /// Clear the played flag from an item for the current user.
+    ///
+    /// Uses the preferred `DELETE /UserPlayedItems/{itemId}` endpoint, with
+    /// a fallback to `DELETE /Users/{userId}/PlayedItems/{itemId}` for
+    /// older Jellyfin builds that answer 404 / 405.
+    ///
+    /// Server-side this resets `PlayCount` to zero and clears
+    /// `LastPlayedDate`. Returns the updated [`UserItemData`] for the same
+    /// no-refetch UI refresh as [`Self::mark_played`].
+    ///
+    /// Requires an authenticated session; returns
+    /// [`JellifyError::NotAuthenticated`] if no token is set. See #133.
+    pub async fn mark_unplayed(&self, item_id: &str) -> Result<UserItemData> {
+        self.require_token()?;
+
+        let url = self.endpoint(&format!("UserPlayedItems/{item_id}"))?;
+        let resp = self
+            .send_with_retry_raw(|| {
+                Ok(self.http.delete(url.clone()).headers(self.build_headers()?))
+            })
+            .await?;
+
+        if resp.status().is_success() {
+            let raw: RawUserData = resp.json().await?;
+            return Ok(raw.into());
+        }
+
+        if matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            if let Some(user_id) = self.user_id.as_ref() {
+                let legacy_url =
+                    self.endpoint(&format!("Users/{user_id}/PlayedItems/{item_id}"))?;
+                let legacy_resp = self
+                    .send_with_retry(|| {
+                        Ok(self
+                            .http
+                            .delete(legacy_url.clone())
+                            .headers(self.build_headers()?))
+                    })
+                    .await?;
+                let raw: RawUserData = legacy_resp.json().await?;
+                return Ok(raw.into());
+            }
+        }
+
+        let raw: RawUserData = Self::check(resp).await?.json().await?;
+        Ok(raw.into())
+    }
+
+    /// Convenience dispatcher: route to [`Self::mark_played`] when `played`
+    /// is `true` and [`Self::mark_unplayed`] otherwise. Mirrors the shape
+    /// of [`Self::toggle_favorite`] for callers that only know the desired
+    /// target state. See #133.
+    pub async fn set_played(&self, item_id: &str, played: bool) -> Result<UserItemData> {
+        if played {
+            self.mark_played(item_id).await
+        } else {
+            self.mark_unplayed(item_id).await
+        }
+    }
+
     /// Create a new playlist for the current user via `POST /Playlists`.
     ///
     /// The request body uses Jellyfin's PascalCase keys:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -693,6 +693,42 @@ impl JellifyCore {
         self.with_client(|c| self.runtime.block_on(c.toggle_favorite(&item_id, favorite)))
     }
 
+    /// Mark an item (track / album / playlist) as played for the current
+    /// user. Returns the full updated [`UserItemData`] so the UI can update
+    /// `played` + `play_count` + `last_played_at` without refetching. Errors
+    /// with [`JellifyError::NotAuthenticated`] if no session is active.
+    /// See issue #133.
+    pub fn mark_played(
+        &self,
+        item_id: String,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.mark_played(&item_id)))
+    }
+
+    /// Clear the played flag from an item for the current user. Returns the
+    /// updated [`UserItemData`] (with `play_count = 0` and `last_played_at =
+    /// None`). Errors with [`JellifyError::NotAuthenticated`] if no session
+    /// is active. See issue #133.
+    pub fn mark_unplayed(
+        &self,
+        item_id: String,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.mark_unplayed(&item_id)))
+    }
+
+    /// Set or clear an item's played flag in a single call. `played=true`
+    /// dispatches to [`Self::mark_played`], `false` dispatches to
+    /// [`Self::mark_unplayed`]. Mirrors the shape of [`Self::toggle_favorite`]
+    /// for multi-select callers that compute the target state from the
+    /// majority current state of the selection. See issue #133.
+    pub fn set_played(
+        &self,
+        item_id: String,
+        played: bool,
+    ) -> std::result::Result<UserItemData, JellifyError> {
+        self.with_client(|c| self.runtime.block_on(c.set_played(&item_id, played)))
+    }
+
     /// Create a new playlist for the current user. Returns the new
     /// playlist id — callers refetch the full [`Playlist`] via
     /// [`JellifyCore::fetch_item`] if they need the populated record.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -393,6 +393,22 @@ impl JellifyCore {
         })
     }
 
+    /// Every audio track in an artist's catalog, paginated, in catalog order
+    /// (album name → disc → track). Filters by `AlbumArtistIds` so guest
+    /// features on other artists' albums don't leak in. Powers the artist
+    /// page "Play All" / "Shuffle" affordances — see #156.
+    pub fn tracks_by_artist(
+        &self,
+        artist_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, JellifyError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.tracks_by_artist(&artist_id, Paging::new(offset, limit)))
+        })
+    }
+
     /// Seed a station around any item (track, album, artist, playlist,
     /// genre) via Jellyfin's polymorphic `/Items/{id}/InstantMix`. Returns a
     /// freshly generated queue of audio tracks the caller drops into the

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7197,3 +7197,101 @@ async fn mark_played_without_session_returns_not_authenticated() {
         requests
     );
 }
+
+// ============================================================================
+// tracks_by_artist (#156)
+// ============================================================================
+
+#[tokio::test]
+async fn tracks_by_artist_filters_by_album_artist_with_catalog_sort() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("AlbumArtistIds", "artist-77"))
+        .and(query_param("Recursive", "true"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(query_param("SortBy", "Album,ParentIndexNumber,IndexNumber"))
+        .and(query_param("SortOrder", "Ascending,Ascending,Ascending"))
+        .and(query_param("EnableUserData", "true"))
+        .and(query_param("Limit", "500"))
+        .and(query_param("StartIndex", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "t1", "Name": "Track One", "Type": "Audio", "AlbumId": "a1", "AlbumArtist": "X" },
+                { "Id": "t2", "Name": "Track Two", "Type": "Audio", "AlbumId": "a1", "AlbumArtist": "X" }
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_artist("artist-77", Paging::new(0, 500))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 2);
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.items[0].id, "t1");
+    assert_eq!(page.items[1].id, "t2");
+}
+
+#[tokio::test]
+async fn tracks_by_artist_propagates_pagination_offset() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .and(query_param("AlbumArtistIds", "artist-77"))
+        .and(query_param("Limit", "50"))
+        .and(query_param("StartIndex", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 250
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_artist("artist-77", Paging::new(100, 50))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 250, "server-reported total wins over page len");
+    assert!(page.items.is_empty());
+}
+
+#[tokio::test]
+async fn tracks_by_artist_without_session_returns_not_authenticated() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .tracks_by_artist("artist-77", Paging::new(0, 500))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "guard must short-circuit before any HTTP call"
+    );
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -6980,3 +6980,220 @@ async fn user_item_data_is_none_when_server_omits_it() {
     assert!(!tracks[0].is_favorite);
     assert_eq!(tracks[0].play_count, 0);
 }
+
+// ============================================================================
+// mark_played / mark_unplayed (#133)
+// Mirrors the favorite-endpoint test shape: preferred /UserPlayedItems route
+// for new servers, legacy /Users/{userId}/PlayedItems fallback for old ones,
+// and an auth-required guard before any HTTP traffic.
+// ============================================================================
+
+#[tokio::test]
+async fn mark_played_uses_preferred_endpoint_and_returns_user_data() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": true,
+            "PlayCount": 3,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": "2026-04-25T18:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_played("track-abc").await.unwrap();
+    assert!(state.played);
+    assert_eq!(state.play_count, 3);
+    assert_eq!(state.last_played_at.as_deref(), Some("2026-04-25T18:00:00Z"));
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/UserPlayedItems/track-abc")
+        .expect("expected POST to preferred played endpoint");
+    assert!(post.body.is_empty(), "expected empty body, got {:?}", post.body);
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().starts_with("/Users/u1/PlayedItems/")),
+        "unexpected fallback to legacy route"
+    );
+}
+
+#[tokio::test]
+async fn mark_unplayed_uses_preferred_endpoint_and_returns_user_data() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": false,
+            "PlayCount": 0,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_unplayed("track-abc").await.unwrap();
+    assert!(!state.played);
+    assert_eq!(state.play_count, 0);
+    assert!(state.last_played_at.is_none());
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "DELETE"
+            && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected DELETE to /UserPlayedItems/track-abc"
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().starts_with("/Users/u1/PlayedItems/")),
+        "unexpected fallback to legacy route"
+    );
+}
+
+#[tokio::test]
+async fn mark_played_falls_back_to_legacy_route_on_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Users/u1/PlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": true,
+            "PlayCount": 1,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": "2026-04-25T18:30:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_played("track-abc").await.unwrap();
+    assert!(state.played);
+    assert_eq!(state.play_count, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST" && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected preferred route to be tried first"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "POST"
+                && r.url.path() == "/Users/u1/PlayedItems/track-abc"),
+        "expected fallback to legacy route after 404"
+    );
+}
+
+#[tokio::test]
+async fn mark_unplayed_falls_back_to_legacy_route_on_405() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/UserPlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/Users/u1/PlayedItems/track-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "IsFavorite": false,
+            "Played": false,
+            "PlayCount": 0,
+            "PlaybackPositionTicks": 0,
+            "LastPlayedDate": null
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let state = client.mark_unplayed("track-abc").await.unwrap();
+    assert!(!state.played);
+    assert_eq!(state.play_count, 0);
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.method.as_str() == "DELETE"
+            && r.url.path() == "/UserPlayedItems/track-abc"),
+        "expected preferred route to be tried first"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE"
+                && r.url.path() == "/Users/u1/PlayedItems/track-abc"),
+        "expected fallback to legacy route after 405"
+    );
+}
+
+#[tokio::test]
+async fn mark_played_without_session_returns_not_authenticated() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.mark_played("anything").await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    let err = client.mark_unplayed("anything").await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::JellifyError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+    // No HTTP traffic should have escaped the guard.
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "guard should short-circuit before any HTTP call, got {:?}",
+        requests
+    );
+}

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -3058,19 +3058,49 @@ final class AppModel {
 
     // MARK: - Artist actions
 
-    /// Play every track by an artist in catalog order.
-    /// TODO: #156 / #465 — artist-tracks FFI (and an ItemsQuery filter for
-    /// `artist_id`) isn't wired yet, so this is a logging stub.
+    /// Play every track in an artist's catalog (album → disc → track order).
+    /// Caps at the soft 500-track ceiling — prolific artists may have more,
+    /// but the player gets a deterministic prefix that matches what
+    /// `tracks_by_artist` returned. See #156.
     func playAll(artist: Artist) {
-        // TODO: #156 / #465 — artist-tracks FFI not yet wired.
-        print("[AppModel] playAll(artist:) not yet wired — see #156 / #465")
+        Task {
+            let tracks = await loadTracks(forArtist: artist.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks, startIndex: 0)
+        }
     }
 
-    /// Shuffle every track by an artist.
-    /// TODO: #156 / #465 — same artist-tracks FFI dependency as `playAll`.
+    /// Shuffle every track in an artist's catalog. Loads in catalog order,
+    /// shuffles client-side, plays from the head. Same 500-track soft cap
+    /// as `playAll(artist:)`. See #156.
     func shuffle(artist: Artist) {
-        // TODO: #156 / #465 — artist-tracks FFI not yet wired.
-        print("[AppModel] shuffle(artist:) not yet wired — see #156 / #465")
+        Task {
+            let tracks = await loadTracks(forArtist: artist.id)
+            guard !tracks.isEmpty else { return }
+            play(tracks: tracks.shuffled(), startIndex: 0)
+        }
+    }
+
+    /// Internal helper — fetch the first page of an artist's catalog via the
+    /// `tracks_by_artist` FFI. Mirrors `loadTracks(forAlbum:)` in shape so
+    /// `playAll(artist:)` / `shuffle(artist:)` collapse to a one-liner. The
+    /// 500-row limit is a deliberate soft cap to keep the FFI / queue under
+    /// a single round-trip. See #156.
+    private func loadTracks(forArtist artistId: String) async -> [Track] {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.tracksByArtist(artistId: artistId, offset: 0, limit: 500)
+            }.value
+            return page.items
+        } catch {
+            if !handleAuthError(error) {
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = JellifyErrorPresenter.message(for: error, context: .libraryLoad)
+            }
+            return []
+        }
     }
 
     /// Play the artist's top tracks (play-count-weighted). Fetches the

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -104,6 +104,11 @@ final class AppModel {
     /// by `loadArtistTopTracks(artistId:)` when the Artist detail screen
     /// opens. Held for the session; cleared on logout. See #229.
     var artistTopTracks: [String: [Track]] = [:]      // artistID → top tracks
+    /// Cache of "Similar Artists" lookups keyed by artist id. Populated on
+    /// demand by `loadSimilarArtists(artistId:)` when the Artist detail
+    /// screen opens (or when `showSimilar(artist:)` navigates to it).
+    /// Held for the session; cleared on logout. See #146.
+    var similarArtistsByArtist: [String: [Artist]] = [:]
     var recentlyPlayed: [Track] = []
     /// Tracks surfaced in the Discover "For You" carousel (#249). Today this
     /// is a best-effort fallback to the first 20 `recentlyPlayed` tracks. A
@@ -2014,6 +2019,39 @@ final class AppModel {
         }
     }
 
+    /// Fetch artists similar to the given artist via Jellyfin's
+    /// `/Artists/{id}/Similar` endpoint (wired through `core.similarArtists`).
+    /// Cached per-artist for the session — `showSimilar(artist:)` and the
+    /// "Similar Artists" carousel on `ArtistDetailView` both read through
+    /// this so a single navigation seeds both. Errors swallowed silently —
+    /// the carousel collapses on empty rather than surfacing a banner. See #146.
+    @discardableResult
+    func loadSimilarArtists(artistId: String, limit: UInt32 = 6) async -> [Artist] {
+        if let cached = similarArtistsByArtist[artistId] { return cached }
+        do {
+            let artists = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.similarArtists(artistId: artistId, limit: limit)
+            }.value
+            similarArtistsByArtist[artistId] = artists
+            serverReachability.noteSuccess()
+            return artists
+        } catch {
+            if handleAuthError(error) { return [] }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            return []
+        }
+    }
+
+    /// Synchronous accessor for the similar-artists cache. Used by
+    /// `ArtistDetailView`'s carousel to render off the cache without
+    /// re-issuing a fetch on every body re-evaluation. Empty until
+    /// `loadSimilarArtists(artistId:)` populates it. See #146.
+    func similarArtists(for artistId: String) -> [Artist] {
+        similarArtistsByArtist[artistId] ?? []
+    }
+
     /// Fetch the ordered tracks for a playlist, preserving the server-side
     /// playlist order. Mirrors `loadTracks(forAlbum:)` — results are cached
     /// for the session, scoped to `playlistTracks[playlist.id]`. Backed by
@@ -3169,11 +3207,15 @@ final class AppModel {
         screen = .artist(artist.id)
     }
 
-    /// Show artists similar to this one.
-    /// TODO: #146 — similar_artists FFI not yet wired.
+    /// Navigate to the artist's detail page, where the now-populated
+    /// "Similar Artists" carousel surfaces the result. The detail view's
+    /// `.task(id:)` block also kicks off `loadSimilarArtists` if the cache
+    /// is cold, so this is a self-contained UX even when invoked from a
+    /// surface that hasn't pre-fetched (e.g. the artist tile context menu
+    /// in a Library grid). See #146.
     func showSimilar(artist: Artist) {
-        // TODO: #146 — similar_artists FFI not yet wired.
-        print("[AppModel] showSimilar(artist:) not yet wired — see #146")
+        Task { _ = await loadSimilarArtists(artistId: artist.id) }
+        screen = .artist(artist.id)
     }
 
     // MARK: - Artist sharing

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -2769,6 +2769,14 @@ final class AppModel {
     /// round-trip.
     var favoriteById: [String: Bool] = [:]
 
+    /// In-memory played flag keyed by item id (track / album / playlist).
+    /// Mirrors `favoriteById` — populated lazily from
+    /// `track.userData?.played` and stamped with the server's authoritative
+    /// answer after every `mark_played` / `mark_unplayed` call. Used to
+    /// drive the "played" glyph in track rows and to compute the toggle
+    /// target state in `toggleMarkPlayed(tracks:)`. See #133.
+    var playedById: [String: Bool] = [:]
+
     /// Toggle the favorite flag for an album on the Jellyfin server. Reads
     /// the current state from `favoriteById` (falling back to `false` on a
     /// cold start) and calls the opposite side of `set_favorite` /
@@ -2818,6 +2826,33 @@ final class AppModel {
                 serverReachability.noteFailure()
             }
             errorMessage = JellifyErrorPresenter.message(for: error, context: .favorite)
+        }
+    }
+
+    /// Read the locally-cached played state for an item id. Mirrors
+    /// `isFavorite(id:)`; used by row views + `toggleMarkPlayed(tracks:)`
+    /// to compute the target state for a multi-select toggle. See #133.
+    func isPlayed(id: String) -> Bool {
+        playedById[id] ?? false
+    }
+
+    /// Internal helper — hits `mark_played` / `mark_unplayed` on the core
+    /// and mirrors the server's answer (full `UserItemData`) into
+    /// `playedById`. Mirrors `setFavorite(itemId:enabled:)` in shape so a
+    /// single-item toggle has a single failure path. See #133.
+    private func setPlayed(itemId: String, played: Bool) async {
+        do {
+            let state = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.setPlayed(itemId: itemId, played: played)
+            }.value
+            playedById[itemId] = state.played
+            serverReachability.noteSuccess()
+        } catch {
+            if handleAuthError(error) { return }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            errorMessage = JellifyErrorPresenter.message(for: error, context: .markPlayed)
         }
     }
 
@@ -2967,11 +3002,16 @@ final class AppModel {
         playInstantMix(seedId: album.id)
     }
 
-    /// Mark every track on the album as played.
-    /// TODO: #133 / #222 — `mark_played` FFI not yet wired.
+    /// Mark the album as played server-side. Matches Jellyfin web's
+    /// "Mark Played" affordance: the album's `UserData.Played` flips and
+    /// `LastPlayedDate` stamps, but per-track `PlayCount` is **not**
+    /// incremented (Jellyfin doesn't cascade the operation to children).
+    /// `playedById[album.id]` flips immediately for the optimistic glyph
+    /// flip, then reconciles with the server's authoritative response. See #133.
     func markAllAsPlayed(album: Album) {
-        // TODO(#133): mark_played FFI not yet wired.
-        print("[AppModel] markAllAsPlayed(album:) not yet wired — see #133 / #222")
+        let target = !isPlayed(id: album.id)
+        playedById[album.id] = target
+        Task { await setPlayed(itemId: album.id, played: target) }
     }
 
     /// Present the album metadata editor. Admin-only once the sheet lands.
@@ -3694,12 +3734,30 @@ final class AppModel {
         print("[AppModel] toggleDownload(tracks: \(tracks.count)) not yet wired — see #70")
     }
 
-    /// Mark or unmark every track in the selection as played.
-    /// TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
+    /// Toggle the played flag across a multi-select of tracks. Target
+    /// state is "everyone unplayed" if **all** selected tracks are
+    /// currently played; otherwise "everyone played". This matches the
+    /// menubar / context-menu convention where a single click on a
+    /// mixed selection commits to one direction. Each track's flip is
+    /// optimistic locally and reconciled against the server's response;
+    /// failures don't abort the rest of the batch. See #133.
     func toggleMarkPlayed(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
-        // TODO(#133): mark_played / mark_unplayed FFIs not yet wired.
-        print("[AppModel] toggleMarkPlayed(tracks: \(tracks.count)) not yet wired — see #133")
+        // Decide target: prefer the cached value, fall back to the track's
+        // embedded user_data, finally `false` if nothing is known. Mark
+        // played unless every track is *already* played.
+        let allPlayed = tracks.allSatisfy { track in
+            if let cached = playedById[track.id] { return cached }
+            return track.userData?.played ?? false
+        }
+        let target = !allPlayed
+        // Optimistic flip on the whole selection so the glyph updates instantly.
+        for track in tracks { playedById[track.id] = target }
+        Task {
+            for track in tracks {
+                await setPlayed(itemId: track.id, played: target)
+            }
+        }
     }
 
     // MARK: - Track sharing

--- a/macos/Sources/Jellify/JellifyErrorPresenter.swift
+++ b/macos/Sources/Jellify/JellifyErrorPresenter.swift
@@ -128,6 +128,7 @@ enum JellifyErrorPresenter {
         case search
         case playback
         case favorite
+        case markPlayed
         case playlistAdd
 
         fileprivate var fallbackKey: String? {
@@ -142,6 +143,7 @@ enum JellifyErrorPresenter {
             case .search: return "error.search"
             case .playback: return "error.playback"
             case .favorite: return "error.favorite"
+            case .markPlayed: return "error.markPlayed"
             case .playlistAdd: return "error.playlist.add"
             }
         }

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -469,6 +469,18 @@
         }
       }
     },
+    "error.markPlayed" : {
+      "comment" : "Banner copy when marking an item played / unplayed fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't update played status."
+          }
+        }
+      }
+    },
     "error.playlist.add" : {
       "comment" : "Banner copy when adding a track to a playlist fails.",
       "extractionState" : "manual",

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -41,6 +41,7 @@ struct ArtistDetailView: View {
     @State private var artistAlbums: [Album] = []
     @State private var fetchedArtist: Artist?
     @State private var isBioExpanded = false
+    @State private var similarArtistsState: [Artist] = []
 
     /// Resolve the artist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Missing (server
@@ -74,6 +75,7 @@ struct ArtistDetailView: View {
             // rendered empty for most artists on a large library (#60).
             artistAlbums = await model.loadArtistAlbums(artistId: artistID)
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
+            similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
             isLoadingTopTracks = false
         }
     }
@@ -552,16 +554,12 @@ struct ArtistDetailView: View {
         }
     }
 
-    /// Similar artists list. Empty today — returns `[]` so the section
-    /// collapses silently rather than surfacing a broken "similar to" shelf.
-    ///
-    /// TODO(core-#146): wire through `core.similar_artists(artist_id, limit)`
-    /// once the FFI lands. Jellyfin exposes `/Artists/{id}/Similar` — the
-    /// core just needs to pass it through. With that in place this returns
-    /// the server's list trimmed to 6 items per #232.
+    /// Similar artists list, sourced from `model.similarArtistsByArtist`
+    /// via `loadSimilarArtists(artistId:)` in the `.task(id:)` block above.
+    /// Empties (and the section collapses) until the fetch lands or when
+    /// the server has no similar artists for the current item. See #146.
     private var similarArtists: [Artist] {
-        // TODO(core-#146): return model.similarArtists(for: artistID, limit: 6)
-        []
+        similarArtistsState
     }
 
     // MARK: - About / bio (#231)


### PR DESCRIPTION
## Summary

Closes #146. Replaces one \`print(\"…not yet wired…\")\` stub in \`AppModel.swift\` (\`showSimilar(artist:)\`) and the empty-TODO computed property on \`ArtistDetailView\` that returned \`[]\` for the Similar Artists carousel.

**Pure Swift** — \`core.similar_artists\` and the \`similarArtists\` uniffi export already shipped in earlier work. This wires them through.

**Stacked on #679** (artist play/shuffle).

## AppModel

- \`similarArtistsByArtist: [String: [Artist]]\` — session-scoped cache keyed by artist id
- \`loadSimilarArtists(artistId:limit:)\` — mirrors \`loadArtistTopTracks\` shape: \`Task.detached\`, reachability nudges, silent fallback to \`[]\` on error
- \`similarArtists(for:)\` — synchronous cache accessor
- \`showSimilar(artist:)\` — kicks off \`loadSimilarArtists\`, navigates to \`.artist(artist.id)\`. User lands on the detail page where the now-populated Similar Artists section renders the result

## ArtistDetailView

- \`@State similarArtistsState: [Artist]\` holds per-screen result, refetched on artist switch via \`.task(id:)\`
- Empty-stub \`similarArtists\` computed property now reads from state. Section still collapses when empty (server with no recommendations stays clean)

## Verification

- [x] \`rm -rf macos/.build && swift build -c release\` — clean cold build (30s)
- [x] xcframework unchanged (no core changes); existing \`similarArtists\` binding consumed
- [ ] CI passes
- [ ] Manual smoke: navigate to an artist with similar-artist data → Similar Artists row populates
- [ ] Manual smoke: artist context-menu "Show Similar" from a Library tile → lands on artist detail with Similar Artists shown