### PR TITLE
macos: drop supportsNewPlaylistPicker — picker sheet not on roadmap

### DIFF
--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -24,13 +24,6 @@ extension AppModel {
     /// they route through wired FFIs.
     var supportsArtistPlayShuffle: Bool { true }
 
-    /// New-playlist picker (#72, #126). Gates the "New Playlist…" entry
-    /// at the bottom of Add to Playlist submenus on album and track
-    /// surfaces. The route-through helpers `addAlbumToPlaylist` /
-    /// `addTracksToPlaylist` remain available — only the picker sheet
-    /// is the missing piece.
-    var supportsNewPlaylistPicker: Bool { false }
-
     /// Album metadata editor (#96, #222). Gates "Edit Album…".
     var supportsEditAlbum: Bool { false }
 

--- a/macos/Sources/Lyrebird/Components/AddToPlaylistSubmenu.swift
+++ b/macos/Sources/Lyrebird/Components/AddToPlaylistSubmenu.swift
@@ -2,33 +2,19 @@ import SwiftUI
 @preconcurrency import LyrebirdCore
 
 /// "Add to Playlist" submenu — shared by the track and album context menus.
-/// Renders one `Button` per user-owned playlist, plus a "New Playlist…"
-/// affordance at the top that opens the create-playlist flow.
-///
-/// Both callbacks land in `AppModel`: `onPick` fires with the chosen
-/// playlist, `onNewPlaylist` fires for the create-new shortcut. The
-/// submenu intentionally renders a flat list with a hard cap (see
-/// `maxPlaylists`) so a pathological 500-playlist library doesn't build
-/// a scroll-hostile menu — the spec mentions a search affordance in a
-/// future iteration (#72).
-///
-/// Disabled when `model.playlists` is empty, beyond the "New Playlist…"
-/// entry, so the user can still create one inline.
+/// Renders one `Button` per user-owned playlist. `onPick` lands the chosen
+/// playlist in `AppModel`. The submenu intentionally renders a flat list
+/// with a hard cap (see `maxPlaylists`) so a pathological 500-playlist
+/// library doesn't build a scroll-hostile menu.
 struct AddToPlaylistSubmenu: View {
     @Environment(AppModel.self) private var model
     let onPick: (Playlist) -> Void
-    let onNewPlaylist: () -> Void
 
     /// Safety cap — keeps the submenu usable when the server vends
-    /// thousands of playlists. The spec in #72 calls for a search field;
-    /// until that lands, capping at 50 matches Spotify's behavior.
+    /// thousands of playlists. Matches Spotify's behavior.
     private let maxPlaylists = 50
 
     var body: some View {
-        if model.supportsNewPlaylistPicker {
-            Button("New Playlist…", systemImage: "plus") { onNewPlaylist() }
-            if !model.playlists.isEmpty { Divider() }
-        }
         if !model.playlists.isEmpty {
             ForEach(model.playlists.prefix(maxPlaylists), id: \.id) { playlist in
                 Button(playlist.name) { onPick(playlist) }

--- a/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
@@ -42,9 +42,6 @@ struct AlbumContextMenu: View {
         Menu("Add to Playlist", systemImage: "text.badge.plus") {
             AddToPlaylistSubmenu { playlist in
                 model.addAlbumToPlaylist(album: album, playlist: playlist)
-            } onNewPlaylist: {
-                // New-playlist picker is v1.x scope (#72/#126). supportsNewPlaylistPicker
-                // gates this button off so this closure is never triggered today.
             }
         }
 

--- a/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
@@ -70,9 +70,6 @@ struct TrackContextMenu: View {
         Menu("Add to Playlist", systemImage: "text.badge.plus") {
             AddToPlaylistSubmenu { playlist in
                 model.addTracksToPlaylist(tracks: selection, playlist: playlist)
-            } onNewPlaylist: {
-                // New-playlist picker is v1.x scope (#126). supportsNewPlaylistPicker
-                // gates this button off so this closure is never triggered today.
             }
         }
 


### PR DESCRIPTION
## Summary

- `supportsNewPlaylistPicker` was set to `false` citing closed FFIs **#72** and **#126**. Both shipped, but no picker sheet was ever built — only the menu entries that would *open* one. There's no live tracking issue.
- Users who want to add a track / album to a brand-new playlist can create the playlist from the sidebar first (existing flow) and then use the per-playlist entries already in the "Add to Playlist" submenu.
- Drop the flag, the always-empty `onNewPlaylist` closures, and the unused parameter on `AddToPlaylistSubmenu` so the call sites read as the simple list they actually are.

## Test plan

- [x] `swift build --package-path macos` passes.
- [ ] Right-click an album / track → "Add to Playlist" submenu still lists user playlists.
- [ ] No "New Playlist…" entry appears in that submenu (it never did; this just removes the dead branch).