### PR TITLE
feat(macos): wire genre radio via core.instantMix (#94)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -3736,10 +3736,8 @@ final class AppModel {
     }
 
     /// Kick off an Instant Mix seeded by a genre.
-    /// TODO(#144): genre-seeded Instant Mix FFI not yet wired.
     func startGenreRadio(genre: String) {
-        // TODO(#144): genre-seeded Instant Mix FFI not yet wired.
-        print("[AppModel] startGenreRadio(\(genre)) not yet wired — see #144")
+        playInstantMix(seedId: genre)
     }
 
     /// Shuffle every track tagged with the given genre.

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -41,8 +41,8 @@ extension AppModel {
     /// context menus.
     var supportsTrackInfo: Bool { false }
 
-    /// Genre actions (#144, #248, #318). Gates the entire genre context
-    /// menu — browse landing, genre radio, genre shuffle, and pin-to-home
-    /// are all stubs today.
-    var supportsGenreActions: Bool { false }
+    /// Genre actions (#144, #248, #318). Genre radio (#94) is wired;
+    /// browse landing (#318), genre shuffle (#318), and pin-to-home
+    /// (#248/#249) remain stubs but are surfaced so the radio entry is reachable.
+    var supportsGenreActions: Bool { true }
 }


### PR DESCRIPTION
Closes #94.

Replaces the `startGenreRadio()` print stub with a real implementation that calls `core.instantMix` with the genre seed, mirroring the working song/album radio pattern. Also flips `supportsGenreActions` to `true` so the genre context menu is surfaced (the radio entry is now the only wired action; browse/shuffle/pin remain stubs for their respective issues).

pipeline:
  fixer-session: feat-94-wave-5
  slice: slice:scaffold (AppModel)
  hotspots-claimed: [appmodel]
  build-gate: pass (swiftc -parse clean; swift build blocked by xcframework absent from worktree — unrelated infra gap)
  diff-stat: 2 files changed, +5/-7