### PR TITLE
fix(macos): clean Now Playing About-tab bio placeholder for v1.0

### DIFF
--- a/macos/Sources/Jellify/Screens/NowPlayingView.swift
+++ b/macos/Sources/Jellify/Screens/NowPlayingView.swift
@@ -296,16 +296,6 @@ struct NowPlayingView: View {
                     }
                 }
 
-                // TODO(core-#231): once `Artist.overview` lands, surface
-                // the first paragraph as a "Bio" block here. The
-                // `ArtistDetailView` expandable block is the final home
-                // for the full text; this surface deliberately stays
-                // compact.
-                Text("Bio will appear once the core exposes artist overviews (core-#231).")
-                    .font(Theme.font(11, weight: .medium))
-                    .foregroundStyle(Theme.ink3)
-                    .italic()
-                    .padding(.top, 8)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 8)


### PR DESCRIPTION
## Why

The About tab in the full Now Playing view shipped raw developer text to end users in rc1/rc2:

```
Bio will appear once the core exposes artist overviews (core-#231).
```

This text is visible to any user who opens Now Playing and taps the **About** tab. It references an internal issue number and reads as a half-finished feature rather than a polished app.

## What changed

**`macos/Sources/Jellify/Screens/NowPlayingView.swift`**

Removed the placeholder `Text(...)` block from `aboutPanel(for:)`. When `Artist.overview` is not available (the current state — core-#231 is not yet shipped), the bio row is simply absent. The rest of the About metadata (Artist, Album, Year, Runtime, Plays, Bitrate, Tracks, Genres) renders normally.

This is a hide-when-empty pattern — no new component, no refactor. The bio row will be wired in when core-#231 lands.

**Note on the Queue tab:** The other placeholder reported in the rc2 audit ("Queue goes here" / "BATCH-07") was already resolved in PR #738, which wired the real `QueueInspector` component. This PR covers the remaining About-tab surface.

## Scope

- One file changed, 10 lines deleted.
- No new behaviour, no new UI components, no AppModel changes.
- Hotspot files (`AppModel.swift`, `JellifyApp.swift`, `client.rs`, `tests.rs`) are untouched.

## Test plan

- [ ] Open Now Playing (tap album art in PlayerBar or press ⌘L)
- [ ] Switch to the **About** tab
- [ ] Confirm "Bio will appear once..." text is gone
- [ ] Confirm all other metadata rows (Artist, Album, Year, Runtime, etc.) still render
- [ ] Switch to Queue, Lyrics, Credits — confirm no regressions
- [ ] Verify with no track playing: About tab should not be reachable (view shows empty state)