### PR TITLE
fix(macos): playlist description read-only until #130 lands

### DIFF
--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -33,10 +33,6 @@ struct PlaylistView: View {
     @State private var titleDraft: String? = nil
     @FocusState private var titleFocused: Bool
 
-    /// Editor draft state for the description. Same lifecycle as `titleDraft`.
-    @State private var descriptionDraft: String? = nil
-    @FocusState private var descriptionFocused: Bool
-
     /// Tracks which row currently has keyboard focus so Alt+Up / Alt+Down
     /// reorder can move without requiring multi-select. `nil` = no row focused.
     @FocusState private var keyboardFocusedIndex: Int?
@@ -88,15 +84,13 @@ struct PlaylistView: View {
         .onChange(of: model.playlistTracks[playlistID]) { _, newValue in
             if let newValue = newValue { tracks = newValue }
         }
-        // Clear click-to-edit drafts when the user navigates away (#602).
+        // Clear the title draft when the user navigates away (#602).
         // SwiftUI may reuse the view struct across back-forward navigations
-        // (especially with `NavigationStack`), so stale `titleDraft` /
-        // `descriptionDraft` from a prior session would appear pre-filled
-        // on the next visit to the same playlist. Resetting on disappear
-        // ensures the next open starts with the committed (server) values.
+        // (especially with `NavigationStack`), so a stale `titleDraft` from a
+        // prior session would appear pre-filled on the next visit. Resetting
+        // on disappear ensures the next open starts with the committed value.
         .onDisappear {
             titleDraft = nil
-            descriptionDraft = nil
         }
     }
 
@@ -196,52 +190,20 @@ struct PlaylistView: View {
         titleDraft = nil
     }
 
-    // MARK: - Click-to-edit description
+    // MARK: - Read-only description
+    // Editing is hidden until the server-side update_playlist FFI lands (#130).
+    // The description renders as plain Text; when empty, nothing is shown
+    // (consistent with how empty bios and subtitles are handled elsewhere).
 
     @ViewBuilder
     private func editableDescription(playlist: Playlist) -> some View {
-        if let draft = descriptionDraft {
-            TextField(
-                "Add a description…",
-                text: Binding(
-                    get: { draft },
-                    set: { descriptionDraft = $0 }
-                ),
-                axis: .vertical
-            )
-            .textFieldStyle(.plain)
-            .lineLimit(1...4)
-            .font(Theme.font(14, weight: .medium))
-            .foregroundStyle(Theme.ink2)
-            .focused($descriptionFocused)
-            .onSubmit { commitDescription(playlist: playlist) }
-            .onChange(of: descriptionFocused) { _, focused in
-                if !focused { commitDescription(playlist: playlist) }
-            }
-            .accessibilityLabel("Edit playlist description")
-        } else {
-            // Placeholder copy when the description is empty; matches the
-            // spec's 14pt `ink2` / placeholder treatment.
-            let text = description.isEmpty ? "Add a description…" : description
-            let color: Color = description.isEmpty ? Theme.ink3 : Theme.ink2
-            Text(text)
+        if !description.isEmpty {
+            Text(description)
                 .font(Theme.font(14, weight: .medium))
-                .foregroundStyle(color)
+                .foregroundStyle(Theme.ink2)
                 .lineLimit(4)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    descriptionDraft = description
-                    DispatchQueue.main.async { descriptionFocused = true }
-                }
-                .accessibilityLabel(description.isEmpty ? "No description" : description)
-                .accessibilityHint("Tap to edit description")
+                .accessibilityLabel(description)
         }
-    }
-
-    private func commitDescription(playlist: Playlist) {
-        guard let draft = descriptionDraft else { return }
-        model.updatePlaylistDescription(playlist, newDescription: draft)
-        descriptionDraft = nil
     }
 
     // MARK: - Stat cell


### PR DESCRIPTION
## Problem

`PlaylistView` had a click-to-edit description field that appeared fully functional: the user could tap, type, and press Enter or blur to commit. Under the hood, `commitDescription` called `model.updatePlaylistDescription`, which is a stub — it only updates in-memory local state and never sends a PATCH to the Jellyfin server. On next launch the optimistic edit is silently gone.

This is a data-loss bug: the UI promises persistence it cannot deliver.

Related: #130 (the `update_playlist` FFI is not yet implemented in core).

## Fix

Make the description field read-only until #130 lands:

- Removed `@State private var descriptionDraft` and `@FocusState private var descriptionFocused` (no longer needed).
- Replaced the `editableDescription(playlist:)` implementation: the `TextField` + tap-to-activate + blur-to-commit flow is gone, replaced by a plain `Text(description)` that renders when non-empty and renders nothing when empty (matching the app's pattern for empty bios and subtitles elsewhere).
- Removed `commitDescription(playlist:)` — the only caller of `updatePlaylistDescription` from this view.
- `updatePlaylistDescription` itself is **not** removed from `AppModel`; it stays for when #130 wires the real FFI call.
- Updated the `onDisappear` comment to remove the stale `descriptionDraft` reference.

The title field remains click-to-edit (it has the same underlying stub situation, tracked separately).

## Test plan

- [ ] Open any playlist with an existing description — description renders as plain non-interactive text, no tap target, no TextField appears.
- [ ] Open a playlist with no description — nothing renders in the description slot (no placeholder "Add a description…" text, no tappable area).
- [ ] Verify the title field still functions: tap the playlist title, edit, blur/Enter — title updates as before.
- [ ] `swift build --package-path macos` passes (no new errors introduced by this PR).