### PR TITLE
fix(macos): wire PlayerBar Shuffle and Repeat buttons

### DIFF
--- a/macos/Sources/Jellify/Components/PlayerBar.swift
+++ b/macos/Sources/Jellify/Components/PlayerBar.swift
@@ -101,7 +101,11 @@ struct PlayerBar: View {
     private var centerTransport: some View {
         VStack(spacing: 6) {
             HStack(spacing: 20) {
-                iconBtn("shuffle", label: "Shuffle")
+                iconBtn(
+                    "shuffle",
+                    label: "Shuffle",
+                    tint: model.status.shuffle ? Theme.accent : Theme.ink2
+                ) { model.mediaSessionSetShuffle(!model.status.shuffle) }
                     .help("Shuffle")
                 iconBtn("backward.fill", label: "Previous track", size: 16) { model.skipPrevious() }
                     .help("Previous · ⌘←")
@@ -120,7 +124,20 @@ struct PlayerBar: View {
                 .help(isPlaying ? "Pause · Space" : "Play · Space")
                 iconBtn("forward.fill", label: "Next track", size: 16) { model.skipNext() }
                     .help("Next · ⌘→")
-                iconBtn("repeat", label: "Repeat")
+                iconBtn(
+                    model.status.repeatMode == .one ? "repeat.1" : "repeat",
+                    label: "Repeat",
+                    tint: model.status.repeatMode != .off ? Theme.accent : Theme.ink2
+                ) {
+                    let next: RepeatMode = {
+                        switch model.status.repeatMode {
+                        case .off: return .all
+                        case .all: return .one
+                        case .one: return .off
+                        }
+                    }()
+                    model.mediaSessionSetRepeatMode(next)
+                }
                     .help("Repeat")
             }
             scrubber
@@ -285,12 +302,13 @@ struct PlayerBar: View {
         _ name: String,
         label: String,
         size: CGFloat = 14,
+        tint: Color = Theme.ink2,
         action: @escaping () -> Void = {}
     ) -> some View {
         Button(action: action) {
             Image(systemName: name)
                 .font(.system(size: size))
-                .foregroundStyle(Theme.ink2)
+                .foregroundStyle(tint)
                 .frame(width: 28, height: 28)
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary

- The Shuffle and Repeat buttons in the PlayerBar center transport were constructed with empty action closures: visually present, completely non-functional. Among the most-used controls in a music player, silently broken.
- Wires both buttons to the existing AppModel toggle/cycle helpers.
- Adds active-state tinting: shuffle and repeat icons go to Theme.accent when on, Theme.ink2 when off. Repeat-one switches the SF Symbol to `repeat.1`.

pipeline:
  fixer-session: fix-shuffle-repeat
  slice: slice:components (PlayerBar)
  hotspots-claimed: []
  build-gate: pass (cool-fermat reference build; agent worktree xcframework mismatch is pre-existing)