### PR TITLE
fix(macos): PlayerBar tap opens Now Playing full player; dedup ⌘L

### DIFF
--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct PlayerBar: View {
     @Environment(AppModel.self) private var model
-    @State private var showNowPlaying = false
 
     /// Local scrubber position used while the user is actively dragging the
     /// Slider. We don't bind the Slider straight to `status.positionSeconds`
@@ -52,20 +51,21 @@ struct PlayerBar: View {
         // before the persistent chrome at the bottom. See #334.
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Playback controls")
-        .sheet(isPresented: $showNowPlaying) {
-            NowPlayingSheet()
-                .environment(model)
-        }
     }
 
     @ViewBuilder
     private var leftMeta: some View {
         if let track = model.status.currentTrack {
-            // Tapping the track meta opens the Now Playing sheet (#279)
-            // which currently surfaces track artwork, title/artist/album,
-            // and the Credits block. The button is styled flush so it
-            // reads as a regular bar region, not a chrome control.
-            Button(action: { showNowPlaying = true }) {
+            // Tapping the track meta pushes Route.nowPlaying onto navPath,
+            // opening the full Now Playing view (Queue / Lyrics / About /
+            // Credits tabs). Guard prevents double-push if the view is
+            // already on the stack. The button is styled flush so it reads
+            // as a regular bar region, not a chrome control.
+            Button(action: {
+                if !model.isShowingNowPlaying {
+                    model.navPath.append(AppModel.Route.nowPlaying)
+                }
+            }) {
                 HStack(spacing: 12) {
                     Artwork(
                         url: model.imageURL(for: track.albumId ?? track.id, tag: track.imageTag, maxWidth: 120),
@@ -89,7 +89,7 @@ struct PlayerBar: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Now Playing: \(track.name) by \(track.artistName)")
-            .accessibilityHint("Shows track details")
+            .accessibilityHint("Opens Now Playing")
         } else {
             Text("player.nothing_playing")
                 .font(Theme.font(12, weight: .medium))

--- a/macos/Sources/Jellify/JellifyApp.swift
+++ b/macos/Sources/Jellify/JellifyApp.swift
@@ -281,7 +281,6 @@ struct JellifyCommands: Commands {
             Button("menu.nav.now_playing") {
                 toggleNowPlaying()
             }
-            .keyboardShortcut("l", modifiers: .command)
             .disabled(model.session == nil)
         }
 

--- a/macos/Sources/Jellify/Screens/NowPlayingView.swift
+++ b/macos/Sources/Jellify/Screens/NowPlayingView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 @preconcurrency import JellifyCore
 
 /// Full Now Playing view — takes over the detail column when the user
-/// opens the "full player" from the `PlayerBar` quote-icon or via the
-/// `Cmd+Opt+L` shortcut. Replaces the compact `NowPlayingSheet` used for
+/// opens the "full player" from the `PlayerBar` artwork tap or via the
+/// `⌘L` shortcut. Replaces the compact `NowPlayingSheet` used for
 /// a quick glance at credits.
 ///
 /// Layout mirrors `design/project/src/panels.jsx`: large album art on the
@@ -17,13 +17,8 @@ import SwiftUI
 /// #273 (lyrics drawer), #278 (about block), #287 (LRC parser),
 /// #288 (auto-scroll).
 ///
-/// Out of scope — tracked in separate batches:
-/// - The quote-icon entry on the `PlayerBar` is wired in BATCH-02 (the
-///   `PlayerBar` is off-limits for this batch). `Cmd+Opt+L` from
-///   `JellifyCommands` plus pushing `Route.nowPlaying` onto `navPath`
-///   are enough to reach this view today.
-/// - The queue inspector (#272) is owned by BATCH-07 — the Queue tab
-///   here renders a placeholder until that lands.
+/// The queue inspector (#272) is owned by BATCH-07 — the Queue tab
+/// here renders a placeholder until that lands.
 struct NowPlayingView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion


### PR DESCRIPTION
## Summary
- PlayerBar's tap-on-artwork now pushes `Route.nowPlaying` onto `navPath`, opening the full player (Queue / Lyrics / About / Credits tabs) instead of the compact `NowPlayingSheet` modal that was bound previously.
- The PlayerBar is the only always-visible Now Playing affordance; landing on the wrong surface meant most users couldn't discover the full player at all (only reachable via ⌘L, which is undiscoverable).
- Removed the duplicate `⌘L` registration in the Playback menu (View menu's binding at line 204 remains canonical). macOS shadows duplicate shortcuts; this prevents the latent inconsistency.
- Fixed a stale doc comment in NowPlayingView that referred to `Cmd+Opt+L`; actual shortcut is plain `⌘L`.

## Test plan
- [ ] PlayerBar tap on a playing track → full Now Playing view loads (Queue / Lyrics / About / Credits tabs visible).
- [ ] Second tap on the PlayerBar while Now Playing is already showing → no double-push (guard on `isShowingNowPlaying` holds).
- [ ] ⌘L still toggles Now Playing from anywhere in the app.
- [ ] Playback menu's "Now Playing" item still appears and is clickable; no longer carries a shortcut badge.

pipeline:
  fixer-session: fix-nowplaying-wave-9
  slice: slice:components + slice:scaffold (JellifyApp)
  build-gate: pass