### PR TITLE
fix(macos): hide HomeView mock sections + Favorites See All link (#18, #23)

### DIFF
--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -25,7 +25,10 @@ struct HomeView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
                 header
-                quickTilesRow
+                // quickTilesRow — hidden for v1.0: uses albums.prefix(3) as a
+                // placeholder for "top tracks of the day"; random albums are
+                // not meaningful here. Re-enable once the ranked data sources
+                // land (#206, #209).
                 recentlyPlayedSection
                 jumpBackInSection
                 recentlyPlayedTracksSection
@@ -33,7 +36,10 @@ struct HomeView: View {
                 quickPicksSection
                 suggestionsSection
                 favoritesSection
-                pinnedStationsRow
+                // pinnedStationsRow — hidden for v1.0: section is backed by
+                // @AppStorage mock data only; tapping tiles or the + button
+                // does nothing. Re-enable once the real pin infrastructure
+                // lands (#144, #253).
                 artistRadioRow
                 Spacer(minLength: 24)
             }
@@ -581,10 +587,19 @@ struct HomeView: View {
     }
 
     /// Right-hand CTA cluster for the Favorites header — "Shuffle All
-    /// Favorites" (primary accent pill) + "Reshuffle" (ghost). Extracted
-    /// so the narrow and wide layouts share one source of truth.
+    /// Favorites" (primary accent pill) + "Reshuffle" (ghost) + "See All"
+    /// link to the full FavoritesView (#23). Extracted so the narrow and
+    /// wide layouts share one source of truth.
     private var favoritesCTAs: some View {
         HStack(spacing: 8) {
+            Button("See All") {
+                model.selectTab(.favorites)
+            }
+            .buttonStyle(.plain)
+            .font(Theme.font(13, weight: .semibold))
+            .foregroundStyle(Theme.accent)
+            .help("Open the full Favorites screen")
+            .accessibilityLabel("See all favorites")
             Button {
                 model.shuffleAllFavorites()
             } label: {


### PR DESCRIPTION
## Summary

- **Pinned Stations section hidden** (#18a, #144, #253): The row was backed entirely by `@AppStorage` mock data (`PinnedStation` triples). Tapping a pinned tile or the `+` button logged to console and did nothing else — no routing, no core call. Shipping this UI would mislead users into thinking the feature works. The section is commented out at the `body` call site with a note to re-enable once the real pin infrastructure (server-side pin model + `instantMix` FFI #144) lands.

- **"Top Tracks of the Day" quick-tiles row hidden** (#18b, #206, #209): The 3-column quick-tiles row at the top of Home used `albums.prefix(3)` as a stand-in for ranked play data. Random library albums labelled implicitly as "top tracks" are misleading. The row is commented out at the `body` call site pending the `core.recently_played` / `core.most_played` data sources (#206/#209).

- **"See All" Favorites link added** (#23): The Home Favorites carousel had no way to jump to the full `FavoritesView`. A `"See All"` plain-style button styled with `Theme.accent` is now the leftmost item in `favoritesCTAs` (the right-hand header cluster), invoking `model.selectTab(.favorites)`. Both the wide (`HStack`) and narrow (`VStack`) `ViewThatFits` variants pick it up automatically since they share the `favoritesCTAs` computed property.

## Test plan

- [ ] Launch the app — the 3-column quick-tiles row should not appear above the Recently Played carousel
- [ ] The "Pinned Stations" section should not appear between the Favorites carousel and the Artist Radio row
- [ ] All existing sections (Recently Played, Jump Back In, Recently Played Tracks, Recently Added, Quick Picks, You Might Like, Favorites, Artist Radio) continue to render normally
- [ ] In the Favorites section header, "See All" appears to the left of "Shuffle All Favorites" and "Reshuffle"
- [ ] Clicking "See All" switches to the Favorites tab
- [ ] On narrow windows, the `ViewThatFits` narrow layout also shows "See All" (it inherits from the shared `favoritesCTAs`)