### PR TITLE
macos: wire pinGenreToHome to PinnedStationsStore (#823)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4293,10 +4293,17 @@ final class AppModel {
     }
 
     /// Pin a genre tile to the Home screen so the user can one-click-browse.
-    /// TODO(#823): Home personalization (pinned tiles) not yet wired.
-    func pinGenreToHome(genre: String) {
-        // TODO(#823): pinned tiles not yet wired.
-        Log.app.notice("pinGenreToHome(\(genre, privacy: .public)) not yet wired — see #823")
+    /// Persists into `PinnedStationsStore` — the placeholder JSON-in-UserDefaults
+    /// bridge that backs the Home pinned-stations row (#253). When a real pin
+    /// FFI lands this body becomes a thin adapter; the signature stays.
+    func pinGenreToHome(genre: Genre) {
+        var stations = PinnedStationsStore.load()
+        // Dedup: drop any existing entry with the same id so we don't double-pin.
+        stations.removeAll { $0.id == genre.id }
+        stations.insert(PinnedStation(type: .genre, id: genre.id, title: genre.name), at: 0)
+        // Cap at 6 — matches the Home shelf layout in PinnedStationTile.
+        if stations.count > 6 { stations = Array(stations.prefix(6)) }
+        PinnedStationsStore.save(stations)
     }
 
     func pause() { audio.pause() }

--- a/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
@@ -9,30 +9,30 @@ import SwiftUI
 ///     ─
 ///     Pin to Home
 ///
-/// The core does not yet expose a Genre type (genres are surfaced as
-/// bare strings on `Album`/`Artist` today), so this menu accepts the
-/// genre name directly. When #823 introduces a proper `Genre` struct this
-/// view can grow an overload without touching call sites.
+/// Takes a `Genre` so we have a stable id (name-derived today, real id when
+/// the genre-id resolver lands). The browse / radio / shuffle entries still
+/// hand `genre.name` to their `String`-typed AppModel stubs; those signatures
+/// migrate to `Genre` in Wave 2 of #823.
 ///
-/// All actions call through to `AppModel`. Every entry here is a TODO
-/// stub pending the genre-id resolver + tracksForGenre/albumsForGenre
+/// All actions call through to `AppModel`. The three radio/browse/shuffle
+/// entries remain TODO stubs pending the tracksForGenre / albumsForGenre
 /// FFIs tracked in #823.
 struct GenreContextMenu: View {
     @Environment(AppModel.self) private var model
-    let genre: String
+    let genre: Genre
 
     var body: some View {
         // Every entry in this menu is gated on FFIs that don't ship in 0.2
         // (#823). When `supportsGenreActions` flips on these will come back.
         if model.supportsGenreActions {
             Button("Browse genre", systemImage: "square.grid.2x2") {
-                model.browseGenre(genre: genre)
+                model.browseGenre(genre: genre.name)
             }
             Button("Start genre radio", systemImage: "dot.radiowaves.left.and.right") {
-                model.startGenreRadio(genre: genre)
+                model.startGenreRadio(genre: genre.name)
             }
             Button("Shuffle genre", systemImage: "shuffle") {
-                model.shuffleGenre(genre: genre)
+                model.shuffleGenre(genre: genre.name)
             }
 
             Divider()

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -343,13 +343,23 @@ struct HomeView: View {
         print("[HomeView] Pin a station tapped — pin picker UI not yet built (#253).")
     }
 
-    /// Inert handler for a tapped pinned station. Logs the triple so we can
-    /// see it in the console. Real routing (start this radio / open this
-    /// playlist) waits on the Instant Mix FFI (#144) and the pin model.
+    /// Handler for a tapped pinned station. Dispatches on `station.type`.
+    /// Genre routing is logged for now — the full browse wiring lands in
+    /// Wave 2 of #823 alongside the `browseGenre(genre:)` signature change.
+    /// Artist / playlist / mood / mix routing still waits on the Instant
+    /// Mix FFI (#144) and the typed pin model.
     private func handleStationTap(_ station: PinnedStation) {
-        // TODO: #144 / #253 — route to start the corresponding station once
-        // the typed pin model + Instant Mix FFI land.
-        print("[HomeView] Pinned station tapped: type=\(station.type.rawValue) id=\(station.id) title=\"\(station.title)\"")
+        switch station.type {
+        case .genre:
+            // TODO(#823 Wave 2): replace with `model.browseGenre(genre:)` once
+            // that method's signature accepts a `Genre`. Logging-only for now
+            // so we don't create a rebase landmine against the Wave 2 PR.
+            Log.app.notice("PinnedStation tap (.genre id=\(station.id, privacy: .public)) — routing lands in Wave 2 of #823")
+        case .artist, .playlist, .mood, .mix:
+            // TODO: #144 / #253 — route to start the corresponding station
+            // once the typed pin model + Instant Mix FFI land.
+            Log.app.notice("PinnedStation tap (type=\(station.type.rawValue, privacy: .public) id=\(station.id, privacy: .public)) — routing not yet wired")
+        }
     }
 
     /// The albums surfaced as quick tiles — capped at 3. Pulled from the

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -720,7 +720,7 @@ private struct GenreResultRow: View {
             }
             .buttonStyle(.plain)
             .onHover { isHovering = $0 }
-            .contextMenu { GenreContextMenu(genre: name) }
+            .contextMenu { GenreContextMenu(genre: Genre(name: name)) }
             .accessibilityLabel("Browse genre \(name)")
         }
     }


### PR DESCRIPTION
## Summary
- Wire `pinGenreToHome` to the existing `PinnedStationsStore` (dedup + 6-entry cap).
- Change signature `genre: String` → `genre: Genre` so the stable id is captured (fixes upcoming UUID-mismatch bug in `startGenreRadio`).
- Update `GenreContextMenu` / `SearchView` call sites.
- Stub `HomeView.handleStationTap` for `.genre` with a log entry — full tap routing lands in Wave 2 of #823.

## Test plan
- [x] `rm -rf macos/.build && swift build --package-path macos` clean.
- [ ] Manual smoke after merge: tap genre context menu → Pin to Home → reopen Home → tile appears.

Refs #823