### PR TITLE
fix(macos): sidebar badges show server total, not loaded count (#788)

### DIFF
--- a/macos/Sources/Jellify/Components/Sidebar.swift
+++ b/macos/Sources/Jellify/Components/Sidebar.swift
@@ -64,8 +64,8 @@ struct Sidebar: View {
             sectionHeader("sidebar.section.your_library")
             VStack(alignment: .leading, spacing: 2) {
                 favoritesRow
-                libRow("square.stack", label: "sidebar.stats.albums", count: UInt32(model.albums.count), tab: .albums)
-                libRow("person.crop.circle", label: "sidebar.stats.artists", count: UInt32(model.artists.count), tab: .artists)
+                libRow("square.stack", label: "sidebar.stats.albums", count: model.albumsTotal, tab: .albums)
+                libRow("person.crop.circle", label: "sidebar.stats.artists", count: model.artistsTotal, tab: .artists)
                 libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count), tab: .playlists)
             }
             .padding(.horizontal, 10)


### PR DESCRIPTION
The left-sidebar badges next to "Albums" and "Artists" were rendering `model.albums.count` / `model.artists.count`, i.e. the size of the in-memory paginated cache. That number starts at 100 and only grows as the user scrolls deeper into Library, so it never reflects the actual library size (~20k albums / ~3k artists on real servers). Swap both bindings to `model.albumsTotal` / `model.artistsTotal`, which the core populates from the server's `TotalRecordCount` on every paginated fetch.

Playlists row stays on `model.playlists.count` — playlists fit in a single page on every library the app currently supports, so the count already coincides with the server total there.

Cold-start: both `albumsTotal` and `artistsTotal` default to `0` before the first fetch resolves, matching the prior `.count`-based behavior — no regression in the empty/loading state.

Closes #788