### PR TITLE
fix(macos): refresh Home Recently Played on track change (#794)

### DIFF
--- a/macos/Sources/Jellify/Screens/HomeView.swift
+++ b/macos/Sources/Jellify/Screens/HomeView.swift
@@ -48,6 +48,16 @@ struct HomeView: View {
             .padding(.bottom, 32)
         }
         .background(backgroundWash)
+        // Keep the Recently Played carousel fresh as tracks play (#794).
+        // `loadHomeData()` only seeds the section on initial library load,
+        // so without this hook a user who plays a few songs and returns to
+        // Home sees stale entries from a prior session. `.task(id:)` fires
+        // once when the view first appears and again on every transition
+        // of `currentTrack?.id` (start of playback, skip-next, auto-advance),
+        // which is exactly when the server's recently-played list grows.
+        .task(id: model.status.currentTrack?.id) {
+            await model.refreshRecentlyPlayed()
+        }
     }
 
     /// Time-of-day aware greeting header with two pill CTAs (#204).


### PR DESCRIPTION
`loadHomeData()` seeds `model.recentlyPlayed` on initial library load only; if a user plays a few tracks and returns to Home, the carousel keeps showing entries from a prior session because nothing re-fetches.

Add `.task(id: model.status.currentTrack?.id)` to `HomeView` so the carousel refreshes once on first appear and again on every transition of the current track id — precisely when the server's recently-played list grows (start of playback, skip-next, auto-advance). Uses the existing `AppModel.refreshRecentlyPlayed()` (one network call per transition).

Closes #794