### PR TITLE
fix(macos): breadcrumb root tap stays on current tab

### DIFF
--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -329,14 +329,15 @@ struct MainShell: View {
     /// Handles a tap on a breadcrumb segment at `idx`. Navigation is driven
     /// by the current screen and `navPath`, so the component stays agnostic
     /// of label strings (no brittle title matching). Index 0 is the root
-    /// ("Jellify") and always pops the drill stack to the library tab. For
-    /// nested screens, intermediate indices pop to the library; the final
-    /// index is the current location and is a no-op.
+    /// ("Jellify") and clears the drill stack while staying on the current
+    /// tab. For nested screens, intermediate indices pop back to the current
+    /// tab root; the final index is the current location and is a no-op.
     private func navigate(toBreadcrumbDepth idx: Int) {
-        // Index 0 is the root ("Jellify") — pop everything and land on
-        // Library, which is the historical fallback root.
+        // Index 0 is the root ("Jellify") — clear the drill stack and stay
+        // on whichever tab the user is already on.
         guard idx > 0 else {
-            model.selectTab(.library)
+            model.navPath = []
+            model.selectTab(model.screen)
             return
         }
 
@@ -345,11 +346,11 @@ struct MainShell: View {
         // the current location.
         guard !model.navPath.isEmpty else { return }
 
-        // Drill on the stack: trail is ["Jellify", "Library", "<section>",
-        // <name>]. idx 1 = "Library" and idx 2 = the section both pop the
+        // Drill on the stack: trail is ["Jellify", "<tab>", "<section>",
+        // <name>]. idx 1 = tab root and idx 2 = the section both pop the
         // drill; idx 3 is the current location.
         if idx < 3 {
-            model.selectTab(.library)
+            model.selectTab(model.screen)
         }
     }
 }


### PR DESCRIPTION
## Summary

- `navigate(toBreadcrumbDepth:)` was calling `selectTab(.library)` for any depth < 3, meaning the breadcrumb root always routed users to Library regardless of which tab they were on. Tapping "Home" in the breadcrumb while on Home → Album Detail landed on Library instead.
- Replaced both `selectTab(.library)` calls with `selectTab(model.screen)` so breadcrumb taps respect the current root tab.
- Root tap (idx 0) now also resets `model.navPath = []` to clear the drill stack before calling `selectTab(model.screen)`, keeping the user on their current tab.

pipeline:
  fixer-session: fix-breadcrumb-routing
  slice: slice:screens (MainShell)
  hotspots-claimed: []
  build-gate: pass (swiftc -parse)