### PR TITLE
macos: read-only TrackInfoSheet for #95 (⌘I lands)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -3862,13 +3862,19 @@ final class AppModel {
         navPath.append(Route.artist(artistID))
     }
 
-    /// Present the per-track info sheet (title, album, bitrate, people).
-    /// TODO(#95): info sheet not yet implemented. Logging stub so ⌘I has a
-    /// landing pad.
+    /// Present the per-track info sheet (title, album, year, runtime,
+    /// codec/bitrate, play count). Read-only landing — edit-in-place is
+    /// tracked under #96 and arrives separately. The sheet itself lives at
+    /// `Components/TrackInfoSheet.swift`; mounting happens on `MainShell`
+    /// driven by `trackInfoSubject`. See #95.
     func showTrackInfo(track: Track) {
-        // TODO(#95): track info sheet not yet wired.
-        print("[AppModel] showTrackInfo(track: \(track.name)) not yet wired — see #95")
+        trackInfoSubject = track
     }
+
+    /// Track being shown in the info sheet, or `nil` when the sheet is
+    /// dismissed. Mounted via `.sheet(item:)` on `MainShell` so any screen
+    /// can request the modal without owning a presentation anchor. See #95.
+    var trackInfoSubject: Track?
 
     /// Remove a selection of tracks from a specific playlist. Used by the
     /// multi-select context menu when scoped to a playlist detail view.
@@ -4457,6 +4463,11 @@ extension Track {
         return String(format: "%d:%02d", m, s)
     }
 }
+
+// `.sheet(item:)` requires Identifiable; Track's `id: String` already plays
+// the role so the conformance is a one-liner. Used by the track-info sheet
+// (#95) and any future per-track modal driven off optional `Track?` state.
+extension Track: @retroactive Identifiable {}
 
 extension Array {
     subscript(safe index: Int) -> Element? {

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -39,7 +39,7 @@ extension AppModel {
 
     /// Track-info sheet (#95). Gates "Show Track Info" on track
     /// context menus.
-    var supportsTrackInfo: Bool { false }
+    var supportsTrackInfo: Bool { true }
 
     /// Genre actions (#144, #248, #318). Genre radio (#94) is wired;
     /// browse landing (#318), genre shuffle (#318), and pin-to-home

--- a/macos/Sources/Jellify/Components/TrackInfoSheet.swift
+++ b/macos/Sources/Jellify/Components/TrackInfoSheet.swift
@@ -1,0 +1,156 @@
+import JellifyCore
+import SwiftUI
+
+/// Read-only metadata sheet for a single track — the "Get Info" affordance
+/// the macOS Apple Music app surfaces on ⌘I and the right-click menu. Pulls
+/// fields straight off the [`Track`] payload returned by the core; no extra
+/// FFI round-trip on present.
+///
+/// What's surfaced (each row hides itself when its source is `nil`/empty so
+/// thin metadata doesn't leave gaps):
+/// - Album + track number + disc number
+/// - Year, runtime
+/// - Codec / container + bitrate
+/// - Server-side play count
+///
+/// Edit-in-place / "Edit Info" is tracked separately under #96 — this is
+/// the read-only landing pad first. See #95.
+struct TrackInfoSheet: View {
+    let track: Track
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(Theme.border)
+            metadataGrid
+            footer
+        }
+        .frame(width: 420)
+        .background(Theme.bg)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+
+    // MARK: - Header
+
+    /// Title + artist subtitle. Mirrors the now-playing block typography
+    /// so the sheet feels like a smaller version of the full-screen player.
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(track.name)
+                .font(Theme.font(18, weight: .bold))
+                .foregroundStyle(Theme.ink)
+                .lineLimit(2)
+            Text(track.artistName)
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.top, 22)
+        .padding(.bottom, 14)
+    }
+
+    // MARK: - Metadata grid
+
+    /// Two-column label/value list, top-aligned. Each row collapses when its
+    /// source field is empty so the sheet adapts to thin metadata (e.g. a
+    /// loose mp3 with no album, no year, no bitrate).
+    private var metadataGrid: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let album = track.albumName, !album.isEmpty {
+                row(label: "track.info.album", value: album)
+            }
+            if let trackPosition = trackPositionString {
+                row(label: "track.info.track", value: trackPosition)
+            }
+            if let year = track.year {
+                row(label: "track.info.year", value: String(year))
+            }
+            row(label: "track.info.duration", value: durationString)
+            if let format = formatString {
+                row(label: "track.info.format", value: format)
+            }
+            row(label: "track.info.plays", value: String(track.playCount))
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+    }
+
+    /// Dismiss-only footer. Edit affordances live under #96 and arrive as a
+    /// follow-up, so keeping this sheet read-only avoids implying a feature
+    /// that doesn't exist yet.
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button(action: onDismiss) {
+                Text("common.done")
+                    .font(Theme.font(13, weight: .semibold))
+                    .frame(width: 100, height: 32)
+                    .foregroundStyle(Theme.bg)
+                    .background(Theme.ink)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 22)
+    }
+
+    // MARK: - Helpers
+
+    private func row(label: LocalizedStringKey, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(label)
+                .font(Theme.font(11, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+                .frame(width: 88, alignment: .leading)
+                .accessibilityHidden(true)
+            Text(value)
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+    }
+
+    /// "3 of 12" / "Disc 2 · 3 of 12" / "3" depending on what's available.
+    private var trackPositionString: String? {
+        guard let index = track.indexNumber else { return nil }
+        let trackNumber = String(index)
+        if let disc = track.discNumber {
+            return "\(String(localized: "track.info.disc")) \(disc) · \(trackNumber)"
+        }
+        return trackNumber
+    }
+
+    /// `mm:ss` (or `hh:mm:ss` on the rare > 1h track). Jellyfin's `runtime_ticks`
+    /// is the Apple-style 100-ns count (`seconds * 10_000_000`); divide once
+    /// at present-time so callers don't repeat the math.
+    private var durationString: String {
+        let totalSeconds = Int(track.runtimeTicks / 10_000_000)
+        let h = totalSeconds / 3600
+        let m = (totalSeconds % 3600) / 60
+        let s = totalSeconds % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+
+    /// `FLAC · 1042 kbps` / `MP3 · 320 kbps` / `MP3` if bitrate's unknown.
+    /// Container is upper-cased so the codec reads at-a-glance; bitrate is
+    /// rounded to a nominal kbps from the bps field the server reports.
+    private var formatString: String? {
+        guard let container = track.container, !container.isEmpty else { return nil }
+        let codec = container.uppercased()
+        if let bitrate = track.bitrate, bitrate > 0 {
+            let kbps = Int((Double(bitrate) / 1000.0).rounded())
+            return "\(codec) · \(kbps) kbps"
+        }
+        return codec
+    }
+}

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -145,6 +145,102 @@
         }
       }
     },
