### PR TITLE
fix(macos): AlbumDetailView 'More by Artist' uses eager HStack

### DIFF
--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -485,7 +485,7 @@ struct AlbumDetailView: View {
                     .padding(.horizontal, 40)
 
                 ScrollView(.horizontal, showsIndicators: false) {
-                    LazyHStack(alignment: .top, spacing: 16) {
+                    HStack(alignment: .top, spacing: 16) {
                         ForEach(moreByArtist, id: \.id) { related in
                             HomeAlbumTile(album: related, hint: "Double-click to open album")
                         }


### PR DESCRIPTION
Brings AlbumDetailView's "More by Artist" carousel in line with the rc9 ArtistDetailView fix so it can't hit the macOS 26.4 + Apple Silicon use-after-free in lazy horizontal child recycling across NavigationStack push/pop.

Closes #860

pipeline:
  fixer-session: wf_cd55d074-0e0-26
  slice: slice:screens
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +1/-1
