### PR TITLE
fix(macos): add Remove from Playlist to track context menu (#789)

### DIFF
--- a/macos/Sources/Jellify/Components/TrackRow.swift
+++ b/macos/Sources/Jellify/Components/TrackRow.swift
@@ -29,6 +29,10 @@ struct TrackRow: View {
     /// already have `idx` from a `ForEach(enumerated)` don't have to pay
     /// for a linear scan through `siblings`.
     var siblingIndex: Int = 0
+    /// When non-nil, the row is being rendered inside a playlist detail
+    /// view; forwarded to `TrackContextMenu` so the right-click menu can
+    /// surface a "Remove from Playlist" entry (#789).
+    var playlistScope: Playlist? = nil
 
     @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
     @State private var isHovering = false
@@ -131,7 +135,7 @@ struct TrackRow: View {
         .onHover { isHovering = $0 }
         .onTapGesture(count: 2) { onPlay?() }
         .onTapGesture(count: 1) { onPlay?() }
-        .contextMenu { TrackContextMenu(selection: [track]) }
+        .contextMenu { TrackContextMenu(selection: [track], playlistScope: playlistScope) }
         // VoiceOver reads the row as a single "<title> by <artist>" line
         // with the button trait + hint so the double-tap play action is
         // discoverable without sighted hover affordances. See #331.

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -295,7 +295,8 @@ struct PlaylistView: View {
                     TrackRow(
                         track: track,
                         number: idx + 1,
-                        onPlay: { model.play(tracks: tracks, startIndex: idx) }
+                        onPlay: { model.play(tracks: tracks, startIndex: idx) },
+                        playlistScope: playlist
                     )
                     // BATCH-06b (#73 / #235): drag-to-reorder. The modifier
                     // lives in `PlaylistReorderHandle.swift` and routes drops


### PR DESCRIPTION
The track row's right-click context menu didn't surface a "Remove from Playlist" entry when invoked from inside a playlist. `TrackContextMenu` already conditioned the action on a non-nil `playlistScope` and `AppModel.removeTracksFromPlaylist` is already wired with optimistic update plus rollback on FFI failure — the missing piece was threading the resolved `Playlist` through `TrackRow` at the `PlaylistView` call site so the menu has the context it needs to render the entry.

Closes #789