### PR TITLE
fix(macos): playlist mutations surface errors + reroute print stubs to Log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,11 @@ for when PRs land:
 
 1. **`try?` + `print` stubs rot silently.** Any function whose body is
    `print("[AppModel] X not yet wired — see #Y")` should be treated as
-   a live bug, not a TODO. Grep pattern: `print.*not yet wired` +
-   `TODO\(core-#`. Several of these had shipped for weeks before being
-   rewired.
+   a live bug, not a TODO. As of rc12 the `print(...)` form has been
+   replaced with `Log.app.notice(...)` so the messages now surface in
+   Console.app under `subsystem == "org.jellify.desktop"` instead of
+   vanishing into Xcode's debug console — grep pattern updated:
+   `Log.app.notice.*not yet wired`.
 
 2. **Sync FFI on the MainActor.** Every `try core.X(...)` on a
    `@MainActor`-attributed function takes the Rust `Inner` mutex on the
@@ -183,8 +185,12 @@ for when PRs land:
    - Memoize idempotent ones (e.g. `imageURL`).
    - Wrap the call in `Task.detached` and marshal the result back to
      main.
-   - Move polling loops off main (the 500ms `core.status()` poll
-     remains on main in the polling timer — pending fix).
+   - Polling: as of rc11 the `core.status()` poll runs at 1Hz and skips
+     entirely when `status.state != .playing`; the AVPlayer
+     `periodicTimeObserver` matches at 1Hz and skips `core.markPosition`
+     when `player.rate == 0`. Together they cut idle wakes from
+     ~14,400/h to zero. Don't reintroduce a faster cadence without
+     measuring Activity Monitor's "Energy Impact" column.
 
 3. **Paged-cache-only resolution.** Any screen that resolves its subject
    via `model.<things>.first { $0.id == targetId }` breaks for libraries
@@ -197,16 +203,46 @@ for when PRs land:
    do/catch blocks so one flaky endpoint doesn't sink a whole page.
 
 5. **Optimistic UI without server echo.** Any mutation that updates
-   local state + prints "TODO not yet wired" — grep for them before
-   treating as done. Server state drifts silently.
+   local state + a swallowed `try?` on the corresponding FFI is a
+   silent-corruption bug. As of rc12 the playlist mutations
+   (`removeFromPlaylist`, `undoRemoveFromPlaylist`, `addToPlaylist`)
+   surface errors via `errorMessage` and roll back local state on
+   failure — pattern to match for any future mutation. Search for
+   `Task.detached.*core\.` and check each for proper do/catch +
+   rollback.
 
 ## Deferred / known-open work
 
