### PR TITLE
fix(macos): TrackRow single tap is the only play gesture

### DIFF
--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -133,7 +133,6 @@ struct TrackRow: View {
         )
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
-        .onTapGesture(count: 2) { onPlay?() }
         .onTapGesture(count: 1) { onPlay?() }
         .contextMenu { TrackContextMenu(selection: [track], playlistScope: playlistScope) }
         // VoiceOver reads the row as a single "<title> by <artist>" line


### PR DESCRIPTION
Double-clicking a track row no longer restarts playback to 0:00.

`TrackRow` registered both a count-2 and a count-1 tap gesture, each calling
`onPlay?()`. On macOS the count-1 recognizer fires first on a double-click,
then count-2 fires, so `onPlay?()` ran twice and the scrubber snapped back to
the start. Removing the redundant count-2 gesture leaves a single click as the
sole play gesture, matching the keyboard (`.return`) path which already calls
`onPlay?()` once.

Closes #856

pipeline:
  fixer-session: wf_415260a0-0e8-37
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +0/-1
