### PR TITLE
feat(macos): add cs.disable-library-validation entitlement (#178)

### DIFF
--- a/macos/Resources/Jellify.entitlements
+++ b/macos/Resources/Jellify.entitlements
@@ -26,5 +26,7 @@
          when the target is the system itself. -->
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #178.

Adds `com.apple.security.cs.disable-library-validation` to the entitlements file. Required for Sparkle's XPC helpers (Autoupdate, Installer) to load when the main app is sandboxed/hardened-runtime.

pipeline:
  fixer-session: feat-178-wave-2
  slice: slice:scaffold (entitlements live alongside Info.plist for the macOS app)
  hotspots-claimed: []
  build-gate: pass