### PR TITLE
feat(macos): dedicated Favorites surface for songs/albums/artists (#760)

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -28,7 +28,7 @@ final class AppModel {
     /// Active root tab. Drill destinations (album / artist / playlist /
     /// nowPlaying) live on `navPath` instead so back navigation is handled
     /// by `NavigationStack` natively. See #1 / #4.
-    enum Screen: Hashable { case home, discover, library, search, settings }
+    enum Screen: Hashable { case home, discover, library, favorites, search, settings }
     var screen: Screen = .library
 
     /// Typed value-type for `NavigationStack` destinations. Root tabs and
@@ -39,6 +39,7 @@ final class AppModel {
         case home
         case discover
         case library
+        case favorites
         case search
         case settings
         case album(String)
@@ -1451,14 +1452,10 @@ final class AppModel {
     }
 
     /// Navigate to the full library scoped to favorites (#55 "See All").
-    /// The library view doesn't yet carry a "filter to favorites" chip
-    /// (tracked alongside the filter UI in a future library polish pass),
-    /// so this just routes the user to the library for now. The view
-    /// accepts additional filters once the chip row grows one.
+    /// Open the dedicated Favorites screen. Used by the sidebar's
+    /// Favorites row and the Home Favorites carousel "See all" CTA.
     func showAllFavorites() {
-        // TODO(library-filter): once the library chip row supports a
-        //   "Favorites" filter, route here with the filter pre-selected.
-        selectTab(.library)
+        selectTab(.favorites)
     }
 
     /// Shared helper: build a `GET /Items` request against the user's
@@ -1599,6 +1596,78 @@ final class AppModel {
         }
     }
 
+    // MARK: - Favorites surface (#760)
+    //
+    // Public load helpers backing the dedicated Favorites screen. Each
+    // returns the user's favorited items in stable, name-sorted order
+    // (Random order on the Home shuffle CTA is the exception above).
+
+    /// Fetch up to `limit` favorited audio tracks, sorted by name.
+    /// Backs the "Songs" section of the Favorites screen. Returns an
+    /// empty array on auth/network/parse failure.
+    @discardableResult
+    func loadFavoriteTracks(limit: UInt32 = 500) async -> [Track] {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "Audio",
+            sortBy: "SortName",
+            sortOrder: "Ascending",
+            filters: "IsFavorite",
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: nil,
+            parentId: nil
+        ) else { return [] }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return []
+            }
+            return Self.parseTracksFromItems(data: data)
+        } catch {
+            print("[AppModel] loadFavoriteTracks failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Fetch up to `limit` favorited albums, sorted by name. Backs the
+    /// "Albums" section of the Favorites screen.
+    func loadFavoriteAlbums(limit: UInt32 = 500) async -> [Album] {
+        await fetchAlbumsViaItemsQuery(
+            sortBy: "SortName",
+            filters: "IsFavorite",
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: nil
+        )
+    }
+
+    /// Fetch up to `limit` favorited artists, sorted by name. Backs the
+    /// "Artists" section of the Favorites screen.
+    func loadFavoriteArtists(limit: UInt32 = 500) async -> [Artist] {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "MusicArtist",
+            sortBy: "SortName",
+            sortOrder: "Ascending",
+            filters: "IsFavorite",
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: nil,
+            parentId: nil
+        ) else { return [] }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return []
+            }
+            return Self.parseArtistsFromItems(data: data)
+        } catch {
+            print("[AppModel] loadFavoriteArtists failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
     /// Build an authenticated `GET /Items` request against the current
     /// session's server. Returns `nil` when there is no session or the
     /// core refuses to hand out an auth header. Keeps the URL
@@ -1715,6 +1784,52 @@ final class AppModel {
     /// typed `Album` the core produces. Returns `nil` when the minimum
     /// required fields (`Id`, `Name`) aren't present so we don't render
     /// blank tiles.
+    /// Parse `{ Items: [...] }` into typed `Artist` values. Mirror of
+    /// `parseAlbumsFromItems` — used by the Favorites screen's "Artists"
+    /// section. See `loadFavoriteArtists`.
+    private static func parseArtistsFromItems(data: Data) -> [Artist] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = root["Items"] as? [[String: Any]]
+        else { return [] }
+        return items.compactMap { Self.artistFromDTO($0) }
+    }
+
+    /// Project a Jellyfin `BaseItemDto` into the typed `Artist` shape.
+    /// `albumCount` / `songCount` come back from the server when they're
+    /// available; defaults to 0 otherwise so the tile count line stays
+    /// renderable.
+    private static func artistFromDTO(_ entry: [String: Any]) -> Artist? {
+        guard
+            let id = (entry["Id"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !id.isEmpty,
+            let name = (entry["Name"] as? String)?.trimmingCharacters(in: .whitespaces),
+            !name.isEmpty
+        else { return nil }
+        let albumCount: UInt32 = {
+            if let c = entry["AlbumCount"] as? Int, c >= 0 { return UInt32(c) }
+            return 0
+        }()
+        let songCount: UInt32 = {
+            if let c = entry["SongCount"] as? Int, c >= 0 { return UInt32(c) }
+            return 0
+        }()
+        let genres: [String] = (entry["Genres"] as? [String]) ?? []
+        let imageTag: String? = {
+            if let tags = entry["ImageTags"] as? [String: String],
+               let primary = tags["Primary"], !primary.isEmpty { return primary }
+            return nil
+        }()
+        return Artist(
+            id: id,
+            name: name,
+            albumCount: albumCount,
+            songCount: songCount,
+            genres: genres,
+            imageTag: imageTag,
+            userData: nil
+        )
+    }
+
     private static func albumFromDTO(_ entry: [String: Any]) -> Album? {
         guard
             let id = (entry["Id"] as? String)?.trimmingCharacters(in: .whitespaces),

--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -63,10 +63,7 @@ struct Sidebar: View {
             // in place; the playlist list lives as its own section below.
             sectionHeader("sidebar.section.your_library")
             VStack(alignment: .leading, spacing: 2) {
-                // "Favorites" has no dedicated surface yet — route to the
-                // library's default tab for now so the row isn't a dead
-                // click (follow-up: dedicated favorites tab, #133).
-                libRow("heart", label: "sidebar.stats.favorites", count: nil, tab: .albums)
+                favoritesRow
                 libRow("square.stack", label: "sidebar.stats.albums", count: UInt32(model.albums.count), tab: .albums)
                 libRow("person.crop.circle", label: "sidebar.stats.artists", count: UInt32(model.artists.count), tab: .artists)
                 libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count), tab: .playlists)
@@ -298,6 +295,34 @@ struct Sidebar: View {
         // user hears which one they're on without parsing visual chrome.
         .accessibilityLabel(label)
         .accessibilityAddTraits(active ? [.isSelected, .isButton] : .isButton)
+    }
+
+    /// Sidebar entry for the dedicated Favorites surface. Mirrors libRow
+    /// visually but routes to `.favorites` (its own root tab) instead of
+    /// the Library with a tab pre-selected.
+    @ViewBuilder
+    private var favoritesRow: some View {
+        Button {
+            model.selectTab(.favorites)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "heart")
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 18)
+                    .accessibilityHidden(true)
+                Text("sidebar.stats.favorites")
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("sidebar.stats.favorites")
+        .accessibilityAddTraits(.isButton)
     }
 
     @ViewBuilder

--- a/macos/Sources/Jellify/Screens/FavoritesView.swift
+++ b/macos/Sources/Jellify/Screens/FavoritesView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+@preconcurrency import JellifyCore
+
+/// Dedicated Favorites surface. Users had no place to browse the items
+/// they'd hearted from context menus and detail screens — the sidebar
+/// "Favorites" row routed to the all-albums library tab as a stopgap.
+/// This screen surfaces favorited Songs, Albums, and Artists in their
+/// own sections, sourced via `IsFavorite` filters on `/Items` queries.
+///
+/// Playlist favorites are intentionally out of scope here: the user's
+/// playlists already live in the sidebar and are reachable directly
+/// from there, so a separate "favorited playlists" surface would be
+/// redundant for v1.0. Adding it later is a small follow-up if usage
+/// shows demand.
+struct FavoritesView: View {
+    @Environment(AppModel.self) private var model
+
+    @State private var tracks: [Track] = []
+    @State private var albums: [Album] = []
+    @State private var artists: [Artist] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 36) {
+                header
+                if isLoading && tracks.isEmpty && albums.isEmpty && artists.isEmpty {
+                    loadingState
+                } else if tracks.isEmpty && albums.isEmpty && artists.isEmpty {
+                    emptyState
+                } else {
+                    if !tracks.isEmpty { songsSection }
+                    if !albums.isEmpty { albumsSection }
+                    if !artists.isEmpty { artistsSection }
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 28)
+        }
+        .background(Theme.bg)
+        .task(id: model.session?.user.id) {
+            await refresh()
+        }
+    }
+
+    // MARK: - Header
+
+    /// 80pt eyebrow / title block. Mirrors HomeView and LibraryView's
+    /// hero rather than the smaller chip rows so the page feels like
+    /// its own destination, not a filter applied elsewhere.
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("FAVORITES")
+                .font(Theme.font(11, weight: .bold))
+                .tracking(2)
+                .foregroundStyle(Theme.ink3)
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                Text("Your Library")
+                    .font(Theme.font(34, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+                Spacer()
+                if !tracks.isEmpty {
+                    Button {
+                        model.play(tracks: tracks.shuffled(), startIndex: 0)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "shuffle")
+                            Text("Shuffle All")
+                        }
+                        .font(Theme.font(13, weight: .semibold))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Theme.surface)
+                        .foregroundStyle(Theme.ink)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Theme.border, lineWidth: 1)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Shuffle all favorite songs")
+                }
+            }
+            countLine
+        }
+    }
+
+    /// Subtitle that summarizes what the user is looking at. Renders the
+    /// counts in a single line so the user sees scope at a glance.
+    private var countLine: some View {
+        let parts: [String] = [
+            tracks.isEmpty ? nil : "\(tracks.count) song\(tracks.count == 1 ? "" : "s")",
+            albums.isEmpty ? nil : "\(albums.count) album\(albums.count == 1 ? "" : "s")",
+            artists.isEmpty ? nil : "\(artists.count) artist\(artists.count == 1 ? "" : "s")",
+        ].compactMap { $0 }
+        return Text(parts.isEmpty ? " " : parts.joined(separator: " · "))
+            .font(Theme.font(13, weight: .medium))
+            .foregroundStyle(Theme.ink3)
+    }
+
+    // MARK: - Sections
+
+    /// Songs section — vertical list. Tap plays the song against the
+    /// full favorites track list so Up Next reflects the user's
+    /// intent ("play from my favorites").
+    @ViewBuilder
+    private var songsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(title: "Songs", count: tracks.count)
+            VStack(spacing: 0) {
+                ForEach(Array(tracks.prefix(50).enumerated()), id: \.element.id) { idx, track in
+                    TrackListRow(
+                        track: track,
+                        tracks: tracks,
+                        index: idx
+                    )
+                }
+            }
+            .padding(.vertical, 4)
+            .background(Theme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Theme.border, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            if tracks.count > 50 {
+                Text("Showing 50 of \(tracks.count). The full list shuffles via Shuffle All.")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    /// Albums section — adaptive grid mirroring LibraryView's tile size.
+    private var albumsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(title: "Albums", count: albums.count)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 168, maximum: 220), spacing: 18)],
+                alignment: .leading,
+                spacing: 24
+            ) {
+                ForEach(albums, id: \.id) { album in
+                    AlbumCard(album: album)
+                }
+            }
+        }
+    }
+
+    /// Artists section — circular tiles. Wraps every six tiles via the
+    /// same adaptive grid the library uses; ArtistCard owns its own
+    /// circular crop so we don't have to clip here.
+    private var artistsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(title: "Artists", count: artists.count)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 144, maximum: 200), spacing: 20)],
+                alignment: .leading,
+                spacing: 24
+            ) {
+                ForEach(artists, id: \.id) { artist in
+                    ArtistCard(artist: artist)
+                }
+            }
+        }
+    }
+
+    // MARK: - States
+
+    /// Skeleton-flavored loading state — same visual weight as the
+    /// real content so the page doesn't reflow when sections fill in.
+    private var loadingState: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Loading your favorites…")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 60)
+    }
+
+    /// Empty state when the user hasn't favorited anything yet. Points
+    /// at the heart icons that drive the IsFavorite mutation so users
+    /// know how to seed the view.
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "heart")
+                    .font(.system(size: 28, weight: .light))
+                    .foregroundStyle(Theme.ink2)
+                Text("No favorites yet")
+                    .font(Theme.font(20, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+            }
+            Text("Tap the heart on a song, album, or artist and it shows up here.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 60)
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func sectionHeader(title: String, count: Int) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(Theme.font(20, weight: .bold))
+                .foregroundStyle(Theme.ink)
+            Text("\(count)")
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+            Spacer()
+        }
+    }
+
+    /// Pull all three lists in parallel. Each load is independent so a
+    /// flaky endpoint on one type doesn't sink the others — same pattern
+    /// as ArtistDetailView's parallel album/top-tracks/similar fetches.
+    private func refresh() async {
+        isLoading = true
+        async let t = model.loadFavoriteTracks()
+        async let a = model.loadFavoriteAlbums()
+        async let r = model.loadFavoriteArtists()
+        let (loadedTracks, loadedAlbums, loadedArtists) = await (t, a, r)
+        tracks = loadedTracks
+        albums = loadedAlbums
+        artists = loadedArtists
+        isLoading = false
+    }
+}

