### PR TITLE
chore(macos): clean user-visible TODO references for v1.0

### DIFF
--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesAccount.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesAccount.swift
@@ -137,7 +137,7 @@ struct PreferencesAccount: View {
             // Not yet implemented; see #609.
             Button("Quick Connect") {}
                 .disabled(true)
-                .help("Coming soon — see #609")
+                .help("Quick Connect pairing is not yet supported.")
                 .accessibilityLabel("Quick Connect")
                 .accessibilityHint("Not yet available. Jellyfin Quick Connect pairing is coming in a future update.")
         }

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesDownloads.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesDownloads.swift
@@ -31,7 +31,7 @@ struct PreferencesDownloads: View {
 
             PreferenceSection(
                 title: "Location",
-                footnote: "Offline copies live inside Jellify's cache folder so macOS can evict them under disk pressure. Choosing a custom location lives with the rest of the download manager work — TODO(#570)."
+                footnote: "Offline copies live inside Jellify's cache folder so macOS can evict them under disk pressure."
             ) {
                 PreferenceRow(
                     label: "Download location",

--- a/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
+++ b/macos/Sources/Jellify/Screens/Preferences/PreferencesGeneral.swift
@@ -60,7 +60,7 @@ struct PreferencesGeneral: View {
 
             PreferenceSection(
                 title: "Language",
-                footnote: "Only English ships today. The picker is here so you can see the setting exists — additional languages will appear as translations land. TODO(i18n-#345)."
+                footnote: "Only English ships today — additional languages will appear as translations land."
             ) {
                 PreferenceRow(
                     label: "Language",

--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -694,33 +694,35 @@ private struct GenreResultRow: View {
     @State private var isHovering = false
 
     var body: some View {
-        Button(action: { model.browseGenre(genre: name) }) {
-            HStack(spacing: 12) {
-                Image(systemName: "guitars")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(Theme.ink2)
-                    .frame(width: 24)
-                Text(name)
-                    .font(Theme.font(13, weight: .semibold))
-                    .foregroundStyle(Theme.ink)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(Theme.ink3)
-                    .opacity(isHovering ? 1 : 0.4)
+        if model.supportsGenreActions {
+            Button(action: { model.browseGenre(genre: name) }) {
+                HStack(spacing: 12) {
+                    Image(systemName: "guitars")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .frame(width: 24)
+                    Text(name)
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .opacity(isHovering ? 1 : 0.4)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovering ? Theme.rowHover : .clear)
+                )
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isHovering ? Theme.rowHover : .clear)
-            )
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .onHover { isHovering = $0 }
+            .contextMenu { GenreContextMenu(genre: name) }
+            .accessibilityLabel("Browse genre \(name)")
         }
-        .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
-        .contextMenu { GenreContextMenu(genre: name) }
-        .accessibilityLabel("Browse genre \(name)")
     }
 }
 


### PR DESCRIPTION
## Summary

- Strip raw `TODO(#570)`, `TODO(i18n-#345)`, and `#609` issue numbers from three Preferences screen footnotes/tooltips; replace with professional user-facing copy that preserves the same intent
- Gate `GenreResultRow` in `SearchView` behind `model.supportsGenreActions` (Option B — the whole row body), matching every other genre-action surface in the app

## Files changed

| File | Line | Change |
|------|------|--------|
| `PreferencesDownloads.swift` | ~34 | Footnote: drop "— TODO(#570)" fragment |
| `PreferencesGeneral.swift` | ~63 | Footnote: drop "TODO(i18n-#345)" fragment |
| `PreferencesAccount.swift` | ~140 | Tooltip: "Coming soon — see #609" → "Quick Connect pairing is not yet supported." |
| `SearchView.swift` | ~696-724 | Wrap `GenreResultRow.body` in `if model.supportsGenreActions` |

## Test plan

- [ ] Open Preferences → Downloads; confirm "Location" footnote reads without any TODO/issue number
- [ ] Open Preferences → General; confirm Language picker footnote reads cleanly
- [ ] Open Preferences → Account; hover Quick Connect button; confirm tooltip is "Quick Connect pairing is not yet supported."
- [ ] In a library where genre actions are disabled, trigger a search returning genre results in the "All" scope; confirm genre rows do not render
- [ ] In a library where genre actions are enabled, confirm genre rows render and tap navigates correctly