### PR TITLE
fix(macos): bound MediaSession artwork cache with NSCache

### DIFF
--- a/macos/Sources/LyrebirdAudio/MediaSession.swift
+++ b/macos/Sources/LyrebirdAudio/MediaSession.swift
@@ -65,7 +65,11 @@ public protocol MediaSessionDelegate: AnyObject {
 @MainActor
 public final class MediaSession {
     private weak var delegate: MediaSessionDelegate?
-    private var artworkCache: [String: MPMediaItemArtwork] = [:]
+    private let artworkCache: NSCache<NSString, MPMediaItemArtwork> = {
+        let cache = NSCache<NSString, MPMediaItemArtwork>()
+        cache.countLimit = 100
+        return cache
+    }()
     private var artworkTask: Task<Void, Never>?
     private var currentTrackID: String?
 
@@ -139,7 +143,7 @@ public final class MediaSession {
 
         // Keep the previous artwork in place until the new one decodes —
         // clearing it first shows a blank square mid-transition (see #30).
-        if let cached = artworkCache[track.id] {
+        if let cached = artworkCache.object(forKey: track.id as NSString) {
             info[MPMediaItemPropertyArtwork] = cached
         } else if let lastArt = MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] {
             info[MPMediaItemPropertyArtwork] = lastArt
@@ -480,7 +484,7 @@ public final class MediaSession {
 
         // Cached hit from a prior play of the same track — publish
         // immediately without a network hop.
-        if let cached = artworkCache[track.id] {
+        if let cached = artworkCache.object(forKey: track.id as NSString) {
             guard currentTrackID == expectedTrackID else { return }
             publishArtwork(cached)
             return
@@ -511,7 +515,7 @@ public final class MediaSession {
             let artwork = MPMediaItemArtwork(boundsSize: image.size) { requestedSize in
                 Self.resize(image, to: requestedSize)
             }
-            artworkCache[track.id] = artwork
+            artworkCache.setObject(artwork, forKey: track.id as NSString)
             publishArtwork(artwork)
         } catch is CancellationError {
             // Track changed during the fetch — silent no-op.


### PR DESCRIPTION
Long shuffle sessions across many albums grew resident memory without bound because the now-playing artwork cache never evicted decoded images.

`MediaSession.artworkCache` was an unbounded `[String: MPMediaItemArtwork]`. Each `MPMediaItemArtwork` closure captures a decoded `NSImage` (fetched at 600px wide), so every unique track played held ~1-2 MB of heap for the whole session lifetime with no eviction path. This backs the cache with an `NSCache<NSString, MPMediaItemArtwork>` capped at `countLimit = 100`, which evicts least-recently-used entries and also releases under system memory pressure. The three access sites are converted to the `NSCache` get/set API; behaviour is otherwise unchanged.

Closes #883

pipeline:
  fixer-session: wf_367922fa-3ba-36
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +6/-2