-- `/Sessions/Playing*` reporting (report_playback_started / progress /
-  stopped) FFIs exist, zero Swift callers. No PlayCount, no Now Playing
-  on other clients, no resume points.
 - Queue `playNext` / `addToQueue` semantics: fall through to `play()`
   and clobber queue. Needs core `insert_next` / `append_to_queue`
   primitives (#282).
 - PRs still open needing rebase: #555 (typed enums + ItemsQuery), #560
   (i18n String Catalog), #639 (heartbeat scheduler).
+- Print-stub features (`Log.app.notice` after rc12) gated behind
+  `Capabilities.swift` flags: downloads (#70/#222), edit album (#96),
+  export playlist (#98/#125), genre actions (#144/#248/#318),
+  new-playlist picker (#72/#126). All flagged false by default; flip
+  one only when the corresponding FFI lands.
+
+## Resolved (don't re-file)
+
+- ✅ `/Sessions/Playing*` reporting — wired in JellifyAudio/AudioEngine
+  (`reportPlaybackStarted/Progress/Stopped`). PlayCount, Now Playing on
+  other clients, and resume points all flow through it. Earlier CLAUDE.md
+  versions claimed this was unwired; that was stale.
+- ✅ 500ms polling on MainActor (rc11). See gap pattern #2 for the
+  current cadence + skip-when-paused contract.
+- ✅ Album-tracks `Recursive=true` (rc7). Removed because Jellyfin's
+  flat-tree walk on a 100k+-track library was 3.6s/request; the flag
+  bought nothing for music albums (multi-disc lives on
+  `ParentIndexNumber`, not nested folders).
+- ✅ ArtistDetailView `LazyHStack` UAF on macOS 26.4 + Apple Silicon
+  (rc9). Replaced with eager `HStack` for discography + similar artists
+  shelves.
+- ✅ Favorite cache snapshot fallback (rc6). `model.isFavorite(track:)`
+  / `(album:)` / `(artist:)` walk cache → `userData?.isFavorite` →
+  legacy mirror, so tap-to-favorite on a server-favorited item correctly
+  un-favorites instead of redundantly favoriting.
+- ✅ Playlist mutations (`removeFromPlaylist`, `undoRemoveFromPlaylist`,
+  `addToPlaylist`) now surface errors + roll back optimistic state on
+  server failure (rc12).

--- a/macos/Sources/Jellify/AppModel.swift
+++ b/macos/Sources/Jellify/AppModel.swift
@@ -666,7 +666,7 @@ final class AppModel {
                 run: { [weak self] in
                     guard self?.status.currentTrack != nil else { return }
                     // TODO(#70): wire to the download engine once it lands.
-                    print("[AppModel] Download Current — not yet wired (see #70)")
+                    Log.app.notice("Download Current — not yet wired (see #70)")
                 }
             ))
         }
@@ -784,7 +784,7 @@ final class AppModel {
             // No banner — the user sees the login form, which is already the
             // recovery path, and the library refetch after a manual sign-in
             // will noisily surface any persistent server problem.
-            print("[AppModel] attemptRestoreSession failed: \(error.localizedDescription)")
+            Log.auth.error("attemptRestoreSession failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -1163,7 +1163,7 @@ final class AppModel {
                 try core.playlistLibraryId()
             }.value
         } catch {
-            print("[AppModel] ensurePlaylistLibraryId: core.playlistLibraryId() failed (\(error.localizedDescription)); falling back to empty ParentId.")
+            Log.net.error("ensurePlaylistLibraryId: core.playlistLibraryId() failed (\(error.localizedDescription, privacy: .public)); falling back to empty ParentId.")
             resolved = ""
         }
         playlistLibraryId = resolved
@@ -1200,7 +1200,7 @@ final class AppModel {
             // both fail in the same refresh. The Playlists tab empty state
             // already explains "nothing to see here" when `playlists` is
             // empty.
-            print("[AppModel] refreshPlaylists failed: \(error.localizedDescription)")
+            Log.net.error("refreshPlaylists failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -1494,7 +1494,7 @@ final class AppModel {
             }
             return Self.parseAlbumsFromItems(data: data)
         } catch {
-            print("[AppModel] fetchAlbumsViaItemsQuery failed: \(error.localizedDescription)")
+            Log.net.error("fetchAlbumsViaItemsQuery failed: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -1526,7 +1526,7 @@ final class AppModel {
             }
             return Self.parseAlbumsWithPlayCounts(data: data)
         } catch {
-            print("[AppModel] fetchAlbumsWithPlayCounts failed: \(error.localizedDescription)")
+            Log.net.error("fetchAlbumsWithPlayCounts failed: \(error.localizedDescription, privacy: .public)")
             return ([], [:])
         }
     }
@@ -1567,7 +1567,7 @@ final class AppModel {
             // `{Items, TotalRecordCount}` wrapper — parse accordingly.
             return Self.parseLatestAlbumsWithDates(data: data)
         } catch {
-            print("[AppModel] fetchLatestAlbumsWithDates failed: \(error.localizedDescription)")
+            Log.net.error("fetchLatestAlbumsWithDates failed: \(error.localizedDescription, privacy: .public)")
             return ([], [:])
         }
     }
