### PR TITLE
chore(ci): bump Rust toolchain to 1.92 to unbreak CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,11 @@ jobs:
       - run: cargo doc --workspace --all-features --no-deps
 
   msrv:
-    name: MSRV (Rust 1.86)
+    name: MSRV (Rust 1.92)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.86
+      - uses: dtolnay/rust-toolchain@1.92
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.92"
 license = "GPL-3.0-only"
 repository = "https://github.com/Jellify-Music/Jellify"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.92.0"
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

CI/CD has been failing on every push since the dependency tree drifted past the toolchain pin. `gh run list` shows the same shape on every run: `CI: failure`, `E2E: failure`, `Coverage: failure`, `CodeQL: success`. CodeQL is the only one that survives because it doesn't shell out to cargo.

Root cause: `rust-toolchain.toml` was pinned to `1.83.0` (added in #701), but:
- Transitive deps (`toml_datetime`, `clap_builder`, etc.) now require Cargo's `edition2024` feature (stabilized in 1.85).
- The `linux/` crate's GTK deps (`gio`, `glib`, `gobject-sys`, `glib-macros`) now require rustc `1.92`.

So every `cargo` invocation has been bailing with:

```
feature `edition2024` is required ... not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29))
```

The pin was correct on the day it landed — the dep tree drifted underneath it.

## Changes

- `rust-toolchain.toml`: `1.83.0` → `1.92.0` (minimum that satisfies all deps)
- `Cargo.toml`: `rust-version = "1.75"` → `"1.92"` so the declared MSRV matches reality
- `.github/workflows/ci.yml`: MSRV job action `dtolnay/rust-toolchain@1.86` → `@1.92` and label updated to match. (Side note: the MSRV job has been silently no-op'd this whole time — `rust-toolchain.toml` overrides the action's install — but that's a separate structural fix.)

## Test plan

- [x] `cargo check --workspace` — passes locally on 1.92.0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green on this branch — `CI`, `E2E`, `Coverage`, `CodeQL` should all pass; the MSRV (1.92) job should now actually do work
- [ ] Merge to main → next push to main produces 4 greens