### PR TITLE
chore(dependabot): pin glib-rs and wiremock to MSRV-compat versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,23 @@ updates:
         patterns:
           - serde
           - serde_*
+    ignore:
+      # The 0.22 line of glib-rs (gio, glib, glib-build-tools, glib-macros,
+      # glib-sys, gio-sys, gobject-sys) raises rust-version metadata to 1.92.
+      # Workspace MSRV is 1.86 (intentional pin — Rust 1.92 doesn't exist as
+      # a stable release). Cargo's MSRV-aware resolver rejects every workspace
+      # `cargo` invocation when these are bumped. Held to 0.20 in #751 (#750).
+      # Re-enable when the wider Rust-toolchain bump is on the table.
+      - dependency-name: gio
+      - dependency-name: glib
+      - dependency-name: glib-build-tools
+      - dependency-name: glib-macros
+      - dependency-name: glib-sys
+      - dependency-name: gio-sys
+      - dependency-name: gobject-sys
+      # wiremock 0.6.5 introduced unstable `let` expressions that don't
+      # compile under workspace MSRV (Rust 1.86). Held at 0.6.4 in #751.
+      - dependency-name: wiremock
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why

Three dependabot PRs immediately reopened the MSRV regression #751 just closed:

- #755: gio 0.20.12 → 0.22.6 (rust-version 1.92)
- #754: glib 0.20.12 → 0.22.6 (rust-version 1.92)
- #753: wiremock 0.6.4 → 0.6.5 (unstable let expressions)

Workspace MSRV is 1.86 (pinned intentionally). Without ignores, dependabot will keep filing these bumps weekly.

## What

Add cargo-ecosystem `ignore` rules for:
- gio, glib, glib-build-tools, glib-macros, glib-sys, gio-sys, gobject-sys (all 0.22+ raise rust-version to 1.92)
- wiremock (0.6.5 introduced unstable let expressions)

Re-enable when MSRV moves.