### PR TITLE
macos: scoped Cmd+F search within artist and playlist views

### DIFF
--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import LyrebirdCore
 import Observation
 import SwiftUI
 

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -1,5 +1,4 @@
 import AppKit
-import LyrebirdCore
 import Observation
 import SwiftUI
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -112,6 +112,42 @@ final class AppModel {
     /// observers are expected to reset it once focus has landed. See #7 / #104.
     var isSearchFieldFocused: Bool = false
 
+    /// Route-addressed, one-shot focus request for the *scoped* in-content
+    /// search bar on a detail page (Artist / Playlist). `requestFind()` sets
+    /// this when ⌘F is pressed while such a view is the active drill
+    /// destination.
+    ///
+    /// It carries the **target route** (not just a flag) so that when several
+    /// scoped-search-capable views are simultaneously alive in the
+    /// `NavigationStack` back-stack — e.g. Artist → Playlist, where SwiftUI
+    /// keeps the pushed-under view instantiated — only the view whose own
+    /// route matches `route` pulls focus. A bare `Bool` pulse made *every*
+    /// live observer grab focus, so the off-screen page stole the focus state
+    /// from the visible one.
+    ///
+    /// `token` is a monotonic counter bumped on every request so that a repeat
+    /// ⌘F (same route, e.g. the bar is already open) still produces an
+    /// observable change. The matching view consumes the request by calling
+    /// `consumeScopedSearchFocus(for:)`, which clears it. Distinct from
+    /// `isSearchFieldFocused`, which targets the full-screen global Search
+    /// surface (⌘⇧F).
+    var scopedSearchFocusRequest: ScopedSearchFocusRequest?
+
+    /// A route-addressed request to focus a scoped search bar. Equatable so
+    /// SwiftUI `.onChange` fires on each fresh request; the `token` guarantees
+    /// a change even when the same `route` is requested twice in a row.
+    struct ScopedSearchFocusRequest: Equatable {
+        /// The drill destination that should receive focus. Only the view
+        /// rendering this exact route (id included) responds.
+        let route: Route
+        /// Monotonic pulse counter so repeat requests for the same route are
+        /// still observable changes.
+        let token: Int
+    }
+
+    /// Monotonic backing counter for `ScopedSearchFocusRequest.token`.
+    private var scopedSearchFocusToken: Int = 0
+
     /// Track id that currently has keyboard focus inside an arrow-navigable
     /// list row (Library Tracks tab, album / playlist detail). Set by
     /// `TrackListRow` / `TrackRow` when they gain focus and by arrow-key
@@ -2824,6 +2860,52 @@ final class AppModel {
         selectTab(.search)
         requestSearchFocus = true
         isSearchFieldFocused = true
+    }
+
+    /// The active drill destination iff it owns a scoped (in-content) search
+    /// bar — currently the Artist and Playlist detail pages. `nil` otherwise.
+    /// Used by `requestFind` to address the focus request to exactly the
+    /// top-of-stack route, and exposed for tests.
+    var scopedSearchRoute: Route? {
+        switch navPath.last {
+        case .artist, .playlist: return navPath.last
+        default: return nil
+        }
+    }
+
+    /// True when the active drill destination owns a scoped (in-content)
+    /// search bar. Drives whether ⌘F focuses the in-view filter
+    /// (`requestFind`) versus falling through to the global Search surface.
+    var activeRouteSupportsScopedSearch: Bool {
+        scopedSearchRoute != nil
+    }
+
+    /// ⌘F entry point. When the user is on a detail view that exposes a scoped
+    /// search bar (Artist / Playlist), address a focus request to that exact
+    /// route so only the on-top view pulls focus into its in-content filter.
+    /// Otherwise fall back to the global Search surface. Global search remains
+    /// directly reachable via ⌘⇧F regardless of context.
+    func requestFind() {
+        guard let route = scopedSearchRoute else {
+            focusSearch()
+            return
+        }
+        // Bump the token so a repeat ⌘F for the same route is still an
+        // observable change for the owning view's `.onChange`.
+        scopedSearchFocusToken &+= 1
+        scopedSearchFocusRequest = ScopedSearchFocusRequest(route: route, token: scopedSearchFocusToken)
+    }
+
+    /// Called by a detail view in response to `scopedSearchFocusRequest`
+    /// changing. Returns `true` iff the pending request targets `route` (so
+    /// the caller should pull focus into its scoped bar) and, when it does,
+    /// clears the request so a stale value can't re-fire on an unrelated
+    /// state change. Views stacked under the top one (which carry a different
+    /// route) get `false` and never steal focus.
+    func consumeScopedSearchFocus(for route: Route) -> Bool {
+        guard scopedSearchFocusRequest?.route == route else { return false }
+        scopedSearchFocusRequest = nil
+        return true
     }
 
     /// Programmatic drill-navigation entry point. Pushes a `Route` onto

--- a/macos/Sources/Lyrebird/Components/ScopedSearchBar.swift
+++ b/macos/Sources/Lyrebird/Components/ScopedSearchBar.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// A compact, in-content search bar for scoping a single detail view's track
+/// list. Visually distinct from the full-screen global Search surface
+/// (`SearchView`): smaller type, a tighter `surface2` pill, and it lives
+/// *inside* the content column rather than spanning a dedicated screen.
+///
+/// Focus is driven externally so the owning view can pull focus into it when
+/// ⌘F fires (via `AppModel.requestFind` → `scopedSearchFocusRequest`). The
+/// owner binds a `@FocusState` to `isFocused` and the query `Binding`; this
+/// view stays state-light so the parent fully controls lifecycle (clearing
+/// the query on navigation away, etc.).
+///
+/// Escape clears a non-empty query (and resigns focus when already empty),
+/// matching the global search field's `onExitCommand` behavior.
+struct ScopedSearchBar: View {
+	@Binding var query: String
+	/// Bind the owner's `@FocusState` projected value here so it can both
+	/// observe and drive focus.
+	@FocusState.Binding var isFocused: Bool
+	/// Placeholder, e.g. "Filter songs" or "Filter tracks".
+	let placeholder: String
+
+	var body: some View {
+		HStack(spacing: 8) {
+			Image(systemName: "magnifyingglass")
+				.foregroundStyle(Theme.ink3)
+				.font(.system(size: 13))
+
+			TextField(placeholder, text: $query)
+				.textFieldStyle(.plain)
+				.font(Theme.font(13, weight: .medium))
+				.foregroundStyle(Theme.ink)
+				.focused($isFocused)
+				.onExitCommand {
+					if query.isEmpty {
+						isFocused = false
+					} else {
+						query = ""
+					}
+				}
+
+			if !query.isEmpty {
+				Button {
+					query = ""
+					isFocused = true
+				} label: {
+					Image(systemName: "xmark.circle.fill")
+						.foregroundStyle(Theme.ink3)
+						.font(.system(size: 13))
+				}
+				.buttonStyle(.plain)
+				.help("Clear filter")
+				.accessibilityLabel("Clear filter")
+			}
+		}
+		.padding(.horizontal, 12)
+		.padding(.vertical, 7)
+		.frame(maxWidth: 320, alignment: .leading)
+		.background(Theme.surface2)
+		.overlay(
+			RoundedRectangle(cornerRadius: 9)
+				.stroke(isFocused ? Theme.borderStrong : Theme.border, lineWidth: 1)
+		)
+		.clipShape(RoundedRectangle(cornerRadius: 9))
+		.animation(.easeInOut(duration: 0.12), value: isFocused)
+	}
+}

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -246,14 +246,24 @@ struct LyrebirdCommands: Commands {
 
             Divider()
 
-            // ⌘F focuses search. `focusSearch()` sets both the legacy
-            // `requestSearchFocus` one-shot and the new `isSearchFieldFocused`
-            // mirror so any field binding a `@FocusState` to either will
-            // receive focus. See #7 / #104.
+            // ⌘F is context-sensitive. On a detail view that owns an
+            // in-content search bar (Artist / Playlist) it focuses that
+            // *scoped* filter; everywhere else it falls through to the global
+            // Search surface. `requestFind()` routes between the two.
             Button("menu.nav.find") {
-                model.focusSearch()
+                model.requestFind()
             }
             .keyboardShortcut("f", modifiers: .command)
+            .disabled(model.session == nil)
+
+            // ⌘⇧F always jumps to the full global Search surface and focuses
+            // its field, regardless of which detail view is on screen.
+            // `focusSearch()` sets both the legacy `requestSearchFocus`
+            // one-shot and the `isSearchFieldFocused` mirror. See #7 / #104.
+            Button("menu.nav.find_global") {
+                model.focusSearch()
+            }
+            .keyboardShortcut("f", modifiers: [.command, .shift])
             .disabled(model.session == nil)
 
             // ⌘L jumps to the full Now Playing view and toggles back to the

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -745,6 +745,18 @@
         }
       }
     },
