### PR TITLE
feat(macos): tooltips reveal keyboard shortcuts on PlayerBar (#106)

### DIFF
--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -102,7 +102,9 @@ struct PlayerBar: View {
         VStack(spacing: 6) {
             HStack(spacing: 20) {
                 iconBtn("shuffle", label: "Shuffle")
+                    .help("Shuffle")
                 iconBtn("backward.fill", label: "Previous track", size: 16) { model.skipPrevious() }
+                    .help("Previous · ⌘←")
                 Button(action: model.togglePlayPause) {
                     Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                         .font(.system(size: 15))
@@ -115,8 +117,11 @@ struct PlayerBar: View {
                 // Symbol name so VoiceOver reads the action the user is
                 // about to take. See #331.
                 .accessibilityLabel(Text(isPlaying ? "Pause" : "Play"))
+                .help(isPlaying ? "Pause · Space" : "Play · Space")
                 iconBtn("forward.fill", label: "Next track", size: 16) { model.skipNext() }
+                    .help("Next · ⌘→")
                 iconBtn("repeat", label: "Repeat")
+                    .help("Repeat")
             }
             scrubber
         }


### PR DESCRIPTION
Closes #106.

Adds Spotify-style `Action · Shortcut` tooltips to PlayerBar transport buttons via `.help()` modifier. Shortcut text mirrors the actual bindings in JellifyCommands.

- Shuffle → "Shuffle"
- Previous → "Previous · ⌘←"
- Play/Pause → "Play · Space" / "Pause · Space" (reactive to playback state)
- Next → "Next · ⌘→"
- Repeat → "Repeat"

pipeline:
  fixer-session: feat-106-wave-6
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass