### PR TITLE
chore: ignore dtolnay/rust-toolchain version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,11 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      # dtolnay/rust-toolchain tags follow Rust release versions
+      # (`@1.86` → 1.86 stable). Dependabot can't reason about those —
+      # it tried to bump 1.86 → 1.92 → 1.100, both of which are not
+      # real Rust releases. The MSRV reference must stay pinned to the
+      # workspace's `rust-version`, and other call sites use `@stable`,
+      # so version bumps on this dependency are always wrong.
+      - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
## Why

Dependabot has now twice tried to bump `dtolnay/rust-toolchain` to a non-existent Rust version:

- 1.86 → 1.92 — opened, **merged**, broke main, reverted via #732 / #734
- 1.86 → 1.100 — opened (#710), caught before merge, closed

Both are not real Rust releases.

## Root cause

The action's tags follow Rust releases (`@1.86`, `@stable`). Dependabot reads them as semver and tries to bump the minor component. But:

- Every CI workflow uses `@stable` (no version bump needed — `@stable` always resolves to the latest)
- The MSRV check is *intentionally* pinned to the workspace's `rust-version` (1.86 today). Bumping it would defeat the purpose of an MSRV check.

So version bumps on this specific dependency are always wrong. Adding an explicit `ignore` rule prevents recurrence.

## Test plan

- [x] Confirmed local `actions/dependabot.yml` still parses
- [ ] Wait for next Monday's dependabot run; confirm no new PR for `dtolnay/rust-toolchain`
- [ ] Other actions (`tj-actions/changed-files`, `actions/setup-dotnet`, etc.) still get bumps via the existing `actions-patch` group