### PR TITLE
fix(macos): localize `sidebar.nav.discover` (#786)

### DIFF
--- a/macos/Sources/Jellify/Resources/Localizable.xcstrings
+++ b/macos/Sources/Jellify/Resources/Localizable.xcstrings
@@ -961,6 +961,18 @@
         }
       }
     },
+    "sidebar.nav.discover" : {
+      "comment" : "Sidebar primary nav item: Discover.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discover"
+          }
+        }
+      }
+    },
     "sidebar.nav.library" : {
       "comment" : "Sidebar primary nav item: Library.",
       "extractionState" : "manual",


### PR DESCRIPTION
The Discover sidebar entry rendered the raw catalog key `sidebar.nav.discover` because the String Catalog had no matching localization — SwiftUI's `LocalizedStringKey` lookup falls back to the literal key when the catalog has no entry for it. The sibling entries (`sidebar.nav.home`, `sidebar.nav.library`, `sidebar.nav.search`) all exist and rendered correctly; this PR adds the missing `sidebar.nav.discover` entry alongside them in `macos/Sources/Jellify/Resources/Localizable.xcstrings`.

Closes #786

pipeline:
  fixer-session: admiring-mestorf-bc010e
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +12/-0