### PR TITLE
fix(macos): drop dead Share entries from context menus (#10)

### DIFF
--- a/macos/Sources/Jellify/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/ArtistContextMenu.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     ─
 ///     Follow / Unfollow, Go to Artist Page
 ///     ─
-///     Copy Link, Share
+///     Copy Link
 ///
 /// `showGoToArtist` is omitted when the menu is invoked from the artist's
 /// own detail screen — mirrors the spec's "if invoked elsewhere" qualifier.
@@ -57,11 +57,5 @@ struct ArtistContextMenu: View {
 
         Button("Copy Link", systemImage: "link") { model.copyShareLink(artist: artist) }
             .disabled(model.webURL(for: artist) == nil)
-        // Share is not yet wired — disabled per spec. NSSharingServicePicker
-        // support lands with #318.
-        Button("Share", systemImage: "square.and.arrow.up") {
-            // TODO(#318): present NSSharingServicePicker.
-        }
-        .disabled(true)
     }
 }

--- a/macos/Sources/Jellify/Components/TrackContextMenu.swift
+++ b/macos/Sources/Jellify/Components/TrackContextMenu.swift
@@ -19,7 +19,7 @@ import SwiftUI
 ///     ─
 ///     Favorite / Unfavorite, Download / Remove Download, Mark as Played / Unplayed
 ///     ─
-///     Copy Link, Share
+///     Copy Link
 ///
 /// For multi-selection: the "Go to …" actions are omitted (they can't
 /// disambiguate across a selection); a "Remove from Playlist" action
@@ -28,7 +28,7 @@ import SwiftUI
 ///
 /// Backing actions call through to `AppModel`. Several are TODO stubs
 /// pending FFI work (song radio, track info, download engine,
-/// mark-played, share). Disabled states follow suit per spec.
+/// mark-played). Disabled states follow suit per spec.
 struct TrackContextMenu: View {
     @Environment(AppModel.self) private var model
     /// The selection this menu acts on. Single-track call sites pass
@@ -126,12 +126,6 @@ struct TrackContextMenu: View {
             if let track = first { model.copyShareLink(track: track) }
         }
         .disabled(isMulti || first.flatMap { model.webURL(for: $0) } == nil)
-        // Share is not yet wired — disabled per spec. NSSharingServicePicker
-        // support lands with #318.
-        Button("Share", systemImage: "square.and.arrow.up") {
-            // TODO(#318): present NSSharingServicePicker.
-        }
-        .disabled(true)
     }
 
     /// True when every track in the selection is already favorited, so the


### PR DESCRIPTION
## Summary

- `TrackContextMenu` and `ArtistContextMenu` both rendered a `Button("Share", ...)` with `.disabled(true)`. On macOS, disabled context menu items appear grayed out but remain in the menu — users see the entry, tap it, and get no feedback. That's worse than not showing it at all.
- Per Apple HIG: hide menu items for features that aren't implemented yet; only disable items that are contextually unavailable but would otherwise work.
- Removing the entry entirely until #318 (NSSharingServicePicker infrastructure) actually lands.

## Changes

- Deleted the `Button("Share", ...)` + `.disabled(true)` block from both context menus.
- No surrounding `Section { }` or `Divider()` needed adjustment — the last `Divider()` above `Copy Link` still makes sense as a separator from the actions group above it.
- Updated doc-comment menu maps to drop the "Share" entry.

## Test plan

- [ ] Right-click any track row — confirm "Share" no longer appears; "Copy Link" is still present and functional.
- [ ] Right-click any artist row/card — same check.
- [ ] Verify no orphan empty sections or extra dividers at the bottom of either menu.
- [ ] `swift build --package-path macos` passes (pre-existing `AudioEngine.swift` errors are unrelated to this change and exist on `main`).