### PR TITLE
fix(smoketest): poll for transport convergence instead of fixed sleeps

### DIFF
--- a/macos/Sources/SmokeTest/main.swift
+++ b/macos/Sources/SmokeTest/main.swift
@@ -109,12 +109,22 @@ struct SmokeTest {
         print("[play] state=.playing reached")
 
         // Position must advance — catches "queue stuck on track 0 / paused
-        // immediately after play" regressions.
+        // immediately after play" regressions. Polled rather than a fixed
+        // sleep because headless macOS runners need more time than a dev's
+        // Mac for AVPlayer to buffer the stream off a remote server (the
+        // origin is across an open internet hop from `macos-15` runners).
+        // Local runs still complete in ~1s; CI now has up to 15s to
+        // converge. The correctness signal is unchanged: if position is
+        // stuck, the FAIL line still fires.
         let posBeforeWait = core.status().positionSeconds
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        let posAfterWait = core.status().positionSeconds
+        let posAfterWait = await waitFor(
+            positionAdvanceFrom: posBeforeWait,
+            on: core,
+            byAtLeast: 0.5,
+            timeout: 15.0
+        )
         guard posAfterWait > posBeforeWait + 0.5 else {
-            fputs("FAIL[11]: position didn't advance: \(posBeforeWait) → \(posAfterWait)\n", stderr)
+            fputs("FAIL[11]: position didn't advance after 15s: \(posBeforeWait) → \(posAfterWait)\n", stderr)
             exit(11)
         }
         print("[play] position advanced \(String(format: "%.2fs", posBeforeWait)) → \(String(format: "%.2fs", posAfterWait))")
@@ -138,11 +148,18 @@ struct SmokeTest {
         guard await waitFor(state: .playing, on: core, timeout: 2.0) else {
             fputs("FAIL[14]: resume didn't transition to .playing within 2s\n", stderr); exit(14)
         }
+        // After resume, AVPlayer is already buffered, so this should be
+        // quick — but the same poll-and-break helper keeps the timeout
+        // headroom for CI. Local converges in <1s.
         let posAtResume = core.status().positionSeconds
-        try? await Task.sleep(nanoseconds: 1_500_000_000)
-        let posAfterResume = core.status().positionSeconds
+        let posAfterResume = await waitFor(
+            positionAdvanceFrom: posAtResume,
+            on: core,
+            byAtLeast: 0.5,
+            timeout: 5.0
+        )
         guard posAfterResume > posAtResume + 0.5 else {
-            fputs("FAIL[15]: resume didn't advance position: \(posAtResume) → \(posAfterResume)\n", stderr)
+            fputs("FAIL[15]: resume didn't advance position after 5s: \(posAtResume) → \(posAfterResume)\n", stderr)
             exit(15)
         }
         print("[resume] position advanced \(String(format: "%.2fs", posAtResume)) → \(String(format: "%.2fs", posAfterResume))")
@@ -152,10 +169,16 @@ struct SmokeTest {
             let beforeId = core.status().currentTrack?.id
             if let next = core.skipNext() {
                 try? engine.play(track: next)
-                try? await Task.sleep(nanoseconds: 1_500_000_000)
-                let afterId = core.status().currentTrack?.id
+                // Poll instead of sleeping — AudioEngine.play() schedules
+                // the AVPlayer item replacement asynchronously, which on a
+                // headless runner can take longer than a fixed 1.5s.
+                let afterId = await waitFor(
+                    currentTrackChangeFrom: beforeId,
+                    on: core,
+                    timeout: 5.0
+                )
                 guard afterId != nil, afterId != beforeId else {
-                    fputs("FAIL[16]: skipNext didn't change currentTrack: \(beforeId ?? "nil") → \(afterId ?? "nil")\n", stderr)
+                    fputs("FAIL[16]: skipNext didn't change currentTrack after 5s: \(beforeId ?? "nil") → \(afterId ?? "nil")\n", stderr)
                     exit(16)
                 }
                 print("[skipNext] track changed \(beforeId ?? "nil") → \(afterId ?? "nil")")
@@ -189,6 +212,50 @@ struct SmokeTest {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
         return false
+    }
+
+    /// Poll `core.status().positionSeconds` at 250ms intervals up to
+    /// `timeout` seconds, short-circuiting as soon as it has moved past
+    /// `start + delta`. Returns the latest sampled position whether the
+    /// threshold was met or the deadline expired — callers compare and
+    /// emit their own FAIL line so the exit code identifies which step.
+    private static func waitFor(
+        positionAdvanceFrom start: Double,
+        on core: JellifyCore,
+        byAtLeast delta: Double,
+        timeout: TimeInterval
+    ) async -> Double {
+        let deadline = Date().addingTimeInterval(timeout)
+        var latest = core.status().positionSeconds
+        while Date() < deadline {
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            latest = core.status().positionSeconds
+            if latest > start + delta {
+                return latest
+            }
+        }
+        return latest
+    }
+
+    /// Poll `core.status().currentTrack?.id` at 250ms intervals up to
+    /// `timeout` seconds, short-circuiting as soon as the id differs from
+    /// `before`. Returns the latest sampled id (which may equal `before`
+    /// on timeout). Callers compare and emit their own FAIL line.
+    private static func waitFor(
+        currentTrackChangeFrom before: String?,
+        on core: JellifyCore,
+        timeout: TimeInterval
+    ) async -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var latest = core.status().currentTrack?.id
+        while Date() < deadline {
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            latest = core.status().currentTrack?.id
+            if latest != before {
+                return latest
+            }
+        }
+        return latest
     }
 }
 


### PR DESCRIPTION
## Summary

Three timing checks in the macos-app E2E SmokeTest were using fixed `Task.sleep()` before sampling. That was fine against the Docker Jellyfin fixture (everything local, sub-millisecond RTT), but with #779 the SmokeTest runs against the live `music.skalthoff.com` server for the first time — and on a headless `macos-15` runner the combined remote-network buffer fill + AVPlayer audio-output bringup pushes past 2s. Result: `rc=11` "position didn't advance: 0.0 → 0.0" despite `state=.playing` being reached.

## Verified this isn't a product regression

Built and ran SmokeTest locally with the exact CI env:
```
JELLYFIN_URL=https://music.skalthoff.com JELLYFIN_USER=test JELLYFIN_PASS=test \
  ./.build/arm64-apple-macosx/debug/SmokeTest
# exit 0 — position advances 0.00 → 1.00s in 2s on a developer's Mac.
```
So the protocol, the queue logic, and the AudioEngine are correct — the issue is the runner's slower convergence.

## What changed

Replace the three brittle fixed sleeps with poll-and-break helpers:

| Step | Before | After |
|---|---|---|
| play position-advance | `sleep(2s)` then check | poll up to 15s, return on first `+0.5s` sample |
| resume position-advance | `sleep(1.5s)` then check | poll up to 5s, same shape |
| skipNext currentTrack-change | `sleep(1.5s)` then check id | poll up to 5s, return on first `id != before` |

**Pause-frozen check stays as a fixed 1s sleep** — that one *must* be timed (we're asserting nothing happens — drift < 0.2s).

The correctness signals are unchanged: every FAIL line still fires on a real regression. We've only relaxed the false-negative timer. Local runs still complete in ~5s; CI now has the headroom it actually needs.

## Test plan

- [x] Reproduce the runner failure locally? **No, local passes** — that's the diagnosis. Local network is too fast to hit the bug.
- [x] Re-run with poll helpers locally — `exit 0` in ~5s, all assertions still hit
- [ ] Post-merge: `macOS app (live Jellyfin)` E2E goes green on the new HEAD