### PR TITLE
fix(macos): cap loadArtistAlbums to 200 + breadcrumb logging for SIGABRT crash

### DIFF
--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -2185,17 +2185,30 @@ final class AppModel {
     /// stable for the duration of the user's browsing session and the
     /// detail screen may be entered / left repeatedly.
     @discardableResult
-    func loadArtistAlbums(artistId: String, limit: UInt32 = 500) async -> [Album] {
-        // Soft cap. Prolific catalogues > 500 will still truncate; pagination tracked as v1.x follow-up.
+    func loadArtistAlbums(artistId: String, limit: UInt32 = 200) async -> [Album] {
+        // Soft cap of 200. Was 500 in rc7, but a "Various Artists" entry
+        // returning the full 500 expands to a 4×125 fan-out across the
+        // discography groups (Albums / Singles / Compilations / Live), each
+        // rendered through a `LazyHStack`. On macOS 26.4 + M5 we observed
+        // SwiftUI's HVStack layout cache OOM during `_ContiguousArrayBuffer`
+        // allocation — the lazy stacks bound rendered tiles, but the parent
+        // VStack's subview enumeration scales with the total. 200 is plenty
+        // for any single artist; pagination for the long-tail compilations
+        // case is a v1.x follow-up.
         if let cached = artistAlbumsCache[artistId] { return cached }
+        let start = Date()
+        Log.app.info("loadArtistAlbums start artist=\(artistId, privacy: .public) limit=\(limit, privacy: .public)")
         do {
             let page = try await Task.detached(priority: .userInitiated) { [core] in
                 try core.albumsByArtist(artistId: artistId, offset: 0, limit: limit)
             }.value
+            let elapsed = Date().timeIntervalSince(start) * 1000
+            Log.app.info("loadArtistAlbums ok artist=\(artistId, privacy: .public) count=\(page.items.count, privacy: .public) ms=\(Int(elapsed), privacy: .public)")
             artistAlbumsCache[artistId] = page.items
             serverReachability.noteSuccess()
             return page.items
         } catch {
+            Log.app.error("loadArtistAlbums failed artist=\(artistId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             if handleAuthError(error) { return [] }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()
@@ -2239,16 +2252,24 @@ final class AppModel {
     /// `loadArtistTopTracks` — detached FFI call, silent fallback. See #146.
     @discardableResult
     func loadSimilarArtists(artistId: String, limit: UInt32 = 12) async -> [Artist] {
-        if let cached = artistSimilarCache[artistId] { return cached }
+        if let cached = artistSimilarCache[artistId] {
+            Log.app.debug("loadSimilarArtists cache hit artist=\(artistId, privacy: .public) count=\(cached.count, privacy: .public)")
+            return cached
+        }
+        let start = Date()
+        Log.app.info("loadSimilarArtists start artist=\(artistId, privacy: .public)")
         do {
             let similar = try await Task.detached(priority: .userInitiated) { [core] in
                 try core.similarArtists(artistId: artistId, limit: limit)
             }.value
+            let elapsed = Date().timeIntervalSince(start) * 1000
+            Log.app.info("loadSimilarArtists ok artist=\(artistId, privacy: .public) count=\(similar.count, privacy: .public) ms=\(Int(elapsed), privacy: .public)")
             artistSimilarCache[artistId] = similar
             serverReachability.noteSuccess()
             return similar
         } catch {
             // Silent fallback — don't surface errors for a secondary widget.
+            Log.app.notice("loadSimilarArtists failed artist=\(artistId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             if handleAuthError(error) { return [] }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()

--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 @preconcurrency import JellifyCore
 
@@ -64,6 +65,7 @@ struct ArtistDetailView: View {
         }
         .background(Theme.bg)
         .task(id: artistID) {
+            Log.app.info("ArtistDetailView.task fire artist=\(artistID, privacy: .public)")
             isLoadingTopTracks = true
             if model.artists.first(where: { $0.id == artistID }) == nil {
                 fetchedArtist = await model.resolveArtist(id: artistID)
@@ -76,6 +78,7 @@ struct ArtistDetailView: View {
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
             isLoadingTopTracks = false
             similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
+            Log.app.info("ArtistDetailView.task done artist=\(artistID, privacy: .public) albums=\(artistAlbums.count, privacy: .public) topTracks=\(topTracks.count, privacy: .public) similar=\(similarArtistsState.count, privacy: .public)")
         }
     }
 


### PR DESCRIPTION
## Summary

User reported a crash in rc7 (macOS 26.4 + M5):

```
EXC_CRASH (SIGABRT)
Thread 0 (main):
  swift_abortAllocationFailure ← swift_slowAllocTyped
   ← _ContiguousArrayBuffer.init(_uninitializedCount:minimumCapacity:)
   ← HVStack.updateCache(_:subviews:)
Thread 12: tokio worker awaiting `JellifyCore.similarArtists(...)`
```

ArtistDetailView's `.task` was in flight (`similarArtists` pending) when SwiftUI's layout engine OOM'd allocating the subview cache. The album_tracks fix from rc7 was verified working in the user's log (97ms / 54ms loads) — this is a separate regression that surfaced on macOS 26.4 + M5.

## Likely cause

rc7 included a `loadArtistAlbums(limit: 500)` bump (#767). For prolific catalogues (e.g. "Various Artists" entries on a 20k-album library), that returns up to 500 albums fanned across four DiscographyGroup `LazyHStack`s. `LazyHStack` bounds *rendered tiles*, but the parent `VStack`'s subview enumeration during `updateCache` walks the whole tree, allocating an array per HVStack. macOS 26.4 + M5 SwiftUI 7.4.27 appears to OOM when that array gets large.

## Changes

1. **`loadArtistAlbums(limit:)`** default 500 → **200**. Still plenty for any single artist; long-tail compilations pagination is a v1.x follow-up.

2. **Breadcrumb logging** at the `.task` entry/exit of `ArtistDetailView` and inside `loadArtistAlbums` / `loadSimilarArtists`. Pairs with rc7's "Open in Console.app" button — the user can stream `subsystem == "org.jellify.desktop"` while reproducing, and the entries immediately preceding any future SIGABRT identify the offending screen.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `swift build --package-path macos`
- [ ] User test rc8: confirm no crash, check Console.app shows the new `ArtistDetailView.task fire/done` + `loadArtistAlbums ok` breadcrumbs