### PR TITLE
macos: add Notifications preferences pane (track-change banner, sound, menu-bar)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4968,7 +4968,7 @@ final class AppModel {
                     } else {
                         Task { await self.fetchCurrentTrackDetails() }
                         Task { await self.fetchCurrentTrackLyrics() }
-                        // Notifications (#266): post a Now Playing banner for
+                        // Post a Now Playing banner for
                         // the new track. The manager no-ops when the toggle is
                         // off, so this is cheap on every change. `before != nil`
                         // skips the very first track at startup-from-resume
@@ -4984,7 +4984,7 @@ final class AppModel {
                         }
                     }
                 }
-                // Menu-bar "while playing" (#266): mirror the play/pause state
+                // Menu-bar "while playing": mirror the play/pause state
                 // onto the transient menu-bar icon when the user opts in. Only
                 // acts on a real state transition so we don't churn the
                 // NSStatusItem every tick.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -362,6 +362,10 @@ final class AppModel {
     // MARK: - Player
     var status: PlayerStatus
     var pollTimer: Timer?
+    /// Whether the menu-bar "while playing" visibility has been seeded since
+    /// polling started. Lets the first poll apply the icon on a resume-into-
+    /// playing launch instead of waiting for a pause/resume transition. See #266.
+    private var didApplyMenuBarPlayingState = false
 
     // MARK: - Queue inspector (BATCH-07a, #79 / #80 / #282)
     //
