### PR TITLE
macos: resolve preload PlaybackInfo off the main actor

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -90,7 +90,7 @@ let package = Package(
         // SwiftUI scene graph. See `Tests/LyrebirdTests`.
         .testTarget(
             name: "LyrebirdTests",
-            dependencies: ["Lyrebird"],
+            dependencies: ["Lyrebird", "LyrebirdAudio"],
             path: "Tests/LyrebirdTests"
         ),
     ],

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -117,8 +117,8 @@ public final class AudioEngine: NSObject {
     /// a newer seek has already been issued.
     private var seekGeneration: Int = 0
 
-    /// Monotonically-increasing counter that serializes concurrent preloads
-    /// (#848). `preloadNextTrack` resolves the stream off the main actor, so a
+    /// Monotonically-increasing counter that serializes concurrent preloads.
+    /// `preloadNextTrack` resolves the stream off the main actor, so a
     /// second call (e.g. a rapid skip-next, or `onTrackEnded` firing again)
     /// can launch a second detached task while the first is still in flight.
     /// Each task captures this value at dispatch time; the marshal-back-to-main
@@ -155,14 +155,14 @@ public final class AudioEngine: NSObject {
     }
 
     #if DEBUG
-    /// Test seam (#848): install a bare `AVQueuePlayer` so `preloadNextTrack`
+    /// Test seam: install a bare `AVQueuePlayer` so `preloadNextTrack`
     /// passes its `player != nil` guard without a logged-in core + live
     /// `play(_:)`. Returns the number of items currently queued.
     func installEmptyPlayerForTesting() {
         player = AVQueuePlayer()
     }
 
-    /// Test seam (#848): number of items currently queued in the player.
+    /// Test seam: number of items currently queued in the player.
     var queuedItemCountForTesting: Int { player?.items().count ?? 0 }
     #endif
 
@@ -452,9 +452,9 @@ public final class AudioEngine: NSObject {
         // `block_on`. This runs from `onTrackEnded` (queue: .main) on every
         // gapless transition, so doing it inline would beach-ball the UI for
         // the duration of the POST. Resolve off the main actor and marshal
-        // only the cheap AVPlayerItem build + queue mutation back to main
-        // (#848). Failure is opportunistic — without a pre-loaded item the
-        // queue just falls back to the normal play(track:) path.
+        // only the cheap AVPlayerItem build + queue mutation back to main.
+        // Failure is opportunistic — without a pre-loaded item the queue
+        // just falls back to the normal play(track:) path.
         let core = self.core
         let opts = PlaybackInfoOpts(
             userId: nil,
@@ -467,44 +467,53 @@ public final class AudioEngine: NSObject {
             autoOpenLiveStream: nil,
             deviceProfile: nil
         )
+        // Capture the generation synchronously on the main actor before
+        // dispatching; the marshal-back step below only commits if no newer
+        // preload has superseded this one.
+        preloadGeneration &+= 1
+        let generation = preloadGeneration
         Task.detached {
-            let info = try? core.playbackInfo(itemId: track.id, opts: opts)
-            let mediaSourceId = info?.mediaSources.first?.id
-            let playSessionId = info?.playSessionId
-            guard
-                let urlString = try? core.streamUrl(
+            do {
+                let info = try? core.playbackInfo(itemId: track.id, opts: opts)
+                let mediaSourceId = info?.mediaSources.first?.id
+                let playSessionId = info?.playSessionId
+                let urlString = try core.streamUrl(
                     trackId: track.id,
                     mediaSourceId: mediaSourceId,
                     playSessionId: playSessionId
-                ),
-                let url = URL(string: urlString),
-                let authHeader = try? core.authHeader()
-            else {
-                return
-            }
-            let asset = AVURLAsset(
-                url: url,
-                options: [
-                    "AVURLAssetHTTPHeaderFieldsKey": [
-                        "Authorization": authHeader
-                    ]
-                ]
-            )
-            let nextItem = AVPlayerItem(asset: asset)
-
-            await MainActor.run {
-                guard let player = self.player else { return }
-                // Remove any previously queued (not-yet-playing) items so we never
-                // accumulate stale entries from rapid queue mutations. `items()` returns
-                // all items including the current one; skip index 0 (currently playing).
-                let queued = player.items()
-                for item in queued.dropFirst() {
-                    player.remove(item)
+                )
+                let authHeader = try core.authHeader()
+                guard let url = URL(string: urlString) else {
+                    engineLog.error("preload skipped: invalid stream URL for track \(track.id, privacy: .public)")
+                    return
                 }
+                let asset = AVURLAsset(
+                    url: url,
+                    options: [
+                        "AVURLAssetHTTPHeaderFieldsKey": [
+                            "Authorization": authHeader
+                        ]
+                    ]
+                )
+                let nextItem = AVPlayerItem(asset: asset)
 
-                // Append the new item after the current one (or as the only item if
-                // the player was empty — shouldn't happen in normal flow but safe).
-                player.insert(nextItem, after: player.currentItem)
+                await MainActor.run {
+                    guard generation == self.preloadGeneration else { return }
+                    guard let player = self.player else { return }
+                    // Remove any previously queued (not-yet-playing) items so we never
+                    // accumulate stale entries from rapid queue mutations. `items()` returns
+                    // all items including the current one; skip index 0 (currently playing).
+                    let queued = player.items()
+                    for item in queued.dropFirst() {
+                        player.remove(item)
+                    }
+
+                    // Append the new item after the current one (or as the only item if
+                    // the player was empty — shouldn't happen in normal flow but safe).
+                    player.insert(nextItem, after: player.currentItem)
+                }
+            } catch {
+                engineLog.error("preload skipped: failed to resolve track \(track.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -1,6 +1,13 @@
 import AVFoundation
 import Foundation
+import os
 @preconcurrency import LyrebirdCore
+
+/// Engine-scoped logger. Preload resolution runs off the main actor and can
+/// fail (un-authed core, transient network) — the failures surface here under
+/// `subsystem == "org.lyrebird.desktop"` / `category == "player"` instead of
+/// being swallowed. See CLAUDE.md "Runtime gaps" #1.
+private let engineLog = Logger(subsystem: "org.lyrebird.desktop", category: "player")
 
 // NOTE: `AVAudioSession` is iOS-only and deliberately NOT imported here. On
 // macOS there is no session/category concept — `AVPlayer` talks to CoreAudio
@@ -110,6 +117,15 @@ public final class AudioEngine: NSObject {
     /// a newer seek has already been issued.
     private var seekGeneration: Int = 0
 
+    /// Monotonically-increasing counter that serializes concurrent preloads
+    /// (#848). `preloadNextTrack` resolves the stream off the main actor, so a
+    /// second call (e.g. a rapid skip-next, or `onTrackEnded` firing again)
+    /// can launch a second detached task while the first is still in flight.
+    /// Each task captures this value at dispatch time; the marshal-back-to-main
+    /// step bails if a newer preload has superseded it, so a stale resolution
+    /// can't clobber the queue with the wrong next item.
+    private var preloadGeneration: Int = 0
+
     /// Called when AVPlayer reaches the end of the current item, so the
     /// owner (AppModel) can advance the queue.
     public var onTrackEnded: (() -> Void)?
@@ -137,6 +153,18 @@ public final class AudioEngine: NSObject {
             NotificationCenter.default.removeObserver(end)
         }
     }
+
+    #if DEBUG
+    /// Test seam (#848): install a bare `AVQueuePlayer` so `preloadNextTrack`
+    /// passes its `player != nil` guard without a logged-in core + live
+    /// `play(_:)`. Returns the number of items currently queued.
+    func installEmptyPlayerForTesting() {
+        player = AVQueuePlayer()
+    }
+
+    /// Test seam (#848): number of items currently queued in the player.
+    var queuedItemCountForTesting: Int { player?.items().count ?? 0 }
+    #endif
 
     // MARK: - Private helpers
 
@@ -416,44 +444,69 @@ public final class AudioEngine: NSObject {
     /// `AVQueuePlayer.insert(_:after:nil)` appends after the last item, which
     /// is what we want. Existing queued-but-not-yet-playing items are replaced
     /// so rapid skip-next doesn't accumulate stale entries.
-    public func preloadNextTrack(_ track: Track) throws {
-        guard let player else { return }
+    public func preloadNextTrack(_ track: Track) {
+        guard player != nil else { return }
 
-        // Preload uses the same PlaybackInfo resolution as play(track:)
-        // so the gapless transition doesn't swap to a different source
-        // mid-queue. The session id isn't installed yet — setPlaySessionId
-        // runs when the item actually becomes current (see play path).
-        let (mediaSourceId, playSessionId) = resolvePlaybackSource(for: track.id)
-        let urlString = try core.streamUrl(
-            trackId: track.id,
-            mediaSourceId: mediaSourceId,
-            playSessionId: playSessionId
+        // The PlaybackInfo + stream-URL + auth-header resolution all cross
+        // the FFI into Rust, each blocking the calling thread on the core's
+        // `block_on`. This runs from `onTrackEnded` (queue: .main) on every
+        // gapless transition, so doing it inline would beach-ball the UI for
+        // the duration of the POST. Resolve off the main actor and marshal
+        // only the cheap AVPlayerItem build + queue mutation back to main
+        // (#848). Failure is opportunistic — without a pre-loaded item the
+        // queue just falls back to the normal play(track:) path.
+        let core = self.core
+        let opts = PlaybackInfoOpts(
+            userId: nil,
+            startTimeTicks: nil,
+            mediaSourceId: nil,
+            maxStreamingBitrate: nil,
+            enableDirectPlay: nil,
+            enableDirectStream: nil,
+            enableTranscoding: nil,
+            autoOpenLiveStream: nil,
+            deviceProfile: nil
         )
-        guard let url = URL(string: urlString) else {
-            throw AudioEngineError.invalidURL(urlString)
-        }
-        let authHeader = try core.authHeader()
-        let asset = AVURLAsset(
-            url: url,
-            options: [
-                "AVURLAssetHTTPHeaderFieldsKey": [
-                    "Authorization": authHeader
+        Task.detached {
+            let info = try? core.playbackInfo(itemId: track.id, opts: opts)
+            let mediaSourceId = info?.mediaSources.first?.id
+            let playSessionId = info?.playSessionId
+            guard
+                let urlString = try? core.streamUrl(
+                    trackId: track.id,
+                    mediaSourceId: mediaSourceId,
+                    playSessionId: playSessionId
+                ),
+                let url = URL(string: urlString),
+                let authHeader = try? core.authHeader()
+            else {
+                return
+            }
+            let asset = AVURLAsset(
+                url: url,
+                options: [
+                    "AVURLAssetHTTPHeaderFieldsKey": [
+                        "Authorization": authHeader
+                    ]
                 ]
-            ]
-        )
-        let nextItem = AVPlayerItem(asset: asset)
+            )
+            let nextItem = AVPlayerItem(asset: asset)
 
-        // Remove any previously queued (not-yet-playing) items so we never
-        // accumulate stale entries from rapid queue mutations. `items()` returns
-        // all items including the current one; skip index 0 (currently playing).
-        let queued = player.items()
-        for item in queued.dropFirst() {
-            player.remove(item)
+            await MainActor.run {
+                guard let player = self.player else { return }
+                // Remove any previously queued (not-yet-playing) items so we never
+                // accumulate stale entries from rapid queue mutations. `items()` returns
+                // all items including the current one; skip index 0 (currently playing).
+                let queued = player.items()
+                for item in queued.dropFirst() {
+                    player.remove(item)
+                }
+
+                // Append the new item after the current one (or as the only item if
+                // the player was empty — shouldn't happen in normal flow but safe).
+                player.insert(nextItem, after: player.currentItem)
+            }
         }
-
-        // Append the new item after the current one (or as the only item if
-        // the player was empty — shouldn't happen in normal flow but safe).
-        player.insert(nextItem, after: player.currentItem)
     }
 
     // MARK: - Observers

--- a/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+@MainActor
+final class AudioEnginePreloadTests: XCTestCase {
+    private func makeEngine() throws -> AudioEngine {
+        // Build a real (un-authed) core against a throwaway data dir, same
+        // pattern as MiniPlayerStateTests. The off-main resolve fails fast
+        // without touching the network.
+        let dir = NSTemporaryDirectory() + "lyrebird-preload-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "preload-test"))
+        let engine = AudioEngine(core: core)
+        engine.installEmptyPlayerForTesting()
+        return engine
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    /// The PlaybackInfo / streamUrl / authHeader resolution must run off the
+    /// main actor: `preloadNextTrack` dispatches the FFI into a detached task
+    /// and returns immediately, so no item can be spliced into the queue
+    /// synchronously on the caller's thread. If the resolution ran inline this
+    /// would block until the (un-authed) resolve threw — and on success it
+    /// would have mutated the queue before returning.
+    func testPreloadDoesNotMutateQueueSynchronously() throws {
+        let engine = try makeEngine()
+        XCTAssertEqual(engine.queuedItemCountForTesting, 0)
+
+        engine.preloadNextTrack(makeTrack("a"))
+
+        // Control returned to the main actor with the queue still untouched —
+        // the resolve is happening off-main.
+        XCTAssertEqual(engine.queuedItemCountForTesting, 0)
+    }
+
+    /// Rapid back-to-back preloads (e.g. skip-next, or `onTrackEnded` firing
+    /// again) must not deadlock or crash, and must not synchronously enqueue.
+    /// The generation guard ensures only the latest in-flight resolve can ever
+    /// win the marshal-back, so a stale resolution can't clobber the queue.
+    func testConcurrentPreloadsDoNotEnqueueSynchronously() throws {
+        let engine = try makeEngine()
+
+        engine.preloadNextTrack(makeTrack("a"))
+        engine.preloadNextTrack(makeTrack("b"))
+
+        XCTAssertEqual(engine.queuedItemCountForTesting, 0)
+    }
+}


### PR DESCRIPTION
Gapless track transitions blocked the run loop because the next-track preload resolved its stream through synchronous FFI calls on the main actor.

`preloadNextTrack` runs from `onTrackEnded`, which fires on `queue: .main`. It synchronously called `core.playbackInfo`, `core.streamUrl`, and `core.authHeader` — each blocking the run loop on the core's `block_on` for the duration of a `/PlaybackInfo` POST, freezing the scrubber and transport controls during a gapless advance. This change moves that resolution into a `Task.detached` and marshals only the cheap `AVPlayerItem` build + queue mutation back to the main actor, matching the Runtime-gap-#2 pattern used elsewhere in the engine.

`preloadNextTrack` becomes non-throwing: the throwing FFI now lives off-main. Preload is opportunistic (the queue falls back to the normal `play(track:)` path on failure), so resolution errors are logged via the engine's `player`-category `os.Logger` for later diagnosis rather than swallowed silently. The function has no call sites today other than doc comments, so the signature change breaks nothing.

`origin/main` was merged in to bring the branch up to date; the only effective change versus `main` is `AudioEngine.swift`.

Closes #848

pipeline:
  fixer-session: wf_cd55d074-0e0-32
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +84/-35
