### PR TITLE
ci(e2e): drop CF Access plumbing now that the test server is direct-routed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,12 +23,6 @@ env:
   JELLIFY_E2E_URL: https://music.skalthoff.com
   JELLIFY_E2E_USER: test
   JELLIFY_E2E_PASS: test
-  # The test server is fronted by Cloudflare Access, which 403s anonymous
-  # traffic from GitHub Actions runner IPs. The service-token pair below
-  # is scoped to read-only / E2E use; client.rs auto-attaches them to
-  # every outbound request when both are set.
-  CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-  CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
 jobs:
   rust-core:
@@ -42,10 +36,7 @@ jobs:
           key: e2e-rust-core
       - name: Verify test server reachable
         run: |
-          curl -fsS --max-time 20 \
-            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
-            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
+          curl -fsS --max-time 20 "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
             || { echo "::error::test server $JELLIFY_E2E_URL unreachable"; exit 1; }
       - name: cargo test --test e2e_live
         run: cargo test --package jellify_core --test e2e_live -- --nocapture --test-threads=1
@@ -87,10 +78,7 @@ jobs:
             spm-macos-15-
       - name: Verify test server reachable
         run: |
-          curl -fsS --max-time 20 \
-            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
-            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
+          curl -fsS --max-time 20 "$JELLIFY_E2E_URL/System/Info/Public" >/dev/null \
             || { echo "::error::test server $JELLIFY_E2E_URL unreachable"; exit 1; }
       - name: Build xcframework
         working-directory: macos

--- a/docs/GITHUB-SECRETS.md
+++ b/docs/GITHUB-SECRETS.md
@@ -11,21 +11,9 @@ See `.env.example` for the local-dev counterpart of these values.
 
 Target: [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml). Runs on every push to `main` / nightly cron against the **live `music.skalthoff.com` test instance** using the read-only `test` account.
 
-The test server URL and `test` / `test` credentials are baked into the workflow env block. The account is read-isolated — favorites and played-flags it writes are scoped to the user and don't pollute production data. If the server is unreachable, the workflow fails fast (<20s) at the healthcheck step.
+**No secret needed.** The test server URL and `test` / `test` credentials are baked into the workflow env block. The account is read-isolated — favorites and played-flags it writes are scoped to the user and don't pollute production data. If the server is unreachable, the workflow fails fast (<20s) at the healthcheck step.
 
-The server is fronted by Cloudflare Access, which 403s anonymous traffic from GitHub Actions runner IPs. The CI workflow attaches a Cloudflare Access service-token pair on every outbound request:
-
-| Secret | What it is | How to get it |
-|---|---|---|
-| `CF_ACCESS_CLIENT_ID` | Cloudflare Access service-token client ID. | Cloudflare Zero Trust → Access → Service Auth → Service Tokens → "Create Service Token". |
-| `CF_ACCESS_CLIENT_SECRET` | Matching service-token secret. | Same dialog; only shown once on creation, copy immediately. |
-
-```bash
-gh secret set CF_ACCESS_CLIENT_ID
-gh secret set CF_ACCESS_CLIENT_SECRET
-```
-
-`core/src/client.rs::cf_access_headers` auto-attaches the pair to every outbound request when both env vars are set, so no test code changes are needed.
+If you run your own Jellyfin behind Cloudflare Access, `core/src/client.rs::cf_access_headers` will auto-attach `CF-Access-Client-Id` and `CF-Access-Client-Secret` to every outbound request when both env vars are set. The shared CI test server doesn't need this any more (it's no longer proxied through Cloudflare), but the helper stays for users who do.
 
 ---
 


### PR DESCRIPTION
## Summary

`music.skalthoff.com` is no longer proxied through Cloudflare, so the service-token plumbing added in #782 is dead config. This PR removes it from the workflow + docs but keeps the `cf_access_headers()` helper in `core/src/client.rs` — it's still useful for users who run their own Jellyfin behind Cloudflare Access.

## Changes

- **`.github/workflows/e2e.yml`** — drop `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from the env block; restore the bare-curl healthcheck (no `-H` headers).
- **`docs/GITHUB-SECRETS.md`** — revert the E2E section back to "no secret needed", with a one-line note pointing at the helper for self-hosters who do still need it.
- **Repo secrets** — `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` already deleted from the repo via `gh secret delete`.

## Test plan

- [x] Manual probe: `curl https://music.skalthoff.com/System/Info/Public` returns HTTP 200, `server: openresty` (no `cf-ray`, no `server: cloudflare`)
- [ ] Post-merge: E2E workflow passes with the simplified healthcheck