### PR TITLE
fix(core): filter suggestions to Audio items only (#815)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1251,7 +1251,12 @@ impl JellyfinClient {
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
         let raw: RawItems<RawItem> = resp.json().await?;
-        Ok(raw.items.into_iter().map(Track::from).collect())
+        Ok(raw
+            .items
+            .into_iter()
+            .filter(|i| i.kind.as_deref() == Some("Audio"))
+            .map(Track::from)
+            .collect())
     }
 
     /// Artists similar to `artist_id` — Jellyfin's `GET /Artists/{id}/Similar`.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7483,3 +7483,62 @@ async fn login_forwards_whitespace_only_password_as_empty() {
         "whitespace-only Pw must be trimmed to empty"
     );
 }
+
+// ============================================================================
+// suggestions defensive Type filter — #815 / auto-audit
+// ============================================================================
+
+/// Regression for the Home "You might like" shelf. Jellyfin's
+/// `/Items/Suggestions` endpoint ignores `IncludeItemTypes=Audio,MusicAlbum`
+/// and returns a mix of Audio, MusicAlbum, and MusicArtist items
+/// (verified live against music.skalthoff.com on 2026-05-12). Non-Audio
+/// items mapped through `Track::from` produce structurally broken tracks
+/// with no container / no album_id, which then fail to stream. The client
+/// now post-filters by `Type == "Audio"` so the downstream UI never sees
+/// non-audio rows regardless of what the server returns.
+#[tokio::test]
+async fn suggestions_rejects_non_audio_items() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // Simulate the live server behaviour: return a mix of Audio, MusicAlbum,
+    // and MusicArtist items even though the request asks for Audio,MusicAlbum.
+    Mock::given(method("GET"))
+        .and(path("/Items/Suggestions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Real Track", "Type": "Audio",
+                    "AlbumId": "a1", "Album": "Discover",
+                    "AlbumArtist": "Artist", "Artists": ["Artist"],
+                    "RunTimeTicks": 1800000000u64
+                },
+                {
+                    "Id": "al1", "Name": "Quite A Shame", "Type": "MusicAlbum",
+                    "AlbumArtist": "Some Artist"
+                },
+                {
+                    "Id": "ar1", "Name": "Boston", "Type": "MusicArtist"
+                }
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let tracks = client.suggestions(20).await.unwrap();
+
+    // Only the Audio entry survives; the MusicAlbum / MusicArtist items
+    // would otherwise produce unplayable Track objects in the Home shelf.
+    assert_eq!(tracks.len(), 1, "non-Audio rows must be dropped");
+    assert_eq!(tracks[0].id, "t1");
+    assert_eq!(tracks[0].name, "Real Track");
+}


### PR DESCRIPTION
## Why

`/Items/Suggestions` ignores `IncludeItemTypes` and returns mixed Audio / MusicAlbum / MusicArtist items, so the Home "You might like" shelf rendered `MusicArtist` and `MusicAlbum` rows as broken `Track` objects (no container, no album_id) — tapping Play failed silently.

## Change

One filter in `suggestions()`, mirroring the existing `playlist_tracks` guard at `client.rs:947`:

\`\`\`rust
.filter(|i| i.kind.as_deref() == Some("Audio"))
\`\`\`

Test appended at EOF of `core/src/tests.rs` (`suggestions_rejects_non_audio_items`) that returns a mixed Audio / MusicAlbum / MusicArtist response from a `MockServer` and asserts only the Audio entry survives. Test fails on `main` (`tracks.len() == 3`) and passes after the filter.

## Real-server smoke test

Per CLAUDE.md authorization, hit `https://music.skalthoff.com/Items/Suggestions?IncludeItemTypes=Audio,MusicAlbum&Limit=20` with the `test/test` token (`UserId=10d61bc2cc0a4090bfc2b4bc62344d4f`). Server returned 20 items with the following types:

\`\`\`
Audio : FAKE LOVE
Audio : Warriors in Valour
Audio : The Strenuous Life
Audio : Love Is Pain
MusicAlbum : Quite A Shame
Audio : Gaslight
Audio : Take Your Mask Off
Audio : Doll House
Audio : When I Met You
Audio : Bohemian Skies (For Harry Grammer)
MusicAlbum : Girl All the Bad Guys Want
Audio : One Cup of Coffee -> Judge Not
Audio : Ya Hey
Audio : Bon Voyage
Audio : All You Wanna Do
Audio : Let's Love
Audio : My Wife's Home Town
Audio : Unknown
Audio : Clean the House
Audio : Zero
\`\`\`

2 of 20 items were `MusicAlbum` despite the `IncludeItemTypes=Audio,MusicAlbum` request — confirms the issue's premise that the server ignores the filter. (Earlier issue-author run on the same endpoint also surfaced a `MusicArtist` row.)

## Build gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lyrebird_core --all-targets -- -D warnings` — clean
- `cargo test -p lyrebird_core` — 203 passed / 0 failed (incl. new `suggestions_rejects_non_audio_items`)

Closes #815

Hotspot locks (release on merge):
- clientrs (#825)
- testsrs (#826)

\`\`\`
pipeline:
  fixer-session: cool-jepsen-79265c
  slice: slice:client
  hotspots-claimed: [clientrs, testsrs]
  build-gate: pass
  diff-stat: 2 files changed, +65/-1
\`\`\`