### PR TITLE
feat(macos): add Discover entry to sidebar nav

### DIFF
--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -53,6 +53,7 @@ struct Sidebar: View {
             VStack(alignment: .leading, spacing: 2) {
                 navItem("house", label: "sidebar.nav.home", screen: .home)
                 navItem("music.note.list", label: "sidebar.nav.library", screen: .library)
+                navItem("sparkles", label: "sidebar.nav.discover", screen: .discover)
                 navItem("magnifyingglass", label: "sidebar.nav.search", screen: .search)
             }
             .padding(.horizontal, 10)


### PR DESCRIPTION
## Summary
- DiscoverView exists and is routed in MainShell, but the sidebar didn't expose it. Discover was previously only reachable via the command palette.
- Adds a Discover row to the sidebar nav matching the existing Home / Library / Search pattern.

pipeline:
  fixer-session: fix-sidebar-discover
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass