### PR TITLE
core: add tracks_by_genre FFI (#823)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1440,6 +1440,50 @@ impl JellyfinClient {
             .await
     }
 
+    /// Every audio track tagged with the given genre, paginated. Mirrors
+    /// [`JellyfinClient::items_by_genre`] but returns tracks instead of
+    /// albums — feeds the macOS genre detail "Shuffle Genre" action and
+    /// the planned full-tracks tab on genre pages (#823).
+    ///
+    /// Sorts catalog-style — `SortName,Album,SortName` keeps tracks
+    /// grouped by album name while still giving a stable name-first
+    /// fallback for items that share an album title. Includes the same
+    /// projection as [`JellyfinClient::tracks_by_artist`] so callers get
+    /// the full set of `Track` fields (media sources, user data, album +
+    /// artist credits, runtime) needed to enqueue and render rows.
+    pub async fn tracks_by_genre(&self, genre_id: &str, paging: Paging) -> Result<PaginatedTracks> {
+        ItemsQuery::new()
+            .genre(genre_id)
+            .recursive()
+            .item_types(vec![ItemKind::Audio])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort_by(vec![
+                ItemSortBy::SortName,
+                ItemSortBy::Album,
+                ItemSortBy::SortName,
+            ])
+            .sort_order(vec![
+                SortOrder::Ascending,
+                SortOrder::Ascending,
+                SortOrder::Ascending,
+            ])
+            .fields(vec![
+                ItemField::MediaSources,
+                ItemField::UserData,
+                ItemField::ParentId,
+                ItemField::AlbumId,
+                ItemField::AlbumArtist,
+                ItemField::Artists,
+                ItemField::ProductionYear,
+                ItemField::PrimaryImageAspectRatio,
+                ItemField::RunTimeTicks,
+            ])
+            .enable_user_data()
+            .fetch_tracks(self)
+            .await
+    }
+
     /// Full artist record with biography, backdrops, and external links —
     /// extends [`JellyfinClient::fetch_item`] with an artist-focused field
     /// projection. Powers the artist detail header (bio + MusicBrainz /

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -496,6 +496,22 @@ impl LyrebirdCore {
         })
     }
 
+    /// Audio tracks belonging to a genre, paginated. Mirrors
+    /// [`Self::items_by_genre`] but returns tracks instead of albums —
+    /// feeds the genre detail "Shuffle Genre" action and the planned
+    /// all-tracks tab on genre pages (#823).
+    pub fn tracks_by_genre(
+        &self,
+        genre_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.tracks_by_genre(&genre_id, Paging::new(offset, limit)))
+        })
+    }
+
     /// Full artist record with biography, backdrop image tags, and
     /// external links (MusicBrainz / Last.fm / Discogs). Feeds the artist
     /// detail header.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1244,6 +1244,103 @@ async fn items_by_genre_builds_query_and_parses() {
     assert!(q.contains("Limit=30"), "query: {q}");
 }
 
+#[tokio::test]
+async fn tracks_by_genre_builds_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Smooth Solo", "Type": "Audio",
+                    "AlbumId": "a1", "AlbumArtist": "Sax Man"
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_genre("g-1", Paging::new(20, 40))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].id, "t1");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("GenreIds=g-1"), "query: {q}");
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("Limit=40"), "query: {q}");
+    assert!(q.contains("StartIndex=20"), "query: {q}");
+}
+
+#[tokio::test]
+async fn tracks_by_genre_parses_pagination() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Track One", "Type": "Audio",
+                    "AlbumId": "a1", "AlbumArtist": "Artist X"
+                },
+                {
+                    "Id": "t2", "Name": "Track Two", "Type": "Audio",
+                    "AlbumId": "a2", "AlbumArtist": "Artist Y"
+                },
+                {
+                    "Id": "t3", "Name": "Track Three", "Type": "Audio",
+                    "AlbumId": "a3", "AlbumArtist": "Artist Z"
+                }
+            ],
+            "TotalRecordCount": 42
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_genre("g-1", Paging::new(0, 100))
+        .await
+        .unwrap();
+    assert_eq!(
+        page.total_count, 42,
+        "server-reported total wins over page len"
+    );
+    assert_eq!(page.items.len(), 3);
+    assert_eq!(page.items[0].id, "t1");
+    assert_eq!(page.items[1].id, "t2");
+    assert_eq!(page.items[2].id, "t3");
+}
+
 // ---------------------------------------------------------------------------
 // Artist detail
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `tracks_by_genre(genre_id, offset, limit) -> PaginatedTracks` to core, mirroring `items_by_genre` but for tracks.
- Reuse existing `PaginatedTracks` model — no UniFFI binding regen needed.
- Two new tests: query shape + pagination parsing.

Unblocks Wave 2 of the #823 plan (wiring shuffleGenre in the macOS app).

## Test plan
- [x] `cargo clippy -p lyrebird-core -- -D warnings`
- [x] `cargo test -p lyrebird-core tracks_by_genre`
- [x] `rm -rf macos/.build && swift build --package-path macos` clean

Refs #823