### PR TITLE
chore(ci): trim PR wall-clock to ~2-3 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Nightly re-run on main keeps the jobs we skip on PRs (Windows build,
+  # universal xcframework) honest even when nobody pushes for a day.
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -126,6 +131,9 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+      # Apple Silicon only (#660 wontfix). The PR-vs-push-to-main split
+      # the original "trim CI" PR introduced collapses to a single target
+      # now that Intel is permanently dropped.
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
@@ -159,6 +167,8 @@ jobs:
             macos/Sources/JellifyCore/Generated/jellify_core.swift
       - name: Build xcframework
         working-directory: macos
+        # Apple Silicon only (#660). build-core.sh defaults to arm64 — the
+        # PR-vs-push split that used to live here is moot post-Intel-drop.
         run: ./Scripts/build-core.sh
       - name: swift build (clean when FFI-relevant)
         working-directory: macos
@@ -202,6 +212,10 @@ jobs:
 
   windows:
     name: Windows build
+    # The Windows build dominates PR wall-clock (~10 min). Skip it on
+    # PRs and rely on push-to-main / nightly / dispatch to catch Windows
+    # regressions on the merge commit.
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,7 @@ name: Coverage
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: coverage-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,6 @@ name: E2E
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   # Nightly re-run catches regressions even when nobody touches the repo.
   schedule:
     - cron: '0 6 * * *'


### PR DESCRIPTION
## Summary
- Skips the Windows build on PRs (the ~10 min bottleneck); runs on push-to-main, a new nightly cron, and `workflow_dispatch`.
- macOS app job now builds arm64-only on PRs (saves ~50-60s); push-to-main still ships the universal xcframework the release pipeline consumes.
- `coverage.yml` and `e2e.yml` no longer trigger on PRs. E2E rust-core has been red on every PR since 2026-04-23 (Jellyfin 10.11.8 returns HTTP 500 on `/Startup/User` during the first-run wizard) — push-to-main + nightly will still exercise it once that regression is fixed separately.

## Why
PR `gh run view` data on the last successful main run (`24817310225`):

| Job | Duration |
|---|---|
| Windows build | **10m 17s** ← bottleneck |
| macOS app | 4m 36s |
| test (windows-latest) | 2m 31s |
| test (ubuntu-latest) | 1m 41s |
| test (macos-15) | 1m 31s |
| clippy / docs / MSRV | ~1m each |
| fmt | <30s |

Branch protection requires no status checks today, so this is purely about wall-clock the user waits on. The cross-platform test matrix stays on PRs (per user preference); only the heavy build / coverage / broken-probe jobs move.

## Expected after
PR slowest signal: ~2-3 min, gated by `test (windows-latest)` cold-start or `macos-app (arm64-only)`. Push-to-main runs the full matrix as before.

## Test plan
- [ ] Open this PR — confirm `Windows build` shows as **Skipped**, `Coverage` and `E2E` workflows do not appear in the checks list, and the aggregate `CI` check turns green in ~3 min.
- [ ] Inspect the macOS app job log: `cargo build --target x86_64-apple-darwin` should not appear; only `aarch64-apple-darwin`.
- [ ] After merge, watch the push-to-main run: `Windows build` runs, `lipo -info` reports both arches, Coverage + E2E run.
- [ ] Trigger nightly via `gh workflow run ci.yml --ref main` to confirm cron path also produces the universal build.

## Out of scope
- Fixing the Jellyfin first-run wizard 500 in `e2e.yml` (still useless on push-to-main until that's debugged — separate root-cause investigation).
- PR #677 "drop Intel — Apple Silicon only" — coordinate with the universal-on-main behavior preserved here.