### PR TITLE
macos: add Song Radio CTA seeded from current context

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4253,6 +4253,28 @@ final class AppModel {
         playInstantMix(seedId: track.id)
     }
 
+    /// Routing for the Discover-screen "Song Radio" CTA (#255), split out from
+    /// the SwiftUI closure so the seed-source decision is unit-testable.
+    /// Returns the action it dispatched so tests can assert the branch without
+    /// reaching into the FFI: `.songRadio` when a track is playing, `.instantMix`
+    /// when nothing is, which leans on `startInstantMix`'s own library fallback
+    /// rather than dead-ending the button.
+    @discardableResult
+    func startDiscoverSongRadio() -> SongRadioRoute {
+        if let current = status.currentTrack {
+            startSongRadio(track: current)
+            return .songRadio
+        }
+        startInstantMix()
+        return .instantMix
+    }
+
+    /// Which seed source `startDiscoverSongRadio()` dispatched to.
+    enum SongRadioRoute: Equatable {
+        case songRadio
+        case instantMix
+    }
+
     /// Append a selection of tracks to a user-picked playlist.
     /// Route-through to the async `addToPlaylist(trackIds:playlistId:)`
     /// so every context menu **Add to Playlist** entry actually hits the

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -111,21 +111,14 @@ struct DiscoverView: View {
         }
     }
 
-    /// "Song Radio" CTA, seeded from the current context. Always
-    /// available: when a track is playing it labels itself with that track and
-    /// seeds the station from it (`startSongRadio`); when nothing is playing it
-    /// falls through to `startInstantMix`, which has its own
-    /// current-track → recently-played → album seed fallback so the action is
-    /// never a dead end. Mirrors the "Start Song Radio" entry in
-    /// `TrackContextMenu`.
+    /// "Song Radio" CTA, the Discover-screen twin of `TrackContextMenu`'s
+    /// "Start Song Radio". Kept always-enabled rather than disabled-when-idle so
+    /// the surface never presents a dead button: with no current track it seeds
+    /// from `startInstantMix`'s own library fallback instead.
     private var songRadioButton: some View {
         let current = model.status.currentTrack
         return Button {
-            if let current {
-                model.startSongRadio(track: current)
-            } else {
-                model.startInstantMix()
-            }
+            model.startDiscoverSongRadio()
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: "dot.radiowaves.left.and.right")

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -111,7 +111,7 @@ struct DiscoverView: View {
         }
     }
 
-    /// "Song Radio" CTA, seeded from the current context (#255). Always
+    /// "Song Radio" CTA, seeded from the current context. Always
     /// available: when a track is playing it labels itself with that track and
     /// seeds the station from it (`startSongRadio`); when nothing is playing it
     /// falls through to `startInstantMix`, which has its own

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -72,9 +72,8 @@ struct DiscoverView: View {
             }
             Spacer()
             HStack(spacing: 10) {
-                // TODO: #144 / #327 — Instant Mix FFI + modal not yet wired.
-                // The AppModel stub logs to stdout for now so the CTA has a
-                // landing pad.
+                songRadioButton
+
                 Button {
                     model.startInstantMix()
                 } label: {
@@ -110,6 +109,55 @@ struct DiscoverView: View {
                 .buttonStyle(.plain)
             }
         }
+    }
+
+    /// "Song Radio" CTA, seeded from the current context (#255). Always
+    /// available: when a track is playing it labels itself with that track and
+    /// seeds the station from it (`startSongRadio`); when nothing is playing it
+    /// falls through to `startInstantMix`, which has its own
+    /// current-track → recently-played → album seed fallback so the action is
+    /// never a dead end. Mirrors the "Start Song Radio" entry in
+    /// `TrackContextMenu`.
+    private var songRadioButton: some View {
+        let current = model.status.currentTrack
+        return Button {
+            if let current {
+                model.startSongRadio(track: current)
+            } else {
+                model.startInstantMix()
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .font(.system(size: 14, weight: .bold))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Song Radio")
+                        .font(Theme.font(13, weight: .bold))
+                    if let current {
+                        Text(current.name)
+                            .font(Theme.font(10, weight: .medium))
+                            .foregroundStyle(Theme.ink2)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .foregroundStyle(Theme.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                Capsule()
+                    .stroke(Theme.borderStrong, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(
+            current.map { "Start a radio station based on \($0.name)" }
+                ?? "Start a radio station from your library"
+        )
+        .accessibilityLabel(
+            current.map { "Song Radio, based on \($0.name)" } ?? "Song Radio"
+        )
+        .accessibilityHint("Starts a radio station seeded by the current song")
     }
 
     private var backgroundWash: some View {

--- a/macos/Tests/LyrebirdTests/DiscoverSongRadioRouteTests.swift
+++ b/macos/Tests/LyrebirdTests/DiscoverSongRadioRouteTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Discover-screen "Song Radio" CTA routing (#255).
+///
+/// The button is always enabled and must never dead-end: with a current track
+/// it seeds a station from that track; with nothing playing it falls through to
+/// the Instant Mix library seed. `startDiscoverSongRadio()` returns the branch
+/// it took so we can assert the decision without reaching into the FFI (the
+/// actual `core.instantMix` hop runs in a detached task and fails fast on this
+/// un-authed core — the routing decision returns synchronously first).
+///
+/// Same isolation contract as `MiniPlayerStateTests`: `AppModel` is
+/// `@MainActor` and boots a live core pointed at a throwaway data dir.
+@MainActor
+final class DiscoverSongRadioRouteTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-songradio-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    private func status(currentTrack: Track?) -> PlayerStatus {
+        PlayerStatus(
+            state: currentTrack == nil ? .idle : .playing,
+            currentTrack: currentTrack,
+            positionSeconds: 0,
+            durationSeconds: 0,
+            volume: 1,
+            queuePosition: 0,
+            queueLength: 0,
+            shuffle: false,
+            repeatMode: .off,
+            playSessionId: nil
+        )
+    }
+
+    func testRoutesToSongRadioWhenATrackIsPlaying() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: makeTrack("now-playing"))
+
+        XCTAssertEqual(
+            model.startDiscoverSongRadio(),
+            .songRadio,
+            "with a current track the CTA must seed Song Radio from it"
+        )
+    }
+
+    /// The reviewer-flagged fallthrough: nothing playing must NOT dead-end the
+    /// button — it falls through to the Instant Mix library seed instead.
+    func testFallsThroughToInstantMixWhenNothingIsPlaying() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: nil)
+
+        XCTAssertEqual(
+            model.startDiscoverSongRadio(),
+            .instantMix,
+            "with no current track the CTA must fall through to Instant Mix, not no-op"
+        )
+    }
+}


### PR DESCRIPTION
Surfaces a "Song Radio" action on the Discover screen so a one-click station can be started from the currently-playing track, complementing the existing "Start Song Radio" track context-menu entry.

Closes #255

The CTA is always available: when a track is playing it labels itself with that track and seeds the station via `startSongRadio(track:)`; when nothing is playing it falls through to `startInstantMix()` (which has its own current-track → recently-played → album seed fallback), so the button is never a dead end. Both routes go through the existing `playInstantMix` driver → `core.instant_mix` FFI (off the MainActor, with `errorMessage` on failure). No new core FFI, no binding/xcframework changes.

pipeline:
- fixer-session: feature-builder-255 (wave 4)
- slice: screens
- hotspots-claimed: none
- build-gate: pass (cargo fmt --check, clippy -D warnings, cargo test --workspace, swift build — all green)
- diff-stat: 1 file changed, 51 insertions(+), 3 deletions(-)
