### PR TITLE
fix(macos): inline heart on track rows (#8)

### DIFF
--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -128,6 +128,20 @@ struct TrackListRow: View {
                         .frame(maxWidth: 240, alignment: .trailing)
                 }
 
+                let isFav = model.isFavorite(id: track.id)
+                if isFav || isHovering {
+                    Button {
+                        model.toggleFavorite(track: track)
+                    } label: {
+                        Image(systemName: isFav ? "heart.fill" : "heart")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                            .frame(width: 28, height: 28)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
+                }
+
                 Text(track.durationFormatted)
                     .font(Theme.font(12, weight: .medium))
                     .foregroundStyle(Theme.ink3)

--- a/macos/Sources/Jellify/Components/TrackRow.swift
+++ b/macos/Sources/Jellify/Components/TrackRow.swift
@@ -93,6 +93,20 @@ struct TrackRow: View {
 
             Spacer()
 
+            let isFav = model.isFavorite(id: track.id)
+            if isFav || isHovering {
+                Button {
+                    model.toggleFavorite(track: track)
+                } label: {
+                    Image(systemName: isFav ? "heart.fill" : "heart")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
+            }
+
             Text(track.durationFormatted)
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)


### PR DESCRIPTION
## Summary

Track rows in all list contexts (Library, Album Detail, Playlist Detail, Favorites, Now Playing Queue) previously exposed the Favorite action only via right-click context menu. This matches neither the Apple Music nor the Spotify interaction model, where a heart icon is visible inline on hover.

- **TrackListRow** (Library Tracks tab): heart appears between the album name column and the duration, visible on hover or when already favorited
- **TrackRow** (Album Detail, Playlist Detail, Search): heart appears between Spacer and the duration, same visibility rules
- `heart.fill` + accent colour when favorited (always visible regardless of hover)
- `heart` outline + `Theme.ink2` on hover when not favorited
- Tap calls `model.toggleFavorite(track:)` — no AppModel changes required
- `accessibilityLabel` is "Favorite" / "Unfavorite" accordingly

## Test plan

- [ ] Hover a track row in the Library Tracks tab — heart outline appears
- [ ] Click the heart — it fills and stays filled without hover
- [ ] Hover away — filled heart remains visible
- [ ] Click the filled heart — it outlines, disappears on hover-out
- [ ] Repeat in Album Detail, Playlist Detail, and Search results tracks section
- [ ] VoiceOver: row announces "Favorite" / "Unfavorite" action correctly