### PR TITLE
macos: wire genre browse / shuffle / radio (#823)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -46,6 +46,7 @@ final class AppModel {
         case album(String)
         case artist(String)
         case playlist(String)
+        case genre(Genre)
         case nowPlaying
     }
 
@@ -4268,28 +4269,135 @@ final class AppModel {
 
     // MARK: - Genre actions
     //
-    // Backing calls for `GenreContextMenu`. The core doesn't yet expose a
-    // Genre type (genres are surfaced as bare strings on `Album`/`Artist`
-    // today). All four actions are TODO stubs pending follow-up work in
-    // #823 (genre-id resolver + tracksForGenre/albumsForGenre FFIs).
+    // Backing calls for `GenreContextMenu` + `GenreDetailView`. Genres
+    // surface as bare strings on `Album` / `Artist` records, but the
+    // genre-scoped FFIs (`tracksByGenre`, `itemsByGenre`, `instantMix`)
+    // require a real Jellyfin UUID. `resolvedGenreId(forName:)` lazily
+    // loads `/MusicGenres` once and caches the name→UUID map so the
+    // three actions below can dispatch on the real id without each call
+    // site re-fetching. See #823 Wave 2.
 
-    /// Navigate to the genre's browse view.
-    /// TODO(#823): genre detail screen not yet implemented.
-    func browseGenre(genre: String) {
-        // TODO(#823): genre detail screen not yet implemented.
-        Log.app.notice("browseGenre(\(genre, privacy: .public)) not yet wired — see #823")
+    /// Cache of /MusicGenres results keyed by display name → Jellyfin UUID.
+    /// Populated lazily on the first genre-action call. ~291 entries on a
+    /// real library — one page of 500 covers it. The Swift `Genre` carries
+    /// `id == name` because Album/Artist records only ship the bare name,
+    /// so this map is the only path to the real UUID. Stored as a flat
+    /// `[String: String]` rather than `[String: LyrebirdCore.Genre]` to
+    /// avoid the module/class name collision — `LyrebirdCore.Genre` parses
+    /// as a member of the `LyrebirdCore` *class* (which doesn't have one)
+    /// rather than the `LyrebirdCore` *module*. The UUID is the only field
+    /// we need anyway.
+    private var _genreIdsByName: [String: String] = [:]
+    private var _genresLoaded: Bool = false
+
+    /// Resolve a Swift-side display name to the real Jellyfin UUID via
+    /// the lazy `/MusicGenres` cache. Returns `nil` when the name has no
+    /// match (genre exists in Album/Artist metadata but not as its own
+    /// `MusicGenre` item — possible for empty / freshly-tagged genres).
+    /// The FFI call runs off the MainActor per CLAUDE.md gap pattern #2.
+    private func resolvedGenreId(forName name: String) async -> String? {
+        if !_genresLoaded {
+            let pairs: [(String, String)]? = await Task.detached(priority: .userInitiated) { [core] in
+                (try? core.genres(offset: 0, limit: 500))?.items.map { ($0.name, $0.id) }
+            }.value
+            guard let pairs else { return nil }
+            _genreIdsByName = Dictionary(uniqueKeysWithValues: pairs)
+            _genresLoaded = true
+        }
+        return _genreIdsByName[name]
     }
 
-    /// Kick off an Instant Mix seeded by a genre.
-    func startGenreRadio(genre: String) {
-        playInstantMix(seedId: genre)
+    /// Open the genre detail screen. Resolves the display name to a real
+    /// Jellyfin UUID first so downstream FFIs in `GenreDetailView` get a
+    /// UUID instead of the name string.
+    func browseGenre(genre: Genre) {
+        Task { @MainActor in
+            guard let realId = await resolvedGenreId(forName: genre.name) else {
+                errorMessage = "Genre '\(genre.name)' not found on server"
+                return
+            }
+            // Push a Genre carrying the resolved UUID so downstream FFI
+            // calls in GenreDetailView don't have to re-resolve.
+            navigate(to: .genre(Genre(id: realId, name: genre.name)))
+        }
     }
 
-    /// Shuffle every track tagged with the given genre.
-    /// TODO(#823): genre-scoped track list FFI not yet wired.
-    func shuffleGenre(genre: String) {
-        // TODO(#823): genre-scoped track list FFI not yet wired.
-        Log.app.notice("shuffleGenre(\(genre, privacy: .public)) not yet wired — see #823")
+    /// Kick off an Instant Mix seeded by this genre. Fixes the prior
+    /// UUID-mismatch bug where the genre *name* was passed to
+    /// `core.instantMix(itemId:)` which expects a UUID.
+    func startGenreRadio(genre: Genre) {
+        Task { @MainActor in
+            guard let realId = await resolvedGenreId(forName: genre.name) else {
+                errorMessage = "Genre '\(genre.name)' not found on server"
+                return
+            }
+            playInstantMix(seedId: realId)
+        }
+    }
+
+    /// Shuffle every track in this genre. Loads the first 500-track page
+    /// via `core.tracksByGenre`, shuffles client-side, then plays.
+    func shuffleGenre(genre: Genre) {
+        Task { @MainActor in
+            guard let realId = await resolvedGenreId(forName: genre.name) else {
+                errorMessage = "Genre '\(genre.name)' not found on server"
+                return
+            }
+            do {
+                let page = try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.tracksByGenre(genreId: realId, offset: 0, limit: 500)
+                }.value
+                let tracks = page.items
+                guard !tracks.isEmpty else { return }
+                play(tracks: tracks.shuffled(), startIndex: 0)
+            } catch {
+                if handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = "Couldn't load tracks for \(genre.name): \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Internal: load a page of albums tagged with the given resolved
+    /// genre UUID. Used by `GenreDetailView` for the albums shelf. The
+    /// FFI call runs off the MainActor per CLAUDE.md gap pattern #2.
+    func loadAlbums(forGenreId genreId: String, limit: UInt32 = 50) async -> [Album] {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.itemsByGenre(genreId: genreId, offset: 0, limit: limit)
+            }.value
+            return page.items
+        } catch {
+            if !handleAuthError(error) {
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = LyrebirdErrorPresenter.message(for: error, context: .libraryLoad)
+            }
+            return []
+        }
+    }
+
+    /// Internal: load a page of tracks tagged with the given resolved
+    /// genre UUID. Used by `GenreDetailView` for the tracks shelf. The
+    /// FFI call runs off the MainActor per CLAUDE.md gap pattern #2.
+    func loadTracks(forGenreId genreId: String, limit: UInt32 = 50) async -> [Track] {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.tracksByGenre(genreId: genreId, offset: 0, limit: limit)
+            }.value
+            return page.items
+        } catch {
+            if !handleAuthError(error) {
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = LyrebirdErrorPresenter.message(for: error, context: .libraryLoad)
+            }
+            return []
+        }
     }
 
     /// Pin a genre tile to the Home screen so the user can one-click-browse.
@@ -4837,6 +4945,17 @@ struct Genre: Hashable, Identifiable, Sendable {
         // Name doubles as id — genres are unique by label in Jellyfin's
         // surface and we don't have the real collection ids yet.
         self.id = name
+    }
+
+    /// Memberwise init used by the Wave 2 name→UUID resolver
+    /// (`AppModel.resolvedGenreId(forName:)`): once the real Jellyfin id has
+    /// been fetched from `/MusicGenres`, we rebuild the Swift `Genre` with
+    /// the real UUID in `id` so downstream FFI calls (`tracksByGenre`,
+    /// `itemsByGenre`, `instantMix`) get a UUID instead of the display
+    /// name. See #823 Wave 2.
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
     }
 }
 

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -33,11 +33,13 @@ extension AppModel {
     /// context menus.
     var supportsTrackInfo: Bool { true }
 
-    /// Genre actions (#823). Disabled until the genre-id resolver +
-    /// `tracksForGenre` / `albumsForGenre` FFIs land — the stub actions
-    /// today pass a genre name (e.g. "Jazz") as an item id to
-    /// `core.instantMix(itemId:)` which expects a UUID, producing garbage.
-    /// Flip to `true` once `browseGenre`, `shuffleGenre`, and
-    /// `pinGenreToHome` are wired to real core FFIs.
-    var supportsGenreActions: Bool { false }
+    /// Genre actions (#823). Gates the genre context menu (Browse /
+    /// Radio / Shuffle / Pin), the `GenreResultRow` row in search, and
+    /// the genre detail screen reachable via `Route.genre`. Wired
+    /// end-to-end on top of `core.genres`, `core.itemsByGenre`,
+    /// `core.tracksByGenre`, and `core.instantMix`; the flag stays as a
+    /// kill-switch / regression fallback. See
+    /// `supportsMarkPlayed` / `supportsArtistPlayShuffle` for the same
+    /// pattern.
+    var supportsGenreActions: Bool { true }
 }

