### PR TITLE
feat(macos): 'You might like' Home row from suggestions FFI (#145)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -148,6 +148,11 @@ final class AppModel {
     /// 12. Re-derived every time the backing set is refreshed so the view
     /// doesn't have to know about the shuffle.
     var favoriteAlbumsVisible: [Album] = []
+    /// Server-curated "You might like" tracks for the Home discovery row
+    /// (#145). Backed by `core.suggestions()`, which hits Jellyfin's
+    /// `/Items/Suggestions` endpoint. Up to 20 tracks. Hidden until data
+    /// arrives so first-time users don't see an empty shelf.
+    var suggestions: [Track] = []
     var searchResults: SearchResults?
     var searchQuery: String = ""
 
@@ -778,6 +783,7 @@ final class AppModel {
         quickPicksPlayCounts = [:]
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
+        suggestions = []
         searchResults = nil
         searchQuery = ""
 
@@ -839,6 +845,7 @@ final class AppModel {
         quickPicksPlayCounts = [:]
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
+        suggestions = []
         searchResults = nil
         searchQuery = ""
 
@@ -995,6 +1002,7 @@ final class AppModel {
         await refreshRecentlyAdded()
         await refreshQuickPicks()
         await refreshFavoriteAlbums()
+        await refreshSuggestions()
     }
 
     /// Fetch the next page of albums and append to `albums`. No-op when a
@@ -1365,6 +1373,20 @@ final class AppModel {
     /// the server.
     func reshuffleFavoriteAlbumsVisible() {
         self.favoriteAlbumsVisible = Array(favoriteAlbumsAll.shuffled().prefix(12))
+    }
+
+    /// Refresh the "You might like" discovery row (#145). Calls
+    /// `core.suggestions()` which hits Jellyfin's `/Items/Suggestions`
+    /// endpoint filtered to Audio + MusicAlbum/MusicArtist. Returns up to
+    /// 20 tracks server-ranked by play history and social signals. Runs
+    /// off the MainActor per the gap-#2 pattern so the Rust mutex doesn't
+    /// block the UI thread. Silent on error — an empty shelf is a fine
+    /// first-time-user state.
+    func refreshSuggestions() async {
+        let fetched = await Task.detached(priority: .userInitiated) { [core] in
+            (try? core.suggestions(limit: 20)) ?? []
+        }.value
+        self.suggestions = fetched
     }
 
     /// Load every favorite track on the server and play them shuffled.

--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -31,6 +31,7 @@ struct HomeView: View {
                 recentlyPlayedTracksSection
                 recentlyAddedSection
                 quickPicksSection
+                suggestionsSection
                 favoritesSection
                 pinnedStationsRow
                 artistRadioRow
@@ -489,6 +490,31 @@ struct HomeView: View {
                                 PlayCountBadge(plays: plays)
                             }
                         }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "You might like" — server-curated discovery tracks (#145). Backed by
+    /// `core.suggestions()` which calls Jellyfin's `/Items/Suggestions`
+    /// endpoint. Hidden until data arrives so new users don't see an empty
+    /// shelf. Rendered as compact track rows (same component as the
+    /// Recently Played track list) — tap to play a single track instantly.
+    @ViewBuilder
+    private var suggestionsSection: some View {
+        if !model.suggestions.isEmpty {
+            carouselSection(
+                icon: "wand.and.sparkles",
+                iconColor: Theme.primary,
+                title: "You Might Like",
+                subtitle: "Picks the server thinks you'll love",
+                onSeeAll: nil
+            ) {
+                LazyHStack(alignment: .top, spacing: 12) {
+                    ForEach(model.suggestions, id: \.id) { track in
+                        RecentlyPlayedTrackRow(track: track)
                     }
                 }
                 .padding(.vertical, 4)


### PR DESCRIPTION
Closes #145.

Wires the existing `core.suggestions()` FFI to a new "You Might Like" carousel on the Home screen, mirroring the pattern of `quickPicksSection` and `recentlyPlayedTracksSection`.

## Changes

- **AppModel.swift**: `@Published var suggestions: [Track]` property + `refreshSuggestions()` async func (Task.detached off MainActor per gap-#2) + cleared on logout/forgetToken + called from `refreshLibrary()` after the other Home carousels.
- **HomeView.swift**: `suggestionsSection` using `carouselSection` scaffold + `RecentlyPlayedTrackRow` per track (same component as the Recently Played track list). Hidden when empty. Inserted between Quick Picks and Favorites in the stack.

## Details

- FFI signature: `core.suggestions(limit: UInt32) throws -> [Track]`
- Endpoint: `/Items/Suggestions` (already in the xcframework)
- Limit: 20 tracks
- Error handling: `try?` silent fallback — empty shelf is fine for first-time users

pipeline:
  fixer-session: feat-145-wave-7
  slice: slice:scaffold + slice:screens
  hotspots-claimed: [appmodel]
  build-gate: pass (swiftc -parse; full swift build blocked by pre-existing xcframework staleness across all worktrees)