### PR TITLE
macos: expose Export as .m3u8 — drop dead supportsExportPlaylist gate

### DIFF
--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-/// Capability flags that gate UI affordances whose backing FFI hasn't
-/// landed yet. Each flag is `false` for the 0.2 release; flip to `true`
-/// per-feature once the named issue closes.
+/// Capability flags that gate UI affordances whose backing FFI may not
+/// have landed yet. A flag returns `false` when the surface is wired in
+/// the UI but the backing FFI is still a stub; it flips to `true` once
+/// the named issue closes and the action is real. Flags that already
+/// ship enabled keep the flag around as a kill-switch / regression
+/// fallback rather than removing the gate outright.
 ///
 /// Why a flag instead of just deleting the call site: keeping the menu
 /// entry, button, and `AppModel` method around — but hidden — means the

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -34,9 +34,6 @@ extension AppModel {
     /// Album metadata editor (#96, #222). Gates "Edit Album…".
     var supportsEditAlbum: Bool { false }
 
-    /// Playlist M3U8 export (#98, #125). Gates "Export as .m3u8…".
-    var supportsExportPlaylist: Bool { false }
-
     /// Track-info sheet (#95). Gates "Show Track Info" on track
     /// context menus.
     var supportsTrackInfo: Bool { true }

--- a/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
@@ -60,10 +60,8 @@ struct PlaylistContextMenu: View {
 
         Divider()
 
-        if model.supportsExportPlaylist {
-            Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
-                model.exportPlaylist(playlist: playlist)
-            }
+        Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
+            model.exportPlaylist(playlist: playlist)
         }
         Button("Copy Link", systemImage: "link") { model.copyShareLink(playlist: playlist) }
             .disabled(model.webURL(for: playlist) == nil)


### PR DESCRIPTION
## Summary

- `AppModel.exportPlaylist(playlist:)` is fully implemented: fetches tracks via `playlist_tracks`, builds an extended M3U with `#EXTINF` metadata, opens `NSSavePanel`, writes to disk with token-free stream paths (per #76).
- `supportsExportPlaylist` was `false` citing closed FFIs **#98** and **#125** — both shipped without flipping the flag. The gate is now hiding a working feature.
- Drop the flag from `Capabilities.swift`; remove the `if model.supportsExportPlaylist` guard around the playlist context-menu entry so "Export as .m3u8…" always renders.

## Test plan

- [x] `swift build --package-path macos` passes.
- [ ] Right-click a playlist in the sidebar / detail view → "Export as .m3u8…" appears and opens the save panel.
- [ ] Exported file is a valid extended M3U with one `#EXTINF,…` + stream URL line pair per track.