### PR TITLE
fix(macos): drop LazyHStack from ArtistDetailView (rc8 SIGSEGV in HVStack.updateCache)

### DIFF
--- a/macos/Sources/Jellify/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/ArtistDetailView.swift
@@ -386,8 +386,16 @@ struct ArtistDetailView: View {
                         message: "No play history yet for this artist."
                     )
                 } else {
-                    ForEach(Array(topTracks.enumerated()), id: \.element.id) { idx, track in
-                        TopTrackRow(track: track, rank: idx + 1, queue: topTracks)
+                    // rc9: drop the `Array(topTracks.enumerated())` wrapper.
+                    // The wrapped sequence allocates fresh `(Int, Track)`
+                    // tuples each render and `id: \.element.id` was the only
+                    // identity hint SwiftUI had; the indirection appears to
+                    // confuse macOS 26.4's layout-cache invalidation. Direct
+                    // `ForEach(topTracks, id: \.id)` gives SwiftUI a stable
+                    // identity rooted in the persistent `Track.id` value.
+                    ForEach(topTracks, id: \.id) { track in
+                        let rank = (topTracks.firstIndex(where: { $0.id == track.id }) ?? 0) + 1
+                        TopTrackRow(track: track, rank: rank, queue: topTracks)
                     }
                 }
             }
@@ -439,7 +447,17 @@ struct ArtistDetailView: View {
                 .font(Theme.font(18, weight: .bold))
                 .foregroundStyle(Theme.ink)
             ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(alignment: .top, spacing: 16) {
+                // rc9: regular `HStack` instead of `LazyHStack`. macOS 26.4 +
+                // Apple Silicon SwiftUI 7.4.27 has a use-after-free in
+                // `_ArrayBuffer._consumeAndCreateNew` when a `LazyHStack`
+                // inside a `ScrollView(.horizontal)` reuses children across
+                // navigation — confirmed by two consecutive crashes
+                // (rc7 OOM + rc8 SIGSEGV) both inside `HVStack.updateCache`
+                // during ArtistDetailView render. Each discography group
+                // here holds at most ~50 tiles (loadArtistAlbums limit / 4
+                // groups), so the eager `HStack` is plenty cheap and avoids
+                // the lazy-recycle buffer churn that triggers the UAF.
+                HStack(alignment: .top, spacing: 16) {
                     ForEach(group.albums, id: \.id) { album in
                         ArtistDiscographyTile(album: album)
                     }
@@ -542,7 +560,11 @@ struct ArtistDetailView: View {
             VStack(alignment: .leading, spacing: 12) {
                 sectionHeader(eyebrow: "YOU MIGHT ALSO LIKE", title: "Similar Artists")
                 ScrollView(.horizontal, showsIndicators: false) {
-                    LazyHStack(alignment: .top, spacing: 18) {
+                    // rc9: regular `HStack` instead of `LazyHStack`. See the
+                    // matching note in `discographyGroup` — same UAF surface,
+                    // same fix. `loadSimilarArtists(limit: 12)` caps the row
+                    // at twelve tiles, so eager rendering is essentially free.
+                    HStack(alignment: .top, spacing: 18) {
                         ForEach(similar, id: \.id) { similarArtist in
                             SimilarArtistTile(artist: similarArtist)
                         }


### PR DESCRIPTION
## Summary

User reproduced the rc7 OOM crash on rc8 — same surface, different terminal symptom:

| Build | Stack | Symptom |
|-------|-------|---------|
| rc7 | `swift_abortAllocationFailure` | OOM allocating subview cache |
| rc8 | `_swift_release_dealloc` at `0xee59accab01535e0` (not in any region) | SIGSEGV releasing freed reference |

Both inside `HVStack.updateCache(_:subviews:)` → `_ArrayBuffer._consumeAndCreateNew(bufferIsUnique:minimumCapacity:growForAppend:)` while ArtistDetailView is rendering and `similarArtists` is in flight.

User log immediately preceding the crash:
```
ArtistDetailView.task fire artist=3e72…
loadSimilarArtists start artist=3e72…
[crash within ~80ms]
```

So the rc8 cap (500→200) didn't help because the count wasn't the trigger. The real bug is `LazyHStack` inside `ScrollView(.horizontal)` with `ForEach(_, id: \.id)` recycling children across navigation. On macOS 26.4 + Apple Silicon the lazy recycle path releases the wrong reference, which manifests as either OOM (corrupted buffer metadata makes the next alloc bogus) or SIGSEGV (refcount transfer walks freed memory).

## Changes (ArtistDetailView only)

1. **`discographyGroup`** — `LazyHStack` → `HStack`. Each group holds at most ~50 tiles (200-album cap / 4 categories), so eager rendering is essentially free.
2. **`similarArtistsSection`** — same swap. `loadSimilarArtists(limit: 12)` caps the row at twelve tiles.
3. **`topSongsSection`** — drop `ForEach(Array(topTracks.enumerated()), id: \.element.id)`. The wrapper allocates fresh `(Int, Track)` tuples each render and `\.element.id` is the only identity hint; on macOS 26.4 SwiftUI's layout-cache invalidation appears to lose track. Direct `ForEach(topTracks, id: \.id)` roots identity in the persistent `Track.id`, with rank computed in the closure.

Falsifiable: if the user opens the same artist (3e72…) on rc9 and the crash reproduces, the LazyHStack hypothesis is wrong and the issue is elsewhere in the view tree.

## Test plan

- [x] `swift build --package-path macos`
- [ ] User test rc9: open artist 3e72…, confirm no crash, attach Console.app log if it recurs