### PR TITLE
fix(macos): drop dead 'Search Jellyfin metadata' suggestion (#15)

### DIFF
--- a/macos/Sources/Jellify/Screens/SearchView.swift
+++ b/macos/Sources/Jellify/Screens/SearchView.swift
@@ -730,11 +730,9 @@ private struct GenreResultRow: View {
 
 /// Illustrative zero-results state shown when a committed query returns
 /// no rows across any scope. In addition to the illustration + headline,
-/// it surfaces two helper suggestions the user can click — the
-/// first bounces them to a simplified query (artist name only), the
-/// second is a placeholder for a future "search full Jellyfin metadata"
-/// pass. Both are stubs that keep the affordance visible rather than
-/// leaving the user staring at a dead page. See #245.
+/// it surfaces a helper suggestion the user can click — bouncing them
+/// to a simplified query (artist name only). See #245 for the planned
+/// "wider metadata search" follow-up.
 private struct ZeroResultsState: View {
     let query: String
     /// Invoked when the user taps a suggestion — lets the parent commit
@@ -772,18 +770,6 @@ private struct ZeroResultsState: View {
                             .map(String.init)
                             ?? query
                         onUseSuggestion(firstToken)
-                    }
-                )
-                suggestionRow(
-                    label: "Search Jellyfin metadata",
-                    symbol: "magnifyingglass.circle",
-                    action: {
-                        // TODO: #245 — hook up a "wider metadata" search
-                        // pass once the core surface lands. For now this
-                        // is a visible-but-inert stub; tapping it just
-                        // re-commits the same query so the user gets
-                        // feedback rather than a silent no-op.
-                        onUseSuggestion(query)
                     }
                 )
             }


### PR DESCRIPTION
## Summary

- The `ZeroResultsState` view in `SearchView.swift` showed two suggestion rows; the second ("Search Jellyfin metadata") was a stub that re-ran the identical query on tap — a placebo, not a useful action.
- Removed the entire stub `suggestionRow(...)` block. The working "Try: artist name only" row remains.
- Updated the struct doc-comment to drop the reference to the removed row.

## Notes

The layout holds fine with a single suggestion in the `VStack` — no spacing adjustments needed.

For the actual "wider metadata search" follow-up, see #245.

## Test plan

- [ ] Build succeeds (`swift build --package-path macos`)
- [ ] Search a term with no results → one suggestion row ("Try: artist name only") appears; tapping it re-runs with the first token
- [ ] No second row visible