### PR TITLE
fix(core): request only Audio in suggestions() so the shelf fills to limit

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1226,7 +1226,7 @@ impl JellyfinClient {
     }
 
     /// Server-curated suggestions for the Home "You might like" row.
-    /// Backed by `GET /Items/Suggestions?mediaType=Audio&type=MusicAlbum,MusicArtist`.
+    /// Backed by `GET /Items/Suggestions?IncludeItemTypes=Audio`.
     ///
     /// Jellyfin ranks the result on the server side using tag / play-history
     /// overlap, so this is more useful than the pure recency-ordered
@@ -1244,10 +1244,7 @@ impl JellyfinClient {
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", user_id);
-            q.append_pair(
-                "IncludeItemTypes",
-                &enums::csv(&[ItemKind::Audio, ItemKind::MusicAlbum], ItemKind::as_str),
-            );
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
             q.append_pair("Limit", &limit.max(1).to_string());
             q.append_pair("EnableUserData", "true");
         }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -898,6 +898,10 @@ async fn suggestions_builds_query_and_parses() {
         "expected IncludeItemTypes in query: {q}"
     );
     assert!(
+        !q.contains("MusicAlbum"),
+        "must request Audio only; MusicAlbum rows consume Limit slots and get discarded: {q}"
+    );
+    assert!(
         !q.contains("MediaType=Audio"),
         "must not send MediaType=Audio (returns movies+TV): {q}"
     );


### PR DESCRIPTION
Mixed item types in the `/Items/Suggestions` response consumed `Limit` slots and were then dropped client-side, so the Home "You might like" shelf rendered fewer tracks than requested.

Closes #868

pipeline:
  fixer-session: wf_367922fa-3ba-13
  slice: slice:client
  hotspots-claimed: [client]
  build-gate: pass
  diff-stat: 2 files changed, +6/-5
