### PR TITLE
feat(macos): hidden title bar for edge-to-edge sidebar (#2)

### DIFF
--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -40,7 +40,13 @@ struct Sidebar: View {
                 Spacer()
             }
             .padding(.horizontal, 18)
-            .padding(.top, 16)
+            // Reserve clearance for the traffic-light controls floating
+            // over the sidebar — `.windowStyle(.hiddenTitleBar)` lets our
+            // content flow into the title-bar strip, so without this top
+            // padding the brand mark would render directly under
+            // close / minimize / zoom on a window that doesn't carve out
+            // a dedicated title-bar strip.
+            .padding(.top, 28)
             .padding(.bottom, 12)
 
             // Primary nav

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -46,6 +46,14 @@ struct JellifyApp: App {
                 .focusedSceneValue(\.appModel, model)
         }
         .defaultSize(width: 1280, height: 820)
+        // Hide the system title bar so the sidebar runs edge-to-edge
+        // under the traffic lights (Apple Music / Music for Classical /
+        // Reeder / Spark layout). `.hiddenTitleBar` flips
+        // `titlebarAppearsTransparent` and adds `.fullSizeContentView`
+        // to the window's `styleMask`, letting our content flow into
+        // the title-bar strip. The unified toolbar style stays in place
+        // so any `.toolbar {}` content still lands in the right strip.
+        .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unifiedCompact)
         .commands {
             JellifyCommands(model: model)


### PR DESCRIPTION
Adopts `.windowStyle(.hiddenTitleBar)` on the WindowGroup so the sidebar runs edge-to-edge under the traffic lights, matching the look of Apple Music, Music for Classical, Reeder, and Spark.

Why:
- `.hiddenTitleBar` flips `titlebarAppearsTransparent` and adds `.fullSizeContentView` to the window's `styleMask`, letting our content flow into the title-bar strip.
- The unified toolbar style stays in place so future `.toolbar {}` content (the upcoming back / forward / sidebar-toggle / search field) still lands in the correct strip.
- Reserves 28pt of top padding on the sidebar's brand header so the brand mark doesn't render directly under the traffic-light controls.

Closes #2