### PR TITLE
fix(core): widen bitrate to i64 so PlaybackInfo survives the -1000 sentinel

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2632,7 +2632,7 @@ pub struct RawItem {
     #[serde(rename = "Container")]
     pub container: Option<String>,
     #[serde(rename = "Bitrate")]
-    pub bitrate: Option<u32>,
+    pub bitrate: Option<i64>,
     #[serde(rename = "Path")]
     pub path: Option<String>,
     #[serde(rename = "PlaylistItemId")]

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -76,7 +76,7 @@ pub struct Track {
     /// See [`Self::is_favorite`].
     pub play_count: u32,
     pub container: Option<String>,
-    pub bitrate: Option<u32>,
+    pub bitrate: Option<i64>,
     pub image_tag: Option<String>,
     /// Jellyfin `PlaylistItemId` — only populated when the track was fetched
     /// as part of a playlist (via `playlist_tracks`). Used by
@@ -545,7 +545,7 @@ pub struct MediaSourceInfo {
     #[serde(default)]
     pub container: Option<String>,
     #[serde(default)]
-    pub bitrate: Option<u32>,
+    pub bitrate: Option<i64>,
     #[serde(default)]
     pub size: Option<i64>,
     #[serde(default)]

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7778,3 +7778,36 @@ async fn playback_info_parses_negative_bitrate_sentinel() {
     assert_eq!(resp.media_sources.len(), 1);
     assert_eq!(resp.media_sources[0].bitrate, Some(-1000));
 }
+
+#[tokio::test]
+async fn album_tracks_parses_negative_bitrate_sentinel() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "user", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Yona", "Type": "Audio",
+                    "AlbumId": "a1", "Container": "flac", "Bitrate": -1000,
+                    "RunTimeTicks": 2220000000u64
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("user", "pw").await.unwrap();
+    let tracks = client.album_tracks("a1").await.unwrap();
+    assert_eq!(tracks.len(), 1);
+    assert_eq!(tracks[0].bitrate, Some(-1000));
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7737,3 +7737,44 @@ async fn suggestions_rejects_non_audio_items() {
     assert_eq!(tracks[0].id, "t1");
     assert_eq!(tracks[0].name, "Real Track");
 }
+
+#[tokio::test]
+async fn playback_info_parses_negative_bitrate_sentinel() {
+    use crate::models::PlaybackInfoOpts;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Items/flac-xyz/PlaybackInfo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "MediaSources": [
+                {
+                    "Id": "src-1",
+                    "Container": "flac",
+                    "Bitrate": -1000,
+                    "SupportsDirectPlay": true
+                }
+            ],
+            "PlaySessionId": "play-session-flac"
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let resp = client
+        .playback_info("flac-xyz", PlaybackInfoOpts::default())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.play_session_id.as_deref(), Some("play-session-flac"));
+    assert_eq!(resp.media_sources.len(), 1);
+    assert_eq!(resp.media_sources[0].bitrate, Some(-1000));
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -2019,8 +2019,8 @@ final class AppModel {
             return 0
         }()
         let container = (entry["Container"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        let bitrate: UInt32? = {
-            if let b = entry["Bitrate"] as? Int, b > 0 { return UInt32(b) }
+        let bitrate: Int64? = {
+            if let b = entry["Bitrate"] as? Int, b > 0 { return Int64(b) }
             return nil
         }()
         let imageTag: String? = {

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -350,7 +350,7 @@ struct NowPlayingView: View {
         count == 1 ? "1 play" : "\(count) plays"
     }
 
-    private func formatBitrate(_ bitrate: UInt32) -> String {
+    private func formatBitrate(_ bitrate: Int64) -> String {
         let kbps = Int(bitrate) / 1000
         return "\(kbps) kbps"
     }


### PR DESCRIPTION
Jellyfin emits `Bitrate: -1000` as an "unmeasurable" sentinel for some FLAC tracks, and `Option<u32>` rejected it during deserialization — sinking the whole `PlaybackInfo` response (and any item listing carrying the sentinel), which silently disabled playback-session tracking, `PlayCount`, and Now-Playing-on-other-clients for those tracks.

This widens the `bitrate` field to `Option<i64>` on `MediaSourceInfo` and `ItemRef` (and the internal `RawItem`) so the negative sentinel deserializes cleanly; downstream display code already guards `bitrate > 0`, so sentinels are filtered at render time exactly as before.

Build-gate notes:
- Rust: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --exclude lyrebird-desktop --all-features` all pass (incl. new regression test `playback_info_parses_negative_bitrate_sentinel`).
- Swift: clean `rm -rf macos/.build && swift build --package-path macos` after regenerating the xcframework + bindings (these are gitignored / CI-regenerated in this repo, so not committed). The `Int64?` migration required updating `formatBitrate(_:)` in `NowPlayingView` and the DTO parser's `bitrate` local in `AppModel` to match the new binding type.

Hotspot lock claimed: #892 (`clientrs`) — release on merge.

Closes #890

pipeline:
  fixer-session: wf_367922fa-3ba-34
  slice: slice:models
  hotspots-claimed: [clientrs]
  build-gate: pass
  diff-stat: 5 files changed, +47/-6
