### PR TITLE
macos: drop supportsEditAlbum — admin editor not on roadmap

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3429,13 +3429,6 @@ final class AppModel {
         Task { await setPlayed(itemId: album.id, played: target) }
     }
 
-    /// Present the album metadata editor. Admin-only once the sheet lands.
-    /// TODO: #96 / #222 — metadata editor sheet not yet implemented.
-    func requestEditAlbum(album: Album) {
-        // TODO(#96): metadata editor sheet not yet implemented.
-        Log.app.notice("requestEditAlbum(album:) not yet wired — see #96 / #222")
-    }
-
     /// Append every track on the album to a user-picked playlist. Loads
     /// the tracklist (cached) then routes through the async
     /// `addToPlaylist(trackIds:playlistId:)` path.

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -29,9 +29,6 @@ extension AppModel {
     /// they route through wired FFIs.
     var supportsArtistPlayShuffle: Bool { true }
 
-    /// Album metadata editor (#96, #222). Gates "Edit Album…".
-    var supportsEditAlbum: Bool { false }
-
     /// Track-info sheet (#95). Gates "Show Track Info" on track
     /// context menus.
     var supportsTrackInfo: Bool { true }

--- a/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///     ─
 ///     Favorite Album, Mark All as Played
 ///     ─
-///     Download, Edit Album…, Copy Link
+///     Download, Copy Link
 ///
 /// `showGoToAlbum` is omitted when the menu is invoked from the album's own
 /// detail screen — mirrors the spec's "if invoked from a context outside the
@@ -73,11 +73,6 @@ struct AlbumContextMenu: View {
         if model.supportsDownloads {
             Button("Download", systemImage: "arrow.down.circle") {
                 model.enqueueDownload(album: album)
-            }
-        }
-        if model.supportsEditAlbum {
-            Button("Edit Album…", systemImage: "pencil") {
-                model.requestEditAlbum(album: album)
             }
         }
         Button("Copy Link", systemImage: "link") { model.copyShareLink(album: album) }


### PR DESCRIPTION
## Summary

- `supportsEditAlbum` was `false` citing closed FFIs **#96** and **#222**. Both shipped without ever building the album metadata editor sheet, and there is no live tracking issue.
- Album metadata editing is admin-flavored (server-side tag editing, overlaps Jellyfin web's admin UI) — not a consumer music-player surface. Dropping rather than re-filing.
- Removes the flag, the unused `AppModel.requestEditAlbum(album:)` stub, and the hidden "Edit Album…" entry from `AlbumContextMenu`.

## Test plan

- [x] `swift build --package-path macos` passes.
- [ ] Right-click an album → context menu shows Download (when gated on) and Copy Link in the last group; no "Edit Album…" entry.