### PR TITLE
fix(macos): remove dead 'New playlist' row from AlbumDetail popover

### DIFF
--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -698,9 +698,7 @@ private struct CreditChip: View {
 
 /// Popover-style picker shown by the album detail's `+` button. Lists the
 /// current user's playlists and calls `AppModel.addToPlaylist(...)` with
-/// the album's track ids when the user picks one. A "New playlist" row is
-/// surfaced at the top but wired as a TODO stub pending the create-playlist
-/// UI (tracked in #127 follow-up).
+/// the album's track ids when the user picks one.
 ///
 /// Empty-state copy explains "No playlists yet"; callers close the popover
 /// via the passed-in `onDismiss` closure after a successful append.
@@ -720,32 +718,6 @@ private struct AddToPlaylistPopover: View {
                 .padding(.horizontal, 14)
                 .padding(.top, 14)
                 .padding(.bottom, 10)
-
-            // TODO(core-#127): wire create-playlist flow once the UI for
-            // naming a new playlist lands. For now this is a stub row so
-            // the affordance is visible.
-            Button {
-                // TODO(core-#127): prompt for a name + call
-                // `core.createPlaylist(name:itemIds:)`.
-                print("[AlbumDetailView] new-playlist flow not yet wired — see core-#127")
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "plus.circle")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Theme.accent)
-                    Text("New playlist")
-                        .font(Theme.font(13, weight: .semibold))
-                        .foregroundStyle(Theme.ink)
-                    Spacer()
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            Divider()
-                .padding(.vertical, 4)
 
             if model.playlists.isEmpty {
                 Text("No playlists yet")


### PR DESCRIPTION
## Summary

- The `+` icon in the album hero CTA bar opens `AddToPlaylistPopover`. The first row in this popover was a "New playlist…" button wired only to a `print(...)` stub — tapping it silently did nothing.
- Existing-playlist rows below it are fully functional (`addAlbumToPlaylist` calls the `add_track_to_playlist` FFI correctly).
- This PR removes the dead "New playlist" row and its Divider separator, along with the stale doc-comment text that described the stub. The popover's existing-playlist list is unchanged.

**Strategy: HIDE** — the row is removed entirely. The create-playlist flow will be re-introduced as a proper UI feature when the `create_playlist` FFI surface lands (tracked separately from this fix).

The stub handler is not shared — `AddToPlaylistSubmenu`'s `onNewPlaylist` parameter is a separate pattern used in context menus, and is untouched.

## Test plan

- [ ] Build the macOS target (`swift build --package-path macos`)
- [ ] Open any album's detail view; tap the `+` (Add to playlist) CTA button
- [ ] Verify the popover shows only existing playlists (no "New playlist" row at the top)
- [ ] Tap an existing playlist row — confirm tracks are added and the popover closes
- [ ] With no playlists, verify the "No playlists yet" empty-state copy appears correctly (no dead row above it)