### PR TITLE
fix(macos): drop dead LyricsView tick State that forced 200ms re-renders

### DIFF
--- a/macos/Sources/Lyrebird/Components/LyricsView.swift
+++ b/macos/Sources/Lyrebird/Components/LyricsView.swift
@@ -174,10 +174,6 @@ struct LyricsView: View {
     /// Current active line id. Driven by the ticker; the view re-renders
     /// on each change to move the highlight + trigger the scroll.
     @State private var activeId: Int?
-    /// Cached `Date` used to drive the ticker's Combine timer publisher.
-    /// The actual polling cadence is 200ms per the issue, tight enough
-    /// to feel live but loose enough not to pummel the main thread.
-    @State private var tick: Date = .now
 
     var body: some View {
         Group {
@@ -254,7 +250,6 @@ struct LyricsView: View {
             // compare, and we only mutate `activeId` when it changes, so
             // most ticks are no-ops.
             .onReceive(Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()) { _ in
-                tick = .now
                 updateActiveLine()
             }
             .onChange(of: activeId) { _, newValue in


### PR DESCRIPTION
Removes a `@State` whose only purpose was to force `LyricsView.body` to re-execute every 200ms even while playback is paused, violating the rc11 idle-wake contract.

`tick` was assigned in the 200ms timer callback but never read anywhere in `body` or any computed property, so each assignment marked the view dirty for no visual effect. The timer-driven `updateActiveLine()` call is unchanged, so lyric highlight / auto-scroll behaviour is identical.

Closes #873

pipeline:
  fixer-session: wf_cd0923b5-888-19
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, 0 insertions(+)/6 deletions(-)
