### PR TITLE
fix(macos): pluralize track-count copy (#792)

### DIFF
--- a/macos/Sources/Jellify/Components/LibraryListRow.swift
+++ b/macos/Sources/Jellify/Components/LibraryListRow.swift
@@ -194,7 +194,7 @@ struct LibraryListRow: View {
     private var countMeta: String {
         switch payload {
         case .album(let album):
-            return "\(album.trackCount) tracks"
+            return album.trackCount == 1 ? "1 track" : "\(album.trackCount) tracks"
         case .artist(let artist):
             return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
         case .playlist(let playlist):

--- a/macos/Sources/Jellify/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Jellify/Screens/AlbumDetailView.swift
@@ -549,11 +549,12 @@ struct AlbumDetailView: View {
     /// spans multiple discs ("12 tracks · 2 discs").
     private func tracksSummary(album: Album) -> String {
         let trackCount = tracks.isEmpty ? Int(album.trackCount) : tracks.count
+        let trackWord = trackCount == 1 ? "track" : "tracks"
         let discs = Set(tracks.compactMap { $0.discNumber.map(Int.init) }).count
         if discs > 1 {
-            return "\(trackCount) tracks · \(discs) discs"
+            return "\(trackCount) \(trackWord) · \(discs) discs"
         }
-        return "\(trackCount) tracks"
+        return "\(trackCount) \(trackWord)"
     }
 
     /// Format summary used by both the hero stat and the liner-note row.

--- a/macos/Sources/Jellify/Screens/PlaylistDetailView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistDetailView.swift
@@ -168,7 +168,7 @@ struct PlaylistDetailView: View {
                 }
 
                 HStack(spacing: 10) {
-                    Text("\(tracks.count) tracks")
+                    Text("\(tracks.count) \(tracks.count == 1 ? "track" : "tracks")")
                         .font(Theme.font(12, weight: .semibold))
                         .foregroundStyle(Theme.ink3)
                     Text("·")

--- a/macos/Sources/Jellify/Screens/PlaylistView.swift
+++ b/macos/Sources/Jellify/Screens/PlaylistView.swift
@@ -340,7 +340,7 @@ struct PlaylistView: View {
     @ViewBuilder
     private var footer: some View {
         if let playlist = playlist {
-            Text("\(playlist.trackCount) tracks · \(formatMinutes(playlist.runtimeTicks)) min runtime")
+            Text("\(playlist.trackCount) \(playlist.trackCount == 1 ? "track" : "tracks") · \(formatMinutes(playlist.runtimeTicks)) min runtime")
                 .font(Theme.font(11, weight: .medium))
                 .foregroundStyle(Theme.ink3)
                 .padding(.horizontal, 32)


### PR DESCRIPTION
Single-track items were rendering as "1 tracks" because four call sites interpolated `"\(count) tracks"` unconditionally without checking for the singular case.

Sites fixed (all `Screens/` and `Components/`):
- `Screens/AlbumDetailView.swift:550` — `tracksSummary` (album-detail liner-note row, plus the "X tracks · Y discs" multi-disc variant)
- `Screens/PlaylistView.swift:343` — playlist-detail hero footer
- `Screens/PlaylistDetailView.swift:171` — playlist-detail header subtitle
- `Components/LibraryListRow.swift:197` — library-list album-row meta column

`Components/LibraryListRow.swift` and `Components/PlaylistCard.swift` already pluralised the playlist case (their `case 1: return "1 track"` switch arm); `Screens/ArtistDetailView.swift` already uses the `albumCount == 1` idiom at lines 677-678 and 806. Pattern mirrored from those existing sites.

Tactical fix only — proper `.stringsdict` / xcstrings variations remain tracked on #350.

Refs #350
Closes #792