+    "common.done" : {
+      "comment" : "Generic Done action label, used to dismiss read-only sheets.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "track.info.album" : {
+      "comment" : "Track-info sheet row label — the album the track belongs to.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
+          }
+        }
+      }
+    },
+    "track.info.disc" : {
+      "comment" : "Track-info sheet — disc-number prefix (e.g. \"Disc 2\").",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disc"
+          }
+        }
+      }
+    },
+    "track.info.duration" : {
+      "comment" : "Track-info sheet row label — playback duration.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration"
+          }
+        }
+      }
+    },
+    "track.info.format" : {
+      "comment" : "Track-info sheet row label — file format / codec / bitrate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format"
+          }
+        }
+      }
+    },
+    "track.info.plays" : {
+      "comment" : "Track-info sheet row label — server-tracked play count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plays"
+          }
+        }
+      }
+    },
+    "track.info.track" : {
+      "comment" : "Track-info sheet row label — track number (and disc, when present).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track"
+          }
+        }
+      }
+    },
+    "track.info.year" : {
+      "comment" : "Track-info sheet row label — release year.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
+          }
+        }
+      }
+    },
     "common.dismiss.a11y" : {
       "comment" : "Accessibility label for a close/dismiss button on toasts and banners.",
       "extractionState" : "manual",

--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -145,102 +145,6 @@
         }
       }
     },
-    "common.done" : {
-      "comment" : "Generic Done action label, used to dismiss read-only sheets.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
-          }
-        }
-      }
-    },
-    "track.info.album" : {
-      "comment" : "Track-info sheet row label — the album the track belongs to.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album"
-          }
-        }
-      }
-    },
-    "track.info.disc" : {
-      "comment" : "Track-info sheet — disc-number prefix (e.g. \"Disc 2\").",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disc"
-          }
-        }
-      }
-    },
-    "track.info.duration" : {
-      "comment" : "Track-info sheet row label — playback duration.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duration"
-          }
-        }
-      }
-    },
-    "track.info.format" : {
-      "comment" : "Track-info sheet row label — file format / codec / bitrate.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Format"
-          }
-        }
-      }
-    },
-    "track.info.plays" : {
-      "comment" : "Track-info sheet row label — server-tracked play count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plays"
-          }
-        }
-      }
-    },
-    "track.info.track" : {
-      "comment" : "Track-info sheet row label — track number (and disc, when present).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Track"
-          }
-        }
-      }
-    },
-    "track.info.year" : {
-      "comment" : "Track-info sheet row label — release year.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Year"
-          }
-        }
-      }
-    },
     "common.dismiss.a11y" : {
       "comment" : "Accessibility label for a close/dismiss button on toasts and banners.",
       "extractionState" : "manual",
@@ -249,6 +153,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dismiss"
+          }
+        }
+      }
+    },
+    "common.done" : {
+      "comment" : "Generic Done action label, used to dismiss read-only sheets.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         }
       }