@@ -4968,12 +4972,11 @@ final class AppModel {
                     } else {
                         Task { await self.fetchCurrentTrackDetails() }
                         Task { await self.fetchCurrentTrackLyrics() }
-                        // Post a Now Playing banner for
-                        // the new track. The manager no-ops when the toggle is
-                        // off, so this is cheap on every change. `before != nil`
-                        // skips the very first track at startup-from-resume
-                        // isn't suppressed — a fresh play is exactly when the
-                        // user wants the banner.
+                        // Notify on the new track. The manager no-ops when the
+                        // banner toggle is off, so this is cheap on every change.
+                        // The first track after a startup-from-resume is left
+                        // unsuppressed — a fresh play is exactly when the user
+                        // wants the banner.
                         if let track = self.status.currentTrack {
                             NotificationManager.shared.notifyTrackChange(
                                 title: track.name,
@@ -4984,15 +4987,18 @@ final class AppModel {
                         }
                     }
                 }
-                // Menu-bar "while playing": mirror the play/pause state
-                // onto the transient menu-bar icon when the user opts in. Only
-                // acts on a real state transition so we don't churn the
-                // NSStatusItem every tick.
-                if beforeState != self.status.state,
-                    NotificationPreference.showInMenuBarWhilePlaying {
+                // Menu-bar "while playing": mirror the play/pause state onto the
+                // transient menu-bar icon when the user opts in. Apply on the
+                // first eligible poll (so a session that resumes already-playing
+                // shows the icon immediately, without waiting for a pause/resume
+                // transition) and thereafter only on a real state transition, so
+                // we don't churn the NSStatusItem every tick.
+                if NotificationPreference.showInMenuBarWhilePlaying,
+                    !self.didApplyMenuBarPlayingState || beforeState != self.status.state {
                     MenuBarController.shared.setVisibleWhilePlaying(
                         self.status.state == .playing
                     )
+                    self.didApplyMenuBarPlayingState = true
                 }
                 // Keep MediaSession's queue index in sync when a skip
                 // happens. `AudioEngine.play(track:)` already fires
@@ -5019,6 +5025,7 @@ final class AppModel {
     private func stopPolling() {
         pollTimer?.invalidate()
         pollTimer = nil
+        didApplyMenuBarPlayingState = false
     }
 
     // MARK: - Queue inspector (BATCH-07a)

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4944,6 +4944,7 @@ final class AppModel {
                 let before = beforeTrack?.id
                 let beforeQueuePos = self.status.queuePosition
                 let beforeQueueLen = self.status.queueLength
+                let beforeState = self.status.state
                 self.status = self.core.status()
                 let after = self.status.currentTrack?.id
                 // Trigger a details refetch when the track changes. Scoped
@@ -4963,10 +4964,35 @@ final class AppModel {
                         self.currentTrackPeopleForId = nil
                         self.currentLyrics = nil
                         self.currentLyricsForId = nil
+                        MenuBarController.shared.setNowPlaying(nil)
                     } else {
                         Task { await self.fetchCurrentTrackDetails() }
                         Task { await self.fetchCurrentTrackLyrics() }
+                        // Notifications (#266): post a Now Playing banner for
+                        // the new track. The manager no-ops when the toggle is
+                        // off, so this is cheap on every change. `before != nil`
+                        // skips the very first track at startup-from-resume
+                        // isn't suppressed — a fresh play is exactly when the
+                        // user wants the banner.
+                        if let track = self.status.currentTrack {
+                            NotificationManager.shared.notifyTrackChange(
+                                title: track.name,
+                                artist: track.artistName,
+                                album: track.albumName
+                            )
+                            MenuBarController.shared.setNowPlaying(track.name)
+                        }
                     }
+                }
+                // Menu-bar "while playing" (#266): mirror the play/pause state
+                // onto the transient menu-bar icon when the user opts in. Only
+                // acts on a real state transition so we don't churn the
+                // NSStatusItem every tick.
+                if beforeState != self.status.state,
+                    NotificationPreference.showInMenuBarWhilePlaying {
+                    MenuBarController.shared.setVisibleWhilePlaying(
+                        self.status.state == .playing
+                    )
                 }
                 // Keep MediaSession's queue index in sync when a skip
                 // happens. `AudioEngine.play(track:)` already fires

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -44,7 +44,7 @@ struct LyrebirdApp: App {
                 .task { appDelegate.bind(appModel: model) }
                 // Re-request notification authorization on launch if the user
                 // already opted in, so track-change banners work without
-                // re-toggling. No-ops when the preference is off. See #266.
+                // re-toggling. No-ops when the preference is off.
                 .task { NotificationManager.shared.requestAuthorizationIfNeeded() }
                 // Publish the current window's `AppModel` as a focused
                 // scene value so `@FocusedValue(\.appModel)` readers

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -42,6 +42,10 @@ struct LyrebirdApp: App {
                 .frame(minWidth: 960, minHeight: 640)
                 .preferredColorScheme(preferredColorScheme)
                 .task { appDelegate.bind(appModel: model) }
+                // Re-request notification authorization on launch if the user
+                // already opted in, so track-change banners work without
+                // re-toggling. No-ops when the preference is off. See #266.
+                .task { NotificationManager.shared.requestAuthorizationIfNeeded() }
                 // Publish the current window's `AppModel` as a focused
                 // scene value so `@FocusedValue(\.appModel)` readers
                 // (e.g. future menu commands that live outside the

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Notifications preferences pane (#266).
+/// Notifications preferences pane.
 ///
 /// Three toggles, all `@AppStorage`-backed so they persist across launches
 /// and are readable by `NotificationManager` / `MenuBarController` through the

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
@@ -18,6 +18,8 @@ import SwiftUI
 ///
 /// Spec: `research/06-screen-specs.md` — Settings ▸ Notifications.
 struct PreferencesNotifications: View {
+    @Environment(AppModel.self) private var model
+
     @AppStorage(NotificationPreference.trackChangeKey)
     private var trackChange: Bool = false
     @AppStorage(NotificationPreference.soundKey)
@@ -36,6 +38,29 @@ struct PreferencesNotifications: View {
                 if newValue {
                     NotificationManager.shared.requestAuthorizationIfNeeded()
                 }
+            }
+        )
+    }
+
+    /// Binding that applies the "Show in menu bar while playing" preference
+    /// immediately, rather than waiting for the next playback state transition.
+    ///
+    /// Without this, flipping the toggle on while a track is already playing
+    /// did nothing until the user paused/resumed — the AppModel poll loop only
+    /// drives `setVisibleWhilePlaying(_:)` on a `state` change. Resolving the
+    /// current playback state here makes the toggle take effect on the spot:
+    /// enabling it while playing shows the icon now; disabling it removes the
+    /// transient icon now (unless the persistent General toggle is keeping it).
+    private var showInMenuBarWhilePlayingBinding: Binding<Bool> {
+        Binding(
+            get: { showInMenuBarWhilePlaying },
+            set: { newValue in
+                showInMenuBarWhilePlaying = newValue
+                // When turned on, reflect the live playback state immediately;
+                // when turned off, drop the transient icon (passing `false`
+                // so it only stays if the persistent toggle pins it).
+                let playing = newValue && model.status.state == .playing
+                MenuBarController.shared.setVisibleWhilePlaying(playing)
             }
         )
     }
@@ -88,7 +113,7 @@ struct PreferencesNotifications: View {
                         ? "On — the menu-bar icon appears while a track is playing."
                         : "Off — the menu-bar icon follows the General setting only."
                 ) {
-                    Toggle("", isOn: $showInMenuBarWhilePlaying)
+                    Toggle("", isOn: showInMenuBarWhilePlayingBinding)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .accessibilityLabel("Show in menu bar while playing")
@@ -112,6 +137,10 @@ struct PreferencesNotifications: View {
 }
 
 #Preview {
+    // Real rendering requires an `AppModel` in the environment; the Settings
+    // scene in `LyrebirdApp` injects one. Previews without a model will crash
+    // on `@Environment(AppModel.self)` — this preview is kept as documentation
+    // for where the view lives.
     PreferencesNotifications()
         .frame(width: 560, height: 520)
         .padding(32)

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesNotifications.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Notifications preferences pane (#266).
+///
+/// Three toggles, all `@AppStorage`-backed so they persist across launches
+/// and are readable by `NotificationManager` / `MenuBarController` through the
+/// shared `NotificationPreference` keys:
+///
+/// - **Show notification on track change** — posts a "Now Playing"
+///   `UNUserNotificationCenter` banner whenever the track changes. Enabling it
+///   triggers the system authorization prompt (once per install).
+/// - **Play sound** — whether the track-change notification plays the default
+///   sound. Disabled when track-change notifications are off.
+/// - **Show in menu bar while playing** — surfaces the menu-bar icon
+///   transiently while audio is playing, complementing the always-on toggle in
+///   General. `AppModel` drives `MenuBarController.setVisibleWhilePlaying(_:)`
+///   off the playback state.
+///
+/// Spec: `research/06-screen-specs.md` — Settings ▸ Notifications.
+struct PreferencesNotifications: View {
+    @AppStorage(NotificationPreference.trackChangeKey)
+    private var trackChange: Bool = false
+    @AppStorage(NotificationPreference.soundKey)
+    private var sound: Bool = false
+    @AppStorage(NotificationPreference.showInMenuBarWhilePlayingKey)
+    private var showInMenuBarWhilePlaying: Bool = false
+
+    /// Binding that requests notification authorization the moment the user
+    /// opts in, so the system prompt is tied to the explicit toggle rather
+    /// than appearing on cold launch.
+    private var trackChangeBinding: Binding<Bool> {
+        Binding(
+            get: { trackChange },
+            set: { newValue in
+                trackChange = newValue
+                if newValue {
+                    NotificationManager.shared.requestAuthorizationIfNeeded()
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Track Changes",
+                footnote: "Posts a Now Playing banner each time a new track starts. macOS will ask for notification permission the first time you enable this."
+            ) {
+                PreferenceRow(
+                    label: "Show notification on track change",
+                    help: trackChange
+                        ? "On — a banner appears whenever the track changes."
+                        : "Off — Lyrebird won't post track-change notifications."
+                ) {
+                    Toggle("", isOn: trackChangeBinding)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Show notification on track change")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Play sound",
+                    help: sound
+                        ? "On — the track-change notification plays the default sound."
+                        : "Off — track-change notifications are silent."
+                ) {
+                    Toggle("", isOn: $sound)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .disabled(!trackChange)
+                        .accessibilityLabel("Play notification sound")
+                }
+            }
+
+            PreferenceSection(
+                title: "Menu Bar",
+                footnote: "Shows the menu-bar icon only while audio is playing. To keep it visible at all times, use Show in menu bar in General."
+            ) {
+                PreferenceRow(
+                    label: "Show in menu bar while playing",
+                    help: showInMenuBarWhilePlaying
+                        ? "On — the menu-bar icon appears while a track is playing."
+                        : "Off — the menu-bar icon follows the General setting only."
+                ) {
+                    Toggle("", isOn: $showInMenuBarWhilePlaying)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Show in menu bar while playing")
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Notifications")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Track-change banners, sound, and menu-bar presence.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+}
+
+#Preview {
+    PreferencesNotifications()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case general, server, playback, audio, library, appearance, downloads, advanced, about
+        case general, server, playback, audio, library, appearance, notifications, downloads, advanced, about
 
         var id: String { rawValue }
 
@@ -30,6 +30,7 @@ struct PreferencesView: View {
             case .audio: return "Audio"
             case .library: return "Library"
             case .appearance: return "Appearance"
+            case .notifications: return "Notifications"
             case .downloads: return "Downloads"
             case .advanced: return "Advanced"
             case .about: return "About"
@@ -44,6 +45,7 @@ struct PreferencesView: View {
             case .audio: return "speaker.wave.2"
             case .library: return "music.note.list"
             case .appearance: return "paintpalette"
+            case .notifications: return "bell"
             case .downloads: return "arrow.down.circle"
             case .advanced: return "wrench.and.screwdriver"
             case .about: return "info.circle"
@@ -81,6 +83,7 @@ struct PreferencesView: View {
         case .audio: PreferencesAudio()
         case .library: PreferencesLibrary()
         case .appearance: AppearancePane()
+        case .notifications: PreferencesNotifications()
         case .downloads: PreferencesDownloads()
         case .advanced: PreferencesAdvanced()
         case .about: PreferencesAbout()

--- a/macos/Sources/Lyrebird/System/MenuBarController.swift
+++ b/macos/Sources/Lyrebird/System/MenuBarController.swift
@@ -20,21 +20,43 @@ final class MenuBarController {
     /// can still show it transiently — see `setVisibleWhilePlaying(_:)`.
     private var persistentVisible = false
 
+    /// Tracks the latest transient "Show in menu bar while playing" state so a
+    /// later change to the persistent toggle re-resolves against it (and vice
+    /// versa) rather than dropping one of the two inputs.
+    private var playingVisible = false
+
     /// Show or hide the menu-bar icon for the persistent General preference.
     /// Safe to call repeatedly with the same value — it checks current state
     /// before creating / destroying the status item.
     func setVisible(_ visible: Bool) {
         persistentVisible = visible
-        applyVisibility(visible)
+        applyVisibility(MenuBarController.resolveVisibility(
+            playing: playingVisible,
+            persistent: visible
+        ))
     }
 
     /// Drive transient menu-bar visibility from playback state for the
-    /// "Show in menu bar while playing" preference (#266). When `playing` is
+    /// "Show in menu bar while playing" preference. When `playing` is
     /// true the icon appears; when playback stops it's removed *unless* the
     /// persistent General toggle is keeping it on. Idempotent.
     func setVisibleWhilePlaying(_ playing: Bool) {
+        playingVisible = playing
         // Never hide an icon the user pinned via the persistent toggle.
-        applyVisibility(playing || persistentVisible)
+        applyVisibility(MenuBarController.resolveVisibility(
+            playing: playing,
+            persistent: persistentVisible
+        ))
+    }
+
+    /// Pure decision for whether the menu-bar icon should be on screen, given
+    /// the persistent "Show in menu bar" toggle and the transient "while
+    /// playing" state. The persistent toggle always wins, so a playing→stopped
+    /// transition never hides an icon the user pinned. Factored out so the
+    /// persistent-vs-transient precedence can be unit-tested without realizing
+    /// a live `NSStatusItem` (which requires a window-server connection).
+    static func resolveVisibility(playing: Bool, persistent: Bool) -> Bool {
+        playing || persistent
     }
 
     /// Update the menu-bar button's tooltip with the current track so hovering

--- a/macos/Sources/Lyrebird/System/MenuBarController.swift
+++ b/macos/Sources/Lyrebird/System/MenuBarController.swift
@@ -14,10 +14,37 @@ final class MenuBarController {
 
     private init() {}
 
-    /// Show or hide the menu-bar icon. Safe to call repeatedly with the
-    /// same value — it checks current state before creating / destroying
-    /// the status item.
+    /// Tracks whether the persistent "Show in menu bar" (General) preference
+    /// is on. When true the icon stays visible regardless of playback. When
+    /// false, the "Show in menu bar while playing" (Notifications) preference
+    /// can still show it transiently — see `setVisibleWhilePlaying(_:)`.
+    private var persistentVisible = false
+
+    /// Show or hide the menu-bar icon for the persistent General preference.
+    /// Safe to call repeatedly with the same value — it checks current state
+    /// before creating / destroying the status item.
     func setVisible(_ visible: Bool) {
+        persistentVisible = visible
+        applyVisibility(visible)
+    }
+
+    /// Drive transient menu-bar visibility from playback state for the
+    /// "Show in menu bar while playing" preference (#266). When `playing` is
+    /// true the icon appears; when playback stops it's removed *unless* the
+    /// persistent General toggle is keeping it on. Idempotent.
+    func setVisibleWhilePlaying(_ playing: Bool) {
+        // Never hide an icon the user pinned via the persistent toggle.
+        applyVisibility(playing || persistentVisible)
+    }
+
+    /// Update the menu-bar button's tooltip with the current track so hovering
+    /// the icon shows what's playing. Passing `nil` resets to the app name.
+    func setNowPlaying(_ title: String?) {
+        statusItem?.button?.toolTip = title.map { "Lyrebird — \($0)" } ?? "Lyrebird"
+    }
+
+    /// Create or destroy the `NSStatusItem` to match `visible`.
+    private func applyVisibility(_ visible: Bool) {
         if visible {
             guard statusItem == nil else { return }
             let item = NSStatusBar.system.statusItem(

--- a/macos/Sources/Lyrebird/System/NotificationManager.swift
+++ b/macos/Sources/Lyrebird/System/NotificationManager.swift
@@ -12,7 +12,7 @@ import UserNotifications
 ///
 /// Authorization is requested lazily the first time the track-change toggle is
 /// enabled (and again on launch if already enabled) so the user only sees the
-/// system prompt when they opt in, never on a cold first launch. See #266.
+/// system prompt when they opt in, never on a cold first launch.
 final class NotificationManager {
     static let shared = NotificationManager()
 

--- a/macos/Sources/Lyrebird/System/NotificationManager.swift
+++ b/macos/Sources/Lyrebird/System/NotificationManager.swift
@@ -49,18 +49,14 @@ final class NotificationManager {
     /// toggle is off. Safe to call on the MainActor — the actual delivery is
     /// handed to `UNUserNotificationCenter` asynchronously.
     func notifyTrackChange(title: String, artist: String?, album: String?) {
-        guard NotificationPreference.trackChangeEnabled else { return }
+        guard NotificationManager.shouldNotify(enabled: NotificationPreference.trackChangeEnabled) else {
+            return
+        }
 
         let content = UNMutableNotificationContent()
         content.title = title
-        // Prefer "Artist — Album"; fall back to whichever is present so the
-        // subtitle is never an awkward bare dash.
-        let subtitleParts = [artist, album].compactMap { part -> String? in
-            guard let part, !part.isEmpty else { return nil }
-            return part
-        }
-        if !subtitleParts.isEmpty {
-            content.body = subtitleParts.joined(separator: " — ")
+        if let body = NotificationManager.subtitle(artist: artist, album: album) {
+            content.body = body
         }
         content.sound = NotificationPreference.soundEnabled ? .default : nil
 
@@ -77,6 +73,27 @@ final class NotificationManager {
                 Log.app.error("Failed to post track-change notification: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    // MARK: - Pure helpers (unit-testable)
+
+    /// Whether a track-change notification should be posted at all. Factored
+    /// out of `notifyTrackChange` so the gate is verifiable without realizing a
+    /// `UNUserNotificationCenter` (which a headless test run can't do).
+    static func shouldNotify(enabled: Bool) -> Bool {
+        enabled
+    }
+
+    /// Compose the notification subtitle from the optional artist / album.
+    /// Prefers "Artist — Album", falls back to whichever is present, and
+    /// returns `nil` when neither is usable so the body is never a bare dash.
+    /// Pure so the composition rule can be unit-tested directly.
+    static func subtitle(artist: String?, album: String?) -> String? {
+        let parts = [artist, album].compactMap { part -> String? in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " — ")
     }
 }
 

--- a/macos/Sources/Lyrebird/System/NotificationManager.swift
+++ b/macos/Sources/Lyrebird/System/NotificationManager.swift
@@ -1,0 +1,103 @@
+import Foundation
+import UserNotifications
+
+/// Posts local "Now Playing" notifications via `UNUserNotificationCenter`
+/// when the track changes, gated behind the user's Notifications preferences.
+///
+/// The three toggles live in `PreferencesNotifications` as `@AppStorage`
+/// keys; this manager reads the same `UserDefaults` keys directly (it isn't a
+/// `View`, so it can't use the property wrapper). Keeping the keys in one
+/// place — `NotificationPreference` — keeps the pane and the manager from
+/// drifting apart.
+///
+/// Authorization is requested lazily the first time the track-change toggle is
+/// enabled (and again on launch if already enabled) so the user only sees the
+/// system prompt when they opt in, never on a cold first launch. See #266.
+final class NotificationManager {
+    static let shared = NotificationManager()
+
+    /// Tracks whether we've already asked the system for authorization this
+    /// process lifetime so repeated track changes don't spam the request.
+    private var didRequestAuthorization = false
+
+    private init() {}
+
+    // MARK: - Authorization
+
+    /// Request notification authorization if the user has the track-change
+    /// toggle enabled. Idempotent — the system only shows the prompt once per
+    /// install regardless of how many times this is called.
+    func requestAuthorizationIfNeeded() {
+        guard NotificationPreference.trackChangeEnabled else { return }
+        guard !didRequestAuthorization else { return }
+        didRequestAuthorization = true
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .sound]
+        ) { granted, error in
+            if let error {
+                Log.app.error("Notification authorization failed: \(error.localizedDescription, privacy: .public)")
+            } else if !granted {
+                Log.app.notice("Notification authorization declined by user")
+            }
+        }
+    }
+
+    // MARK: - Posting
+
+    /// Post a "Now Playing" notification for a newly started track, honoring
+    /// the user's enable / sound preferences. No-ops when the track-change
+    /// toggle is off. Safe to call on the MainActor — the actual delivery is
+    /// handed to `UNUserNotificationCenter` asynchronously.
+    func notifyTrackChange(title: String, artist: String?, album: String?) {
+        guard NotificationPreference.trackChangeEnabled else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        // Prefer "Artist — Album"; fall back to whichever is present so the
+        // subtitle is never an awkward bare dash.
+        let subtitleParts = [artist, album].compactMap { part -> String? in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        if !subtitleParts.isEmpty {
+            content.body = subtitleParts.joined(separator: " — ")
+        }
+        content.sound = NotificationPreference.soundEnabled ? .default : nil
+
+        // `nil` trigger delivers immediately. A stable identifier per track
+        // change isn't needed; a fresh UUID keeps successive track
+        // notifications from collapsing into one.
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                Log.app.error("Failed to post track-change notification: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}
+
+/// Single source of truth for the Notifications preference keys, shared by the
+/// `PreferencesNotifications` pane (`@AppStorage`) and `NotificationManager`
+/// (raw `UserDefaults`). Keys are stable user-defaults strings so on-disk
+/// preferences survive across launches.
+enum NotificationPreference {
+    static let trackChangeKey = "notifications.trackChange"
+    static let soundKey = "notifications.sound"
+    static let showInMenuBarWhilePlayingKey = "notifications.showInMenuBarWhilePlaying"
+
+    static var trackChangeEnabled: Bool {
+        UserDefaults.standard.bool(forKey: trackChangeKey)
+    }
+
+    static var soundEnabled: Bool {
+        UserDefaults.standard.bool(forKey: soundKey)
+    }
+
+    static var showInMenuBarWhilePlaying: Bool {
+        UserDefaults.standard.bool(forKey: showInMenuBarWhilePlayingKey)
+    }
+}

--- a/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
+++ b/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `MenuBarController`'s persistent-vs-transient visibility
+/// precedence — the rule that decides whether the menu-bar `NSStatusItem`
+/// should be on screen given the persistent "Show in menu bar" (General)
+/// toggle and the transient "Show in menu bar while playing" (Notifications)
+/// toggle.
+///
+/// The decision is exercised through the pure `resolveVisibility(playing:
+/// persistent:)` helper so the precedence is verified without realizing a
+/// live `NSStatusItem`, which would require a window-server connection that a
+/// headless test run doesn't have.
+final class MenuBarVisibilityTests: XCTestCase {
+
+    func testBothOffHidesIcon() {
+        XCTAssertFalse(
+            MenuBarController.resolveVisibility(playing: false, persistent: false),
+            "neither toggle on: icon stays hidden"
+        )
+    }
+
+    func testPersistentToggleAloneShowsIcon() {
+        XCTAssertTrue(
+            MenuBarController.resolveVisibility(playing: false, persistent: true),
+            "the persistent General toggle shows the icon regardless of playback"
+        )
+    }
+
+    func testPlayingAloneShowsIconTransiently() {
+        XCTAssertTrue(
+            MenuBarController.resolveVisibility(playing: true, persistent: false),
+            "the while-playing toggle shows the icon during playback"
+        )
+    }
+
+    func testPersistentWinsWhenPlaybackStops() {
+        // Simulate a playing→stopped transition while the persistent toggle is
+        // on: the icon must NOT be hidden — that was the precedence bug.
+        XCTAssertTrue(
+            MenuBarController.resolveVisibility(playing: false, persistent: true),
+            "stopping playback must never hide an icon the user pinned persistently"
+        )
+    }
+
+    func testTransientHidesWhenStoppedAndNotPinned() {
+        XCTAssertFalse(
+            MenuBarController.resolveVisibility(playing: false, persistent: false),
+            "with only the while-playing toggle, stopping playback removes the icon"
+        )
+    }
+
+    func testBothOnShowsIcon() {
+        XCTAssertTrue(
+            MenuBarController.resolveVisibility(playing: true, persistent: true),
+            "both toggles on: icon visible"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
+++ b/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
@@ -37,7 +37,7 @@ final class MenuBarVisibilityTests: XCTestCase {
 
     func testPersistentWinsWhenPlaybackStops() {
         // Simulate a playing→stopped transition while the persistent toggle is
-        // on: the icon must NOT be hidden — that was the precedence bug.
+        // on: the icon must NOT be hidden.
         XCTAssertTrue(
             MenuBarController.resolveVisibility(playing: false, persistent: true),
             "stopping playback must never hide an icon the user pinned persistently"

--- a/macos/Tests/LyrebirdTests/NotificationManagerTests.swift
+++ b/macos/Tests/LyrebirdTests/NotificationManagerTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `NotificationManager`'s pure decision helpers — the
+/// track-change guard and the subtitle composition rule.
+///
+/// Both are exercised through the static `shouldNotify(enabled:)` and
+/// `subtitle(artist:album:)` helpers so the behavior is verified without
+/// realizing a `UNUserNotificationCenter`, which a headless test run can't do.
+final class NotificationManagerTests: XCTestCase {
+
+    // MARK: - Guard
+
+    func testShouldNotifyFalseWhenDisabled() {
+        XCTAssertFalse(
+            NotificationManager.shouldNotify(enabled: false),
+            "track-change notifications must be suppressed when the toggle is off"
+        )
+    }
+
+    func testShouldNotifyTrueWhenEnabled() {
+        XCTAssertTrue(
+            NotificationManager.shouldNotify(enabled: true),
+            "track-change notifications fire when the toggle is on"
+        )
+    }
+
+    // MARK: - Subtitle composition
+
+    func testSubtitleJoinsArtistAndAlbum() {
+        XCTAssertEqual(
+            NotificationManager.subtitle(artist: "Radiohead", album: "Kid A"),
+            "Radiohead — Kid A",
+            "both present: subtitle is 'Artist — Album'"
+        )
+    }
+
+    func testSubtitleArtistOnly() {
+        XCTAssertEqual(
+            NotificationManager.subtitle(artist: "Radiohead", album: nil),
+            "Radiohead",
+            "album missing: subtitle is just the artist (no bare dash)"
+        )
+    }
+
+    func testSubtitleAlbumOnly() {
+        XCTAssertEqual(
+            NotificationManager.subtitle(artist: nil, album: "Kid A"),
+            "Kid A",
+            "artist missing: subtitle is just the album (no bare dash)"
+        )
+    }
+
+    func testSubtitleNilWhenBothMissing() {
+        XCTAssertNil(
+            NotificationManager.subtitle(artist: nil, album: nil),
+            "neither present: no subtitle rather than an empty / dash-only body"
+        )
+    }
+
+    func testSubtitleTreatsEmptyStringsAsMissing() {
+        XCTAssertEqual(
+            NotificationManager.subtitle(artist: "", album: "Kid A"),
+            "Kid A",
+            "empty artist string is dropped so the subtitle never leads with a dash"
+        )
+        XCTAssertNil(
+            NotificationManager.subtitle(artist: "", album: ""),
+            "two empty strings collapse to no subtitle"
+        )
+    }
+}


### PR DESCRIPTION
Adds the Settings ▸ Notifications pane so users can opt into a Now Playing banner on track change, choose whether it plays a sound, and surface the menu-bar icon while playing.

Closes #266

- New `PreferencesNotifications` pane registered in `PreferencesView` (bell icon, after Appearance) with three `@AppStorage`-backed toggles: show-on-track-change, play-sound (disabled until track-change is on), and show-in-menu-bar-while-playing.
- New `NotificationManager` wraps `UNUserNotificationCenter`: requests authorization lazily when the user opts in (and on launch if already enabled), and posts a Now Playing banner respecting the sound toggle. Shared `NotificationPreference` keys keep the pane and the manager in sync.
- `MenuBarController` gains `setVisibleWhilePlaying(_:)` (transient, never hides the persistent General icon) and `setNowPlaying(_:)` (tooltip).
- `AppModel.startPolling` track-change hook fires the notification + drives the transient menu-bar icon off real play/pause state transitions (no per-tick churn).

pipeline:
- fixer-session: feat/266-notifications-settings
- slice: macos / Settings
- hotspots-claimed: none
- build-gate: pass (`swift build` clean; touched no Rust, so xcframework/bindings unchanged — generated artifacts are gitignored)
- diff-stat: 6 files, +2 new files (NotificationManager.swift, PreferencesNotifications.swift)