@@ -1593,7 +1593,7 @@ final class AppModel {
             }
             return Self.parseTracksFromItems(data: data)
         } catch {
-            print("[AppModel] fetchFavoriteTracks failed: \(error.localizedDescription)")
+            Log.net.error("fetchFavoriteTracks failed: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -1630,7 +1630,7 @@ final class AppModel {
             for track in tracks { favoriteById[track.id] = true }
             return tracks
         } catch {
-            print("[AppModel] loadFavoriteTracks failed: \(error.localizedDescription)")
+            Log.tracks.error("loadFavoriteTracks failed: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -1674,7 +1674,7 @@ final class AppModel {
             for artist in artists { favoriteById[artist.id] = true }
             return artists
         } catch {
-            print("[AppModel] loadFavoriteArtists failed: \(error.localizedDescription)")
+            Log.app.error("loadFavoriteArtists failed: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -2395,11 +2395,47 @@ final class AppModel {
                 imageTag: p.imageTag
             )
         }
-        Task.detached(priority: .userInitiated) { [core] in
-            try? core.removeFromPlaylist(
-                playlistId: playlistId,
-                entryIds: playlistItemIds
-            )
+        // Capture the optimistic state so we can roll back on server failure.
+        // Without this rollback the local list and server diverge silently —
+        // user sees the row vanish, refreshes the playlist, row reappears,
+        // and the action looks like a phantom event. Same bug class as the
+        // rc4-rc5 favorite-not-pushed report.
+        let removedSnapshot = removed
+        let playlistRef = playlistId
+        Task { [weak self] in
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.removeFromPlaylist(
+                        playlistId: playlistRef,
+                        entryIds: playlistItemIds
+                    )
+                }.value
+                self?.serverReachability.noteSuccess()
+            } catch {
+                guard let self else { return }
+                if self.handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    self.serverReachability.noteFailure()
+                }
+                // Rollback: restore the rows + the trackCount we just decremented.
+                self.currentPlaylistTracks.append(contentsOf: removedSnapshot)
+                self.playlistTracks[playlistRef] = self.currentPlaylistTracks
+                if let idx = self.playlists.firstIndex(where: { $0.id == playlistRef }) {
+                    let p = self.playlists[idx]
+                    self.playlists[idx] = Playlist(
+                        id: p.id,
+                        name: p.name,
+                        trackCount: p.trackCount + UInt32(removedSnapshot.count),
+                        runtimeTicks: p.runtimeTicks,
+                        imageTag: p.imageTag
+                    )
+                }
+                self.pendingPlaylistRemoval = nil
+                self.errorMessage = JellifyErrorPresenter.message(
+                    for: error,
+                    context: .playlistTracks
+                )
+            }
         }
     }
 
@@ -2428,8 +2464,44 @@ final class AppModel {
                 imageTag: p.imageTag
             )
         }
-        Task.detached(priority: .userInitiated) { [core] in
-            try? core.addToPlaylist(playlistId: playlistId, itemIds: ids, position: nil)
+        // Capture the count of optimistically-reinserted tracks so we can
+        // roll back on server failure. Without this the playlist's count is
+        // inflated locally vs. server.
+        let reinsertedCount = reinserted.count
+        let playlistRef = playlistId
+        let reinsertedIds = Set(reinserted.map(\.id))
+        Task { [weak self] in
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.addToPlaylist(playlistId: playlistRef, itemIds: ids, position: nil)
+                }.value
+                self?.serverReachability.noteSuccess()
+            } catch {
+                guard let self else { return }
+                if self.handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    self.serverReachability.noteFailure()
+                }
+                // Roll back the optimistic re-insert: drop the rows we
+                // just added and decrement the playlist count.
+                self.currentPlaylistTracks.removeAll { reinsertedIds.contains($0.id) }
+                self.playlistTracks[playlistRef] = self.currentPlaylistTracks
+                if let idx = self.playlists.firstIndex(where: { $0.id == playlistRef }) {
+                    let p = self.playlists[idx]
+                    let newCount = max(0, Int(p.trackCount) - reinsertedCount)
+                    self.playlists[idx] = Playlist(
+                        id: p.id,
+                        name: p.name,
+                        trackCount: UInt32(newCount),
+                        runtimeTicks: p.runtimeTicks,
+                        imageTag: p.imageTag
+                    )
+                }
+                self.errorMessage = JellifyErrorPresenter.message(
+                    for: error,
+                    context: .playlistTracks
+                )
+            }
         }
     }
 
