### PR TITLE
macos: retarget genre-actions citations from dead #144/#248/#318 to #823

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4277,14 +4277,14 @@ final class AppModel {
     //
     // Backing calls for `GenreContextMenu`. The core doesn't yet expose a
     // Genre type (genres are surfaced as bare strings on `Album`/`Artist`
-    // today). All four actions are TODO stubs pending follow-up work
-    // (#144 radio, #318 genre detail screen, #248 / #249 Home pinning).
+    // today). All four actions are TODO stubs pending follow-up work in
+    // #823 (genre-id resolver + tracksForGenre/albumsForGenre FFIs).
 
     /// Navigate to the genre's browse view.
-    /// TODO(#318): genre detail screen not yet implemented.
+    /// TODO(#823): genre detail screen not yet implemented.
     func browseGenre(genre: String) {
-        // TODO(#318): genre detail screen not yet implemented.
-        Log.app.notice("browseGenre(\(genre, privacy: .public)) not yet wired — see #318")
+        // TODO(#823): genre detail screen not yet implemented.
+        Log.app.notice("browseGenre(\(genre, privacy: .public)) not yet wired — see #823")
     }
 
     /// Kick off an Instant Mix seeded by a genre.
@@ -4293,17 +4293,17 @@ final class AppModel {
     }
 
     /// Shuffle every track tagged with the given genre.
-    /// TODO(#318): genre-scoped track list FFI not yet wired.
+    /// TODO(#823): genre-scoped track list FFI not yet wired.
     func shuffleGenre(genre: String) {
-        // TODO(#318): genre-scoped track list FFI not yet wired.
-        Log.app.notice("shuffleGenre(\(genre, privacy: .public)) not yet wired — see #318")
+        // TODO(#823): genre-scoped track list FFI not yet wired.
+        Log.app.notice("shuffleGenre(\(genre, privacy: .public)) not yet wired — see #823")
     }
 
     /// Pin a genre tile to the Home screen so the user can one-click-browse.
-    /// TODO(#248 / #249): Home personalization (pinned tiles) not yet wired.
+    /// TODO(#823): Home personalization (pinned tiles) not yet wired.
     func pinGenreToHome(genre: String) {
-        // TODO(#248): pinned tiles not yet wired.
-        Log.app.notice("pinGenreToHome(\(genre, privacy: .public)) not yet wired — see #248 / #249")
+        // TODO(#823): pinned tiles not yet wired.
+        Log.app.notice("pinGenreToHome(\(genre, privacy: .public)) not yet wired — see #823")
     }
 
     func pause() { audio.pause() }
@@ -4827,7 +4827,7 @@ extension Array {
 /// dropdown's genre row. Jellyfin returns genres as bare strings on
 /// `Album`/`Artist` today, so an `id` is derived from the name until a
 /// proper `MusicGenre` item shape lands in core (see `GenreContextMenu`'s
-/// TODO for #318).
+/// TODO for #823).
 struct Genre: Hashable, Identifiable, Sendable {
     let id: String
     let name: String

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -41,8 +41,9 @@ extension AppModel {
     /// context menus.
     var supportsTrackInfo: Bool { true }
 
-    /// Genre actions (#144, #248, #318). Disabled until #318 lands — the
-    /// stub actions pass a genre name (e.g. "Jazz") as an item id to
+    /// Genre actions (#823). Disabled until the genre-id resolver +
+    /// `tracksForGenre` / `albumsForGenre` FFIs land — the stub actions
+    /// today pass a genre name (e.g. "Jazz") as an item id to
     /// `core.instantMix(itemId:)` which expects a UUID, producing garbage.
     /// Flip to `true` once `browseGenre`, `shuffleGenre`, and
     /// `pinGenreToHome` are wired to real core FFIs.

--- a/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
@@ -11,21 +11,19 @@ import SwiftUI
 ///
 /// The core does not yet expose a Genre type (genres are surfaced as
 /// bare strings on `Album`/`Artist` today), so this menu accepts the
-/// genre name directly. When #318 introduces a proper `Genre` struct this
+/// genre name directly. When #823 introduces a proper `Genre` struct this
 /// view can grow an overload without touching call sites.
 ///
-/// All actions call through to `AppModel`. Several are TODO stubs pending
-/// follow-up FFI work (genre browse is #318, genre radio is part of
-/// #144, and pin-to-home lives alongside the Home personalization work
-/// in #248 / #249).
+/// All actions call through to `AppModel`. Every entry here is a TODO
+/// stub pending the genre-id resolver + tracksForGenre/albumsForGenre
+/// FFIs tracked in #823.
 struct GenreContextMenu: View {
     @Environment(AppModel.self) private var model
     let genre: String
 
     var body: some View {
         // Every entry in this menu is gated on FFIs that don't ship in 0.2
-        // (#144 / #248 / #318). When `supportsGenreActions` flips on per
-        // feature these will come back individually.
+        // (#823). When `supportsGenreActions` flips on these will come back.
         if model.supportsGenreActions {
             Button("Browse genre", systemImage: "square.grid.2x2") {
                 model.browseGenre(genre: genre)

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -685,7 +685,7 @@ private struct SearchPageTrackRow: View {
 
 /// Simple row for a genre result. Rendered as a clickable chip-row-ish
 /// surface; routes through `AppModel.browseGenre` which is a logging
-/// stub today until the genre browse FFI lands (#318). The context menu
+/// stub today until the genre browse FFI lands (#823). The context menu
 /// exposes the full genre actions so pin / radio / shuffle work from
 /// here.
 private struct GenreResultRow: View {


### PR DESCRIPTION
## Summary

Companion to #823 — re-wires the `supportsGenreActions` flag and the three `AppModel` genre stubs from closed/repurposed issues to the fresh tracking issue.

- `Capabilities.swift` — `supportsGenreActions` cites #823 and keeps the explanation of the current name-as-id bug (passing `"Jazz"` to `core.instantMix(itemId:)` which expects a UUID).
- `AppModel.swift` — `browseGenre(genre:)`, `shuffleGenre(genre:)`, `pinGenreToHome(genre:)` log `see #823` with matching `TODO(#823)` markers. The genre section header comment + the `Genre` record's doc comment likewise.
- `Components/GenreContextMenu.swift` — its trailing "pending follow-up" doc paragraph and the inner `body` gate comment now cite #823.
- `Screens/SearchView.swift` — the `GenreResultRow` doc comment retargeted to #823.

Out-of-scope references to `#144` / `#248` / `#249` that document the Discover carousel, Artist Radio, or Pinned Stations are unchanged — those track other surfaces that have their own (still-live) plans.

## Test plan

- [x] `swift build --package-path macos` passes.
- [ ] No `not yet wired — see #318` / `see #248 / #249` matches remain on genre actions.
- [ ] Trigger each of `browseGenre` / `shuffleGenre` / `pinGenreToHome` — `Console.app` now logs "see #823".