### PR TITLE
macos: retarget downloads-flag citations from dead #70/#222 to #819

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -665,8 +665,8 @@ final class AppModel {
                 symbol: "arrow.down.circle",
                 run: { [weak self] in
                     guard self?.status.currentTrack != nil else { return }
-                    // TODO(#70): wire to the download engine once it lands.
-                    Log.app.notice("Download Current — not yet wired (see #70)")
+                    // TODO(#819): wire to the download engine once it lands.
+                    Log.app.notice("Download Current — not yet wired (see #819)")
                 }
             ))
         }
@@ -3286,11 +3286,11 @@ final class AppModel {
     }
 
     /// Enqueue a download of every track on the album.
-    /// TODO: #70, #222 — there is no download engine yet; this is a logging
+    /// TODO: #819 — there is no download engine yet; this is a logging
     /// stub so the UI action has a landing pad.
     func enqueueDownload(album: Album) {
-        // TODO: #70 / #222 — download engine not yet wired.
-        Log.app.notice("enqueueDownload(album:) not yet wired — see #70 / #222")
+        // TODO(#819): download engine not yet wired.
+        Log.app.notice("enqueueDownload(album:) not yet wired — see #819")
     }
 
     /// Append a batch of tracks to an existing playlist via `add_to_playlist`
@@ -3631,7 +3631,7 @@ final class AppModel {
     // Playback actions are live now that `playlist_tracks` has landed (#125;
     // see `loadPlaylistTracks`). Mutation actions (favorite, download,
     // rename, delete) remain TODO stubs pending follow-up FFI work:
-    // favorites (#133), download engine (#70), `update_playlist` (#130),
+    // favorites (#133), download engine (#819), `update_playlist` (#130),
     // `delete_playlist` (#131). The UI is wired up now so that when each
     // backing endpoint lands the action just needs its stub swapped for a
     // real call.
@@ -3702,11 +3702,11 @@ final class AppModel {
     }
 
     /// Enqueue a download of every track in the playlist.
-    /// TODO: #70, #222 — there is no download engine yet; this is a logging
+    /// TODO: #819 — there is no download engine yet; this is a logging
     /// stub so the UI action has a landing pad.
     func enqueueDownload(playlist: Playlist) {
-        // TODO: #70 / #222 — download engine not yet wired.
-        Log.app.notice("enqueueDownload(playlist:) not yet wired — see #70 / #222")
+        // TODO(#819): download engine not yet wired.
+        Log.app.notice("enqueueDownload(playlist:) not yet wired — see #819")
     }
 
     /// Flip the sidebar's inline TextField onto an existing playlist row so
@@ -4117,7 +4117,7 @@ final class AppModel {
     // single `Track` so the same surface handles single-row and multi-select
     // invocations — spec in #95 / #310 / #315. Most of these are TODO stubs
     // pending follow-up FFI work (queue primitives #282, favorites #133,
-    // download engine #70, mark-played #133, song radio #144, metadata
+    // download engine #819, mark-played #133, song radio #144, metadata
     // editor #96).
 
     /// Insert a selection of tracks immediately after the currently-playing
@@ -4221,11 +4221,11 @@ final class AppModel {
     }
 
     /// Toggle the download state of every track in the selection.
-    /// TODO(#70): download engine not yet wired.
+    /// TODO(#819): download engine not yet wired.
     func toggleDownload(tracks: [Track]) {
         guard !tracks.isEmpty else { return }
-        // TODO(#70): download engine not yet wired.
-        Log.app.notice("toggleDownload(tracks: \(tracks.count, privacy: .public)) not yet wired — see #70")
+        // TODO(#819): download engine not yet wired.
+        Log.app.notice("toggleDownload(tracks: \(tracks.count, privacy: .public)) not yet wired — see #819")
     }
 
     /// Toggle the played flag across a multi-select of tracks. Target

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -9,9 +9,11 @@ import Foundation
 /// FFI work that enables it can flip a single flag rather than re-wiring
 /// every surface.
 extension AppModel {
-    /// Download engine (#70, #222). Gates "Download Current" in the
-    /// command palette plus per-album / per-playlist / per-track Download
-    /// affordances.
+    /// Download engine (#819). Gates "Download Current" in the command
+    /// palette plus per-album / per-playlist / per-track Download
+    /// affordances. The four AppModel stubs (Download Current,
+    /// enqueueDownload(album:), enqueueDownload(playlist:),
+    /// toggleDownload(tracks:)) flip live once the core engine lands.
     var supportsDownloads: Bool { false }
 
     /// `mark_played` / `mark_unplayed` FFIs (#133, #222). Gates

--- a/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
@@ -140,7 +140,7 @@ struct TrackContextMenu: View {
     }
 
     private var downloadLabel: String {
-        // Download state isn't tracked per-track yet (#70 downloads engine),
+        // Download state isn't tracked per-track yet (#819 downloads engine),
         // so the label always reads as "Download" for now. Once state lands
         // this mirrors favorite's all-on / any-off logic.
         "Download\(countSuffix)"


### PR DESCRIPTION
## Summary

Companion to #819 — re-wires the `supportsDownloads` flag and four `AppModel` download stubs from closed/abandoned issues to the fresh tracking issue.

- `Capabilities.swift` — `supportsDownloads` now cites #819 and inventories the four call sites that flip live once the core engine lands.
- `AppModel.swift` — four `Log.app.notice(...)` stubs now log "see #819" with matching `TODO(#819)` markers:
  - "Download Current" palette action (~L661)
  - `enqueueDownload(album:)` (~L3291)
  - `enqueueDownload(playlist:)` (~L3707)
  - `toggleDownload(tracks:)` (~L4225)
- Two block-comment FFI inventories that named `#70` for the download engine now point to `#819`.
- `TrackContextMenu.downloadLabel`'s explanatory comment updated likewise.

Historical references to `#70` / `#222` that document where a surface *came from* (e.g. "Used by the album detail popover (#222)") are kept — those are provenance, not live tracking.

## Test plan

- [x] `swift build --package-path macos` passes.
- [ ] No grep matches for `not yet wired — see #70` or `see #70 / #222` remain.
- [ ] Trigger each of the four stubs once; `Console.app` now logs "see #819".