### PR TITLE
fix(core): populate artist album_count from `Fields=ItemCounts` (#787)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -561,7 +561,11 @@ impl JellyfinClient {
             q.append_pair(
                 "Fields",
                 &enums::csv(
-                    &[ItemField::Genres, ItemField::PrimaryImageAspectRatio],
+                    &[
+                        ItemField::Genres,
+                        ItemField::ItemCounts,
+                        ItemField::PrimaryImageAspectRatio,
+                    ],
                     ItemField::as_str,
                 ),
             );
@@ -2532,6 +2536,10 @@ pub struct RawItem {
     pub runtime_ticks: u64,
     #[serde(rename = "ChildCount")]
     pub child_count: Option<u32>,
+    #[serde(rename = "AlbumCount", default)]
+    pub album_count: Option<u32>,
+    #[serde(rename = "SongCount", default)]
+    pub song_count: Option<u32>,
     #[serde(rename = "Genres", default)]
     pub genres: Vec<String>,
     #[serde(rename = "UserData")]
@@ -2694,8 +2702,8 @@ impl From<RawItem> for Artist {
         Artist {
             id: r.id,
             name: r.name,
-            album_count: 0,
-            song_count: 0,
+            album_count: r.album_count.unwrap_or(0),
+            song_count: r.song_count.unwrap_or(0),
             genres: r.genres,
             image_tag: r.image_tags.get("Primary").cloned(),
             user_data,


### PR DESCRIPTION
The `/Artists/AlbumArtists` query did not request `ItemCounts`, so every artist deserialized to `album_count: 0` / `song_count: 0`. The Library → Artists list rendered "0 albums" on every row regardless of how many albums the artist actually had on the server.

Add `ItemField::ItemCounts` to the `artists()` Fields projection, surface `AlbumCount` / `SongCount` on `RawItem`, and read them through in `From<RawItem> for Artist` instead of hardcoding zero. Mirrors the `/Genres` pattern (`client.rs:1376`) where the same approach already produces correct per-genre counts.

Closes #787

pipeline:
  fixer-session: admiring-mestorf-bc010e
  slice: slice:core
  hotspots-claimed: [clientrs] (#799)
  build-gate: pass
  diff-stat: 1 file, +11/-3