### PR TITLE
fix(ci): unbreak cargo-audit on MSRV 1.86

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,9 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # rustsec/audit-check@v2 unconditionally installs the latest cargo-audit,
+      # and the 0.22.x line bumped transitive MSRVs (home 1.88, smol_str 1.89,
+      # time 1.88) past the workspace's pinned rustc 1.86. Pin to the last
+      # 0.21.x release and install with --locked so transitive resolution
+      # respects the published Cargo.lock instead of pulling fresh majors.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version 0.21.2
+      - name: Run cargo audit
+        run: cargo audit
 
   deny:
     name: cargo-deny (${{ matrix.checks }})


### PR DESCRIPTION
## Symptom

Every Security workflow run (on every PR, including Dependabot) has been failing in the `cargo-audit` job. The failure is not an advisory; it's that `rustsec/audit-check@v2` always installs the latest `cargo-audit`, and `cargo-audit 0.22.x` now pulls dep MSRVs past CI's pinned rustc 1.86:

```
error: failed to compile `cargo-audit v0.22.1`
Caused by:
  rustc 1.86.0 is not supported by the following packages:
    home@0.5.12 requires rustc 1.88
    smol_str@0.3.6 requires rustc 1.89
    time@0.3.47 requires rustc 1.88.0
    time-core@0.1.8 requires rustc 1.88.0
  Try re-running `cargo install` with `--locked`
```

Same shape as #750 — a dep crept across an MSRV boundary and broke the workspace at its pinned toolchain.

## Fix

`rustsec/audit-check@v2` exposes only `token`, `ignore`, and `working-directory` — no version pin. So replace the action with a manual install plus a direct `cargo audit` invocation, pinning to `cargo-audit 0.21.2` (the last 0.21.x release, rust-version 1.81) and installing with `--locked` so transitive resolution respects the published `Cargo.lock` instead of pulling fresh majors.

`cargo audit` exits non-zero on advisories, which matches what `rustsec/audit-check` was doing. We lose the action's GitHub Checks annotations, but the job failure itself still blocks merge.

Scope-locked to `.github/workflows/security.yml`. No touch to `core/`, `macos/`, `Cargo.toml`, `Cargo.lock`, or the repo MSRV. `cargo-deny` already works in the same workflow and is unchanged.

## Follow-up

After this merges, #785's CI will need a re-run (Dependabot rebase or empty force-push) to unstick it.