--- a/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/GenreContextMenu.swift
@@ -9,30 +9,27 @@ import SwiftUI
 ///     ─
 ///     Pin to Home
 ///
-/// Takes a `Genre` so we have a stable id (name-derived today, real id when
-/// the genre-id resolver lands). The browse / radio / shuffle entries still
-/// hand `genre.name` to their `String`-typed AppModel stubs; those signatures
-/// migrate to `Genre` in Wave 2 of #823.
+/// Takes a `Genre` so we have a stable id (display name today on the Swift
+/// `Genre`; the AppModel actions resolve to real Jellyfin UUIDs via the
+/// name→UUID cache before dispatching any FFI call). See #823 Wave 2.
 ///
-/// All actions call through to `AppModel`. The three radio/browse/shuffle
-/// entries remain TODO stubs pending the tracksForGenre / albumsForGenre
-/// FFIs tracked in #823.
+/// All actions call through to `AppModel`.
 struct GenreContextMenu: View {
     @Environment(AppModel.self) private var model
     let genre: Genre
 
     var body: some View {
-        // Every entry in this menu is gated on FFIs that don't ship in 0.2
-        // (#823). When `supportsGenreActions` flips on these will come back.
+        // `supportsGenreActions` stays as a kill-switch so this menu can
+        // be disabled wholesale if the genre FFIs regress.
         if model.supportsGenreActions {
             Button("Browse genre", systemImage: "square.grid.2x2") {
-                model.browseGenre(genre: genre.name)
+                model.browseGenre(genre: genre)
             }
             Button("Start genre radio", systemImage: "dot.radiowaves.left.and.right") {
-                model.startGenreRadio(genre: genre.name)
+                model.startGenreRadio(genre: genre)
             }
             Button("Shuffle genre", systemImage: "shuffle") {
-                model.shuffleGenre(genre: genre.name)
+                model.shuffleGenre(genre: genre)
             }
 
             Divider()

--- a/macos/Sources/Lyrebird/Screens/GenreDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/GenreDetailView.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Genre detail screen — pushed onto the navigation stack by
+/// `AppModel.browseGenre(genre:)`. Mirrors the shape of `ArtistDetailView`:
+/// a header band with the genre name, a transport row (Play / Shuffle /
+/// Radio / Pin), an Albums shelf, and a Tracks shelf. The shelves render
+/// eagerly (no `LazyHStack`) per CLAUDE.md's rc9 note about the macOS 26.4
+/// UAF in `LazyHStack` inside a horizontal ScrollView.
+///
+/// The incoming `Genre` is constructed by `AppModel.browseGenre` and
+/// carries the *resolved Jellyfin UUID* in `genre.id` (not the display
+/// name — see #823 Wave 2), so this view passes `genre.id` directly to
+/// `core.itemsByGenre` / `core.tracksByGenre`. Don't re-resolve here.
+struct GenreDetailView: View {
+    @Environment(AppModel.self) private var model
+    let genre: Genre
+
+    @State private var albums: [Album] = []
+    @State private var tracks: [Track] = []
+    @State private var isLoadingAlbums = true
+    @State private var isLoadingTracks = true
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                transportBar
+                albumsSection
+                tracksSection
+            }
+        }
+        .background(Theme.bg)
+        .task(id: genre.id) {
+            isLoadingAlbums = true
+            isLoadingTracks = true
+            // Independent do/catch per CLAUDE.md gap pattern #4 — one
+            // flaky endpoint shouldn't sink the other shelf. The two
+            // helpers on AppModel already swallow errors into
+            // `errorMessage`, so we just await each in turn.
+            albums = await model.loadAlbums(forGenreId: genre.id, limit: 50)
+            isLoadingAlbums = false
+            tracks = await model.loadTracks(forGenreId: genre.id, limit: 50)
+            isLoadingTracks = false
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("GENRE")
+                .font(Theme.font(11, weight: .bold))
+                .foregroundStyle(Theme.accent)
+                .tracking(3)
+            Text(genre.name)
+                .font(Theme.font(64, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+                .tracking(-2)
+                .lineLimit(2)
+            subtitleLine
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 32)
+        .padding(.top, 32)
+        .padding(.bottom, 12)
+    }
+
+    /// "N songs · M albums" subtitle — built from whichever counts the
+    /// shelves loaded so far. Falls back to a quiet stat-less line while
+    /// the page is still warming up.
+    @ViewBuilder
+    private var subtitleLine: some View {
+        let songCount = tracks.count
+        let albumCount = albums.count
+        let parts: [String] = {
+            var p: [String] = []
+            if !isLoadingTracks { p.append(songCount == 1 ? "1 song" : "\(songCount) songs") }
+            if !isLoadingAlbums { p.append(albumCount == 1 ? "1 album" : "\(albumCount) albums") }
+            return p
+        }()
+        if !parts.isEmpty {
+            Text(parts.joined(separator: " · "))
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+        } else {
+            Text(" ")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+        }
+    }
+
+    // MARK: - Transport
+
+    @ViewBuilder
+    private var transportBar: some View {
+        HStack(spacing: 14) {
+            // Primary CTA — Play. Plays the loaded track page in order
+            // (no shuffle). Disabled while tracks are still loading.
+            Button {
+                guard !tracks.isEmpty else { return }
+                model.play(tracks: tracks, startIndex: 0)
+            } label: {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.white)
+                    .frame(width: 54, height: 54)
+                    .background(Circle().fill(Theme.accent))
+                    .shadow(color: Theme.accent.opacity(0.35), radius: 12, y: 8)
+            }
+            .buttonStyle(.plain)
+            .disabled(tracks.isEmpty)
+            .help("Play \(genre.name)")
+            .accessibilityLabel("Play all \(genre.name) tracks")
+
+            transportSecondary(icon: "shuffle", help: "Shuffle \(genre.name)") {
+                model.shuffleGenre(genre: genre)
+            }
+
+            transportSecondary(icon: "dot.radiowaves.left.and.right", help: "Start \(genre.name) radio") {
+                model.startGenreRadio(genre: genre)
+            }
+
+            transportSecondary(icon: "pin", help: "Pin \(genre.name) to Home") {
+                model.pinGenreToHome(genre: genre)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func transportSecondary(icon: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.ink2)
+                .frame(width: 36, height: 36)
+        }
+        .buttonStyle(.plain)
+        .help(help)
+        .accessibilityLabel(help)
+    }
+
+    // MARK: - Albums shelf
+
+    @ViewBuilder
+    private var albumsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(eyebrow: "ALBUMS", title: "Albums in \(genre.name)")
+            if isLoadingAlbums {
+                ProgressView()
+                    .tint(Theme.ink2)
+                    .padding(.vertical, 40)
+                    .frame(maxWidth: .infinity)
+            } else if albums.isEmpty {
+                emptySection(icon: "square.stack", message: "No albums tagged with \(genre.name) yet.")
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    // Eager HStack per CLAUDE.md rc9 — LazyHStack inside a
+                    // horizontal ScrollView triggers a UAF on macOS 26.4
+                    // when the carousel reuses children across navigation.
+                    HStack(alignment: .top, spacing: 16) {
+                        ForEach(albums, id: \.id) { album in
+                            HomeAlbumTile(album: album)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 32)
+                }
+            }
+        }
+        .padding(.top, 24)
+    }
+
+    // MARK: - Tracks shelf
+
+    @ViewBuilder
+    private var tracksSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(eyebrow: "TRACKS", title: "Tracks in \(genre.name)")
+            if isLoadingTracks {
+                ProgressView()
+                    .tint(Theme.ink2)
+                    .padding(.vertical, 40)
+                    .frame(maxWidth: .infinity)
+            } else if tracks.isEmpty {
+                emptySection(icon: "music.note.list", message: "No tracks tagged with \(genre.name) yet.")
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(tracks, id: \.id) { track in
+                        let index = tracks.firstIndex(where: { $0.id == track.id }) ?? 0
+                        TrackListRow(track: track, tracks: tracks, index: index)
+                    }
+                }
+                .padding(.horizontal, 32)
+            }
+        }
+        .padding(.top, 28)
+        .padding(.bottom, 40)
+    }
+
+    // MARK: - Section helpers (mirror ArtistDetailView)
+
+    @ViewBuilder
+    private func sectionHeader(eyebrow: String, title: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(eyebrow)
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(2)
+            Text(title)
+                .font(Theme.font(22, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+                .tracking(-1)
+        }
+        .padding(.horizontal, 32)
+    }
+
+    @ViewBuilder
+    private func emptySection(icon: String, message: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.ink3)
+            Text(message)
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 32)
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -344,17 +344,17 @@ struct HomeView: View {
     }
 
     /// Handler for a tapped pinned station. Dispatches on `station.type`.
