### PR TITLE
fix(macos): detect auth expiry in reconnectIfNeeded via typed enum

### DIFF
--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -263,9 +263,13 @@ extension AppModel {
     /// `GET /System/Info/Public` (via `core.probeServer`) against the stored
     /// server URL to verify the connection is still healthy:
     ///
-    /// - **401 / not authenticated**: the token has been revoked or expired
-    ///   while the machine was asleep (VPN key rotation, server restart, etc.).
-    ///   `markAuthExpired()` surfaces the re-auth sheet.
+    /// - **401 / not authenticated**: `probeServer` hits the unauthenticated
+    ///   `/System/Info/Public`, so token revocation during sleep is detected
+    ///   not here but by the authenticated `refreshJumpBackIn` /
+    ///   `refreshRecentlyPlayed` / `refreshRecentlyAdded` calls below, which
+    ///   surface the re-auth sheet via their own `handleAuthError`. The
+    ///   `LyrebirdError` auth-variant catch here is a guard for any future
+    ///   authenticated probe.
     /// - **Network / 5xx error**: the server is temporarily unreachable;
     ///   `serverReachability.noteFailure()` updates the unreachable banner.
     /// - **Success**: `serverReachability.noteSuccess()` clears any stale
@@ -293,13 +297,13 @@ extension AppModel {
                 await refreshRecentlyPlayed()
                 await refreshRecentlyAdded()
             } catch {
-                let description = error.localizedDescription
-                let isAuthError = description.contains("not logged in")
-                    || description.contains("server returned an error: 401")
-                if isAuthError {
+                switch error as? LyrebirdError {
+                case .NotAuthenticated, .Auth, .AuthExpired:
                     markAuthExpired()
-                } else if ServerReachability.shouldCount(error: error) {
-                    serverReachability.noteFailure()
+                default:
+                    if ServerReachability.shouldCount(error: error) {
+                        serverReachability.noteFailure()
+                    }
                 }
             }
         }


### PR DESCRIPTION
After wake from sleep, `reconnectIfNeeded` should recover from a revoked/expired token, but the catch block tested for `LyrebirdError` Display substrings that no longer exist post-BATCH-24, leaving the auth branch permanently dead.

This switches the post-probe catch onto the typed `LyrebirdError` variants (`NotAuthenticated` / `Auth` / `AuthExpired`) — the same pattern `handleAuthError` uses — and corrects the docstring to describe where token revocation during sleep is actually detected (the downstream authenticated refresh calls), since `probeServer` itself only hits the unauthenticated `/System/Info/Public`.

Closes #863

Hotspot lock claimed: #891 (release on merge).

pipeline:
  fixer-session: wf_367922fa-3ba-37
  slice: slice:scaffold
  hotspots-claimed: [appmodel]
  build-gate: pass
  diff-stat: 1 file changed, +11/-7