### PR TITLE
chore(ci): allowlist 'empted' for typos (false positive on 'pre-empted')

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -5,6 +5,8 @@
 #   - "seeked" is the correct past-participle in media APIs (HTMLMediaElement
 #     fires a `seeked` event; our AudioEngine mirrors that naming).
 #   - "missable" is used deliberately in copy (opposite of "unmissable").
+#   - "empted" appears inside "pre-empted" (correct English for an
+#     interrupted operation; typos would coerce it to "emptied").
 #   - design/research docs contain transcribed chat snippets with typos
 #     we do not own and don't want to edit after-the-fact.
 [default]
@@ -15,6 +17,7 @@ extend-ignore-re = [
 [default.extend-words]
 seeked = "seeked"
 missable = "missable"
+empted = "empted"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Summary

- The typos checker has been failing CI on the comment at [macos/Sources/JellifyAudio/AudioEngine.swift:358](https://github.com/skalthoff/jellify-desktop/blob/main/macos/Sources/JellifyAudio/AudioEngine.swift#L358), which uses `pre-empted` (correct English for "interrupted by a higher-priority event"). The tool wants to coerce it to `emptied`.
- Adds `empted = "empted"` to `[default.extend-words]` in `typos.toml` and a one-line note in the comment block.
- This failure was buried under the cargo failures resolved in #731 / #732 and only surfaced once the rust path started compiling.

## Test plan

- [ ] CI green on this branch — specifically the `typos` job
- [ ] Comment text in AudioEngine.swift unchanged (the word `pre-empted` is intentional, the lint is wrong)