### PR TITLE
fix(macos/dist): unify icon filename to AppIcon.icns

### DIFF
--- a/macos/Scripts/make-iconset.sh
+++ b/macos/Scripts/make-iconset.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Render the Jellify app icon out of an SVG source, build the standard
-# macOS .iconset directory, and compile it into Resources/Jellify.icns.
+# macOS .iconset directory, and compile it into Resources/AppIcon.icns.
 #
 # The .icns is what Finder, the Dock, Cmd-Tab, and Launchpad display, and
 # what Sparkle shows in the "Install Update" dialog. Signed DMGs carry it
@@ -12,7 +12,9 @@
 #   2. design/project/assets/teal-icon.svg  (current placeholder in-tree)
 #
 # Output:
-#   macos/Resources/Jellify.icns
+#   macos/Resources/AppIcon.icns
+#   (filename matches CFBundleIconFile in Info.plist and the `cp` in
+#   make-bundle.sh, so the produced .app actually picks up the icon.)
 #
 # Dependencies: macOS-native `sips` (renderer) and `iconutil` (compiler).
 # No Homebrew packages required — both ship with Command Line Tools, so
@@ -27,7 +29,7 @@ MACOS="$ROOT/macos"
 RESOURCES="$MACOS/Resources"
 BUILD="$MACOS/build/icon"
 ICONSET="$BUILD/Jellify.iconset"
-OUT="$RESOURCES/Jellify.icns"
+OUT="$RESOURCES/AppIcon.icns"
 
 # Prefer the canonical icon, fall back to the teal placeholder in design/.
 CANDIDATES=(


### PR DESCRIPTION
## Summary

`make-iconset.sh` writes the produced `.icns` to `macos/Resources/Jellify.icns`, but `make-bundle.sh` and `Info.plist` (`CFBundleIconFile`) both look for `AppIcon.icns`. Because the bundle script's icon copy is a soft `if -f` check, the divergence was silent — release DMGs shipped without a custom icon. Picking `AppIcon.icns` as canonical (matches `CFBundleIconFile` and Apple's convention) is a one-line fix that lets the iconset pipeline actually reach the .app.

## Why this picks `AppIcon`

- `Info.plist:46` already declares `<string>AppIcon</string>`
- `make-bundle.sh:136-137` already reads `AppIcon.icns`
- Apple's standard project template uses `AppIcon.icns`

Updating `make-iconset.sh` is the only change needed to unify the three.

## Test plan

- [x] `bash macos/Scripts/make-iconset.sh` produces `macos/Resources/AppIcon.icns` (164K, 10 size variants compiled by iconutil)
- [ ] Release workflow renders icon, bundle picks it up, Finder shows custom icon for the produced .app
- [ ] Sparkle "Install Update" dialog shows the icon for in-flight users on the next rc/release

Closes #659.