@@ -1185,6 +1101,90 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This will permanently delete this playlist. This action cannot be undone."
+          }
+        }
+      }
+    },
+    "track.info.album" : {
+      "comment" : "Track-info sheet row label — the album the track belongs to.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
+          }
+        }
+      }
+    },
+    "track.info.disc" : {
+      "comment" : "Track-info sheet — disc-number prefix (e.g. \"Disc 2\").",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disc"
+          }
+        }
+      }
+    },
+    "track.info.duration" : {
+      "comment" : "Track-info sheet row label — playback duration.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration"
+          }
+        }
+      }
+    },
+    "track.info.format" : {
+      "comment" : "Track-info sheet row label — file format / codec / bitrate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format"
+          }
+        }
+      }
+    },
+    "track.info.plays" : {
+      "comment" : "Track-info sheet row label — server-tracked play count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plays"
+          }
+        }
+      }
+    },
+    "track.info.track" : {
+      "comment" : "Track-info sheet row label — track number (and disc, when present).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track"
+          }
+        }
+      }
+    },
+    "track.info.year" : {
+      "comment" : "Track-info sheet row label — release year.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
           }
         }
       }

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -145,6 +145,17 @@ struct MainShell: View {
                 model.authExpired = false
             }
         }
+        // Track-info modal — read-only metadata sheet driven by
+        // `AppModel.trackInfoSubject`. Any screen can call
+        // `model.showTrackInfo(track:)` (notably `TrackContextMenu`'s
+        // "Get Info" item and the global ⌘I shortcut) and the sheet is
+        // mounted here so it works regardless of which screen is active.
+        // See #95.
+        .sheet(item: $model.trackInfoSubject) { track in
+            TrackInfoSheet(track: track) {
+                model.trackInfoSubject = nil
+            }
+        }
         // Playlist-delete confirmation — see #98 / #131. Triggered from
         // `PlaylistContextMenu` via `AppModel.confirmDelete(playlist:)`.
         .confirmationDialog(


### PR DESCRIPTION
## Summary

Closes #95. Replaces the \`print(\"…not yet wired…\")\` stub for \`showTrackInfo(track:)\` in \`AppModel.swift\` with a working sheet.

**Pure Swift / UI** — no FFI changes.

**Stacked on #680**.

## What's new

- \`Components/TrackInfoSheet.swift\` — 420pt-wide modal with header (title + artist), two-column metadata grid, Done button
  - Rows: album, track number (+ disc when present), year, duration, format/bitrate, plays
  - Each row hides itself when its source field is empty (loose mp3 with thin metadata stays clean)
  - Duration normalises Jellyfin's 100-ns \`runtime_ticks\` to \`m:ss\` / \`h:mm:ss\`
  - Format folds container + bitrate to \`FLAC · 1042 kbps\` / \`MP3 · 320 kbps\` / \`MP3\`

## Plumbing

- \`AppModel.showTrackInfo(track:)\` sets \`trackInfoSubject\` (replacing the print stub)
- \`AppModel.trackInfoSubject: Track?\` drives the sheet via \`.sheet(item:)\`
- \`Track\` gets a \`@retroactive Identifiable\` extension (its \`id: String\` already plays the role)
- \`MainShell.sheet(item: $model.trackInfoSubject)\` mounted next to the existing \`AuthExpiredSheet\` so any screen can request the modal — notably \`TrackContextMenu\`'s "Get Info" item and the global ⌘I shortcut
- 8 new \`Localizable.xcstrings\` entries (\`common.done\`, \`track.info.{album,disc,duration,format,plays,track,year}\`)

## Verification

- [x] \`rm -rf macos/.build && swift build -c release\` — clean cold build (29s)
- [x] xcframework unchanged (Swift-only PR)
- [ ] CI passes
- [ ] Manual smoke: ⌘I on a track → sheet opens, shows metadata, Done dismisses
- [ ] Manual smoke: TrackContextMenu → "Get Info" → sheet shows for the targeted track regardless of which screen the menu fires from