### PR TITLE
fix(auth): support passwordless Jellyfin accounts

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -158,7 +158,11 @@ impl JellifyCore {
     ) -> std::result::Result<models::Session, JellifyError> {
         let username = username.trim().to_string();
         let password = password.trim().to_string();
-        if username.is_empty() || password.is_empty() {
+        // Jellyfin allows accounts with no password — the server is the
+        // authority on whether a given (user, password) pair is valid, so
+        // we only short-circuit on missing username. Empty password is
+        // forwarded as `Pw: ""` to /Users/AuthenticateByName.
+        if username.is_empty() {
             return Err(JellifyError::InvalidCredentials);
         }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -5380,10 +5380,12 @@ async fn non_cert_transport_error_stays_network() {
 // #577 — username / password whitespace trimming
 // ============================================================================
 
-/// `login` must reject blank (whitespace-only) usernames and passwords before
-/// any network call is made.
+/// `login` must reject blank (whitespace-only) usernames before any network
+/// call is made. Empty / whitespace-only passwords are *allowed* — Jellyfin
+/// supports passwordless accounts and the server is the authority on whether
+/// the password is valid.
 #[test]
-fn login_rejects_whitespace_only_credentials() {
+fn login_rejects_whitespace_only_username() {
     // Error fires before any HTTP call — no server needed.
     let config = CoreConfig {
         data_dir: String::new(),
@@ -5397,14 +5399,6 @@ fn login_rejects_whitespace_only_credentials() {
     assert!(
         matches!(err, JellifyError::InvalidCredentials),
         "whitespace-only username should return InvalidCredentials, got {err:?}"
-    );
-
-    let err = core
-        .login("http://localhost:1".into(), "user".into(), "\t\n".into())
-        .unwrap_err();
-    assert!(
-        matches!(err, JellifyError::InvalidCredentials),
-        "whitespace-only password should return InvalidCredentials, got {err:?}"
     );
 }
 
@@ -7357,4 +7351,108 @@ async fn tracks_by_artist_without_session_returns_not_authenticated() {
         server.received_requests().await.unwrap().is_empty(),
         "guard must short-circuit before any HTTP call"
     );
+}
+
+// ============================================================================
+// passwordless Jellyfin accounts
+// ============================================================================
+
+/// Jellyfin allows user accounts with no password. The client must forward
+/// an empty `Pw` to `/Users/AuthenticateByName` rather than rejecting it
+/// client-side — the server is the authority on whether a given (user, "")
+/// pair is valid.
+#[tokio::test]
+async fn login_forwards_empty_password_to_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "passwordless-token",
+            "ServerId": "passwordless-server",
+            "ServerName": "Passwordless Test",
+            "User": {
+                "Id": "passwordless-user-id",
+                "Name": "guest",
+                "ServerId": "passwordless-server",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: String::new(),
+            device_name: "Test".into(),
+        })
+        .unwrap();
+        let session = core
+            .login(server_url, "guest".into(), "".into())
+            .expect("login with empty password should succeed");
+        assert_eq!(session.access_token, "passwordless-token");
+    })
+    .await
+    .expect("spawn_blocking panicked");
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Users/AuthenticateByName")
+        .expect("expected an AuthenticateByName POST");
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("auth body must be JSON");
+    assert_eq!(
+        body["Pw"],
+        json!(""),
+        "empty Pw must be forwarded as the empty string"
+    );
+    assert_eq!(body["Username"], json!("guest"));
+}
+
+/// Whitespace-only password is trimmed to empty and forwarded as `Pw: ""`,
+/// matching the passwordless contract — the server decides whether to accept
+/// or reject.
+#[tokio::test]
+async fn login_forwards_whitespace_only_password_as_empty() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "ws-token",
+            "ServerId": "ws-server",
+            "ServerName": "WS Test",
+            "User": {
+                "Id": "ws-user-id",
+                "Name": "guest",
+                "ServerId": "ws-server",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = JellifyCore::new(CoreConfig {
+            data_dir: String::new(),
+            device_name: "Test".into(),
+        })
+        .unwrap();
+        core.login(server_url, "guest".into(), "\t\n  ".into())
+            .expect("login with whitespace-only password should succeed (trimmed to empty)");
+    })
+    .await
+    .expect("spawn_blocking panicked");
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Users/AuthenticateByName")
+        .expect("expected an AuthenticateByName POST");
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("auth body must be JSON");
+    assert_eq!(body["Pw"], json!(""), "whitespace-only Pw must be trimmed to empty");
 }