@@ -2440,10 +2512,7 @@ final class AppModel {
     func addToPlaylist(playlistId: String, trackIds: [String]) {
         guard !trackIds.isEmpty else { return }
         let ids = trackIds
-        Task.detached(priority: .userInitiated) { [core] in
-            try? core.addToPlaylist(playlistId: playlistId, itemIds: ids, position: nil)
-        }
-        // Optimistically refresh the currently-loaded list so the drop
+        // Optimistically bump the count BEFORE the FFI call so the drop
         // visually lands without waiting for the round-trip. We don't know
         // the full `Track` records for ids that aren't already resident, so
         // we only bump the count on the in-memory `Playlist` and leave the
@@ -2458,6 +2527,39 @@ final class AppModel {
                 runtimeTicks: p.runtimeTicks,
                 imageTag: p.imageTag
             )
+        }
+        let bumpedCount = trackIds.count
+        let playlistRef = playlistId
+        Task { [weak self] in
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.addToPlaylist(playlistId: playlistRef, itemIds: ids, position: nil)
+                }.value
+                self?.serverReachability.noteSuccess()
+            } catch {
+                guard let self else { return }
+                if self.handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    self.serverReachability.noteFailure()
+                }
+                // Roll back the optimistic count bump so the in-memory
+                // Playlist record stays in sync with the server.
+                if let idx = self.playlists.firstIndex(where: { $0.id == playlistRef }) {
+                    let p = self.playlists[idx]
+                    let newCount = max(0, Int(p.trackCount) - bumpedCount)
+                    self.playlists[idx] = Playlist(
+                        id: p.id,
+                        name: p.name,
+                        trackCount: UInt32(newCount),
+                        runtimeTicks: p.runtimeTicks,
+                        imageTag: p.imageTag
+                    )
+                }
+                self.errorMessage = JellifyErrorPresenter.message(
+                    for: error,
+                    context: .playlistTracks
+                )
+            }
         }
     }
 
