### PR TITLE
fix(macos): HomeView 'See All' uses selectTab to clear drill stack

### DIFF
--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -397,7 +397,7 @@ struct HomeView: View {
                 iconColor: Theme.primary,
                 title: "Jump Back In",
                 subtitle: "Pick up where you left off",
-                onSeeAll: { model.screen = .library }
+                onSeeAll: { model.selectTab(.library) }
             ) {
                 LazyHStack(alignment: .top, spacing: 16) {
                     ForEach(model.jumpBackIn, id: \.id) { album in
@@ -451,7 +451,7 @@ struct HomeView: View {
                 iconColor: Theme.primary,
                 title: "Recently Added",
                 subtitle: "Fresh arrivals in your library",
-                onSeeAll: { model.screen = .library }
+                onSeeAll: { model.selectTab(.library) }
             ) {
                 LazyHStack(alignment: .top, spacing: 16) {
                     ForEach(model.recentlyAdded, id: \.id) { album in


### PR DESCRIPTION
## Summary
- HomeView's two 'See All' buttons assigned `model.screen = .library` directly, bypassing the `selectTab(_:)` helper that B3 added to clear `navPath` on tab change.
- Effect: if the user was mid-drill (e.g., navPath = [.album(id)]) when they tapped 'See All,' the Library tab loaded but the orphan drill page rendered on top — navigation state corrupted.
- Fix: replace direct assignments with `model.selectTab(.library)` so navPath is cleared atomically.

pipeline:
  fixer-session: fix-homeview-seeall
  slice: slice:screens (HomeView)
  hotspots-claimed: []
  build-gate: pass