### PR TITLE
ci(release): mark pre-release tags as prerelease, never Latest

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -80,12 +80,9 @@ jobs:
           tag="${RELEASE_TAG}"
           version="${tag#v}"              # strip leading 'v' for CFBundleShortVersionString
           build=$(date -u +%Y%m%d%H%M)    # UTC timestamp — monotonically increasing CFBundleVersion
-          # A semver pre-release tag carries a hyphenated suffix on the
-          # version core (e.g. v1.0.1-beta.1, -rc.2, -alpha, -pre). The
-          # version core itself only uses dots, so a hyphen anywhere in
-          # the tag marks a pre-release. We must NOT let GitHub's
-          # auto-latest heuristic promote one of these over the current
-          # stable release.
+          # A hyphen only appears in a tag as a semver pre-release suffix
+          # (the version core uses dots); GitHub's auto-latest heuristic
+          # must never promote one of these over the stable release.
           if [[ "$tag" == *-* ]]; then
             is_prerelease=true
           else
@@ -226,12 +223,18 @@ jobs:
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists — uploading asset with --clobber"
             gh release upload "$TAG" macos/build/*.dmg --clobber --repo "$GITHUB_REPOSITORY"
+            # Re-enforce the never-Latest invariant on re-runs: a release
+            # created by an older workflow (or manually) may still be
+            # marked Latest. Demote pre-releases only — re-marking a
+            # stable re-cut as --latest could wrongly promote an old tag
+            # over a newer release.
+            if [[ "$IS_PRERELEASE" == "true" ]]; then
+              gh release edit "$TAG" --prerelease --latest=false --repo "$GITHUB_REPOSITORY"
+            fi
           else
-            # Pre-release tags (v1.0.1-beta.1, -rc.2, …) must ship as a
-            # prerelease and must NOT become "Latest" — otherwise GitHub's
-            # auto-latest heuristic promotes a beta over the stable
-            # release. Stable tags pass --latest explicitly so the same
-            # heuristic can't be confused by an out-of-order tag either.
+            # Stable tags pass --latest explicitly so GitHub's auto-latest
+            # heuristic can't be confused by an out-of-order tag; pre-
+            # releases are pinned out of the Latest slot entirely.
             latest_args=(--prerelease --latest=false)
             if [[ "$IS_PRERELEASE" != "true" ]]; then
               latest_args=(--latest)

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -80,10 +80,22 @@ jobs:
           tag="${RELEASE_TAG}"
           version="${tag#v}"              # strip leading 'v' for CFBundleShortVersionString
           build=$(date -u +%Y%m%d%H%M)    # UTC timestamp — monotonically increasing CFBundleVersion
+          # A semver pre-release tag carries a hyphenated suffix on the
+          # version core (e.g. v1.0.1-beta.1, -rc.2, -alpha, -pre). The
+          # version core itself only uses dots, so a hyphen anywhere in
+          # the tag marks a pre-release. We must NOT let GitHub's
+          # auto-latest heuristic promote one of these over the current
+          # stable release.
+          if [[ "$tag" == *-* ]]; then
+            is_prerelease=true
+          else
+            is_prerelease=false
+          fi
           {
             echo "tag=$tag"
             echo "version=$version"
             echo "build=$build"
+            echo "is_prerelease=$is_prerelease"
           } >> "$GITHUB_OUTPUT"
 
       # ------------------------------------------------------------------
@@ -206,6 +218,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.version.outputs.is_prerelease }}
         run: |
           # Don't clobber a release that already exists (re-runs via
           # workflow_dispatch). Instead, upload the freshly built DMG to
@@ -214,11 +227,21 @@ jobs:
             echo "Release $TAG already exists — uploading asset with --clobber"
             gh release upload "$TAG" macos/build/*.dmg --clobber --repo "$GITHUB_REPOSITORY"
           else
+            # Pre-release tags (v1.0.1-beta.1, -rc.2, …) must ship as a
+            # prerelease and must NOT become "Latest" — otherwise GitHub's
+            # auto-latest heuristic promotes a beta over the stable
+            # release. Stable tags pass --latest explicitly so the same
+            # heuristic can't be confused by an out-of-order tag either.
+            latest_args=(--prerelease --latest=false)
+            if [[ "$IS_PRERELEASE" != "true" ]]; then
+              latest_args=(--latest)
+            fi
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Lyrebird $TAG" \
               --generate-notes \
               --verify-tag \
+              "${latest_args[@]}" \
               macos/build/*.dmg
           fi
 


### PR DESCRIPTION
## Problem

The **Create GitHub release** step in `.github/workflows/macos-release.yml` ran:

```sh
gh release create "$TAG" --title ... --generate-notes --verify-tag macos/build/*.dmg
```

with no `--prerelease` flag and no `--latest` control. GitHub applied its auto-latest heuristic to every tag, so a pre-release tag like `v1.0.1-beta.1` published as a **full release** and was marked **Latest**, displacing the stable `v1.0.0`. Observed live — `v1.0.1-beta.1` grabbed `latest=true` and had to be fixed manually with `gh release edit`.

## Change

- **version-resolve step:** compute `is_prerelease` — a tag is a pre-release when it carries a hyphenated semver suffix (`-rc`, `-beta`, `-alpha`, `-pre`). The version core only uses dots, so `[[ "$tag" == *-* ]]` is a sufficient test.
- **release step:** for pre-releases pass `--prerelease --latest=false`; for stable pass `--latest` explicitly so the auto-latest heuristic can't be confused by an out-of-order tag.
- The re-run / `--clobber` upload path (existing release on `workflow_dispatch`) is **unchanged**.

## Verification

CI-only change; no app code. Verified against the documented `gh release create` flag semantics (`--latest=false` to explicitly NOT mark Latest; `-p/--prerelease`):

```
v1.0.0         -> is_prerelease=false -> --latest
v1.0.1-beta.1  -> is_prerelease=true  -> --prerelease --latest=false
v2.3.4-rc.2    -> is_prerelease=true  -> --prerelease --latest=false
v0.1.0-alpha   -> is_prerelease=true  -> --prerelease --latest=false
v1.2.3-pre     -> is_prerelease=true  -> --prerelease --latest=false
```

`actionlint` runs clean on the edited steps (the one pre-existing SC2046 warning is in the untouched keychain-import step). No real tag was cut.

Closes #886