### PR TITLE
fix(release): emit tag-prefixed enclosure URLs in Sparkle appcast (#742)

### DIFF
--- a/macos/Scripts/generate-appcast.sh
+++ b/macos/Scripts/generate-appcast.sh
@@ -99,11 +99,16 @@ fi
 while IFS= read -r tag; do
   [[ -z "$tag" ]] && continue
   echo "    tag: $tag"
-  # Glob the DMG assets — there may be one (universal) or two (per-arch).
+  # Each tag's DMGs go into their own subdir so generate_appcast emits
+  # relative paths like "$tag/Jellify-X.Y.Z.dmg". Combined with the
+  # url-prefix below (.../releases/download/), this produces the working
+  # GitHub release-asset URL .../releases/download/$tag/Jellify-X.Y.Z.dmg.
+  # Flat layout would drop the $tag segment and 404. Fixes #742.
+  mkdir -p "$DMG_DIR/$tag"
   gh release download "$tag" \
     --repo "$GITHUB_REPOSITORY" \
     --pattern "*.dmg" \
-    --dir "$DMG_DIR" \
+    --dir "$DMG_DIR/$tag" \
     --skip-existing \
     || echo "    (no DMGs on $tag — skipping)"
 done <<<"$TAGS"
@@ -118,7 +123,9 @@ chmod 600 "$KEY_FILE"
 
 # Prefix used when rewriting download URLs in the feed. Each DMG must be
 # reachable at ${PREFIX}/${TAG}/${FILENAME} so Sparkle clients can fetch
-# it directly from the GitHub release.
+# it directly from the GitHub release. The ${TAG}/${FILENAME} portion is
+# emitted by generate_appcast as a *relative path* derived from each DMG's
+# location under $DMG_DIR — see the per-tag subdir layout above.
 DOWNLOAD_URL_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download"
 
 echo "==> Running generate_appcast"
@@ -128,6 +135,16 @@ echo "==> Running generate_appcast"
   --link "https://skalthoff.github.io/jellify-desktop/" \
   -o "$DOCS/appcast.xml" \
   "$DMG_DIR"
+
+# Sanity-check: assert the regenerated appcast contains tag-prefixed enclosure
+# URLs. If we shipped an appcast with bare /releases/download/<filename>.dmg
+# entries (the bug fixed in #742), every Sparkle client would 404 silently.
+# This grep fails the build before publish so a broken appcast never hits
+# gh-pages.
+if grep -q 'enclosure url="[^"]*/releases/download/[^/"]*\.dmg"' "$DOCS/appcast.xml"; then
+  echo "error: appcast contains tag-less enclosure URL. Each <enclosure url> must include the tag segment (e.g. .../releases/download/v1.0.0/Jellify-1.0.0.dmg). See #742." >&2
+  exit 1
+fi
 
 echo "==> Wrote $DOCS/appcast.xml ($(wc -l < "$DOCS/appcast.xml") lines)"
 


### PR DESCRIPTION
## Why

[#742](https://github.com/skalthoff/jellify-desktop/issues/742) — every shipped release has an auto-update URL that 404s.

\`\`\`
$ curl -sIL -o /dev/null -w \"%{http_code}\" \"https://github.com/skalthoff/jellify-desktop/releases/download/Jellify-1.0.0-rc2.dmg\"
404
$ curl -sIL -o /dev/null -w \"%{http_code}\" \"https://github.com/skalthoff/jellify-desktop/releases/download/v1.0.0-rc2/Jellify-1.0.0-rc2.dmg\"
200
\`\`\`

GitHub release-asset URLs need the tag in the path. The script was emitting tag-less URLs.

## What

- Download each release tag's DMGs into per-tag subdirs (\`\$DMG_DIR/\$tag/\`).
- \`generate_appcast\` emits relative paths derived from layout, so \`\$tag/Jellify-X.Y.Z.dmg\` flows through.
- Add a grep gate that fails the script if any \`<enclosure url>\` is tag-less, so a broken appcast can never reach \`gh-pages\`.

## Test plan

- [x] Diff is mechanical / surgical (one file, +20 / -3).
- [ ] After merge, run \`gh workflow run macos-release.yml -f tag=v1.0.0-rc2\` to regenerate the appcast against existing releases (no new build is required to fix prior tags — the appcast step happens late in the pipeline; alternatively, a new lightweight \`appcast-regen.yml\` workflow could be added later).
- [ ] Verify the regenerated \`gh-pages:appcast.xml\` contains \`/releases/download/v1.0.0-rc2/Jellify-1.0.0-rc2.dmg\` (with tag).
- [ ] Curl that URL — must return 200.

## Open companion

The other half of the bug — \`https://skalthoff.github.io/jellify-desktop/appcast.xml\` returning 404 — needs **GitHub Pages** enabled from the \`gh-pages\` branch root. That's a repo Settings change (Settings → Pages → Source = \`gh-pages\`, path = \`/\`). It's tracked in #742; this PR closes only the URL-shape portion.