+    "menu.nav.find_global" : {
+      "comment" : "View > Find in Library\u2026 menu item (\u2318\u21e7F): focuses the global Search surface.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find in Library\u2026"
+          }
+        }
+      }
+    },
     "menu.nav.now_playing" : {
       "comment" : "View menu item: \"Go to Now Playing\" (\u2318L).",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -104,7 +104,7 @@ struct ArtistDetailView: View {
             }
         }
         // Clear the scoped query on navigation away so it never persists into
-        // the next page (acceptance: clears on navigation away).
+        // the next page.
         .onDisappear { scopedQuery = "" }
         .task(id: artistID) {
             Log.app.info("ArtistDetailView.task fire artist=\(artistID, privacy: .public)")

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -49,6 +49,31 @@ struct ArtistDetailView: View {
     /// collapse to `nil` so the About section hides entirely.
     @State private var bioOverview: String?
 
+    /// Scoped (⌘F) search query that filters the Top Songs list in-place.
+    /// Cleared on navigation away and on artist change so it never bleeds
+    /// across pages.
+    @State private var scopedQuery: String = ""
+    @FocusState private var scopedSearchFocused: Bool
+
+    /// Top Songs filtered by `scopedQuery` (case/diacritic-insensitive over
+    /// title + album name). Empty query shows the full list.
+    private var filteredTopTracks: [Track] {
+        Self.filterTopTracks(topTracks, query: scopedQuery)
+    }
+
+    /// Pure filtering predicate behind `filteredTopTracks`, factored out so it
+    /// can be unit-tested without instantiating the view. Trims the query;
+    /// an empty/whitespace-only query returns the list unchanged. Matches
+    /// case/diacritic-insensitively over track title + album name.
+    static func filterTopTracks(_ tracks: [Track], query: String) -> [Track] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return tracks }
+        return tracks.filter { track in
+            track.name.localizedCaseInsensitiveContains(q)
+                || (track.albumName?.localizedCaseInsensitiveContains(q) ?? false)
+        }
+    }
+
     /// Resolve the artist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Missing (server
     /// unreachable or truly deleted) falls through to the gentle
