### PR TITLE
feat(macos): migrate drill destinations to NavigationPath (#1, #4)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -25,12 +25,16 @@ final class AppModel {
     var username: String = ""
 
     // MARK: - Navigation
-    enum Screen: Hashable { case home, discover, library, search, settings, album(String), artist(String), playlist(String), nowPlaying }
+    /// Active root tab. Drill destinations (album / artist / playlist /
+    /// nowPlaying) live on `navPath` instead so back navigation is handled
+    /// by `NavigationStack` natively. See #1 / #4.
+    enum Screen: Hashable { case home, discover, library, search, settings }
     var screen: Screen = .library
 
-    /// Typed value-type for the SwiftUI NavigationStack migration (#1, #4).
-    /// Mirrors `Screen` 1:1. Coexists with `Screen` during the migration —
-    /// `Screen` is removed in B3 once all consumers move to `navPath`.
+    /// Typed value-type for `NavigationStack` destinations. Root tabs and
+    /// drill destinations are both representable so `Route` can address
+    /// any surface in the app, but in production the path only ever
+    /// holds drill entries — the active tab is `screen`. See #1 / #4.
     enum Route: Hashable {
         case home
         case discover
@@ -43,26 +47,28 @@ final class AppModel {
         case nowPlaying
     }
 
-    /// Typed `NavigationPath` for the new NavigationSplitView shell.
-    /// Empty when the user is on the root of a tab; gains entries as they
-    /// drill into albums / artists / playlists.
-    /// B2 wires this into the new shell; B3 makes it the source of truth.
-    var navPath = NavigationPath()
+    /// Drill stack for the current tab. Empty when the user is on the root
+    /// of a tab; gains entries as they push album / artist / playlist /
+    /// nowPlaying detail views. `selectTab(_:)` resets this when the user
+    /// flips tabs so the drill state doesn't leak across roots. Modeled as
+    /// a typed `[Route]` array (rather than `NavigationPath`) so call sites
+    /// can inspect the top of the stack — needed for the "toggle Now
+    /// Playing" menu command and similar reversible drills. See #1 / #4.
+    var navPath: [Route] = []
 
-    /// Returns the `Route` equivalent of the legacy `screen` enum.
-    /// Removed in B3 once all call sites move to `navPath`.
-    func currentRoute() -> Route {
-        switch screen {
-        case .home: return .home
-        case .discover: return .discover
-        case .library: return .library
-        case .search: return .search
-        case .settings: return .settings
-        case .album(let id): return .album(id)
-        case .artist(let id): return .artist(id)
-        case .playlist(let id): return .playlist(id)
-        case .nowPlaying: return .nowPlaying
-        }
+    /// Switch to a root tab and clear the drill stack. Use this from every
+    /// sidebar / menu tab handler so drill state doesn't survive a tab
+    /// change.
+    func selectTab(_ tab: Screen) {
+        screen = tab
+        navPath = []
+    }
+
+    /// True when the full Now Playing view is the top of the drill stack.
+    /// Used by the ⌘L menu toggle (see `JellifyApp.toggleNowPlaying`) so
+    /// the second press pops back rather than stacking another copy.
+    var isShowingNowPlaying: Bool {
+        navPath.last == .nowPlaying
     }
 
     /// Which chip is active on the Library screen. Driven by the sidebar's
@@ -558,13 +564,13 @@ final class AppModel {
             id: "nav.library",
             title: "Go to Library",
             symbol: "music.note.list",
-            run: { [weak self] in self?.screen = .library }
+            run: { [weak self] in self?.selectTab(.library) }
         ))
         actions.append(PaletteAction(
             id: "nav.home",
             title: "Go to Home",
             symbol: "house",
-            run: { [weak self] in self?.screen = .home }
+            run: { [weak self] in self?.selectTab(.home) }
         ))
         actions.append(PaletteAction(
             id: "nav.discover",
@@ -1452,7 +1458,7 @@ final class AppModel {
     func showAllFavorites() {
         // TODO(library-filter): once the library chip row supports a
         //   "Favorites" filter, route here with the filter pre-selected.
-        screen = .library
+        selectTab(.library)
     }
 
     /// Shared helper: build a `GET /Items` request against the user's
@@ -2288,7 +2294,7 @@ final class AppModel {
         if !playlists.contains(where: { $0.id == playlist.id }) {
             playlists.append(playlist)
         }
-        screen = .playlist(playlist.id)
+        navPath.append(Route.playlist(playlist.id))
     }
 
 
@@ -2298,27 +2304,26 @@ final class AppModel {
     /// and the new `isSearchFieldFocused` mirror so toolbar / field bindings
     /// introduced by #7 can attach a `@FocusState` via `$model.isSearchFieldFocused`.
     func focusSearch() {
-        screen = .search
+        selectTab(.search)
         requestSearchFocus = true
         isSearchFieldFocused = true
     }
 
-    /// Programmatic navigation entry point. Views that want to push a screen
-    /// should prefer this over assigning `model.screen` directly so there's
-    /// a single seam to add side effects (analytics, breadcrumb history, nav
-    /// animations) later. Today it's a thin setter — matches the direct
-    /// `model.screen = ...` pattern used elsewhere.
+    /// Programmatic drill-navigation entry point. Pushes a `Route` onto
+    /// `navPath` so the new `NavigationStack` shell renders the matching
+    /// destination. Views that want to drill into a detail screen should
+    /// prefer this over manipulating `navPath` directly so there's a single
+    /// seam to add side effects (analytics, breadcrumb history, etc.) later.
     ///
     /// Wired by the Artist detail page's Similar Artists tiles (BATCH-04)
-    /// and available to future surfaces that want a less brittle navigation
-    /// handle.
-    func navigate(to screen: Screen) {
-        self.screen = screen
+    /// and the command palette.
+    func navigate(to route: Route) {
+        navPath.append(route)
     }
 
     /// Navigate to the Discover screen. See #248.
     func goToDiscover() {
-        screen = .discover
+        selectTab(.discover)
     }
 
     /// Kick off a library-seeded Instant Mix from the Discover screen's CTA.
@@ -3041,14 +3046,14 @@ final class AppModel {
     /// Navigate to the artist detail screen for this album's artist, if known.
     func goToArtist(album: Album) {
         guard let artistID = album.artistId else { return }
-        screen = .artist(artistID)
+        navPath.append(Route.artist(artistID))
     }
 
     /// Navigate to the album's own detail screen. Used when the menu is
     /// invoked from a surface other than the album detail itself (e.g. a
     /// track row that links back to its album).
     func goToAlbum(album: Album) {
-        screen = .album(album.id)
+        navPath.append(Route.album(album.id))
     }
 
     /// Kick off an Instant Mix ("album radio") seeded by this album.
@@ -3172,7 +3177,7 @@ final class AppModel {
     /// from a surface other than the artist detail itself (e.g. a track
     /// row whose secondary line is the artist).
     func goToArtistPage(artist: Artist) {
-        screen = .artist(artist.id)
+        navPath.append(Route.artist(artist.id))
     }
 
     /// Kick off an Instant Mix ("artist radio") seeded by this artist.
@@ -3185,7 +3190,7 @@ final class AppModel {
     /// we just route to `.artist(id)` and let that view (when it lands) pick
     /// up the discography anchor.
     func goToDiscography(artist: Artist) {
-        screen = .artist(artist.id)
+        navPath.append(Route.artist(artist.id))
     }
 
     /// Show artists similar to this one. Navigates to the artist detail page
@@ -3196,7 +3201,7 @@ final class AppModel {
         Task {
             await loadSimilarArtists(artistId: artist.id)
         }
-        screen = .artist(artist.id)
+        navPath.append(Route.artist(artist.id))
     }
 
     // MARK: - Artist sharing
@@ -3778,13 +3783,13 @@ final class AppModel {
     /// Navigate to the album detail screen for this track's album.
     func goToAlbum(track: Track) {
         guard let albumID = track.albumId else { return }
-        screen = .album(albumID)
+        navPath.append(Route.album(albumID))
     }
 
     /// Navigate to the artist detail screen for this track's artist.
     func goToArtist(track: Track) {
         guard let artistID = track.artistId else { return }
-        screen = .artist(artistID)
+        navPath.append(Route.artist(artistID))
     }
 
     /// Present the per-track info sheet (title, album, bitrate, people).
@@ -4273,12 +4278,12 @@ final class AppModel {
             if let playlist = playlists.first(where: { $0.id == id }) {
                 goToPlaylist(playlist)
             } else {
-                screen = .playlist(id)
+                navPath.append(Route.playlist(id))
             }
         case .album:
-            screen = .album(id)
+            navPath.append(Route.album(id))
         case .artist:
-            screen = .artist(id)
+            navPath.append(Route.artist(id))
         case .genre, .search, .radio, .other:
             // No dedicated surface for these source types yet — do nothing
             // rather than route to a placeholder. The label itself is

--- a/macos/Sources/Jellify/Components/ArtistCard.swift
+++ b/macos/Sources/Jellify/Components/ArtistCard.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 /// Square grid tile used in the Library Artists tab. Mirrors the shape and
 /// visual language of `AlbumCard`: square artwork, name below, hover reveals
-/// a play overlay. Tapping the card routes to the artist detail screen via
-/// `model.screen = .artist(artist.id)`.
+/// a play overlay. Tapping the card pushes the artist detail screen onto
+/// `model.navPath` via `Route.artist(artist.id)`.
 ///
 /// Issue: #213 (Library → Artists grid). The overlay play button calls
 /// `AppModel.playAll(artist:)`, which is a logging stub today pending
@@ -34,7 +34,7 @@ struct ArtistCard: View {
 
     var body: some View {
         Button {
-            model.screen = .artist(artist.id)
+            model.navPath.append(AppModel.Route.artist(artist.id))
         } label: {
             VStack(alignment: .leading, spacing: 10) {
                 ZStack(alignment: .bottomTrailing) {

--- a/macos/Sources/Jellify/Components/FormatBadge.swift
+++ b/macos/Sources/Jellify/Components/FormatBadge.swift
@@ -70,7 +70,8 @@ struct FormatBadge: View {
 			artistName: "Artist", artistId: nil, indexNumber: nil,
 			discNumber: nil, year: nil, runtimeTicks: 0,
 			isFavorite: false, playCount: 0,
-			container: "flac", bitrate: 1_411_000, imageTag: nil
+			container: "flac", bitrate: 1_411_000, imageTag: nil,
+			playlistItemId: nil, userData: nil
 		))
 		// MP3 with bitrate
 		FormatBadge(track: Track(
@@ -78,7 +79,8 @@ struct FormatBadge: View {
 			artistName: "Artist", artistId: nil, indexNumber: nil,
 			discNumber: nil, year: nil, runtimeTicks: 0,
 			isFavorite: false, playCount: 0,
-			container: "mp3", bitrate: 320_000, imageTag: nil
+			container: "mp3", bitrate: 320_000, imageTag: nil,
+			playlistItemId: nil, userData: nil
 		))
 		// Container only, no bitrate
 		FormatBadge(track: Track(
@@ -86,7 +88,8 @@ struct FormatBadge: View {
 			artistName: "Artist", artistId: nil, indexNumber: nil,
 			discNumber: nil, year: nil, runtimeTicks: 0,
 			isFavorite: false, playCount: 0,
-			container: "aac", bitrate: nil, imageTag: nil
+			container: "aac", bitrate: nil, imageTag: nil,
+			playlistItemId: nil, userData: nil
 		))
 		// No container — badge hidden
 		FormatBadge(track: Track(
@@ -94,7 +97,8 @@ struct FormatBadge: View {
 			artistName: "Artist", artistId: nil, indexNumber: nil,
 			discNumber: nil, year: nil, runtimeTicks: 0,
 			isFavorite: false, playCount: 0,
-			container: nil, bitrate: nil, imageTag: nil
+			container: nil, bitrate: nil, imageTag: nil,
+			playlistItemId: nil, userData: nil
 		))
 	}
 	.padding(16)

--- a/macos/Sources/Jellify/Components/HomeAlbumTile.swift
+++ b/macos/Sources/Jellify/Components/HomeAlbumTile.swift
@@ -43,7 +43,7 @@ struct HomeAlbumTile<Badge: View>: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture(count: 2) {
-            model.screen = .album(album.id)
+            model.navPath.append(AppModel.Route.album(album.id))
         }
         .onTapGesture(count: 1) {
             model.play(album: album)

--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -229,9 +229,9 @@ struct LibraryListRow: View {
     private func openDetail() {
         switch payload {
         case .album(let album):
-            model.screen = .album(album.id)
+            model.navPath.append(AppModel.Route.album(album.id))
         case .artist(let artist):
-            model.screen = .artist(artist.id)
+            model.navPath.append(AppModel.Route.artist(artist.id))
         case .playlist(let playlist):
             // Route through `goToPlaylist` so the playlist is seeded into
             // `model.playlists` before the screen flips. Without this seed,

--- a/macos/Sources/Jellify/Components/NowPlayingCredits.swift
+++ b/macos/Sources/Jellify/Components/NowPlayingCredits.swift
@@ -149,7 +149,7 @@ struct Person: Equatable {
     let type: String
     /// Jellyfin's `Id` for this person, when the server returns one. The
     /// id points at a `MusicArtist`-ish item for music credits, so the
-    /// album liner-note chips feed it straight into `screen = .artist(id)`.
+    /// album liner-note chips feed it straight into `Route.artist(id)`.
     /// Nil when the field is absent on the raw JSON — callers should render
     /// the chip as non-interactive in that case.
     let id: String?

--- a/macos/Sources/Jellify/Components/PlaylistCard.swift
+++ b/macos/Sources/Jellify/Components/PlaylistCard.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// Context menu routes through `PlaylistContextMenu` so the grid, list rows,
 /// and any future surfaces share one set of actions.
 ///
-/// Spec: #212 (Library chips). Detail screen routed via `AppModel.Screen.playlist`.
+/// Spec: #212 (Library chips). Detail screen pushed via `AppModel.Route.playlist`.
 struct PlaylistCard: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -18,7 +18,7 @@ struct PlaylistCard: View {
 
     var body: some View {
         Button {
-            model.screen = .playlist(playlist.id)
+            model.navPath.append(AppModel.Route.playlist(playlist.id))
         } label: {
             VStack(alignment: .leading, spacing: 10) {
                 ZStack(alignment: .bottomTrailing) {

--- a/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Jellify/Components/RecentlyPlayedTrackRow.swift
@@ -63,12 +63,12 @@ struct RecentlyPlayedTrackRow: View {
             }
             if let albumId = track.albumId, !albumId.isEmpty {
                 Button("Go to Album", systemImage: "square.stack") {
-                    model.screen = .album(albumId)
+                    model.navPath.append(AppModel.Route.album(albumId))
                 }
             }
             if let artistId = track.artistId, !artistId.isEmpty {
                 Button("Go to Artist", systemImage: "person") {
-                    model.screen = .artist(artistId)
+                    model.navPath.append(AppModel.Route.artist(artistId))
                 }
             }
         }

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -177,7 +177,7 @@ struct Sidebar: View {
     private func playlistRow(_ playlist: Playlist) -> some View {
         let isEditing = model.sidebarEditingPlaylistId == playlist.id
         let isActiveScreen: Bool = {
-            if case .playlist(let id) = model.screen { return id == playlist.id }
+            if case .playlist(let id) = model.navPath.last { return id == playlist.id }
             return false
         }()
         let isCopying = model.sidebarCopyingPlaylistIds.contains(playlist.id)
@@ -262,8 +262,8 @@ struct Sidebar: View {
 
     @ViewBuilder
     private func navItem(_ icon: String, label: LocalizedStringKey, screen: AppModel.Screen) -> some View {
-        let active = model.screen == screen
-        Button { model.screen = screen } label: {
+        let active = model.screen == screen && model.navPath.isEmpty
+        Button { model.selectTab(screen) } label: {
             HStack(spacing: 10) {
                 Image(systemName: icon)
                     .foregroundStyle(active ? Theme.accent : Theme.ink2)
@@ -311,7 +311,7 @@ struct Sidebar: View {
             // Library view reads the right chip on its first render. See
             // `AppModel.libraryTab`.
             model.libraryTab = tab
-            model.screen = .library
+            model.selectTab(.library)
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: icon)

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -125,7 +125,7 @@ struct JellifyCommands: Commands {
         // mode on a fresh placeholder row. See BATCH-06b / #71.
         CommandGroup(replacing: .newItem) {
             Button("menu.file.new_playlist") {
-                model.screen = .library
+                model.selectTab(.library)
                 model.beginNewPlaylist()
             }
             .keyboardShortcut("n", modifiers: .command)
@@ -166,19 +166,19 @@ struct JellifyCommands: Commands {
             // and re-assigning it triggers the same `MainShell` animation
             // as clicking the sidebar.
             Button("menu.nav.home") {
-                model.screen = .home
+                model.selectTab(.home)
             }
             .keyboardShortcut("1", modifiers: .command)
             .disabled(model.session == nil)
 
             Button("menu.nav.library") {
-                model.screen = .library
+                model.selectTab(.library)
             }
             .keyboardShortcut("2", modifiers: .command)
             .disabled(model.session == nil)
 
             Button("menu.nav.search") {
-                model.screen = .search
+                model.selectTab(.search)
             }
             .keyboardShortcut("3", modifiers: .command)
             .disabled(model.session == nil)
@@ -340,12 +340,12 @@ struct JellifyCommands: Commands {
     /// the View / Library ⌘L entry and the Playback ⌘L mirror so either
     /// menu gesture does the same thing. See #89.
     private func toggleNowPlaying() {
-        if model.screen == .nowPlaying {
-            model.screen = model.previousScreen ?? .library
-            model.previousScreen = nil
+        // The full player is a drill destination on `navPath`. If it's the
+        // top of the stack already, pop it; otherwise push it.
+        if model.isShowingNowPlaying {
+            model.navPath.removeLast()
         } else {
-            model.previousScreen = model.screen
-            model.screen = .nowPlaying
+            model.navPath.append(AppModel.Route.nowPlaying)
         }
     }
 

--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -122,7 +122,7 @@ struct AlbumDetailView: View {
             }
         if let artistId = album.artistId, !artistId.isEmpty {
             Button {
-                model.screen = .artist(artistId)
+                model.navPath.append(AppModel.Route.artist(artistId))
             } label: {
                 line
             }
@@ -456,7 +456,7 @@ struct AlbumDetailView: View {
                 ForEach(Array(row.people.enumerated()), id: \.offset) { _, person in
                     CreditChip(person: person) {
                         if let id = person.id {
-                            model.screen = .artist(id)
+                            model.navPath.append(AppModel.Route.artist(id))
                         }
                     }
                 }

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -727,7 +727,7 @@ private struct ArtistDiscographyTile: View {
 
     var body: some View {
         Button {
-            model.screen = .album(album.id)
+            model.navPath.append(AppModel.Route.album(album.id))
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 ZStack(alignment: .bottomTrailing) {

--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -210,7 +210,7 @@ struct HomeView: View {
                     subtitle: album.artistName,
                     artworkURL: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 96),
                     seed: album.name,
-                    action: { model.screen = .album(album.id) },
+                    action: { model.navPath.append(AppModel.Route.album(album.id)) },
                     onPlay: { model.play(album: album) }
                 )
             }

--- a/macos/Sources/Jellify/Screens/LibraryView.swift
+++ b/macos/Sources/Jellify/Screens/LibraryView.swift
@@ -746,7 +746,7 @@ struct AlbumCard: View {
 
     var body: some View {
         Button {
-            model.screen = .album(album.id)
+            model.navPath.append(AppModel.Route.album(album.id))
         } label: {
             VStack(alignment: .leading, spacing: 10) {
                 ZStack(alignment: .bottomTrailing) {

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -10,11 +10,11 @@ struct MainShell: View {
             // Native two-column shell (#1, #4). The sidebar lives in the
             // OS-managed column so users get the standard show/hide
             // affordance + draggable separator for free; the detail column
-            // wraps the existing screen switch in a `NavigationStack` driven
-            // by `model.navPath`. `model.screen` remains the source of truth
-            // for which root view renders during B2 — `navPath` is empty in
-            // production until B3 migrates the call sites that still write
-            // `model.screen` over to `model.navPath.append(...)`.
+            // wraps the active root tab in a `NavigationStack` driven by
+            // `model.navPath`. `model.screen` is the active root tab and
+            // drives `mainContent`; drill destinations (album / artist /
+            // playlist / nowPlaying) live as `Route` entries on `navPath`
+            // and render via the `.navigationDestination` handler below.
             NavigationSplitView {
                 // Tab order (#334): sidebar gets first focus, then the
                 // detail column, then the queue inspector / player bar.
@@ -28,11 +28,11 @@ struct MainShell: View {
                 HStack(spacing: 0) {
                     NavigationStack(path: $model.navPath) {
                         contentColumn
-                            // Stub destinations during B2 — the path is
-                            // empty in production because every navigation
-                            // currently goes through `model.screen`. B3
-                            // wires real call sites and these handlers
-                            // dispatch on `Route` instead of `Screen`.
+                            // Drill destinations dispatch on `Route` so the
+                            // active root tab (driven by `model.screen` and
+                            // rendered inside `contentColumn`) stays in
+                            // place while the user pushes album / artist /
+                            // playlist / nowPlaying detail pages on top.
                             .navigationDestination(for: AppModel.Route.self) { route in
                                 routeDestination(for: route)
                             }
@@ -118,11 +118,9 @@ struct MainShell: View {
     }
 
     /// Routes a `Route` value pushed onto `navPath` to the matching screen.
-    /// During B2 the path is always empty in production because navigation
-    /// still writes `model.screen`; these handlers exist so the
-    /// `NavigationStack` is wired and ready for B3 to migrate the call
-    /// sites. Each case mirrors the equivalent `model.screen` arm in
-    /// `mainContent` so the eventual cutover is mechanical.
+    /// In practice only the drill cases (album / artist / playlist /
+    /// nowPlaying) are pushed — root-tab cases are kept on `Route` for
+    /// future deep-linking and render the same view as `mainContent`.
     @ViewBuilder
     private func routeDestination(for route: AppModel.Route) -> some View {
         switch route {
@@ -194,15 +192,12 @@ struct MainShell: View {
             DiscoverView()
         case .search:
             SearchView()
-        case .album(let id):
-            AlbumDetailView(albumID: id)
-        case .artist(let id):
-            ArtistDetailView(artistID: id)
-        case .playlist(let id):
-            PlaylistView(playlistID: id)
-        case .nowPlaying:
-            NowPlayingView()
-        default:
+        case .settings:
+            // Settings have a dedicated `Settings` scene in `JellifyApp`
+            // and aren't a destination inside the main shell. Falling
+            // through to Library keeps the detail column populated if
+            // `screen` is somehow `.settings` while the Settings scene is
+            // closed.
             LibraryView()
         }
     }
@@ -225,20 +220,27 @@ struct MainShell: View {
 
     /// Builds the breadcrumb trail for the current screen. The root segment is
     /// always "Jellify"; subsequent segments describe where in the app the
-    /// user has navigated.
+    /// user has navigated. Drill destinations live on `navPath`; root tabs
+    /// live on `model.screen`.
     private var breadcrumbSegments: [String] {
         var segments: [String] = ["Jellify"]
+        // Root tab segment. Settings is exposed via the dedicated scene and
+        // not breadcrumbed.
         switch model.screen {
-        case .home:
-            segments.append("Home")
-        case .discover:
-            segments.append("Discover")
-        case .library:
-            segments.append("Library")
-        case .search:
-            segments.append("Search")
-        case .album(let id):
-            segments.append("Library")
+        case .home: segments.append("Home")
+        case .discover: segments.append("Discover")
+        case .library: segments.append("Library")
+        case .search: segments.append("Search")
+        case .settings: segments.append("Settings")
+        }
+
+        // Drill segments. The current top of `navPath` is what's actually
+        // rendered; we anchor the trail at "Library > <section>" because
+        // every drill destination today is reachable from the Library
+        // hierarchy regardless of which root tab launched it.
+        switch model.navPath.last {
+        case .album(let id)?:
+            if model.screen != .library { segments.append("Library") }
             segments.append("Albums")
             if let album = model.albums.first(where: { $0.id == id }) {
                 segments.append(album.name)
@@ -247,55 +249,54 @@ struct MainShell: View {
                 // literal fallback ("Albums > Album") that reads like a bug.
                 segments.append("…")
             }
-        case .artist(let id):
-            segments.append("Library")
+        case .artist(let id)?:
+            if model.screen != .library { segments.append("Library") }
             segments.append("Artists")
             if let artist = model.artists.first(where: { $0.id == id }) {
                 segments.append(artist.name)
             } else {
                 segments.append("…")
             }
-        case .playlist(let id):
-            segments.append("Library")
+        case .playlist(let id)?:
+            if model.screen != .library { segments.append("Library") }
             segments.append("Playlists")
             if let playlist = model.playlist(id: id) {
                 segments.append(playlist.name)
             } else {
                 segments.append("…")
             }
-        case .nowPlaying:
+        case .nowPlaying?:
             segments.append("Now Playing")
-        case .settings:
-            segments.append("Settings")
+        case .home?, .discover?, .library?, .search?, .settings?, nil:
+            break
         }
         return segments
     }
 
-    /// Handles a tap on a breadcrumb segment at `idx`. Navigation is driven by
-    /// the current `model.screen` and the tapped index, so the component stays
-    /// agnostic of label strings (no brittle title matching). Index 0 is the
-    /// root ("Jellify") and always returns to the library. For nested screens
-    /// (e.g. album/artist/playlist detail), intermediate indices pop to the
-    /// library; the final index is the current location and is a no-op.
+    /// Handles a tap on a breadcrumb segment at `idx`. Navigation is driven
+    /// by the current screen and `navPath`, so the component stays agnostic
+    /// of label strings (no brittle title matching). Index 0 is the root
+    /// ("Jellify") and always pops the drill stack to the library tab. For
+    /// nested screens, intermediate indices pop to the library; the final
+    /// index is the current location and is a no-op.
     private func navigate(toBreadcrumbDepth idx: Int) {
-        // Index 0 is always the root and pops to library.
+        // Index 0 is the root ("Jellify") — pop everything and land on
+        // Library, which is the historical fallback root.
         guard idx > 0 else {
-            model.screen = .library
+            model.selectTab(.library)
             return
         }
 
-        switch model.screen {
-        case .home, .discover, .library, .search, .settings, .nowPlaying:
-            // Shape: ["Jellify", <current>] — only the final index, which is
-            // the current location and non-navigable. Nothing to do.
-            break
-        case .album, .artist, .playlist:
-            // Shape: ["Jellify", "Library", "<Albums|Artists|Playlists>", <name>].
-            // idx 1 = "Library" and idx 2 = the section both pop to library;
-            // idx 3 is the current location and is a no-op.
-            if idx < 3 {
-                model.screen = .library
-            }
+        // No drill on the stack: the trail is ["Jellify", <tab>] and the
+        // only navigable index (0) was handled above. Higher indices are
+        // the current location.
+        guard !model.navPath.isEmpty else { return }
+
+        // Drill on the stack: trail is ["Jellify", "Library", "<section>",
+        // <name>]. idx 1 = "Library" and idx 2 = the section both pop the
+        // drill; idx 3 is the current location.
+        if idx < 3 {
+            model.selectTab(.library)
         }
     }
 }

--- a/macos/Sources/Jellify/Screens/NowPlayingView.swift
+++ b/macos/Sources/Jellify/Screens/NowPlayingView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// Out of scope — tracked in separate batches:
 /// - The quote-icon entry on the `PlayerBar` is wired in BATCH-02 (the
 ///   `PlayerBar` is off-limits for this batch). `Cmd+Opt+L` from
-///   `JellifyCommands` plus the `AppModel.screen = .nowPlaying` route
+///   `JellifyCommands` plus pushing `Route.nowPlaying` onto `navPath`
 ///   are enough to reach this view today.
 /// - The queue inspector (#272) is owned by BATCH-07 — the Queue tab
 ///   here renders a placeholder until that lands.
@@ -105,8 +105,7 @@ struct NowPlayingView: View {
 
                 Button(action: {
                     if let artistId = track.artistId {
-                        model.previousScreen = .nowPlaying
-                        model.screen = .artist(artistId)
+                        model.navPath.append(AppModel.Route.artist(artistId))
                     }
                 }) {
                     Text(track.artistName)
@@ -121,8 +120,7 @@ struct NowPlayingView: View {
                 if let album = track.albumName, !album.isEmpty {
                     Button(action: {
                         if let albumId = track.albumId {
-                            model.previousScreen = .nowPlaying
-                            model.screen = .album(albumId)
+                            model.navPath.append(AppModel.Route.album(albumId))
                         }
                     }) {
                         Text(album)
@@ -418,8 +416,15 @@ struct NowPlayingView: View {
     }
 
     private func dismiss() {
-        model.screen = model.previousScreen ?? .library
-        model.previousScreen = nil
+        // NavigationStack handles popping the path; we only need to walk
+        // back one entry. If the user reached this view from a non-stack
+        // entry (legacy paths), fall back to the user's previous tab.
+        if !model.navPath.isEmpty {
+            model.navPath.removeLast()
+        } else if let previous = model.previousScreen {
+            model.selectTab(previous)
+            model.previousScreen = nil
+        }
     }
 
     // MARK: - Empty state
@@ -437,7 +442,7 @@ struct NowPlayingView: View {
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)
             Button("Back to Library") {
-                model.screen = .library
+                model.selectTab(.library)
                 model.previousScreen = nil
             }
             .buttonStyle(.borderedProminent)


### PR DESCRIPTION
Closes #1.
Closes #4.

Step 3 of 3 of the NavigationSplitView migration. Migrates every `model.screen = .album/.artist/.playlist/.nowPlaying` call site to `model.navPath.append(Route.X)`. Removes the four drill cases from the `Screen` enum (root tabs remain).

Adds `AppModel.selectTab(_:)` to clear the drill stack on tab change. Sidebar / menu / palette tab handlers updated to use it. `navPath` is now a typed `[Route]` array (rather than the opaque `NavigationPath`) so consumers can inspect the top of the stack — needed for the `⌘L` Now Playing toggle and the breadcrumb trail.

Closes the NavigationSplitView migration that began with #721 (hidden title bar), #725 (Route + navPath scaffolding), #726 (MainShell rewrite).

Manual verification (post-merge):
1. Click an album in Library → opens AlbumDetailView. NavigationStack back arrow returns.
2. Click a tab in the sidebar → drill stack clears (no residual album/artist).
3. ⌘L toggles Now Playing on / off via push + pop.
4. Open Now Playing, tap an artist link → pushes Artist; back arrow returns to Now Playing.

Out of scope:
- Drive-by fix in `FormatBadge.swift` previews to add the new `playlistItemId`/`userData` params on `Track` (preview-only inits broke when those fields landed via #662; build was failing before this PR's changes).

pipeline:
  fixer-session: feat-arch-b3
  slice: slice:scaffold (AppModel) + slice:components (Sidebar) + slice:screens (call sites)
  hotspots-claimed: [appmodel]
  build-gate: pass
  follow-up: PR C — native toolbar + a11y (#3, #343) on the new shell