### PR TITLE
fix(macos): TrackContextMenu uses cache-aware isFavorite (#837)

### DIFF
--- a/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
@@ -129,7 +129,7 @@ struct TrackContextMenu: View {
     /// True when every track in the selection is already favorited, so the
     /// toggle reads as "Unfavorite" rather than "Favorite".
     private var allFavorited: Bool {
-        !selection.isEmpty && selection.allSatisfy { $0.isFavorite }
+        !selection.isEmpty && selection.allSatisfy { model.isFavorite(track: $0) }
     }
 
     private var favoriteLabel: String {


### PR DESCRIPTION
## Why

`TrackContextMenu.allFavorited` was checking `$0.isFavorite` directly on the `Track` struct. That field is a snapshot of the server state from when the track was fetched, so any in-session favorite toggle left the menu label stale — the user could favorite a track, reopen the context menu, and still see "Favorite" instead of "Unfavorite".

The cache-aware source of truth is `AppModel.isFavorite(track:)`, which walks the rc6 favorite cache (`favoriteById` -> `userData?.isFavorite` -> legacy mirror) and reflects optimistic toggles immediately.

## Change

```diff
- !selection.isEmpty && selection.allSatisfy { \$0.isFavorite }
+ !selection.isEmpty && selection.allSatisfy { model.isFavorite(track: \$0) }
```

Single-line swap inside `allFavorited`. Nothing else touched.

Closes #837

pipeline:
  fixer-session: cool-jepsen-79265c
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +1/-1