### PR TITLE
fix(macos): heart in Now Playing + matchingAlbum fallback (#6, #13)

### DIFF
--- a/macos/Sources/Jellify/Screens/NowPlayingView.swift
+++ b/macos/Sources/Jellify/Screens/NowPlayingView.swift
@@ -27,6 +27,7 @@ struct NowPlayingView: View {
     /// the tab the user was last on — a prior-tab memory would surprise
     /// people returning to Now Playing days later.
     @State private var tab: Tab = .queue
+    @State private var resolvedAlbum: Album?
 
     enum Tab: String, CaseIterable, Identifiable {
         case queue = "Queue"
@@ -126,6 +127,19 @@ struct NowPlayingView: View {
                     .disabled(track.albumId == nil)
                     .accessibilityHint(track.albumId == nil ? "" : "Open album page")
                 }
+
+                let isFav = model.isFavorite(id: track.id)
+                Button {
+                    model.toggleFavorite(track: track)
+                } label: {
+                    Image(systemName: isFav ? "heart.fill" : "heart")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                .help(isFav ? "Unfavorite" : "Favorite")
+                .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
             }
             Spacer(minLength: 0)
         }
@@ -281,7 +295,7 @@ struct NowPlayingView: View {
                     )
                 }
 
-                if let album = matchingAlbum(for: track) {
+                if let album = resolvedAlbum {
                     if album.trackCount > 0 {
                         aboutSection(
                             label: "Tracks",
@@ -300,6 +314,13 @@ struct NowPlayingView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 8)
         }
+        .task(id: track.albumId) {
+            guard let albumId = track.albumId else {
+                resolvedAlbum = nil
+                return
+            }
+            resolvedAlbum = await model.resolveAlbum(id: albumId)
+        }
     }
 
     @ViewBuilder
@@ -316,16 +337,6 @@ struct NowPlayingView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")
-    }
-
-    /// Look up the album record for this track in the cached library,
-    /// if any. Returns `nil` when the track's album isn't in the
-    /// currently-loaded page (e.g. a track started from a search
-    /// hint). The About panel gracefully omits album-derived rows in
-    /// that case.
-    private func matchingAlbum(for track: Track) -> Album? {
-        guard let albumId = track.albumId else { return nil }
-        return model.albums.first { $0.id == albumId }
     }
 
     private func formatRuntime(_ seconds: Double) -> String {


### PR DESCRIPTION
## Summary

- **#6 — No way to favorite from full-screen player**: The NowPlayingView hero pane showed artist nav, album nav, and a close button but no heart button. Users had to navigate back to a track list to favorite the current track. A heart button is now rendered immediately below the metadata block, using `model.isFavorite(id:)` for state and `model.toggleFavorite(track:)` on tap. It fills in accent color when favorited and carries `.help`/`.accessibilityLabel` tooltips matching the rest of the app.

- **#13 — About tab missing Tracks/Genres for albums beyond first library page**: `matchingAlbum(for:)` was a synchronous paged-cache lookup (`model.albums.first { $0.id == albumId }`). Any album not in the currently loaded page silently returned nil, hiding the "Tracks" and "Genres" rows in the About panel — a pattern flagged in the April 2026 audit as "paged-cache-only resolution" (audit finding #3). Replaced with `@State private var resolvedAlbum: Album?` populated by a `.task(id: track.albumId)` block that calls `model.resolveAlbum(id:)`. That method already implements the cache-first + FFI fallback pattern (`albums.first { $0.id == id }` → `core.fetchItem`), so the About panel now shows complete metadata for all tracks regardless of library scroll position.

## Changes

- `macos/Sources/Jellify/Screens/NowPlayingView.swift` only — no AppModel, JellifyApp, AudioEngine, or Rust changes.

## Test plan

- [ ] Play a track and open Now Playing (⌘L). Confirm heart button appears below the album name in the hero pane.
- [ ] Tap heart — icon fills in accent color. Tap again — reverts to outline.
- [ ] Verify the favorite state persists after closing and reopening Now Playing.
- [ ] Start a track from a search result (album likely not in paged library). Open About tab — confirm Tracks and Genres rows appear.
- [ ] Start a track from a deep library page (scroll past page 1). Open About tab — confirm same rows appear.
- [ ] Switch tracks rapidly — confirm resolvedAlbum updates cleanly without stale data.