### PR TITLE
fix(macos): LaunchAtLogin uses unified log instead of debugPrint (#813)

### DIFF
--- a/macos/Sources/Lyrebird/System/LaunchAtLogin.swift
+++ b/macos/Sources/Lyrebird/System/LaunchAtLogin.swift
@@ -17,7 +17,7 @@ struct LaunchAtLogin {
         do {
             try SMAppService.mainApp.register()
         } catch {
-            debugPrint("[LaunchAtLogin] register() failed: \(error)")
+            Log.app.error("LaunchAtLogin register() failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -27,7 +27,7 @@ struct LaunchAtLogin {
         do {
             try SMAppService.mainApp.unregister()
         } catch {
-            debugPrint("[LaunchAtLogin] unregister() failed: \(error)")
+            Log.app.error("LaunchAtLogin unregister() failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }


### PR DESCRIPTION
## Why

`debugPrint` compiles away in release builds, so when `SMAppService.mainApp.register()` / `unregister()` throw in a shipped DMG the failure vanishes — the user sees a toggle that quietly does nothing and has no diagnostic to attach to a bug report. Routing both catch blocks through `Log.app.error` surfaces the failure in Console.app under `subsystem == "org.lyrebird.desktop"`, matching the rc12 `print` → `Log.app.notice` migration pattern.

## Change

- `macos/Sources/Lyrebird/System/LaunchAtLogin.swift`: two `debugPrint(...)` calls in the `enable()` / `disable()` catch arms are now `Log.app.error(...)` with `error.localizedDescription` redacted with `.public` so the message survives the privacy redaction.

Function signatures, control flow, and success paths are untouched.

Closes #813

```
pipeline:
  fixer-session: cool-jepsen-79265c
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +2/-2
```