### PR TITLE
feat(macos): native toolbar with sidebar toggle, search, a11y labels (#3, #343)

### DIFF
--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -4,6 +4,11 @@ struct MainShell: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// Drives `NavigationSplitView`'s sidebar visibility so the toolbar
+    /// `Toggle Sidebar` item has somewhere to write. SwiftUI animates the
+    /// column collapse / reveal for us when this changes.
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+
     var body: some View {
         @Bindable var model = model
         VStack(spacing: 0) {
@@ -15,7 +20,7 @@ struct MainShell: View {
             // drives `mainContent`; drill destinations (album / artist /
             // playlist / nowPlaying) live as `Route` entries on `navPath`
             // and render via the `.navigationDestination` handler below.
-            NavigationSplitView {
+            NavigationSplitView(columnVisibility: $columnVisibility) {
                 // Tab order (#334): sidebar gets first focus, then the
                 // detail column, then the queue inspector / player bar.
                 Sidebar()
@@ -35,6 +40,54 @@ struct MainShell: View {
                             // playlist / nowPlaying detail pages on top.
                             .navigationDestination(for: AppModel.Route.self) { route in
                                 routeDestination(for: route)
+                            }
+                            // Native unified toolbar (#3 / #343). NavigationStack
+                            // owns built-in back navigation (swipe, ⌘[ and ⌘←),
+                            // so we surface a sidebar toggle and a global search
+                            // field rather than re-implementing the back button.
+                            // Every item carries `.accessibilityLabel` so
+                            // VoiceOver / Voice Control can target them.
+                            .toolbar {
+                                ToolbarItem(placement: .navigation) {
+                                    Button {
+                                        columnVisibility = (columnVisibility == .all)
+                                            ? .detailOnly
+                                            : .all
+                                    } label: {
+                                        Image(systemName: "sidebar.left")
+                                    }
+                                    .help("Toggle Sidebar")
+                                    .accessibilityLabel("Toggle Sidebar")
+                                }
+
+                                ToolbarItem(placement: .principal) {
+                                    HStack(spacing: 6) {
+                                        Image(systemName: "magnifyingglass")
+                                            .foregroundStyle(Theme.ink2)
+                                        TextField("Search", text: $model.searchPageQuery)
+                                            .textFieldStyle(.plain)
+                                            .font(Theme.font(13, weight: .medium))
+                                            .foregroundStyle(Theme.ink)
+                                            .frame(maxWidth: 280)
+                                            .onSubmit {
+                                                // Hand off to the Search page so
+                                                // `runFullSearch` and the existing
+                                                // results UI light up. ⌘F still
+                                                // routes through `focusSearch()`.
+                                                model.selectTab(.search)
+                                                Task { await model.runFullSearch(query: model.searchPageQuery, scope: model.activeSearchScope) }
+                                            }
+                                    }
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(Theme.surface)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .stroke(Theme.border, lineWidth: 1)
+                                    )
+                                    .cornerRadius(6)
+                                    .accessibilityLabel("Search")
+                                }
                             }
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
Closes #3.
Closes #343.

Adds a native `.toolbar {}` to the `NavigationStack` inside `MainShell`'s detail column. Toolbar items: sidebar toggle (`.navigation`) and a global search field (`.principal`). `NavigationStack`'s built-in back gesture and `⌘[` / `⌘←` handle navigation history, so no explicit toolbar back button is added (SwiftUI doesn't expose a forward stack cleanly). Every toolbar item carries `.accessibilityLabel` so VoiceOver / Voice Control can target them.

`MainShell` now owns a `@State private var columnVisibility: NavigationSplitViewVisibility = .all` so the toggle button has somewhere to write; `NavigationSplitView(columnVisibility:)` animates the column collapse / reveal for us.

The search field binds to `model.searchPageQuery` (the same state that drives the full search results page). On Return, the toolbar selects the Search tab and kicks off `runFullSearch(query:scope:)`. `⌘F` still routes through `focusSearch()` for explicit keyboard focus.

Builds on the NavigationSplitView shell shipped in PRs #721, #725, #726, #728. Closes the macOS shell architectural migration.

pipeline:
  fixer-session: feat-arch-pr-c
  slice: slice:screens (MainShell)
  hotspots-claimed: []
  build-gate: pass (parse + cross-check against origin/main; xcframework is gitignored and rebuilds locally)