### PR TITLE
fix(macos): guard playCommand/pauseCommand on missing delegate (#684)

### DIFF
--- a/macos/Sources/JellifyAudio/MediaSession.swift
+++ b/macos/Sources/JellifyAudio/MediaSession.swift
@@ -213,13 +213,25 @@ public final class MediaSession {
 
         cc.playCommand.isEnabled = true
         cc.playCommand.addTarget { [weak self] _ in
-            self?.delegate?.mediaSessionPlay()
+            guard let self, let delegate = self.delegate else {
+                return .commandFailed
+            }
+            if delegate.currentStatus.currentTrack == nil {
+                return .noActionableNowPlayingItem
+            }
+            delegate.mediaSessionPlay()
             return .success
         }
 
         cc.pauseCommand.isEnabled = true
         cc.pauseCommand.addTarget { [weak self] _ in
-            self?.delegate?.mediaSessionPause()
+            guard let self, let delegate = self.delegate else {
+                return .commandFailed
+            }
+            if delegate.currentStatus.currentTrack == nil {
+                return .noActionableNowPlayingItem
+            }
+            delegate.mediaSessionPause()
             return .success
         }
 


### PR DESCRIPTION
Closes #684.

`playCommand` and `pauseCommand` always returned `.success`, masking failures when the delegate was nil or no track was loaded. Mirrors the guard pattern already in `togglePlayPauseCommand` and `stopCommand`.

pipeline:
  fixer-session: fix-684-wave-1
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass