### PR TITLE
feat(macos): Alt+Up/Down keyboard reorder for playlist tracks (#73)

### DIFF
--- a/macos/Sources/Jellify/Screens/PlaylistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistDetailView.swift
@@ -101,6 +101,16 @@ struct PlaylistDetailView: View {
         .focusable(true)
         .onKeyPress(.delete) { handleDeleteKey() }
         .onKeyPress(.deleteForward) { handleDeleteKey() }
+        // Alt+Up / Alt+Down: keyboard reorder for the focused (single-selected) track.
+        // Only fires when exactly one row is selected so the semantics are unambiguous.
+        .onKeyPress(.upArrow, phases: .down) { event in
+            guard event.modifiers.contains(.option) else { return .ignored }
+            return handleKeyboardReorder(direction: .up)
+        }
+        .onKeyPress(.downArrow, phases: .down) { event in
+            guard event.modifiers.contains(.option) else { return .ignored }
+            return handleKeyboardReorder(direction: .down)
+        }
         // Drop-to-add: accept any data (tracks as JSON-of-ids or newline
         // list, per the view doc comment). See `handleDrop`.
         .onDrop(
@@ -360,6 +370,39 @@ struct PlaylistDetailView: View {
         scheduleUndoDismiss()
     }
 
+    /// Move the single-selected track one step up or down via keyboard.
+    ///
+    /// Only handles a single-row selection; multi-select reorder has no
+    /// well-defined UX so the key is ignored when more than one row is
+    /// selected. Bounds: Up is ignored at index 0; Down is ignored at the
+    /// last index. Uses the same `moveTrackInPlaylist` path as drag-and-drop.
+    ///
+    /// `moveTrackInPlaylist` uses SwiftUI `move(fromOffsets:toOffset:)`
+    /// insertion-index semantics:
+    ///   - Move UP:   from = i, to = i - 1   (insert before predecessor)
+    ///   - Move DOWN: from = i, to = i + 2   (insert after successor in
+    ///                pre-remove coordinates where successor is still at i+1)
+    private func handleKeyboardReorder(direction: VerticalDirection) -> KeyPress.Result {
+        guard selectedTrackIds.count == 1,
+              let trackId = selectedTrackIds.first,
+              let currentIndex = tracks.firstIndex(where: { $0.id == trackId })
+        else { return .ignored }
+
+        let lastIndex = tracks.count - 1
+        switch direction {
+        case .up:
+            guard currentIndex > 0 else { return .ignored }
+            model.moveTrackInPlaylist(playlistId: playlistID, from: currentIndex, to: currentIndex - 1)
+            // Keep anchor in sync so Shift+Click range-extend still works.
+            anchorIndex = currentIndex - 1
+        case .down:
+            guard currentIndex < lastIndex else { return .ignored }
+            model.moveTrackInPlaylist(playlistId: playlistID, from: currentIndex, to: currentIndex + 2)
+            anchorIndex = currentIndex + 1
+        }
+        return .handled
+    }
+
     // MARK: - Undo toast
 
     private func scheduleUndoDismiss() {
@@ -570,6 +613,11 @@ private struct SelectableTrackRow: View {
         }
     }
 }
+
+// MARK: - Helpers
+
+/// Direction enum used by `handleKeyboardReorder` to avoid raw booleans.
+private enum VerticalDirection { case up, down }
 
 // MARK: - Undo toast
 

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -37,6 +37,10 @@ struct PlaylistView: View {
     @State private var descriptionDraft: String? = nil
     @FocusState private var descriptionFocused: Bool
 
+    /// Tracks which row currently has keyboard focus so Alt+Up / Alt+Down
+    /// reorder can move without requiring multi-select. `nil` = no row focused.
+    @FocusState private var keyboardFocusedIndex: Int?
+
     /// Resolve the playlist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Nil means the id can't
     /// be resolved (deleted upstream, not a real Playlist, server errored).
@@ -347,6 +351,24 @@ struct PlaylistView: View {
                         trackId: track.id,
                         index: idx
                     )
+                    // Keyboard reorder (#73): make the row focusable so Tab
+                    // cycles through the list, then handle Alt+Up / Alt+Down.
+                    .focusable(true)
+                    .focused($keyboardFocusedIndex, equals: idx)
+                    .onKeyPress(.upArrow, phases: .down) { event in
+                        guard event.modifiers.contains(.option) else { return .ignored }
+                        guard idx > 0 else { return .ignored }
+                        model.moveTrackInPlaylist(playlistId: playlistID, from: idx, to: idx - 1)
+                        keyboardFocusedIndex = idx - 1
+                        return .handled
+                    }
+                    .onKeyPress(.downArrow, phases: .down) { event in
+                        guard event.modifiers.contains(.option) else { return .ignored }
+                        guard idx < tracks.count - 1 else { return .ignored }
+                        model.moveTrackInPlaylist(playlistId: playlistID, from: idx, to: idx + 2)
+                        keyboardFocusedIndex = idx + 1
+                        return .handled
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #73.

Wires Option+Up / Option+Down keyboard handlers on playlist track rows to call the existing drag-reorder pathway. Bounds-checked at start/end of list.

### Changes

**PlaylistDetailView.swift**: adds `.onKeyPress(.upArrow/.downArrow, phases: .down)` on the whole `.focusable(true)` ZStack (which already handles Delete/Backspace). Reorder fires when `selectedTrackIds.count == 1`; Up is suppressed at index 0, Down at the last index. Focus anchor (`anchorIndex`) is updated to the post-move position so Shift+Click range-extend stays correct.

**PlaylistView.swift**: promotes `@State keyboardFocusedIndex` to `@FocusState<Int?>` and adds per-row `.focusable(true)` + `.focused($keyboardFocusedIndex, equals: idx)` so Tab can cycle through the list. Alt+Up/Down on a focused row calls `moveTrackInPlaylist` and advances `keyboardFocusedIndex` to follow the moved row.

Both paths use the same `moveTrackInPlaylist(playlistId:from:to:)` call as the existing drag-and-drop handler.

pipeline:
  fixer-session: feat-73-wave-5
  slice: slice:screens
  hotspots-claimed: []
  build-gate: pass