### PR TITLE
fix(macos): RecentlyPlayedTrackRow uses TrackContextMenu (#842)

### DIFF
--- a/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
@@ -57,21 +57,7 @@ struct RecentlyPlayedTrackRow: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
-        .contextMenu {
-            Button("Play", systemImage: "play.fill") {
-                model.play(tracks: [track], startIndex: 0)
-            }
-            if let albumId = track.albumId, !albumId.isEmpty {
-                Button("Go to Album", systemImage: "square.stack") {
-                    model.navPath.append(AppModel.Route.album(albumId))
-                }
-            }
-            if let artistId = track.artistId, !artistId.isEmpty {
-                Button("Go to Artist", systemImage: "person") {
-                    model.navPath.append(AppModel.Route.artist(artistId))
-                }
-            }
-        }
+        .contextMenu { TrackContextMenu(selection: [track]) }
         // `.focusable` lets the VoiceOver rotor Tab through the Home
         // Recently Played list; `.combine` presents thumbnail + title +
         // duration as a single playable element. See #588.


### PR DESCRIPTION
Brings the Home → Recently Played carousel rows in line with every other track-row surface so users get the same right-click vocabulary (Play Next / Add to Queue / Favorite / Add to Playlist / Go to Album / Go to Artist) no matter where they invoke it.

The previous bespoke 3-entry menu (Play / Go to Album / Go to Artist) was a strict subset of `TrackContextMenu`'s offering, so swapping in the shared component is a pure superset of behaviour.

Closes #842

pipeline:
  fixer-session: cool-jepsen-79265c
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +1/-15