### PR TITLE
macos: announce track changes to VoiceOver (#342)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -397,6 +397,13 @@ final class AppModel {
     /// `currentTrackPeopleForId`.
     private var currentLyricsForId: String?
 
+    /// In-flight debounced VoiceOver track-change announcement (#342).
+    /// Stored so a rapid next / next / next collapses to a single
+    /// announcement: each call cancels the previous pending task before the
+    /// 300ms window elapses, so only the final track is spoken. Mirrors the
+    /// cancel-previous idiom used by `searchTask`.
+    private var trackAnnounceTask: Task<Void, Never>?
+
     // MARK: - Loading / errors
     var isLoggingIn = false
     var isLoadingLibrary = false
@@ -4489,6 +4496,33 @@ final class AppModel {
     }
 
     // MARK: - Now Playing details
+
+    /// Post a VoiceOver announcement when the playing track changes so VO
+    /// users hear the new track without navigating back to the player bar
+    /// (#342). Hooked from `MainShell` on changes to
+    /// `status.currentTrack?.id`.
+    ///
+    /// Debounced by 300ms via the `searchTask` cancel-previous idiom: a
+    /// rapid next / next / next cancels each pending announcement before
+    /// its window elapses, so only the final track is spoken. The
+    /// announcement itself is `.high`-priority and non-interrupting (see
+    /// `AccessibilityAnnouncer`), so it never yanks VO out of the user's
+    /// current focus context.
+    func announceTrackChange(to track: Track) {
+        trackAnnounceTask?.cancel()
+        let message = "Now playing \(track.name) by \(track.artistName)"
+        trackAnnounceTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: 300_000_000)
+            } catch {
+                // Cancelled by a newer track change before the window
+                // elapsed — the newer call owns the announcement.
+                return
+            }
+            if Task.isCancelled { return }
+            AccessibilityAnnouncer.announce(message)
+        }
+    }
 
     /// Fetch detail fields (currently just `People`) for the track that is
     /// playing right now and publish the result on `currentTrackPeople` so

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -121,6 +121,16 @@ struct MainShell: View {
                 .accessibilitySortPriority(50)
         }
         .background(Theme.bg)
+        // Announce track changes to VoiceOver (#342). Keyed on the track id
+        // so it fires for user skips and autoplay alike but not for
+        // non-identity status churn (position / volume polls). The stop
+        // transition (id -> nil) is intentionally ignored — there is no new
+        // track to announce. Debounce + non-interrupting posting live in
+        // `AppModel.announceTrackChange`.
+        .onChange(of: model.status.currentTrack?.id) { _, newId in
+            guard newId != nil, let track = model.status.currentTrack else { return }
+            model.announceTrackChange(to: track)
+        }
         // Cmd+Opt+Q toggles the queue inspector (#79). Hung off a zero-sized
         // hidden button so the shortcut is global to `MainShell` without
         // requiring a visible chrome affordance — the visible toggle will

--- a/macos/Sources/Lyrebird/System/AccessibilityAnnouncer.swift
+++ b/macos/Sources/Lyrebird/System/AccessibilityAnnouncer.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+/// Posts VoiceOver announcements for app-driven events that happen away from
+/// the user's current focus — the canonical example being a track change
+/// triggered by autoplay or a media key, where the player bar isn't where
+/// VoiceOver is reading (#342).
+///
+/// `.announcementRequested` is the AppKit notification that maps to
+/// `AccessibilityNotification.Announcement`: VoiceOver speaks the message
+/// without moving or interrupting the user's focus context, unlike a
+/// `.layoutChanged` / focus move which would yank them out of whatever
+/// they were navigating. The `.high` priority level ensures playback
+/// announcements aren't dropped when VoiceOver is mid-utterance, while
+/// still deferring to the user's own navigation speech.
+enum AccessibilityAnnouncer {
+    /// Speaks `message` via VoiceOver as a high-priority announcement.
+    ///
+    /// No-ops on an empty string so callers don't have to guard. The post
+    /// is addressed to the main window (the element VoiceOver associates
+    /// announcements with); when there is no main window — e.g. during
+    /// teardown — the announcement is simply not delivered, which is the
+    /// correct behavior.
+    @MainActor
+    static func announce(_ message: String) {
+        guard !message.isEmpty, let window = NSApp.mainWindow else { return }
+        NSAccessibility.post(
+            element: window,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: message,
+                .priority: NSAccessibilityPriorityLevel.high.rawValue,
+            ]
+        )
+    }
+}


### PR DESCRIPTION
VoiceOver users had no way to learn the new track when playback advanced (autoplay or a media-key skip) unless they navigated back to the player bar; this posts a non-interrupting, high-priority announcement on every track change so the track is spoken in place.

## What

- New `AccessibilityAnnouncer` helper (`macos/Sources/Lyrebird/System/AccessibilityAnnouncer.swift`) wrapping `NSAccessibility.post(.announcementRequested, …)` at `.high` priority — speaks without moving VO focus.
- `AppModel.announceTrackChange(to:)` debounces 300ms via the same cancel-previous `Task` idiom as `searchTask`, so a rapid next/next/next collapses to a single announcement.
- `MainShell` hooks it from `.onChange(of: model.status.currentTrack?.id)`, keyed on the track id so it fires for user skips and autoplay alike but ignores position/volume poll churn and the stop (id→nil) transition.

Acceptance criteria from the issue: skip to next with ⌘→ / forward → VO speaks "Now playing <title> by <artist>" without interrupting focus; rapid skips emit only the final one (300ms debounce). Manual VoiceOver verification only — there is no Swift unit-test target in `macos/Package.swift` (app + SmokeTest + libraries), and `AppModel` requires the full core/session graph, so a unit test would mean speculative scaffolding.

Closes #342

```
pipeline:
  fixer-session: feature-builder-342 (Wave 2)
  slice: screens / a11y (macOS VoiceOver)
  hotspots-claimed: none
  build-gate: pass (./macos/Scripts/build-core.sh; cd macos && rm -rf .build && swift build → Build complete)
  diff-stat:  3 files changed, 79 insertions(+)
```