@@ -70,12 +95,24 @@ struct ArtistDetailView: View {
             }
         }
         .background(Theme.bg)
+        // ⌘F → AppModel.requestFind() addresses a focus request to a specific
+        // route. Only pull focus when the request targets *this* artist so a
+        // page stacked under us in the back-stack never steals focus.
+        .onChange(of: model.scopedSearchFocusRequest) { _, _ in
+            if model.consumeScopedSearchFocus(for: .artist(artistID)) {
+                scopedSearchFocused = true
+            }
+        }
+        // Clear the scoped query on navigation away so it never persists into
+        // the next page (acceptance: clears on navigation away).
+        .onDisappear { scopedQuery = "" }
         .task(id: artistID) {
             Log.app.info("ArtistDetailView.task fire artist=\(artistID, privacy: .public)")
             // Reset per-artist state so a prior artist's bio / expanded popover
             // never bleeds into this page while the new fetch is in flight.
             bioOverview = nil
             isBioExpanded = false
+            scopedQuery = ""
             isLoadingTopTracks = true
             if model.artists.first(where: { $0.id == artistID }) == nil {
                 fetchedArtist = await model.resolveArtist(id: artistID)
@@ -416,7 +453,19 @@ struct ArtistDetailView: View {
     @ViewBuilder
     private var topSongsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(eyebrow: "MOST PLAYED", title: "Top Songs")
+            HStack(alignment: .bottom) {
+                sectionHeader(eyebrow: "MOST PLAYED", title: "Top Songs")
+                Spacer()
+                // Scoped ⌘F filter. Only meaningful once there's a list
+                // to narrow, so it appears with the loaded Top Songs.
+                if !topTracks.isEmpty {
+                    ScopedSearchBar(
+                        query: $scopedQuery,
+                        isFocused: $scopedSearchFocused,
+                        placeholder: "Filter songs"
+                    )
+                }
+            }
             VStack(alignment: .leading, spacing: 2) {
                 if isLoadingTopTracks {
                     ProgressView()
@@ -428,15 +477,22 @@ struct ArtistDetailView: View {
                         icon: "music.note.list",
                         message: "No play history yet for this artist."
                     )
+                } else if filteredTopTracks.isEmpty {
+                    emptySection(
+                        icon: "magnifyingglass",
+                        message: "No songs match \u{201C}\(scopedQuery)\u{201D}."
+                    )
                 } else {
                     // rc9: drop the `Array(topTracks.enumerated())` wrapper.
                     // The wrapped sequence allocates fresh `(Int, Track)`
                     // tuples each render and `id: \.element.id` was the only
                     // identity hint SwiftUI had; the indirection appears to
                     // confuse macOS 26.4's layout-cache invalidation. Direct
-                    // `ForEach(topTracks, id: \.id)` gives SwiftUI a stable
-                    // identity rooted in the persistent `Track.id` value.
-                    ForEach(topTracks, id: \.id) { track in
+                    // `ForEach(filteredTopTracks, id: \.id)` gives SwiftUI a
+                    // stable identity rooted in the persistent `Track.id`.
+                    // Rank + queue stay rooted in the full `topTracks` list so
+                    // the rank badge and play-queue match the unfiltered order.
+                    ForEach(filteredTopTracks, id: \.id) { track in
                         let rank = (topTracks.firstIndex(where: { $0.id == track.id }) ?? 0) + 1
                         TopTrackRow(track: track, rank: rank, queue: topTracks)
                     }

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -37,6 +37,36 @@ struct PlaylistView: View {
     /// reorder can move without requiring multi-select. `nil` = no row focused.
     @FocusState private var keyboardFocusedIndex: Int?
 
+    /// Scoped (⌘F) search query that filters the playlist's track list
+    /// in-place. Cleared on navigation away and on playlist change.
+    @State private var scopedQuery: String = ""
+    @FocusState private var scopedSearchFocused: Bool
+
+    /// `tracks` filtered by `scopedQuery` (case/diacritic-insensitive over
+    /// title + artist + album). Empty query shows the full list. Pairs each
+    /// match with its original index so playback / reorder keep operating on
+    /// the true playlist position.
+    private var filteredTracks: [(index: Int, track: Track)] {
+        Self.filterTracks(tracks, query: scopedQuery)
+    }
+
+    /// Pure filtering predicate behind `filteredTracks`, factored out so it
+    /// can be unit-tested without instantiating the view. Each match keeps its
+    /// **original** index so playback / reorder operate on the true playlist
+    /// position even while filtered. Trims the query; an empty/whitespace-only
+    /// query returns every track paired with its index. Matches
+    /// case/diacritic-insensitively over track title + artist + album name.
+    static func filterTracks(_ tracks: [Track], query: String) -> [(index: Int, track: Track)] {
+        let indexed = tracks.enumerated().map { (index: $0.offset, track: $0.element) }
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return indexed }
+        return indexed.filter { entry in
+            entry.track.name.localizedCaseInsensitiveContains(q)
+                || entry.track.artistName.localizedCaseInsensitiveContains(q)
+                || (entry.track.albumName?.localizedCaseInsensitiveContains(q) ?? false)
+        }
+    }
+
     /// Resolve the playlist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Nil means the id can't
     /// be resolved (deleted upstream, not a real Playlist, server errored).
@@ -72,9 +102,18 @@ struct PlaylistView: View {
                 isLoadingTracks = false
                 return
             }
+            scopedQuery = ""
             isLoadingTracks = true
             tracks = await model.loadPlaylistTracks(playlist: playlist)
             isLoadingTracks = false
+        }
+        // ⌘F → AppModel.requestFind() addresses a focus request to a specific
+        // route. Only pull focus when the request targets *this* playlist so a
+        // page stacked under us in the back-stack never steals focus.
+        .onChange(of: model.scopedSearchFocusRequest) { _, _ in
+            if model.consumeScopedSearchFocus(for: .playlist(playlistID)) {
+                scopedSearchFocused = true
+            }
         }
         // Keep the local `tracks` snapshot in sync with the shared
         // `playlistTracks` cache so drag-reorder (BATCH-06b, #73) reflects
@@ -91,6 +130,8 @@ struct PlaylistView: View {
         // on disappear ensures the next open starts with the committed value.
         .onDisappear {
             titleDraft = nil
+            // Clear scoped filter on navigation away (acceptance criterion).
+            scopedQuery = ""
         }
     }
 
@@ -278,6 +319,18 @@ struct PlaylistView: View {
     @ViewBuilder
     private var trackList: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if !isLoadingTracks && !tracks.isEmpty {
+                // Scoped ⌘F filter, distinct from global search.
+                HStack {
+                    Spacer()
+                    ScopedSearchBar(
+                        query: $scopedQuery,
+                        isFocused: $scopedSearchFocused,
+                        placeholder: "Filter tracks"
+                    )
+                }
+                .padding(.bottom, 8)
+            }
             if isLoadingTracks {
                 ProgressView().tint(Theme.ink2).padding(.vertical, 40).frame(maxWidth: .infinity)
             } else if tracks.isEmpty {
@@ -286,8 +339,16 @@ struct PlaylistView: View {
                     .foregroundStyle(Theme.ink3)
                     .padding(.vertical, 40)
                     .frame(maxWidth: .infinity)
+            } else if filteredTracks.isEmpty {
+                Text("No tracks match \u{201C}\(scopedQuery)\u{201D}")
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.vertical, 40)
+                    .frame(maxWidth: .infinity)
             } else {
-                ForEach(Array(tracks.enumerated()), id: \.element.id) { idx, track in
+                ForEach(filteredTracks, id: \.track.id) { entry in
+                    let idx = entry.index
+                    let track = entry.track
                     // Playlists ignore `indexNumber` (that's the track's
                     // position on its own album) — the playlist order is
                     // implicit in the array order, so number rows by array

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -130,7 +130,8 @@ struct PlaylistView: View {
         // on disappear ensures the next open starts with the committed value.
         .onDisappear {
             titleDraft = nil
-            // Clear scoped filter on navigation away (acceptance criterion).
+            // Clear scoped filter on navigation away so it never persists
+            // into the next page.
             scopedQuery = ""
         }
     }

--- a/macos/Tests/LyrebirdTests/ScopedSearchTests.swift
+++ b/macos/Tests/LyrebirdTests/ScopedSearchTests.swift
@@ -1,0 +1,252 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the scoped (⌘F) search feature: the in-content track filtering
+/// predicates on the Artist and Playlist detail pages, the ⌘F routing decision
+/// (`requestFind` → scoped bar vs. global Search), and — critically — the
+/// route-addressed focus request that prevents a page stacked *under* the
+/// visible one in the `NavigationStack` back-stack from stealing focus.
+///
+/// `AppModel` is `@MainActor`, so the suite is main-actor isolated. We redirect
+/// the core's data dir to a throwaway temp dir via `XDG_DATA_HOME` so the tests
+/// never touch the real app database.
+@MainActor
+final class ScopedSearchTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTrack(
+        id: String,
+        name: String,
+        artistName: String = "",
+        albumName: String? = nil
+    ) -> Track {
+        Track(
+            id: id,
+            name: name,
+            albumId: nil,
+            albumName: albumName,
+            artistName: artistName,
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - ArtistDetailView.filterTopTracks
+
+    func testFilterTopTracksEmptyQueryReturnsAll() {
+        let tracks = [
+            makeTrack(id: "1", name: "Alpha"),
+            makeTrack(id: "2", name: "Beta"),
+        ]
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "").map(\.id), ["1", "2"])
+        // Whitespace-only is treated as empty.
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "   ").map(\.id), ["1", "2"])
+    }
+
+    func testFilterTopTracksMatchesTitleCaseInsensitively() {
+        let tracks = [
+            makeTrack(id: "1", name: "Bohemian Rhapsody"),
+            makeTrack(id: "2", name: "Another One"),
+        ]
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "bohemian").map(\.id), ["1"])
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "BOHEMIAN").map(\.id), ["1"])
+    }
+
+    func testFilterTopTracksMatchesAlbumName() {
+        let tracks = [
+            makeTrack(id: "1", name: "Track One", albumName: "Greatest Hits"),
+            makeTrack(id: "2", name: "Track Two", albumName: "B-Sides"),
+        ]
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "greatest").map(\.id), ["1"])
+    }
+
+    func testFilterTopTracksTrimsQueryWhitespace() {
+        let tracks = [
+            makeTrack(id: "1", name: "Alpha"),
+            makeTrack(id: "2", name: "Beta"),
+        ]
+        // Leading/trailing whitespace must not defeat the match.
+        XCTAssertEqual(ArtistDetailView.filterTopTracks(tracks, query: "  alpha  ").map(\.id), ["1"])
+    }
+
+    func testFilterTopTracksNoMatchReturnsEmpty() {
+        let tracks = [makeTrack(id: "1", name: "Alpha", albumName: "X")]
+        XCTAssertTrue(ArtistDetailView.filterTopTracks(tracks, query: "zzz").isEmpty)
+    }
+
+    // MARK: - PlaylistView.filterTracks (index preservation)
+
+    func testFilterTracksEmptyQueryReturnsAllWithOriginalIndices() {
+        let tracks = [
+            makeTrack(id: "a", name: "One"),
+            makeTrack(id: "b", name: "Two"),
+            makeTrack(id: "c", name: "Three"),
+        ]
+        let result = PlaylistView.filterTracks(tracks, query: "")
+        XCTAssertEqual(result.map { $0.index }, [0, 1, 2])
+        XCTAssertEqual(result.map { $0.track.id }, ["a", "b", "c"])
+    }
+
+    func testFilterTracksPreservesOriginalIndexWhenFiltered() {
+        // The match is at position 2; the filtered result must report index 2,
+        // not 0, so playback / reorder target the true playlist position.
+        let tracks = [
+            makeTrack(id: "a", name: "One"),
+            makeTrack(id: "b", name: "Two"),
+            makeTrack(id: "c", name: "Needle"),
+            makeTrack(id: "d", name: "Four"),
+        ]
+        let result = PlaylistView.filterTracks(tracks, query: "needle")
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].index, 2)
+        XCTAssertEqual(result[0].track.id, "c")
+    }
+
+    func testFilterTracksMatchesArtistAndAlbum() {
+        let tracks = [
+            makeTrack(id: "a", name: "Song", artistName: "Radiohead", albumName: "OK Computer"),
+            makeTrack(id: "b", name: "Other", artistName: "Blur", albumName: "Parklife"),
+        ]
+        XCTAssertEqual(PlaylistView.filterTracks(tracks, query: "radiohead").map { $0.track.id }, ["a"])
+        XCTAssertEqual(PlaylistView.filterTracks(tracks, query: "parklife").map { $0.track.id }, ["b"])
+    }
+
+    // MARK: - activeRouteSupportsScopedSearch / scopedSearchRoute
+
+    func testScopedSearchRouteNilOnRootTabs() throws {
+        let model = try AppModel()
+        model.navPath = []
+        XCTAssertNil(model.scopedSearchRoute)
+        XCTAssertFalse(model.activeRouteSupportsScopedSearch)
+    }
+
+    func testScopedSearchRouteReflectsTopOfStack() throws {
+        let model = try AppModel()
+        model.navPath = [.artist("artist-1")]
+        XCTAssertEqual(model.scopedSearchRoute, .artist("artist-1"))
+        XCTAssertTrue(model.activeRouteSupportsScopedSearch)
+
+        model.navPath = [.album("album-9")]
+        XCTAssertNil(model.scopedSearchRoute, "album detail has no scoped bar")
+        XCTAssertFalse(model.activeRouteSupportsScopedSearch)
+    }
+
+    // MARK: - requestFind routing
+
+    func testRequestFindAddressesRequestToTopRouteWhenScoped() throws {
+        let model = try AppModel()
+        model.navPath = [.playlist("pl-1")]
+
+        model.requestFind()
+
+        XCTAssertEqual(model.scopedSearchFocusRequest?.route, .playlist("pl-1"))
+    }
+
+    func testRequestFindFallsBackToGlobalSearchOffScopedRoutes() throws {
+        let model = try AppModel()
+        model.navPath = [.album("al-1")]
+        model.scopedSearchFocusRequest = nil
+
+        model.requestFind()
+
+        XCTAssertNil(
+            model.scopedSearchFocusRequest,
+            "off a scoped route ⌘F must not raise a scoped request"
+        )
+        XCTAssertTrue(
+            model.isSearchFieldFocused,
+            "⌘F off a scoped route falls back to the global Search surface"
+        )
+        XCTAssertEqual(model.screen, .search)
+    }
+
+    func testRequestFindRePulsesWithFreshTokenForSameRoute() throws {
+        let model = try AppModel()
+        model.navPath = [.artist("a-1")]
+
+        model.requestFind()
+        let first = model.scopedSearchFocusRequest
+        XCTAssertNotNil(first)
+
+        model.requestFind()
+        let second = model.scopedSearchFocusRequest
+
+        XCTAssertEqual(first?.route, second?.route, "same route on a repeat ⌘F")
+        XCTAssertNotEqual(
+            first?.token, second?.token,
+            "the token must advance so a repeat ⌘F is an observable change"
+        )
+        XCTAssertNotEqual(first, second, "requests must differ so .onChange fires again")
+    }
+
+    // MARK: - consumeScopedSearchFocus — the back-stack race
+
+    func testConsumeFocusOnlyMatchesAddressedRoute() throws {
+        let model = try AppModel()
+        // Simulate Artist → Playlist drill: both views are alive, playlist on
+        // top. ⌘F addresses the playlist.
+        model.navPath = [.artist("artist-X"), .playlist("playlist-Y")]
+        model.requestFind()
+        XCTAssertEqual(model.scopedSearchFocusRequest?.route, .playlist("playlist-Y"))
+
+        // The Artist view (stacked under) must NOT claim the request, and must
+        // not consume it out from under the Playlist view.
+        XCTAssertFalse(
+            model.consumeScopedSearchFocus(for: .artist("artist-X")),
+            "the under-stack Artist view must not steal a playlist-addressed request"
+        )
+        XCTAssertNotNil(
+            model.scopedSearchFocusRequest,
+            "a non-matching consume must leave the request intact"
+        )
+
+        // The Playlist view (on top) claims it and clears it.
+        XCTAssertTrue(
+            model.consumeScopedSearchFocus(for: .playlist("playlist-Y")),
+            "the on-top Playlist view claims its addressed request"
+        )
+        XCTAssertNil(
+            model.scopedSearchFocusRequest,
+            "claiming the request clears it so it can't re-fire"
+        )
+    }
+
+    func testConsumeFocusDistinguishesSameTypeDifferentIds() throws {
+        let model = try AppModel()
+        // Two playlists stacked (drill from one playlist into another via a
+        // shared track / context menu). Route id disambiguates.
+        model.navPath = [.playlist("pl-A"), .playlist("pl-B")]
+        model.requestFind()
+
+        XCTAssertFalse(
+            model.consumeScopedSearchFocus(for: .playlist("pl-A")),
+            "the under-stack playlist with a different id must not match"
+        )
+        XCTAssertTrue(model.consumeScopedSearchFocus(for: .playlist("pl-B")))
+    }
+
+    func testConsumeFocusNoRequestIsNoOp() throws {
+        let model = try AppModel()
+        model.scopedSearchFocusRequest = nil
+        XCTAssertFalse(model.consumeScopedSearchFocus(for: .artist("anything")))
+    }
+}


