### PR TITLE
feat(macos): wire similar_artists FFI to ArtistDetailView (#146)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -104,6 +104,10 @@ final class AppModel {
     /// by `loadArtistTopTracks(artistId:)` when the Artist detail screen
     /// opens. Held for the session; cleared on logout. See #229.
     var artistTopTracks: [String: [Track]] = [:]      // artistID → top tracks
+    /// Cache of artists similar to a given artist id. Populated on demand by
+    /// `loadSimilarArtists(artistId:)` when the Artist detail screen opens.
+    /// Held for the session; cleared on logout. See #146.
+    var artistSimilarCache: [String: [Artist]] = [:]  // artistID → similar artists
     var recentlyPlayed: [Track] = []
     /// Tracks surfaced in the Discover "For You" carousel (#249). Today this
     /// is a best-effort fallback to the first 20 `recentlyPlayed` tracks. A
@@ -763,6 +767,7 @@ final class AppModel {
         sidebarCopyingPlaylistIds = []
         playlistPendingDelete = nil
         artistTopTracks = [:]
+        artistSimilarCache = [:]
         artistAlbumsCache = [:]
         recentlyPlayed = []
         forYou = []
@@ -823,6 +828,7 @@ final class AppModel {
         sidebarCopyingPlaylistIds = []
         playlistPendingDelete = nil
         artistTopTracks = [:]
+        artistSimilarCache = [:]
         artistAlbumsCache = [:]
         recentlyPlayed = []
         forYou = []
@@ -2014,6 +2020,30 @@ final class AppModel {
         }
     }
 
+    /// Fetch artists similar to `artistId` via Jellyfin's
+    /// `GET /Artists/{id}/Similar`. Results are cached for the session in
+    /// `artistSimilarCache` and cleared on logout. Mirrors the shape of
+    /// `loadArtistTopTracks` — detached FFI call, silent fallback. See #146.
+    @discardableResult
+    func loadSimilarArtists(artistId: String, limit: UInt32 = 12) async -> [Artist] {
+        if let cached = artistSimilarCache[artistId] { return cached }
+        do {
+            let similar = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.similarArtists(artistId: artistId, limit: limit)
+            }.value
+            artistSimilarCache[artistId] = similar
+            serverReachability.noteSuccess()
+            return similar
+        } catch {
+            // Silent fallback — don't surface errors for a secondary widget.
+            if handleAuthError(error) { return [] }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            return []
+        }
+    }
+
     /// Fetch the ordered tracks for a playlist, preserving the server-side
     /// playlist order. Mirrors `loadTracks(forAlbum:)` — results are cached
     /// for the session, scoped to `playlistTracks[playlist.id]`. Backed by
@@ -3099,11 +3129,15 @@ final class AppModel {
         screen = .artist(artist.id)
     }
 
-    /// Show artists similar to this one.
-    /// TODO: #146 — similar_artists FFI not yet wired.
+    /// Show artists similar to this one. Navigates to the artist detail page
+    /// and pre-warms the similar-artists cache so the row is ready when the
+    /// view appears. Backed by `core.similarArtists` via `loadSimilarArtists`.
+    /// See #146.
     func showSimilar(artist: Artist) {
-        // TODO: #146 — similar_artists FFI not yet wired.
-        print("[AppModel] showSimilar(artist:) not yet wired — see #146")
+        Task {
+            await loadSimilarArtists(artistId: artist.id)
+        }
+        screen = .artist(artist.id)
     }
 
     // MARK: - Artist sharing

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -21,7 +21,6 @@ import SwiftUI
 ///    below).
 ///
 /// Data stubs that remain TODO pending core work:
-/// - `similar_artists` FFI (#146) → similar artists row is empty-state today.
 /// - `artist_overview` / `artist_details` FFI (#231) → the About block falls
 ///   back to the artist's genres + a "No bio yet" line.
 /// - `AlbumType` on the `Album` record (#60) → discography grouping uses
@@ -41,6 +40,7 @@ struct ArtistDetailView: View {
     @State private var artistAlbums: [Album] = []
     @State private var fetchedArtist: Artist?
     @State private var isBioExpanded = false
+    @State private var similarArtistsState: [Artist] = []
 
     /// Resolve the artist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Missing (server
@@ -75,6 +75,7 @@ struct ArtistDetailView: View {
             artistAlbums = await model.loadArtistAlbums(artistId: artistID)
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
             isLoadingTopTracks = false
+            similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
         }
     }
 
@@ -530,8 +531,8 @@ struct ArtistDetailView: View {
 
     /// Horizontal carousel of 140pt circular artist tiles, mirroring
     /// `ArtistRadioTile`'s shape but with the real-artist nav action.
-    /// Empty today — see TODO below — and hidden entirely when we have no
-    /// data, so the section doesn't read as a bug.
+    /// Hidden when the server returns no similar artists so the section
+    /// doesn't read as a bug. Data comes from `similarArtistsState`.
     @ViewBuilder
     private var similarArtistsSection: some View {
         let similar = similarArtists
@@ -552,16 +553,12 @@ struct ArtistDetailView: View {
         }
     }
 
-    /// Similar artists list. Empty today — returns `[]` so the section
-    /// collapses silently rather than surfacing a broken "similar to" shelf.
-    ///
-    /// TODO(core-#146): wire through `core.similar_artists(artist_id, limit)`
-    /// once the FFI lands. Jellyfin exposes `/Artists/{id}/Similar` — the
-    /// core just needs to pass it through. With that in place this returns
-    /// the server's list trimmed to 6 items per #232.
+    /// Similar artists list. Backed by `model.loadSimilarArtists` (which
+    /// calls `core.similar_artists` via Jellyfin's `/Artists/{id}/Similar`).
+    /// Populated by the `.task(id:)` block; collapses silently when empty.
+    /// See #146.
     private var similarArtists: [Artist] {
-        // TODO(core-#146): return model.similarArtists(for: artistID, limit: 6)
-        []
+        similarArtistsState
     }
 
     // MARK: - About / bio (#231)
@@ -797,9 +794,8 @@ private struct ArtistDiscographyTile: View {
 /// visual shape of `ArtistRadioTile` but the action is "open detail", not
 /// "start radio", and the subline is the genre rather than the word "Radio".
 ///
-/// Today this is unreachable (similar artists aren't wired — see
-/// `ArtistDetailView.similarArtists`) but we keep the component live so that
-/// when #146 lands the tile just gets data and works.
+/// Wired as of #146 — `ArtistDetailView.similarArtistsState` is now populated
+/// by `model.loadSimilarArtists(artistId:)` in the `.task(id:)` block.
 private struct SimilarArtistTile: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion


### PR DESCRIPTION
Closes #146.

Replaces the `print("[AppModel] showSimilar(artist:) not yet wired — see #146")` stub and the `[]`-returning computed property in `ArtistDetailView` with a real implementation backed by `core.similarArtists`.

## AppModel changes

- `artistSimilarCache: [String: [Artist]]` — session-scoped cache keyed by artist id; cleared on logout (both clear paths)
- `loadSimilarArtists(artistId:limit:)` — mirrors `loadArtistTopTracks` shape: `Task.detached` off MainActor, reachability nudges, silent fallback to `[]` on error; see CLAUDE.md gap #2
- `showSimilar(artist:)` — pre-warms cache via `Task { await loadSimilarArtists(...) }` then navigates to `.artist(artist.id)`

## ArtistDetailView changes

- `@State private var similarArtistsState: [Artist] = []` — per-screen result
- `.task(id:)` block extended: `similarArtistsState = await model.loadSimilarArtists(artistId: artistID)`
- `similarArtists` computed property now reads from state; section still collapses when empty

## Notes

- PR #680 was open for this same work; this is a fresh implementation off `origin/main` without the `#679` stack dependency
- No core FFI changes — `core.similarArtists(artistId:limit:)` already exists in the xcframework
- `swiftc -parse` clean on both changed files

pipeline:
  fixer-session: feat-146-wave-7
  slice: slice:scaffold (AppModel)
  hotspots-claimed: [appmodel]
  build-gate: parse-clean (JellifyAudio pre-existing env failures unrelated to this change)