@@ -3188,7 +3290,7 @@ final class AppModel {
     /// stub so the UI action has a landing pad.
     func enqueueDownload(album: Album) {
         // TODO: #70 / #222 — download engine not yet wired.
-        print("[AppModel] enqueueDownload(album:) not yet wired — see #70 / #222")
+        Log.app.notice("enqueueDownload(album:) not yet wired — see #70 / #222")
     }
 
     /// Append a batch of tracks to an existing playlist via `add_to_playlist`
@@ -3331,7 +3433,7 @@ final class AppModel {
     /// TODO: #96 / #222 — metadata editor sheet not yet implemented.
     func requestEditAlbum(album: Album) {
         // TODO(#96): metadata editor sheet not yet implemented.
-        print("[AppModel] requestEditAlbum(album:) not yet wired — see #96 / #222")
+        Log.app.notice("requestEditAlbum(album:) not yet wired — see #96 / #222")
     }
 
     /// Append every track on the album to a user-picked playlist. Loads
@@ -3604,7 +3706,7 @@ final class AppModel {
     /// stub so the UI action has a landing pad.
     func enqueueDownload(playlist: Playlist) {
         // TODO: #70 / #222 — download engine not yet wired.
-        print("[AppModel] enqueueDownload(playlist:) not yet wired — see #70 / #222")
+        Log.app.notice("enqueueDownload(playlist:) not yet wired — see #70 / #222")
     }
 
     /// Flip the sidebar's inline TextField onto an existing playlist row so
@@ -3723,7 +3825,7 @@ final class AppModel {
     func updatePlaylistDescription(_ playlist: Playlist, newDescription: String) {
         let trimmed = newDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         // TODO: #130 — persist via `core.updatePlaylist` once available.
-        print("[AppModel] updatePlaylistDescription(\(playlist.id)) not yet persisted — see #130")
+        Log.app.notice("updatePlaylistDescription(\(playlist.id, privacy: .public)) not yet persisted — see #130")
         if trimmed.isEmpty {
             playlistDescriptions.removeValue(forKey: playlist.id)
         } else {
@@ -3961,7 +4063,7 @@ final class AppModel {
         }
         // Persist the reorder to the server if the track carries a PlaylistItemId.
         guard let playlistItemId = movedTrack.playlistItemId else {
-            print("[AppModel] moveTrackInPlaylist(\(playlistId)) — track missing PlaylistItemId, local-only")
+            Log.app.notice("moveTrackInPlaylist(\(playlistId, privacy: .public)) — track missing PlaylistItemId, local-only")
             return
         }
         Task {
@@ -4123,7 +4225,7 @@ final class AppModel {
     func toggleDownload(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
         // TODO(#70): download engine not yet wired.
-        print("[AppModel] toggleDownload(tracks: \(tracks.count)) not yet wired — see #70")
+        Log.app.notice("toggleDownload(tracks: \(tracks.count, privacy: .public)) not yet wired — see #70")
     }
 
     /// Toggle the played flag across a multi-select of tracks. Target
@@ -4182,7 +4284,7 @@ final class AppModel {
     /// TODO(#318): genre detail screen not yet implemented.
     func browseGenre(genre: String) {
         // TODO(#318): genre detail screen not yet implemented.
-        print("[AppModel] browseGenre(\(genre)) not yet wired — see #318")
+        Log.app.notice("browseGenre(\(genre, privacy: .public)) not yet wired — see #318")
     }
 
     /// Kick off an Instant Mix seeded by a genre.
@@ -4194,14 +4296,14 @@ final class AppModel {
     /// TODO(#318): genre-scoped track list FFI not yet wired.
     func shuffleGenre(genre: String) {
         // TODO(#318): genre-scoped track list FFI not yet wired.
-        print("[AppModel] shuffleGenre(\(genre)) not yet wired — see #318")
+        Log.app.notice("shuffleGenre(\(genre, privacy: .public)) not yet wired — see #318")
     }
 
     /// Pin a genre tile to the Home screen so the user can one-click-browse.
     /// TODO(#248 / #249): Home personalization (pinned tiles) not yet wired.
     func pinGenreToHome(genre: String) {
         // TODO(#248): pinned tiles not yet wired.
-        print("[AppModel] pinGenreToHome(\(genre)) not yet wired — see #248 / #249")
+        Log.app.notice("pinGenreToHome(\(genre, privacy: .public)) not yet wired — see #248 / #249")
     }
 
     func pause() { audio.pause() }


### PR DESCRIPTION
## Summary

User asked: _\"what other easy fixes are not being addressed that you are aware of like this one, that really should be fixed before 1.0\"_. Three Tier-A items, all small scope, all pre-existing-bug class:

### 1. Playlist mutations were silent on server failure

`removeFromPlaylist`, `undoRemoveFromPlaylist`, and `addToPlaylist` used `try? core.X(...)` inside a detached `Task`. Network glitches / 5xx / auth-expired failures were swallowed; UI claimed success while local state diverged from server. Same bug class as the rc4-rc5 favorite-not-pushed report.

All three now wrap the FFI in `do/catch`, route auth failures through `handleAuthError`, surface `errorMessage` via `JellifyErrorPresenter.message(for:context:)`, and roll the local state back to its pre-mutation snapshot on failure (track rows reappear, playlist `trackCount` restored, `pendingPlaylistRemoval` cleared).

### 2. `print(\"...not yet wired...\")` stubs no longer vanish

19 `print(\"[AppModel] X — not yet wired ...\")` + ad-hoc error prints replaced with `Log.app.notice(...)` / `Log.net.error(...)` / `Log.tracks.error(...)` / `Log.auth.error(...)`. They now surface in Console.app under `subsystem == \"org.jellify.desktop\"` instead of vanishing into Xcode's debug console.

These stubs are hidden behind `Capabilities.swift` flags today, so they only fire if a flag is wrong — but when they do, a user can now attach the breadcrumb to a bug report instead of staring into a black hole.

### 3. Stale CLAUDE.md \"Deferred / known-open work\"

The `/Sessions/Playing*` reporting note has been wrong for several rc cycles. `JellifyAudio/AudioEngine` actually wires `reportPlaybackStarted/Progress/Stopped` — PlayCount and Now Playing on other clients work end-to-end. Moved to a new \"Resolved (don't re-file)\" section so future audit agents don't open dupes, and runtime-gap list updated with rc11 (energy) + rc12 (playlist mutations) patterns.

## Test plan

- [x] `swift build --package-path macos`
- [ ] User test rc12: drag a track into a playlist while server is reachable → success silently. Drag while server is unreachable → red error banner + count rolls back. Repeat for remove + undo-remove.