### PR TITLE
fix(core): carry UserData on Playlist so favorite reflects server state

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2822,12 +2822,14 @@ impl From<RawItem> for Album {
 
 impl From<RawItem> for Playlist {
     fn from(r: RawItem) -> Self {
+        let user_data = r.user_data.map(UserItemData::from);
         Playlist {
             id: r.id,
             name: r.name,
             track_count: r.child_count.unwrap_or(0),
             runtime_ticks: r.runtime_ticks,
             image_tag: r.image_tags.get("Primary").cloned(),
+            user_data,
         }
     }
 }

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -866,8 +866,12 @@ impl JellyfinClient {
             q.append_pair("StartIndex", &paging.offset.to_string());
             q.append_pair(
                 "Fields",
-                &enums::csv(&[ItemField::ChildCount, ItemField::Path], ItemField::as_str),
+                &enums::csv(
+                    &[ItemField::ChildCount, ItemField::Path, ItemField::UserData],
+                    ItemField::as_str,
+                ),
             );
+            q.append_pair("EnableUserData", "true");
         }
         let resp = self
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -103,6 +103,10 @@ pub struct Playlist {
     pub track_count: u32,
     pub runtime_ticks: u64,
     pub image_tag: Option<String>,
+    /// The server's `UserData` projection for this playlist — carries the
+    /// favorite flag, play count, last-played date, etc. `None` when the
+    /// caller did not request `Fields=UserData` or the server omitted it.
+    pub user_data: Option<UserItemData>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1923,8 +1923,6 @@ async fn user_playlists_returns_every_playlist_in_library_view() {
     assert_eq!(page.items[0].name, "My Mix");
     assert_eq!(page.items[0].track_count, 12);
     assert_eq!(page.items[0].image_tag.as_deref(), Some("tag-1"));
-    // The server's favorite projection must land on the model so the
-    // playlist-detail heart paints correctly on first load.
     assert_eq!(
         page.items[0].user_data.as_ref().map(|u| u.is_favorite),
         Some(true),

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1882,7 +1882,8 @@ async fn user_playlists_returns_every_playlist_in_library_view() {
         .and(query_param("IncludeItemTypes", "Playlist"))
         .and(query_param("Limit", "20"))
         .and(query_param("StartIndex", "5"))
-        .and(query_param("Fields", "ChildCount,Path"))
+        .and(query_param("Fields", "ChildCount,Path,UserData"))
+        .and(query_param("EnableUserData", "true"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "Items": [
                 {
@@ -1890,7 +1891,8 @@ async fn user_playlists_returns_every_playlist_in_library_view() {
                     "ChildCount": 12,
                     "RunTimeTicks": 42_000_000_000u64,
                     "Path": "/config/data/users/u1/playlists/my-mix",
-                    "ImageTags": { "Primary": "tag-1" }
+                    "ImageTags": { "Primary": "tag-1" },
+                    "UserData": { "IsFavorite": true }
                 },
                 {
                     "Id": "p2", "Name": "Community Top 40", "Type": "Playlist",
@@ -1921,9 +1923,17 @@ async fn user_playlists_returns_every_playlist_in_library_view() {
     assert_eq!(page.items[0].name, "My Mix");
     assert_eq!(page.items[0].track_count, 12);
     assert_eq!(page.items[0].image_tag.as_deref(), Some("tag-1"));
+    // The server's favorite projection must land on the model so the
+    // playlist-detail heart paints correctly on first load.
+    assert_eq!(
+        page.items[0].user_data.as_ref().map(|u| u.is_favorite),
+        Some(true),
+        "UserData.IsFavorite must be carried through on the playlist"
+    );
     // Crucially, the non-`/data/`-path playlist is included.
     assert_eq!(page.items[1].id, "p2");
     assert_eq!(page.items[1].name, "Community Top 40");
+    assert!(page.items[1].user_data.is_none());
 }
 
 #[tokio::test]

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3304,6 +3304,15 @@ final class AppModel {
         return album.userData?.isFavorite ?? false
     }
 
+    /// Snapshot-aware favorite check for playlists. Mirrors
+    /// `isFavorite(album:)` — falls back to `playlist.userData?.isFavorite`
+    /// when the cache is cold so the playlist-detail heart shows the correct
+    /// state on first paint.
+    func isFavorite(playlist: Playlist) -> Bool {
+        if let cached = favoriteById[playlist.id] { return cached }
+        return playlist.userData?.isFavorite ?? false
+    }
+
     /// Snapshot-aware favorite check for artists. Mirrors
     /// `isFavorite(track:)` — falls back to `artist.userData?.isFavorite`.
     func isFavorite(artist: Artist) -> Bool {

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -2251,7 +2251,8 @@ final class AppModel {
             name: name,
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
-            imageTag: imageTag
+            imageTag: imageTag,
+            userData: nil
         )
     }
 
@@ -2473,7 +2474,8 @@ final class AppModel {
                 name: p.name,
                 trackCount: UInt32(newCount),
                 runtimeTicks: p.runtimeTicks,
-                imageTag: p.imageTag
+                imageTag: p.imageTag,
+                userData: p.userData
             )
         }
         // Capture the optimistic state so we can roll back on server failure.
@@ -2508,7 +2510,8 @@ final class AppModel {
                         name: p.name,
                         trackCount: p.trackCount + UInt32(removedSnapshot.count),
                         runtimeTicks: p.runtimeTicks,
-                        imageTag: p.imageTag
+                        imageTag: p.imageTag,
+                        userData: p.userData
                     )
                 }
                 self.pendingPlaylistRemoval = nil
@@ -2542,7 +2545,8 @@ final class AppModel {
                 name: p.name,
                 trackCount: p.trackCount + UInt32(reinserted.count),
                 runtimeTicks: p.runtimeTicks,
-                imageTag: p.imageTag
+                imageTag: p.imageTag,
+                userData: p.userData
             )
         }
         // Capture the count of optimistically-reinserted tracks so we can
@@ -2575,7 +2579,8 @@ final class AppModel {
                         name: p.name,
                         trackCount: UInt32(newCount),
                         runtimeTicks: p.runtimeTicks,
-                        imageTag: p.imageTag
+                        imageTag: p.imageTag,
+                        userData: p.userData
                     )
                 }
                 self.errorMessage = LyrebirdErrorPresenter.message(
@@ -2606,7 +2611,8 @@ final class AppModel {
                 name: p.name,
                 trackCount: p.trackCount + UInt32(trackIds.count),
                 runtimeTicks: p.runtimeTicks,
-                imageTag: p.imageTag
+                imageTag: p.imageTag,
+                userData: p.userData
             )
         }
         let bumpedCount = trackIds.count
@@ -2633,7 +2639,8 @@ final class AppModel {
                         name: p.name,
                         trackCount: UInt32(newCount),
                         runtimeTicks: p.runtimeTicks,
-                        imageTag: p.imageTag
+                        imageTag: p.imageTag,
+                        userData: p.userData
                     )
                 }
                 self.errorMessage = LyrebirdErrorPresenter.message(
@@ -3781,7 +3788,7 @@ final class AppModel {
     func toggleFavorite(playlist: Playlist) {
         // `/Users/{id}/FavoriteItems/{id}` is polymorphic, so the same
         // set/unset-favorite FFI used for albums/tracks works on playlists.
-        Task { await setFavorite(itemId: playlist.id, enabled: !isFavorite(id: playlist.id)) }
+        Task { await setFavorite(itemId: playlist.id, enabled: !isFavorite(playlist: playlist)) }
     }
 
     /// Enqueue a download of every track in the playlist.
@@ -3979,7 +3986,8 @@ final class AppModel {
                 name: trimmed,
                 trackCount: 0,
                 runtimeTicks: 0,
-                imageTag: nil
+                imageTag: nil,
+                userData: nil
             )
             playlists.insert(newPlaylist, at: 0)
         } catch {
@@ -4004,7 +4012,8 @@ final class AppModel {
             name: trimmed,
             trackCount: existing.trackCount,
             runtimeTicks: existing.runtimeTicks,
-            imageTag: existing.imageTag
+            imageTag: existing.imageTag,
+            userData: existing.userData
         )
         Task {
             do {
@@ -4056,7 +4065,8 @@ final class AppModel {
                 name: copyName,
                 trackCount: UInt32(trackIds.count),
                 runtimeTicks: source.runtimeTicks,
-                imageTag: nil
+                imageTag: nil,
+                userData: nil
             )
             playlists.insert(newPlaylist, at: 0)
             // Prime the tracks cache so the detail view doesn't have to

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -256,7 +256,7 @@ struct PlaylistView: View {
             .disabled(tracks.isEmpty)
 
             if let playlist = playlist {
-                let isFav = model.isFavorite(id: playlist.id)
+                let isFav = model.isFavorite(playlist: playlist)
                 Button { model.toggleFavorite(playlist: playlist) } label: {
                     Image(systemName: isFav ? "heart.fill" : "heart")
                         .font(.system(size: 20))


### PR DESCRIPTION
A playlist the user favorited in a prior session showed an empty heart and inverted the toggle on first paint, because the server's `UserData.IsFavorite` projection had nowhere to land on the `Playlist` model.

Closes #862

This carries `UserData` through to the playlist-detail heart, matching the existing Track / Album / Artist pattern:
- `Playlist` gains `user_data: Option<UserItemData>` (`core/src/models.rs`), populated in `From<RawItem> for Playlist` (`core/src/client.rs`) exactly like `Album`.
- `AppModel` gains `isFavorite(playlist:)` (cache → `userData` fallback); `toggleFavorite(playlist:)` now reads it instead of the cold `isFavorite(id:)`.
- The 10 in-memory `Playlist(...)` construction sites in `AppModel` backfill the new field (`p.userData` on copy paths, `nil` for freshly-created records).

The generated UniFFI bindings and `Lyrebird.xcframework` are `.gitignore`d in this repo (CI regenerates them via `macos/Scripts/build-core.sh`), so they are not part of the diff; both were regenerated locally and a clean `swift build` passes against them.

pipeline:
  fixer-session: wf_cd0923b5-888-21
  slice: slice:models
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 3 files changed, +22/-0
