### PR TITLE
fix(ci): pass Cloudflare Access service-token headers to E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,12 @@ env:
   JELLIFY_E2E_URL: https://music.skalthoff.com
   JELLIFY_E2E_USER: test
   JELLIFY_E2E_PASS: test
+  # The test server is fronted by Cloudflare Access, which 403s anonymous
+  # traffic from GitHub Actions runner IPs. The service-token pair below
+  # is scoped to read-only / E2E use; client.rs auto-attaches them to
+  # every outbound request when both are set.
+  CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+  CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
 jobs:
   rust-core:
@@ -36,7 +42,10 @@ jobs:
           key: e2e-rust-core
       - name: Verify test server reachable
         run: |
-          curl -fsS --max-time 20 "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
+          curl -fsS --max-time 20 \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
             || { echo "::error::test server $JELLIFY_E2E_URL unreachable"; exit 1; }
       - name: cargo test --test e2e_live
         run: cargo test --package jellify_core --test e2e_live -- --nocapture --test-threads=1
@@ -78,7 +87,10 @@ jobs:
             spm-macos-15-
       - name: Verify test server reachable
         run: |
-          curl -fsS --max-time 20 "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
+          curl -fsS --max-time 20 \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
             || { echo "::error::test server $JELLIFY_E2E_URL unreachable"; exit 1; }
       - name: Build xcframework
         working-directory: macos

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -51,6 +51,35 @@ const RETRY_AFTER_CAP: Duration = Duration::from_secs(5);
 /// the same as a failure and surface [`JellifyError::AuthExpired`].
 pub type RefreshTokenFn = dyn Fn() -> Result<Option<String>> + Send + Sync;
 
+/// Optional Cloudflare Access service-token headers, sourced from the
+/// `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` env vars.
+///
+/// When both are set, every outbound HTTP request the client makes carries
+/// `CF-Access-Client-Id` and `CF-Access-Client-Secret`, which lets a Jellyfin
+/// instance fronted by Cloudflare Access (or behind a Cloudflare WAF that
+/// blocks unauthenticated traffic) authenticate the request before it even
+/// reaches the origin. Otherwise the header map is empty and the client
+/// behaves exactly as before — no production user gets these headers unless
+/// they explicitly opt in via env.
+///
+/// Used in CI to let the e2e workflow reach `music.skalthoff.com`, which
+/// returns 403 to anonymous traffic from GitHub Actions runner IPs.
+fn cf_access_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    if let (Ok(id), Ok(secret)) = (
+        std::env::var("CF_ACCESS_CLIENT_ID"),
+        std::env::var("CF_ACCESS_CLIENT_SECRET"),
+    ) {
+        if let (Ok(id_h), Ok(secret_h)) =
+            (HeaderValue::from_str(&id), HeaderValue::from_str(&secret))
+        {
+            headers.insert("CF-Access-Client-Id", id_h);
+            headers.insert("CF-Access-Client-Secret", secret_h);
+        }
+    }
+    headers
+}
+
 /// Per-client memoization of the library-resolution lookups behind
 /// [`JellyfinClient::music_library_id`] and
 /// [`JellyfinClient::playlist_library_id`]. Both endpoints are hit once at
@@ -97,6 +126,7 @@ impl JellyfinClient {
         let http = HttpClient::builder()
             .user_agent(format!("{CLIENT_NAME}/{CLIENT_VERSION}"))
             .timeout(std::time::Duration::from_secs(30))
+            .default_headers(cf_access_headers())
             .build()
             .map_err(|e| JellifyError::Network(e.to_string()))?;
         Ok(Self {

--- a/docs/GITHUB-SECRETS.md
+++ b/docs/GITHUB-SECRETS.md
@@ -11,7 +11,21 @@ See `.env.example` for the local-dev counterpart of these values.
 
 Target: [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml). Runs on every push to `main` / nightly cron against the **live `music.skalthoff.com` test instance** using the read-only `test` account.
 
-**No secret needed.** The test server URL and credentials (`test` / `test`) are baked into the workflow env block. The account is read-isolated — favorites and played-flags it writes are scoped to the user and don't pollute production data. If the server is unreachable, the workflow fails fast (<20s) at the healthcheck step.
+The test server URL and `test` / `test` credentials are baked into the workflow env block. The account is read-isolated — favorites and played-flags it writes are scoped to the user and don't pollute production data. If the server is unreachable, the workflow fails fast (<20s) at the healthcheck step.
+
+The server is fronted by Cloudflare Access, which 403s anonymous traffic from GitHub Actions runner IPs. The CI workflow attaches a Cloudflare Access service-token pair on every outbound request:
+
+| Secret | What it is | How to get it |
+|---|---|---|
+| `CF_ACCESS_CLIENT_ID` | Cloudflare Access service-token client ID. | Cloudflare Zero Trust → Access → Service Auth → Service Tokens → "Create Service Token". |
+| `CF_ACCESS_CLIENT_SECRET` | Matching service-token secret. | Same dialog; only shown once on creation, copy immediately. |
+
+```bash
+gh secret set CF_ACCESS_CLIENT_ID
+gh secret set CF_ACCESS_CLIENT_SECRET
+```
+
+`core/src/client.rs::cf_access_headers` auto-attaches the pair to every outbound request when both env vars are set, so no test code changes are needed.
 
 ---
 


### PR DESCRIPTION
## Summary

The new E2E healthcheck against `music.skalthoff.com` was hitting `HTTP 403` because the server is fronted by Cloudflare Access, which blocks anonymous traffic from GitHub Actions runner IPs.

This PR adds Cloudflare Access service-token support to `JellyfinClient` and wires the secrets through the E2E workflow.

## What changed

- **`core/src/client.rs`** — new `cf_access_headers()` helper. Reads `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from env; if both are set, every outbound request from `JellyfinClient` carries `CF-Access-Client-Id` and `CF-Access-Client-Secret`. If either is missing or unparseable as a header value, the headers are silently omitted. Production users without Cloudflare Access see zero behavior change.
- **`.github/workflows/e2e.yml`** — env block sources `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from repo secrets. The two `Verify test server reachable` curl steps send the pair as `-H` headers so the healthcheck passes; `cargo test` inherits the env and the Rust client picks it up automatically.
- **`docs/GITHUB-SECRETS.md`** — documents the two new secrets and how to mint them in Cloudflare Zero Trust.

## Why this is a real feature, not just a test hack

Jellyfin users running their server behind Cloudflare Access (or a similar identity-aware proxy) are a growing cohort. Hard-coding `CF-Access-Client-*` support behind two env vars lets those users opt in without any client UI changes. The default path (no env vars) is unchanged.

## Test plan

- [x] `cargo test --package jellify_core --test e2e_live -- --test-threads=1` with the live URL + CF Access env vars set — `3 passed; 0 failed` in 11.70s
- [x] `cargo test --package jellify_core --lib` — `202 passed; 0 failed`
- [x] `cargo fmt --all -- --check` — clean
- [ ] Post-merge: E2E workflow on `main` goes green (the goal)