### PR TITLE
fix(macos): guard nextTrackCommand on missing delegate

### DIFF
--- a/macos/Sources/JellifyAudio/MediaSession.swift
+++ b/macos/Sources/JellifyAudio/MediaSession.swift
@@ -261,7 +261,10 @@ public final class MediaSession {
 
         cc.nextTrackCommand.isEnabled = false
         cc.nextTrackCommand.addTarget { [weak self] _ in
-            self?.delegate?.mediaSessionSkipNext()
+            guard let self, let delegate = self.delegate else {
+                return .commandFailed
+            }
+            delegate.mediaSessionSkipNext()
             return .success
         }
 


### PR DESCRIPTION
## Summary
- The `nextTrackCommand.addTarget` handler in `MediaSession.swift` used the bare pattern `self?.delegate?.mediaSessionSkipNext()` and returned `.success` unconditionally — even when `delegate` was `nil`.
- Every other command handler in the same file (`playCommand`, `pauseCommand`, `togglePlayPauseCommand`, `stopCommand`, `previousTrackCommand`) uses `guard let self, let delegate = self.delegate else { return .commandFailed }`.
- This change makes `nextTrackCommand` consistent with that pattern so `MPRemoteCommandCenter` gets an honest result code when the delegate isn't wired up.

I deliberately did not add a `currentTrack` nil check here: skip-next when no track is loaded is harmless (no-op in `AppModel`), and gating it on `currentTrack` would be more conservative than `previousTrackCommand` does today.

## Test plan
- [ ] CI build of the macOS package succeeds
- [ ] Smoke: launch the app, verify Control Center / media-key "next" still skips to the next track
- [ ] Smoke: verify the command behaves the same when the queue is at its last item (existing `refreshRemoteCommandEnablement` already disables the button in that case unless repeat=all)