-    /// Genre routing is logged for now — the full browse wiring lands in
-    /// Wave 2 of #823 alongside the `browseGenre(genre:)` signature change.
+    /// Genre routing browses the genre detail screen (#823 Wave 2).
     /// Artist / playlist / mood / mix routing still waits on the Instant
     /// Mix FFI (#144) and the typed pin model.
     private func handleStationTap(_ station: PinnedStation) {
         switch station.type {
         case .genre:
-            // TODO(#823 Wave 2): replace with `model.browseGenre(genre:)` once
-            // that method's signature accepts a `Genre`. Logging-only for now
-            // so we don't create a rebase landmine against the Wave 2 PR.
-            Log.app.notice("PinnedStation tap (.genre id=\(station.id, privacy: .public)) — routing lands in Wave 2 of #823")
+            // The pinned station's id IS the genre display name (Wave 1
+            // stored it that way because the Swift Genre struct's id == name).
+            // Construct a name-only Genre and let browseGenre resolve the
+            // real Jellyfin UUID via the /MusicGenres cache before pushing.
+            model.browseGenre(genre: Genre(name: station.title))
         case .artist, .playlist, .mood, .mix:
             // TODO: #144 / #253 — route to start the corresponding station
             // once the typed pin model + Instant Mix FFI land.

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -209,6 +209,8 @@ struct MainShell: View {
             ArtistDetailView(artistID: id)
         case .playlist(let id):
             PlaylistView(playlistID: id)
+        case .genre(let g):
+            GenreDetailView(genre: g)
         case .nowPlaying:
             NowPlayingView()
         }
@@ -334,6 +336,10 @@ struct MainShell: View {
             } else {
                 segments.append("…")
             }
+        case .genre(let g)?:
+            if model.screen != .library { segments.append("Library") }
+            segments.append("Genres")
+            segments.append(g.name)
         case .nowPlaying?:
             segments.append("Now Playing")
         case .home?, .discover?, .library?, .favorites?, .search?, .settings?, nil:

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -695,7 +695,7 @@ private struct GenreResultRow: View {
 
     var body: some View {
         if model.supportsGenreActions {
-            Button(action: { model.browseGenre(genre: name) }) {
+            Button(action: { model.browseGenre(genre: Genre(name: name)) }) {
                 HStack(spacing: 12) {
                     Image(systemName: "guitars")
                         .font(.system(size: 14, weight: .medium))


### PR DESCRIPTION
## Summary
- Wire `browseGenre`, `shuffleGenre`, `startGenreRadio` against the now-merged `core.tracksByGenre` + existing `core.itemsByGenre` + `core.instantMix`.
- Add AppModel-level name→UUID resolver (lazy `core.genres()` cache) — required because the Swift `Genre` struct's id field doubles as the display name, while Jellyfin's `/MusicGenres` returns stable UUIDs that the FFIs require.
- Fix the long-standing `startGenreRadio` UUID bug.
- Add `GenreDetailView` (mirrors `ArtistDetailView` shape) and `Route.genre`.
- Wire pinned-genre tap routing in HomeView.
- Flip `Capabilities.supportsGenreActions` to `true`.

Closes #823.

## Test plan
- [x] \`swift build --package-path macos\` clean.
- [ ] Live smoke against \`music.skalthoff.com\`:
  - [ ] Genre context menu → Browse → \`GenreDetailView\` opens, albums + tracks render.
  - [ ] Shuffle → tracks load, audio plays.
  - [ ] Radio → instant mix loads, audio plays.
  - [ ] Pin → tile appears on Home; tap reopens detail.

Closes #823