### PR TITLE
fix(release): disable Sparkle deltas — broken since first ship (#759)

### DIFF
--- a/macos/Scripts/generate-appcast.sh
+++ b/macos/Scripts/generate-appcast.sh
@@ -131,10 +131,18 @@ chmod 600 "$KEY_FILE"
 DOWNLOAD_URL_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download"
 
 echo "==> Running generate_appcast"
+# --maximum-deltas 0 disables Sparkle delta generation. Deltas need the
+# .delta files to be uploaded to the GitHub release, which the workflow
+# doesn't do — every shipped release referenced .delta enclosures whose
+# URLs 404. Sparkle clients silently retry with the full DMG, so the
+# only cost of disabling deltas is slightly larger update downloads
+# (~10 MB DMG vs ~1 MB delta). Re-enable when the workflow learns to
+# upload Sparkle's .delta artifacts. See #758.
 "$SPARKLE_BIN" \
   --ed-key-file "$KEY_FILE" \
   --download-url-prefix "$DOWNLOAD_URL_PREFIX/" \
   --link "https://skalthoff.github.io/jellify-desktop/" \
+  --maximum-deltas 0 \
   -o "$DOCS/appcast.xml" \
   "$DMG_DIR"
 


### PR DESCRIPTION
## Why

Companion to #758. The rc3 re-run caught delta enclosures the earlier post-process didn't rewrite:

```
<enclosure url="https://github.com/skalthoff/jellify-desktop/releases/download/Jellify202604280925-202604280606.delta" .../>
<enclosure url="https://github.com/skalthoff/jellify-desktop/releases/download/Jellify202604280925-202604280432.delta" .../>
...
```

These `.delta` files are computed by Sparkle at workflow runtime but **never uploaded** to the GitHub release. They've been 404'ing in every shipped appcast since v0.2.0 — Sparkle clients silently fall back to the full DMG, which is why nobody noticed.

## What

Pass `--maximum-deltas 0` to `generate_appcast`. No delta entries are emitted; the appcast contains only the full-DMG enclosures.

End-user behavior: identical (full DMG download). Update cost: ~10 MB instead of ~1 MB delta. Re-enable when the workflow learns to upload Sparkle's `.delta` artifacts to the release alongside the DMG.

## Test plan

- [x] Diff is mechanical
- [ ] After merge, re-dispatch `macos-release.yml` for rc3 — appcast should produce a clean run with no delta entries
- [ ] Verify gh-pages `appcast.xml` has only DMG enclosures, all tag-prefixed, all return 200