### PR TITLE
chore(core): pin Rust toolchain via rust-toolchain.toml (#191)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #191.

Adds `rust-toolchain.toml` at repo root pinning to Rust 1.83.0 with targets for both Apple Silicon and Intel (aarch64-apple-darwin, x86_64-apple-darwin) and components rustfmt + clippy. Local devs and CI now resolve to the same toolchain version, eliminating drift between machines.

pipeline:
  fixer-session: chore-191-wave-5
  slice: slice:state (toolchain config)
  hotspots-claimed: []
  build-gate: pass