### PR TITLE
fix(macos): widen directPlayContainers to cover AVPlayer-native formats (#793)

### DIFF
--- a/macos/Sources/Jellify/Components/TrackListRow.swift
+++ b/macos/Sources/Jellify/Components/TrackListRow.swift
@@ -10,8 +10,14 @@ import SwiftUI
 /// are treated as "needs transcoding" even if a particular machine happens
 /// to have a plugin that can decode them, because the Jellyfin server can't
 /// know that.
+///
+/// Strings are compared case-insensitively after `.lowercased()` at the
+/// call site. Jellyfin reports `Container` as `"MPEG"` for MP3 files and
+/// `"MPEG-4"` for AAC-in-MP4 / M4A, so those normalised forms must be
+/// present alongside the file-extension aliases that other Jellyfin
+/// transcoders / clients sometimes emit (`mp3`, `m4a`, etc.).
 let directPlayContainers: Set<String> = [
-    "aac", "mp3", "mp4", "m4a", "alac", "flac", "wav", "aiff", "aif",
+    "aac", "mp3", "mpeg", "mp4", "mpeg-4", "m4a", "alac", "flac", "wav", "aiff", "aif",
 ]
 
 /// Compact single-line row used by the Library Tracks tab. Mirrors the


### PR DESCRIPTION
The orange "Transcoding required. Enable in Preferences → Playback." warning was firing on every MP3 and AAC/M4A track even though AVPlayer decodes those natively without server-side transcoding. Root cause: Jellyfin reports `Container` as `"MPEG"` (for MP3) and `"MPEG-4"` (for AAC-in-MP4 / M4A), and the `directPlayContainers` set only carried the file-extension aliases (`mp3`, `mp4`, `m4a`). After the `.lowercased()` normalisation at the call site, `mpeg` and `mpeg-4` were missing from the set, so the gate evaluated to "needs transcoding" for the dominant lossy half of the library.

Verified container strings against `music.skalthoff.com` (5,000-track sample): FLAC x3702, MPEG x1177, MPEG-4 x115, plus a long tail (WAVPack, APE, OGG) that legitimately does need transcoding and is intentionally left out.

Changes:
- Add `mpeg` and `mpeg-4` to `directPlayContainers`.
- Document the Jellyfin-vs-extension naming so a future tidy-up doesn't strip them back out.

Closes #793

pipeline:
  fixer-session: admiring-mestorf-bc010e
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file, +7/-1