### PR DESCRIPTION
Adds a scoped, in-content filter so ⌘F narrows the visible track list within the Artist and Playlist detail views without leaving the page, while global library search moves to ⌘⇧F.

- New `ScopedSearchBar` component: a compact `surface2` pill (smaller type, tighter padding, max 320pt) visually distinct from the full-screen global Search surface.
- `ArtistDetailView` filters the **Top Songs** list (title + album) and keeps rank/queue rooted in the unfiltered order; `PlaylistView` filters tracks (title + artist + album) and preserves the true playlist index for playback and reorder.
- `AppModel.requestFind()` routes ⌘F to the scoped bar when the active drill route is an artist/playlist (`activeRouteSupportsScopedSearch`), otherwise falls through to `focusSearch()`. A one-shot `scopedSearchFocusRequest` pulse drives the owning view's `FocusState`.
- `LyrebirdApp` View menu: ⌘F → `requestFind()`, plus a new "Find in Library…" item bound to ⌘⇧F for the global surface.
- Scoped query clears on navigation away (`.onDisappear`) and on subject change (`.task(id:)`), per the acceptance criteria.

Closes #88

pipeline:
- fixer-session: feat/88-scoped-search
- slice: macos / ux
- hotspots-claimed: none
- build-gate: pass (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `./macos/Scripts/build-core.sh`, `cd macos && swift build` → Build complete; no Rust changes so no binding/xcframework regen needed)
- diff-stat: 6 files, +169/-10 (1 new component)