--- a/macos/Sources/Jellify/Screens/MainShell.swift
+++ b/macos/Sources/Jellify/Screens/MainShell.swift
@@ -194,6 +194,8 @@ struct MainShell: View {
             DiscoverView()
         case .library:
             LibraryView()
+        case .favorites:
+            FavoritesView()
         case .search:
             SearchView()
         case .settings:
@@ -252,6 +254,8 @@ struct MainShell: View {
             HomeView()
         case .library:
             LibraryView()
+        case .favorites:
+            FavoritesView()
         case .discover:
             DiscoverView()
         case .search:
@@ -294,6 +298,7 @@ struct MainShell: View {
         case .home: segments.append("Home")
         case .discover: segments.append("Discover")
         case .library: segments.append("Library")
+        case .favorites: segments.append("Favorites")
         case .search: segments.append("Search")
         case .settings: segments.append("Settings")
         }
@@ -331,7 +336,7 @@ struct MainShell: View {
             }
         case .nowPlaying?:
             segments.append("Now Playing")
-        case .home?, .discover?, .library?, .search?, .settings?, nil:
+        case .home?, .discover?, .library?, .favorites?, .search?, .settings?, nil:
             break
         }
         return segments


### PR DESCRIPTION
## Why

User report: "there's still no where to see the liked songs albums etc."

The user can heart items from context menus, but there's no browse surface for what they've favorited. The sidebar "Favorites" row was a stopgap that routed to the all-albums library tab.

## What

New `FavoritesView` accessible via the sidebar heart row. Three sections:

- **Songs** — vertical list (top 50 of name-sorted favorites) with a `Shuffle All` CTA in the hero header. Tap-to-play preserves the full favorite set as Up Next.
- **Albums** — adaptive grid using LibraryView's `AlbumCard`.
- **Artists** — adaptive grid using `ArtistCard` (circular tiles).

### AppModel additions
- `loadFavoriteTracks(limit:)` — public; `IsFavorite` filter on `/Items?IncludeItemTypes=Audio`
- `loadFavoriteAlbums(limit:)` — wraps existing `fetchAlbumsViaItemsQuery` with `IsFavorite`
- `loadFavoriteArtists(limit:)` — new; `IsFavorite` filter on `/Items?IncludeItemTypes=MusicArtist`
- New `parseArtistsFromItems` + `artistFromDTO` helpers (mirror `parseAlbumsFromItems`)
- `showAllFavorites()` now routes to `.favorites` (was `.library`)

### Routing
- `Screen.favorites` + `Route.favorites` added; exhaustive switches in `MainShell` breadcrumbs + routing updated
- Sidebar heart row uses a dedicated `favoritesRow` view that calls `selectTab(.favorites)`

## Test plan

- [x] `swift build` clean
- [ ] Sidebar heart row navigates to Favorites screen
- [ ] Songs / Albums / Artists sections each render with the user's favorited items
- [ ] `Shuffle All` button plays the full favorite track set in random order
- [ ] Empty state shows when user has nothing favorited
- [ ] Tapping an album / artist tile navigates to its detail page (existing card behavior)

## Out of scope

- Per-section filtering (Songs/Albums/Artists tabs) — single-page layout is enough for typical libraries
- Favorited playlists — already in the sidebar list
- Live updates when toggling a heart while viewing — `.task` re-runs on next visit

Closes #760.