--- a/macos/Sources/Jellify/Screens/LoginView.swift
+++ b/macos/Sources/Jellify/Screens/LoginView.swift
@@ -364,9 +364,10 @@ struct LoginView: View {
     // MARK: - Derived state
 
     private var canSubmit: Bool {
+        // Empty password is allowed — Jellyfin supports passwordless accounts
+        // and the server is the authority on whether the password is valid.
         !url.trimmingCharacters(in: .whitespaces).isEmpty
             && !username.trimmingCharacters(in: .whitespaces).isEmpty
-            && !password.isEmpty
     }
 
     private var loginErrorMessage: String? {

--- a/macos/Sources/Jellify/Screens/OnboardingView.swift
+++ b/macos/Sources/Jellify/Screens/OnboardingView.swift
@@ -286,9 +286,10 @@ private struct ConnectStep: View {
     }
 
     private var canSubmit: Bool {
+        // Empty password is allowed — Jellyfin supports passwordless accounts
+        // and the server is the authority on whether the password is valid.
         !url.trimmingCharacters(in: .whitespaces).isEmpty
             && !username.trimmingCharacters(in: .whitespaces).isEmpty
-            && !password.isEmpty
     }
 
     /// Generic error banner. Since `AppModel.login` now surfaces errors


### PR DESCRIPTION
## Summary

Jellyfin allows user accounts with no password — the API accepts an empty `Pw` field on `/Users/AuthenticateByName` and lets the user log in if their account permits it. The Jellify client was rejecting empty passwords at three layers before the request even reached the server, so passwordless Jellyfin accounts couldn't sign in at all.

This PR drops all three layers. The server is the authority on whether a given `(user, password)` pair is valid; the client just forwards what the user typed.

## What changed

- **`macos/Sources/Jellify/Screens/LoginView.swift:367-370`** — drop `&& !password.isEmpty` from `canSubmit`, so the Sign In button enables with an empty password.
- **`macos/Sources/Jellify/Screens/OnboardingView.swift:288-292`** — same guard removed from the onboarding flow.
- **`core/src/lib.rs:160-163`** — `JellifyCore::login` no longer short-circuits with `InvalidCredentials` when the trimmed password is empty. The username guard stays (sending `""` as username is meaningless to Jellyfin).
- **`core/src/tests.rs`** — rename `login_rejects_whitespace_only_credentials` → `login_rejects_whitespace_only_username` and drop the password half. Add two new tests:
  - `login_forwards_empty_password_to_server` — captures the wire body and asserts `Pw: ""` is sent.
  - `login_forwards_whitespace_only_password_as_empty` — same for `"\t\n  "`, asserting the trim still happens.

## Why this is safe

- `core/src/client.rs::authenticate_by_name` already takes `&str` and passes whatever value through as `pw: password.to_string()` — no protocol-level changes needed.
- `JellifyCore::login` still trims, so a whitespace-only password becomes `""` rather than going on the wire as literal whitespace. Matches the existing username-trim contract.
- The 401 path is unchanged: if the server rejects the (user, "") pair, the existing `JellifyErrorPresenter` flow surfaces the "wrong username or password" message.
- `resume_session` (lib.rs:222) was scanned and uses a separate username-only invariant; it doesn't re-impose any password check.

## Test plan

- [x] `cargo test --package jellify_core --lib` — `202 passed; 0 failed` locally
- [x] All three new/renamed auth tests pass
- [ ] Manual: build app, enter `https://music.skalthoff.com`, blank password, hit Sign In. Expect either successful login (if a passwordless account exists) or a server-side 401 — *not* a client-side block.