### PR TITLE
feat(macos): Favorites end-to-end + 12 v1.0 UX bug fixes

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -2325,6 +2325,16 @@ final class AppModel {
         let removed = currentPlaylistTracks.filter { removing.contains($0.id) }
         guard !removed.isEmpty else { return }
         let playlistItemIds = removed.compactMap { $0.playlistItemId }
+        // Server call requires playlistItemIds. If any removed track lacks
+        // one, the whole batch can't be reconciled with the server. Bail
+        // BEFORE the optimistic mutation so there's nothing to roll back —
+        // surface a banner so the user knows the action didn't persist.
+        // (Earlier we mutated then rolled back, but the rollback restored
+        // from the already-mutated array — net no-op.)
+        guard !playlistItemIds.isEmpty else {
+            errorMessage = "Couldn't remove this track from the playlist. Try refreshing the playlist."
+            return
+        }
         currentPlaylistTracks.removeAll { removing.contains($0.id) }
         playlistTracks[playlistId] = currentPlaylistTracks
         pendingPlaylistRemoval = PendingRemoval(
@@ -2341,28 +2351,6 @@ final class AppModel {
                 runtimeTicks: p.runtimeTicks,
                 imageTag: p.imageTag
             )
-        }
-        guard !playlistItemIds.isEmpty else {
-            // Roll back the optimistic removal — the server was not changed, so
-            // the track would reappear on next launch. Surface a banner so the
-            // user knows the action did not persist.
-            currentPlaylistTracks = (playlistTracks[playlistId] ?? [])
-            playlistTracks[playlistId] = currentPlaylistTracks
-            // Also roll back the track count on the in-memory Playlist.
-            if let idx = playlists.firstIndex(where: { $0.id == playlistId }) {
-                let p = playlists[idx]
-                let restored = Int(p.trackCount) + removed.count
-                playlists[idx] = Playlist(
-                    id: p.id,
-                    name: p.name,
-                    trackCount: UInt32(restored),
-                    runtimeTicks: p.runtimeTicks,
-                    imageTag: p.imageTag
-                )
-            }
-            pendingPlaylistRemoval = nil
-            errorMessage = "Couldn't remove this track from the playlist. Try refreshing the playlist."
-            return
         }
         Task.detached(priority: .userInitiated) { [core] in
             try? core.removeFromPlaylist(
@@ -3023,7 +3011,7 @@ final class AppModel {
 
     /// Bumps every time `setFavorite(...)` resolves on the server. Views that
     /// list favorites can `.task(id: model.favoriteChangeToken)` to refetch
-    /// without polling. See #2 in v1.0 audit.
+    /// without polling.
     var favoriteChangeToken: UInt64 = 0
 
     /// In-memory played flag keyed by item id (track / album / playlist).

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -474,11 +474,6 @@ final class AppModel {
     /// this set. Cleared on success or error. See `duplicatePlaylist`.
     var sidebarCopyingPlaylistIds: Set<String> = []
 
-    /// Artists the user has "followed" in-app. Today this is purely local
-    /// state (no server-side follow primitive on Jellyfin), persisted to
-    /// `UserDefaults` on write. See #64 / #228.
-    var followedArtistIds: Set<String> = []
-
     // MARK: - Command Palette (⌘K)
 
     /// Whether the command-palette overlay is currently visible. Toggled by
@@ -578,6 +573,12 @@ final class AppModel {
             title: "Go to Discover",
             symbol: "sparkles",
             run: { [weak self] in self?.goToDiscover() }
+        ))
+        actions.append(PaletteAction(
+            id: "nav.favorites",
+            title: "Go to Favorites",
+            symbol: "heart",
+            run: { [weak self] in self?.selectTab(.favorites) }
         ))
 
         // Preferences. macOS exposes the Settings scene through the standard
@@ -1623,7 +1624,10 @@ final class AppModel {
                 markAuthExpired()
                 return []
             }
-            return Self.parseTracksFromItems(data: data)
+            let tracks = Self.parseTracksFromItems(data: data)
+            // Seed favoriteById so track hearts are correct on first paint.
+            for track in tracks { favoriteById[track.id] = true }
+            return tracks
         } catch {
             print("[AppModel] loadFavoriteTracks failed: \(error.localizedDescription)")
             return []
@@ -1633,13 +1637,16 @@ final class AppModel {
     /// Fetch up to `limit` favorited albums, sorted by name. Backs the
     /// "Albums" section of the Favorites screen.
     func loadFavoriteAlbums(limit: UInt32 = 500) async -> [Album] {
-        await fetchAlbumsViaItemsQuery(
+        let albums = await fetchAlbumsViaItemsQuery(
             sortBy: "SortName",
             filters: "IsFavorite",
             limit: limit,
             extraFields: [],
             minDateLastSaved: nil
         )
+        // Seed favoriteById so album hearts are correct on first paint.
+        for album in albums { favoriteById[album.id] = true }
+        return albums
     }
 
     /// Fetch up to `limit` favorited artists, sorted by name. Backs the
@@ -1661,7 +1668,10 @@ final class AppModel {
                 markAuthExpired()
                 return []
             }
-            return Self.parseArtistsFromItems(data: data)
+            let artists = Self.parseArtistsFromItems(data: data)
+            // Seed favoriteById so artist hearts are correct on first paint.
+            for artist in artists { favoriteById[artist.id] = true }
+            return artists
         } catch {
             print("[AppModel] loadFavoriteArtists failed: \(error.localizedDescription)")
             return []
@@ -2153,7 +2163,8 @@ final class AppModel {
     /// stable for the duration of the user's browsing session and the
     /// detail screen may be entered / left repeatedly.
     @discardableResult
-    func loadArtistAlbums(artistId: String, limit: UInt32 = 100) async -> [Album] {
+    func loadArtistAlbums(artistId: String, limit: UInt32 = 500) async -> [Album] {
+        // Soft cap. Prolific catalogues > 500 will still truncate; pagination tracked as v1.x follow-up.
         if let cached = artistAlbumsCache[artistId] { return cached }
         do {
             let page = try await Task.detached(priority: .userInitiated) { [core] in
@@ -2332,7 +2343,25 @@ final class AppModel {
             )
         }
         guard !playlistItemIds.isEmpty else {
-            print("[AppModel] removeFromPlaylist: no PlaylistItemIds on removed tracks — server unchanged; did these come from core.playlistTracks?")
+            // Roll back the optimistic removal — the server was not changed, so
+            // the track would reappear on next launch. Surface a banner so the
+            // user knows the action did not persist.
+            currentPlaylistTracks = (playlistTracks[playlistId] ?? [])
+            playlistTracks[playlistId] = currentPlaylistTracks
+            // Also roll back the track count on the in-memory Playlist.
+            if let idx = playlists.firstIndex(where: { $0.id == playlistId }) {
+                let p = playlists[idx]
+                let restored = Int(p.trackCount) + removed.count
+                playlists[idx] = Playlist(
+                    id: p.id,
+                    name: p.name,
+                    trackCount: UInt32(restored),
+                    runtimeTicks: p.runtimeTicks,
+                    imageTag: p.imageTag
+                )
+            }
+            pendingPlaylistRemoval = nil
+            errorMessage = "Couldn't remove this track from the playlist. Try refreshing the playlist."
             return
         }
         Task.detached(priority: .userInitiated) { [core] in
@@ -2456,6 +2485,20 @@ final class AppModel {
             return
         }
         playInstantMix(seedId: seedId)
+    }
+
+    /// Re-seed the Instant Mix with a different track than the current one.
+    /// Picks a random track from `recentlyPlayed` excluding the currently-
+    /// playing track, so "Generate new mix" actually sounds different. Falls
+    /// back to `startInstantMix` when there is nothing else to pick from.
+    func regenerateInstantMix() {
+        let currentId = status.currentTrack?.id
+        let candidates = recentlyPlayed.filter { $0.id != currentId }
+        if let seed = candidates.randomElement() {
+            playInstantMix(seedId: seed.id)
+        } else {
+            startInstantMix()
+        }
     }
 
     /// Common driver for every "Start Radio" entry point. `core.instantMix`
@@ -2978,6 +3021,11 @@ final class AppModel {
     /// round-trip.
     var favoriteById: [String: Bool] = [:]
 
+    /// Bumps every time `setFavorite(...)` resolves on the server. Views that
+    /// list favorites can `.task(id: model.favoriteChangeToken)` to refetch
+    /// without polling. See #2 in v1.0 audit.
+    var favoriteChangeToken: UInt64 = 0
+
     /// In-memory played flag keyed by item id (track / album / playlist).
     /// Mirrors `favoriteById` — populated lazily from
     /// `track.userData?.played` and stamped with the server's authoritative
@@ -3028,6 +3076,7 @@ final class AppModel {
                 }
             }.value
             favoriteById[itemId] = state.isFavorite
+            favoriteChangeToken &+= 1
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }
@@ -3071,20 +3120,6 @@ final class AppModel {
     func enqueueDownload(album: Album) {
         // TODO: #70 / #222 — download engine not yet wired.
         print("[AppModel] enqueueDownload(album:) not yet wired — see #70 / #222")
-    }
-
-    /// Present an "Add all to playlist" destination picker.
-    ///
-    /// The album detail screen has its own inline popover that does the
-    /// actual picking; this entry point is kept for menu-bar / context-menu
-    /// callers that don't own a popover anchor. When the new
-    /// `addToPlaylist(...)` helper below lands for every surface, this
-    /// becomes a no-op wrapper.
-    /// TODO: #72, #126 — menu-bar picker sheet for surfaces without their
-    /// own popover anchor.
-    func requestAddToPlaylist(album: Album) {
-        // TODO: #72 / #126 — standalone picker sheet for non-popover callers.
-        print("[AppModel] requestAddToPlaylist(album:) not yet wired — see #72 / #126")
     }
 
     /// Append a batch of tracks to an existing playlist via `add_to_playlist`
@@ -3330,32 +3365,37 @@ final class AppModel {
         Task { await setFavorite(itemId: artist.id, enabled: !isFavorite(id: artist.id)) }
     }
 
-    /// Toggle the follow flag for an artist.
-    /// TODO: #64 / #228 — server-side follow primitive TBD. For now,
-    /// toggle a local `followedArtistIds` set so the UI has something to
-    /// render against; persistence lives alongside the real API work.
+    /// Toggle the follow flag for an artist. Routes through `setFavorite`
+    /// since Jellyfin's `/Users/{id}/FavoriteItems/{id}` endpoint is the
+    /// correct server primitive for "following" an artist — the vocabulary
+    /// differs but the data is the same `IsFavorite` flag on the artist item.
     func toggleFollow(artist: Artist) {
-        if followedArtistIds.contains(artist.id) {
-            followedArtistIds.remove(artist.id)
-        } else {
-            followedArtistIds.insert(artist.id)
-        }
+        Task { await setFavorite(itemId: artist.id, enabled: !isFavorite(id: artist.id)) }
     }
 
-    /// `true` when the user has followed this artist (in-app, today).
-    /// See `toggleFollow(artist:)` for the TODO on server-side follow.
+    /// `true` when the user has favorited/followed this artist.
+    /// Reads from the shared `favoriteById` cache so state is consistent
+    /// with `isFavorite(id:)` calls on the same artist id.
     func isFollowing(artist: Artist) -> Bool {
-        followedArtistIds.contains(artist.id)
+        isFavorite(id: artist.id)
     }
 
-    /// Play a handful of the artist's top tracks as "Play Next".
-    /// TODO: #282 — needs an Up Next queue primitive. Until that lands,
-    /// behaves like `playTopTracks` (start playback from the first top
-    /// track) so the UI action has a landing pad.
+    /// Insert a handful of the artist's top tracks immediately after the
+    /// currently-playing track. Uses the `core.playNext` primitive wired
+    /// in for #282. Falls back silently when there are no top tracks to load.
     func playNextArtist(artist: Artist) {
-        // TODO(#282): queue "Up Next" insertion. Fall through to top-tracks
-        // playback so the menu item does something.
-        playTopTracks(artist: artist)
+        Task {
+            let tracks = await loadArtistTopTracks(artistId: artist.id)
+            guard !tracks.isEmpty else { return }
+            if status.currentTrack == nil {
+                play(tracks: tracks, startIndex: 0)
+                return
+            }
+            _ = try? await Task.detached(priority: .userInitiated) { [core] in
+                core.playNext(tracks: tracks)
+            }.value
+            self.status = core.status()
+        }
     }
 
     /// Navigate to the artist detail screen. Used when the menu is invoked
@@ -3956,13 +3996,6 @@ final class AppModel {
     func addTracksToPlaylist(tracks: [Track], playlist: Playlist) {
         guard !tracks.isEmpty else { return }
         Task { await addToPlaylist(trackIds: tracks.map(\.id), playlistId: playlist.id) }
-    }
-
-    /// Present a "new playlist" flow seeded with the given selection.
-    /// TODO(#126): create_playlist FFI + sheet not yet wired.
-    func requestAddTracksToPlaylist(tracks: [Track]) {
-        // TODO(#126): create_playlist + picker sheet not yet wired.
-        print("[AppModel] requestAddTracksToPlaylist(\(tracks.count) tracks) not yet wired — see #126")
     }
 
     /// Navigate to the album detail screen for this track's album.

--- a/macos/Sources/Jellify/Capabilities.swift
+++ b/macos/Sources/Jellify/Capabilities.swift
@@ -41,8 +41,10 @@ extension AppModel {
     /// context menus.
     var supportsTrackInfo: Bool { true }
 
-    /// Genre actions (#144, #248, #318). Genre radio (#94) is wired;
-    /// browse landing (#318), genre shuffle (#318), and pin-to-home
-    /// (#248/#249) remain stubs but are surfaced so the radio entry is reachable.
-    var supportsGenreActions: Bool { true }
+    /// Genre actions (#144, #248, #318). Disabled until #318 lands — the
+    /// stub actions pass a genre name (e.g. "Jazz") as an item id to
+    /// `core.instantMix(itemId:)` which expects a UUID, producing garbage.
+    /// Flip to `true` once `browseGenre`, `shuffleGenre`, and
+    /// `pinGenreToHome` are wired to real core FFIs.
+    var supportsGenreActions: Bool { false }
 }

--- a/macos/Sources/Jellify/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Jellify/Components/AlbumContextMenu.swift
@@ -43,7 +43,8 @@ struct AlbumContextMenu: View {
             AddToPlaylistSubmenu { playlist in
                 model.addAlbumToPlaylist(album: album, playlist: playlist)
             } onNewPlaylist: {
-                model.requestAddToPlaylist(album: album)
+                // New-playlist picker is v1.x scope (#72/#126). supportsNewPlaylistPicker
+                // gates this button off so this closure is never triggered today.
             }
         }
 
@@ -59,7 +60,11 @@ struct AlbumContextMenu: View {
 
         Divider()
 
-        Button("Favorite Album", systemImage: "heart") { model.toggleFavorite(album: album) }
+        let isFav = model.isFavorite(id: album.id)
+        Button(isFav ? "Unfavorite Album" : "Favorite Album",
+               systemImage: isFav ? "heart.fill" : "heart") {
+            model.toggleFavorite(album: album)
+        }
         if model.supportsMarkPlayed {
             Button("Mark All as Played", systemImage: "checkmark.circle") {
                 model.markAllAsPlayed(album: album)

--- a/macos/Sources/Jellify/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Jellify/Components/ArtistContextMenu.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ///     ─
 ///     Start Artist Radio
 ///     ─
-///     Follow / Unfollow, Go to Artist Page
+///     Favorite / Unfavorite, Go to Artist Page
 ///     ─
 ///     Copy Link
 ///
@@ -44,9 +44,9 @@ struct ArtistContextMenu: View {
         Divider()
 
         Button(
-            model.isFollowing(artist: artist) ? "Unfollow" : "Follow",
-            systemImage: model.isFollowing(artist: artist) ? "person.badge.minus" : "person.badge.plus"
-        ) { model.toggleFollow(artist: artist) }
+            model.isFavorite(id: artist.id) ? "Unfavorite Artist" : "Favorite Artist",
+            systemImage: model.isFavorite(id: artist.id) ? "heart.fill" : "heart"
+        ) { model.toggleFavorite(artist: artist) }
         if showGoToArtist {
             Button("Go to Artist Page", systemImage: "person") {
                 model.goToArtistPage(artist: artist)

--- a/macos/Sources/Jellify/Components/TrackContextMenu.swift
+++ b/macos/Sources/Jellify/Components/TrackContextMenu.swift
@@ -71,7 +71,8 @@ struct TrackContextMenu: View {
             AddToPlaylistSubmenu { playlist in
                 model.addTracksToPlaylist(tracks: selection, playlist: playlist)
             } onNewPlaylist: {
-                model.requestAddTracksToPlaylist(tracks: selection)
+                // New-playlist picker is v1.x scope (#126). supportsNewPlaylistPicker
+                // gates this button off so this closure is never triggered today.
             }
         }
 

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -321,13 +321,12 @@ struct ArtistDetailView: View {
                     ) { model.shuffle(artist: artist) }
                 }
 
-                // Follow — today toggles favorite. The "Follow" vocabulary
-                // is Jellify's; server-side it's `IsFavorite` on the artist
-                // item. See `toggleFollow` in AppModel for the shim.
+                // Favorite — heart flips to filled/outlined based on server state.
+                let isFav = model.isFavorite(id: artist.id)
                 transportSecondary(
-                    icon: "person.badge.plus",
-                    help: "Follow"
-                ) { model.toggleFollow(artist: artist) }
+                    icon: isFav ? "heart.fill" : "heart",
+                    help: isFav ? "Unfavorite" : "Favorite"
+                ) { model.toggleFavorite(artist: artist) }
 
                 transportSecondary(
                     icon: "dot.radiowaves.left.and.right",

--- a/macos/Sources/Jellify/Screens/DiscoverView.swift
+++ b/macos/Sources/Jellify/Screens/DiscoverView.swift
@@ -95,9 +95,7 @@ struct DiscoverView: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    // TODO: #144 / #327 — Regenerate also routes through the
-                    // Instant Mix FFI once it lands. Same stub for now.
-                    model.startInstantMix()
+                    model.regenerateInstantMix()
                 } label: {
                     Text("Generate new mix")
                         .font(Theme.font(13, weight: .semibold))

--- a/macos/Sources/Jellify/Screens/FavoritesView.swift
+++ b/macos/Sources/Jellify/Screens/FavoritesView.swift
@@ -38,7 +38,7 @@ struct FavoritesView: View {
             .padding(.vertical, 28)
         }
         .background(Theme.bg)
-        .task(id: model.session?.user.id) {
+        .task(id: "\(model.session?.user.id ?? "")|\(model.favoriteChangeToken)") {
             await refresh()
         }
     }

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -255,21 +255,17 @@ struct PlaylistView: View {
             .accessibilityLabel("Shuffle playlist")
             .disabled(tracks.isEmpty)
 
-            // Favorite + add-to-playlist are non-interactive placeholders
-            // until their backing FFI lands — see `PlaylistContextMenu` for
-            // the matching TODO stubs in `AppModel`. Hidden from VoiceOver
-            // so assistive tech doesn't announce inert icons as tappable
-            // (#331).
-            Image(systemName: "heart")
-                .font(.system(size: 20))
-                .foregroundStyle(Theme.ink2)
-                .frame(width: 36, height: 36)
-                .accessibilityHidden(true)
-            Image(systemName: "plus")
-                .font(.system(size: 20))
-                .foregroundStyle(Theme.ink2)
-                .frame(width: 36, height: 36)
-                .accessibilityHidden(true)
+            if let playlist = playlist {
+                let isFav = model.isFavorite(id: playlist.id)
+                Button { model.toggleFavorite(playlist: playlist) } label: {
+                    Image(systemName: isFav ? "heart.fill" : "heart")
+                        .font(.system(size: 20))
+                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isFav ? "Unfavorite playlist" : "Favorite playlist")
+            }
             Spacer()
         }
         .padding(.horizontal, 32)


### PR DESCRIPTION
## Why

User-reported audit on rc4 surfaced 24 user-perceivable flaws (see filed issue
or this PR's commit message for the full list). This omnibus closes the
12 of them that touch AppModel + adjacent components.

The headline bug: artist "Follow" was local-only, so the Artists section in
the new FavoritesView was always empty and `setFavorite` was never called for
artists. Fixing that + reactive refresh + dynamic context-menu labels makes
the whole Favorites surface actually work end-to-end.

## What

- #1 Follow → toggleFavorite (server-wired); heart icon + dynamic label
- #2 favoriteChangeToken bumps on every setFavorite; FavoritesView re-fetches
- #3 Seed favoriteById with tracks/artists, not just albums
- #4 AlbumContextMenu now toggles "Favorite Album" ↔ "Unfavorite Album"
- #5 Capabilities.supportsGenreActions = false until #318 lands
- #6 Artist Play Next inserts via core.playNext (no longer clobbers queue)
- #7 Remove from Playlist surfaces a banner when playlistItemId is nil
- #8 Discover "Generate new mix" actually picks a different seed
- #9 requestAddToPlaylist/requestAddTracksToPlaylist deleted (dead code)
- #10 loadArtistAlbums limit bumped 100 → 500
- #11 ⌘K palette includes Go to Favorites
- #12 PlaylistView heart wired to toggleFavorite(playlist:); decorative + icon removed

## Test plan
- Right-click an artist anywhere → Favorite → confirm it appears in Favorites
- Right-click an album → see "Favorite Album" / "Unfavorite Album" matching state
- Open Favorites screen, hit a heart elsewhere, return → new state visible
- Right-click an artist → Play Next → current track keeps playing, artist queues after
- Try removing a track from a playlist that lacks playlistItemId → banner appears
- ⌘K → search "favorites" → action visible