### PR TITLE
macos: add Library preferences (default sort, sidebar sections, track numbers, play counts)

### DIFF
--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -17,6 +17,14 @@ struct Sidebar: View {
     /// nothing is hovered.
     @State private var hoveredPlaylistId: String?
 
+    // User-toggleable "Your Library" sections. Each defaults to on so
+    // the sidebar looks unchanged until the user hides a row in
+    // Preferences → Library. Keys live in `LibraryDefaults`.
+    @AppStorage(LibraryDefaults.sidebarShowFavoritesKey) private var showFavorites = true
+    @AppStorage(LibraryDefaults.sidebarShowAlbumsKey) private var showAlbums = true
+    @AppStorage(LibraryDefaults.sidebarShowArtistsKey) private var showArtists = true
+    @AppStorage(LibraryDefaults.sidebarShowPlaylistsKey) private var showPlaylists = true
+
     var body: some View {
         @Bindable var model = model
         VStack(alignment: .leading, spacing: 0) {
@@ -61,21 +69,35 @@ struct Sidebar: View {
             // Stats header. Keep the aggregate "Albums / Artists / Playlists"
             // summary rows above the playlist list so the count glance stays
             // in place; the playlist list lives as its own section below.
-            sectionHeader("sidebar.section.your_library")
-            VStack(alignment: .leading, spacing: 2) {
-                favoritesRow
-                libRow("square.stack", label: "sidebar.stats.albums", count: model.albumsTotal, tab: .albums)
-                libRow("person.crop.circle", label: "sidebar.stats.artists", count: model.artistsTotal, tab: .artists)
-                libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count), tab: .playlists)
+            // The whole "Your Library" stats block is hidden when the
+            // user has switched every section off, so the header doesn't
+            // float over an empty gap.
+            if showFavorites || showAlbums || showArtists || showPlaylists {
+                sectionHeader("sidebar.section.your_library")
+                VStack(alignment: .leading, spacing: 2) {
+                    if showFavorites { favoritesRow }
+                    if showAlbums {
+                        libRow("square.stack", label: "sidebar.stats.albums", count: model.albumsTotal, tab: .albums)
+                    }
+                    if showArtists {
+                        libRow("person.crop.circle", label: "sidebar.stats.artists", count: model.artistsTotal, tab: .artists)
+                    }
+                    if showPlaylists {
+                        libRow("music.note.list", label: "sidebar.stats.playlists", count: UInt32(model.playlists.count), tab: .playlists)
+                    }
+                }
+                .padding(.horizontal, 10)
             }
-            .padding(.horizontal, 10)
 
             // Playlist list — scrolls independently if the user has a long
             // library. Capped to a reasonable chunk of sidebar height so
-            // the server footer stays anchored at the bottom.
-            playlistsSection
-                .padding(.horizontal, 10)
-                .padding(.top, 6)
+            // the server footer stays anchored at the bottom. Hidden with the
+            // Playlists section toggle.
+            if showPlaylists {
+                playlistsSection
+                    .padding(.horizontal, 10)
+                    .padding(.top, 6)
+            }
 
             Spacer(minLength: 0)
 

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -63,6 +63,10 @@ struct TrackListRow: View {
     /// keep their current look.
     var density: AppearanceDensity = .roomy
     @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
+    // Reveal a track's play count on hover when the user opts in. The
+    // Tracks tab has no number column, so the track-numbers toggle doesn't
+    // apply here — only play-count-on-hover does.
+    @AppStorage(LibraryDefaults.showPlayCountOnHoverKey) private var showPlayCountOnHover = false
     @State private var isHovering = false
     @FocusState private var isFocused: Bool
 
@@ -293,6 +297,15 @@ struct TrackListRow: View {
                 })
             }
 
+            if showPlayCountOnHover, isHovering, track.playCount > 0 {
+                Text(playCountLabel)
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+                    .transition(.opacity)
+                    .accessibilityHidden(true)
+            }
+
             Text(track.durationFormatted)
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)
@@ -311,6 +324,12 @@ struct TrackListRow: View {
         if isFocused { return Theme.rowHover }
         if isHovering { return Theme.rowHover }
         return .clear
+    }
+
+    /// "1 play" / "12 plays" readout shown on hover when the user enables
+    /// "Show play counts on hover".
+    private var playCountLabel: String {
+        track.playCount == 1 ? "1 play" : "\(track.playCount) plays"
     }
 
     /// Advance the focused row by `delta` (+1 for down, -1 for up) inside

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -35,6 +35,10 @@ struct TrackRow: View {
     var playlistScope: Playlist? = nil
 
     @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
+    // Library preferences. Track numbers default on; play-count-on-hover
+    // defaults off so the row stays clean until the user opts in.
+    @AppStorage(LibraryDefaults.showTrackNumbersKey) private var showTrackNumbers = true
+    @AppStorage(LibraryDefaults.showPlayCountOnHoverKey) private var showPlayCountOnHover = false
     @State private var isHovering = false
     @FocusState private var isFocused: Bool
 
@@ -58,7 +62,10 @@ struct TrackRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Number / play button / equalizer
+            // Number / play button / equalizer. When the user hides track
+            // numbers the static ordinal disappears but the play /
+            // equalizer affordances stay — and the column keeps its width so
+            // every row's title still aligns.
             ZStack {
                 if isPlaying {
                     EqualizerIcon()
@@ -67,7 +74,7 @@ struct TrackRow: View {
                     Image(systemName: "play.fill")
                         .font(.system(size: 11))
                         .foregroundStyle(Theme.ink)
-                } else {
+                } else if showTrackNumbers {
                     Text("\(number)")
                         .font(Theme.font(12, weight: .medium))
                         .foregroundStyle(isActive ? Theme.accent : Theme.ink3)
@@ -109,6 +116,15 @@ struct TrackRow: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
+            }
+
+            if showPlayCountOnHover, isHovering, track.playCount > 0 {
+                Text(playCountLabel)
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+                    .transition(.opacity)
+                    .accessibilityHidden(true)
             }
 
             Text(track.durationFormatted)
@@ -181,6 +197,12 @@ struct TrackRow: View {
         if isFocused { return Theme.rowHover }
         if isHovering { return Theme.rowHover }
         return .clear
+    }
+
+    /// "1 play" / "12 plays" readout shown on hover when the user enables
+    /// "Show play counts on hover". Matches `TopTrackRow`'s wording.
+    private var playCountLabel: String {
+        track.playCount == 1 ? "1 play" : "\(track.playCount) plays"
     }
 
     /// Move focus by `delta` within `siblings`. No-op when siblings wasn't

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -92,6 +92,19 @@ struct LibraryView: View {
     /// Anchor row index for Shift+Click range extension. Mirrors the pattern
     /// in `PlaylistDetailView`.
     @State private var anchorIndex: Int? = nil
+    /// Persisted default sort applied to the Albums chip on first entry and
+    /// whenever the user switches to it without having hand-picked a sort.
+    /// Set in Preferences → Library. See `LibraryDefaults`.
+    @AppStorage(LibraryDefaults.albumSortKey) private var defaultAlbumSort: LibrarySortOrder = .nameAscending
+    /// Persisted default sort applied to the Tracks (Songs) chip. Same
+    /// mechanics as `defaultAlbumSort`.
+    @AppStorage(LibraryDefaults.songSortKey) private var defaultSongSort: LibrarySortOrder = .nameAscending
+    /// Chips whose persisted default we've already applied this session, so
+    /// re-entering a tab the user already customised doesn't clobber their
+    /// manual sort choice. A tab is removed from the set when its persisted
+    /// default changes in Preferences mid-session, so the new default re-applies
+    /// on next entry (and immediately, if that tab is on screen).
+    @State private var appliedDefaultTabs: Set<LibraryTab> = []
 
     private var density: AppearanceDensity {
         AppearanceDensity(rawValue: densityRaw) ?? .roomy
@@ -150,7 +163,10 @@ struct LibraryView: View {
         // a specific chip. `.onAppear` covers the case where the library
         // is entered fresh; `.onChange` covers the case where the user
         // is already on the library and the sidebar flips the tab.
-        .onAppear { selectedTab = model.libraryTab }
+        .onAppear {
+            selectedTab = model.libraryTab
+            applyDefaultSort(for: selectedTab)
+        }
         .onChange(of: model.libraryTab) { _, newValue in
             selectedTab = newValue
         }
@@ -162,6 +178,7 @@ struct LibraryView: View {
             // Switching chips abandons any track multi-selection — the rows
             // it referenced are no longer on screen. See #217.
             clearSelection()
+            applyDefaultSort(for: newValue)
         }
         // `anchorIndex` is a positional cursor into the displayed list; a sort
         // or filter change reorders that list, so a stale anchor would extend a
@@ -169,6 +186,15 @@ struct LibraryView: View {
         // survives the reorder, so only the anchor needs clearing. See #217.
         .onChange(of: sortOrder) { _, _ in anchorIndex = nil }
         .onChange(of: filter) { _, _ in anchorIndex = nil }
+        // A change to a persisted default while this view is alive means the
+        // user just edited Preferences → Library. Re-apply so the criterion
+        // "changes reflect in list views" holds without a relaunch.
+        .onChange(of: defaultAlbumSort) { _, _ in
+            reapplyDefaultSort(for: .albums)
+        }
+        .onChange(of: defaultSongSort) { _, _ in
+            reapplyDefaultSort(for: .tracks)
+        }
     }
 
     /// The selected tracks resolved against the currently-sorted list, in
@@ -687,6 +713,39 @@ struct LibraryView: View {
         filter.isActive ? model.playlists.filter(passesFilter) : model.playlists
     }
 
+    /// Apply the persisted default sort for `tab` the first time the user
+    /// lands on it. Albums and Tracks (Songs) each carry their own default
+    /// set in Preferences → Library; the other chips keep whatever sort is
+    /// active. Guarded by `appliedDefaultTabs` so re-entering a chip the
+    /// user has manually re-sorted preserves their choice for the session.
+    private func applyDefaultSort(for tab: LibraryTab) {
+        guard !appliedDefaultTabs.contains(tab) else { return }
+        switch tab {
+        case .albums:
+            sortOrder = defaultAlbumSort
+            appliedDefaultTabs.insert(tab)
+        case .tracks:
+            sortOrder = defaultSongSort
+            appliedDefaultTabs.insert(tab)
+        case .artists, .playlists, .downloaded:
+            break
+        }
+    }
+
+    /// React to a mid-session change of a persisted default sort (the user
+    /// edited Preferences → Library while the Library view is alive). Drop the
+    /// affected tab's "already applied" flag so the new default takes effect on
+    /// next entry, and re-apply right away if that tab is currently on screen —
+    /// satisfying the "changes reflect in list views" criterion without
+    /// clobbering a sort the user hand-picked from the header for a *different*
+    /// tab.
+    private func reapplyDefaultSort(for tab: LibraryTab) {
+        appliedDefaultTabs.remove(tab)
+        if selectedTab == tab {
+            applyDefaultSort(for: tab)
+        }
+    }
+
     /// `filteredAlbums` re-ordered for the current `sortOrder`. The underlying
     /// model array is left untouched so pagination accounting (`loaded` vs
     /// `total`, threshold math) keeps working unchanged. Sort keys that
@@ -704,6 +763,16 @@ struct LibraryView: View {
             return filteredAlbums.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
+        case .artist:
+            return filteredAlbums.sorted { lhs, rhs in
+                let cmp = lhs.artistName.localizedCaseInsensitiveCompare(rhs.artistName)
+                if cmp == .orderedSame {
+                    return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                }
+                return cmp == .orderedAscending
+            }
+        case .random:
+            return filteredAlbums.shuffled()
         case .recentlyAdded:
             // `Album` does not carry `DateCreated` on the paginated shape, so
             // preserve the server's load order (which is `SortName` asc by
@@ -793,8 +862,11 @@ struct LibraryView: View {
         case .recentlyAdded:
             // No per-item date on the artist payload — keep server order.
             return filteredArtists
-        case .nameAscending, .longest, .shortest, .yearAscending, .yearDescending:
-            // Year and runtime aren't carried for artists; treat as alpha asc.
+        case .random:
+            return filteredArtists.shuffled()
+        case .nameAscending, .artist, .longest, .shortest, .yearAscending, .yearDescending:
+            // Year and runtime aren't carried for artists, and "Artist" is a
+            // no-op on the artist list itself; treat all as alpha asc.
             return filteredArtists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
@@ -814,6 +886,16 @@ struct LibraryView: View {
             return filteredTracks.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
+        case .artist:
+            return filteredTracks.sorted { lhs, rhs in
+                let cmp = lhs.artistName.localizedCaseInsensitiveCompare(rhs.artistName)
+                if cmp == .orderedSame {
+                    return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                }
+                return cmp == .orderedAscending
+            }
+        case .random:
+            return filteredTracks.shuffled()
         case .recentlyAdded:
             return filteredTracks
         case .recentlyPlayed:
@@ -892,12 +974,35 @@ struct LibraryView: View {
             }
         case .recentlyAdded:
             return filteredPlaylists
-        case .nameAscending, .recentlyPlayed, .mostPlayed, .yearAscending, .yearDescending:
+        case .random:
+            return filteredPlaylists.shuffled()
+        case .nameAscending, .artist, .recentlyPlayed, .mostPlayed, .yearAscending, .yearDescending:
             return filteredPlaylists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         }
     }
+}
+
+/// Stable `@AppStorage` keys for the user-facing Library preferences.
+/// Centralised so `PreferencesLibrary` (which writes them) and the views that
+/// read them never drift on a string literal. Defaults live at each read site
+/// — the keys here are only the on-disk identifiers and must not be renamed
+/// without a migration.
+enum LibraryDefaults {
+    /// `LibrarySortOrder` raw value — default sort for the Albums chip.
+    static let albumSortKey = "library.defaultSort.albums"
+    /// `LibrarySortOrder` raw value — default sort for the Songs/Tracks chip.
+    static let songSortKey = "library.defaultSort.songs"
+    /// `Bool` — show the leading track-number column in numbered track rows.
+    static let showTrackNumbersKey = "library.showTrackNumbers"
+    /// `Bool` — reveal a track's play count on row hover.
+    static let showPlayCountOnHoverKey = "library.showPlayCountOnHover"
+    /// `Bool` toggles for each optional sidebar library section.
+    static let sidebarShowFavoritesKey = "library.sidebar.showFavorites"
+    static let sidebarShowAlbumsKey = "library.sidebar.showAlbums"
+    static let sidebarShowArtistsKey = "library.sidebar.showArtists"
+    static let sidebarShowPlaylistsKey = "library.sidebar.showPlaylists"
 }
 
 /// Persisted selection for the Library list/grid toggle. Stored via
@@ -1089,9 +1194,15 @@ struct AlbumCard: View {
 /// Library header writes this; the `sortedAlbums` / `sortedArtists` /
 /// `sortedTracks` / `sortedPlaylists` computed properties on `LibraryView`
 /// read it.
-enum LibrarySortOrder: Hashable, CaseIterable {
+///
+/// `String`-backed so the choice can be persisted as a default-sort
+/// preference via `@AppStorage` (see `PreferencesLibrary`). Raw values are
+/// stable on-disk keys — never rename them without a migration; the `label`
+/// is display-only and safe to edit.
+enum LibrarySortOrder: String, Hashable, CaseIterable, Identifiable {
     case nameAscending
     case nameDescending
+    case artist
     case recentlyAdded
     case recentlyPlayed
     case mostPlayed
@@ -1099,12 +1210,16 @@ enum LibrarySortOrder: Hashable, CaseIterable {
     case shortest
     case yearAscending
     case yearDescending
+    case random
+
+    var id: String { rawValue }
 
     /// Label shown in the menu, matching the spec's labels exactly.
     var label: String {
         switch self {
         case .nameAscending: return "A–Z"
         case .nameDescending: return "Z–A"
+        case .artist: return "Artist"
         case .recentlyAdded: return "Recently Added"
         case .recentlyPlayed: return "Recently Played"
         case .mostPlayed: return "Most Played"
@@ -1112,6 +1227,7 @@ enum LibrarySortOrder: Hashable, CaseIterable {
         case .shortest: return "Shortest"
         case .yearAscending: return "Year ↑"
         case .yearDescending: return "Year ↓"
+        case .random: return "Random"
         }
     }
 }

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
@@ -3,43 +3,161 @@ import SwiftUI
 
 /// Library preferences pane.
 ///
-/// Minimal shell today — two actions users ask for on every music app:
+/// Two halves:
+///
+/// **Browsing defaults.** Default sort for the Albums and Songs chips,
+/// whether numbered track rows show their ordinal, and whether a track's play
+/// count appears on hover. These write the `LibraryDefaults.*` keys that
+/// `LibraryView`, `Sidebar`, `TrackRow`, and `TrackListRow` read, so a change
+/// here reflects in the list views immediately. The default-library picker is
+/// surfaced but inert until the core grows a `libraries()` FFI — see the row's
+/// footnote and `AppModel.playlistLibraryId`'s note on the same gap.
+///
+/// **Sidebar sections.** Toggles for each optional "Your Library" row
+/// (Favorites / Albums / Artists / Playlists). All default on, so the sidebar
+/// is unchanged until the user hides something.
+///
+/// **Maintenance.** The original Rescan + artwork-cache controls are kept:
 ///
 /// 1. **Rescan Library**: re-pulls albums/artists/tracks from the server, the
-///    same way the Library tab does on pull-to-refresh. The button is wired
-///    to `AppModel.refreshLibrary()` so the action is real even though it's a
-///    shallow surface; the longer-horizon work tracked in `TODO(core-#569)`
-///    is a server-side metadata rescan trigger (`/Library/Refresh`).
-///
-/// 2. **Cache size + Clear Cache**: shows the current on-disk footprint of
-///    the Nuke artwork cache and lets the user nuke it. Artwork is the
-///    single biggest cache in the app (256 MB limit — see `Artwork.swift`),
-///    so a visible clear affordance is the pragmatic escape hatch when a
-///    user is tight on disk. Full cache sweeps (SDK caches, DB caches) land
-///    alongside the broader download-manager work.
+///    same way the Library tab does on pull-to-refresh, wired to
+///    `AppModel.refreshLibrary()`.
+/// 2. **Cache size + Clear Cache**: shows the on-disk footprint of the Nuke
+///    artwork cache and lets the user clear it.
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 71.
 struct PreferencesLibrary: View {
     @Environment(AppModel.self) private var model
 
+    // MARK: Browsing defaults
+
+    @AppStorage(LibraryDefaults.albumSortKey) private var defaultAlbumSort: LibrarySortOrder = .nameAscending
+    @AppStorage(LibraryDefaults.songSortKey) private var defaultSongSort: LibrarySortOrder = .nameAscending
+    @AppStorage(LibraryDefaults.showTrackNumbersKey) private var showTrackNumbers = true
+    @AppStorage(LibraryDefaults.showPlayCountOnHoverKey) private var showPlayCountOnHover = false
+
+    // MARK: Sidebar sections
+
+    @AppStorage(LibraryDefaults.sidebarShowFavoritesKey) private var sidebarShowFavorites = true
+    @AppStorage(LibraryDefaults.sidebarShowAlbumsKey) private var sidebarShowAlbums = true
+    @AppStorage(LibraryDefaults.sidebarShowArtistsKey) private var sidebarShowArtists = true
+    @AppStorage(LibraryDefaults.sidebarShowPlaylistsKey) private var sidebarShowPlaylists = true
+
+    // MARK: Maintenance state
+
     /// Human-readable representation of the artwork cache size. Refreshed
-    /// when the pane appears and after a clear. Initialised as a placeholder
-    /// so the text doesn't jump when the first read comes in.
+    /// when the pane appears and after a clear.
     @State private var cacheSizeLabel: String = "Calculating…"
 
     /// Toggles the "Rescanning…" label on the button while the refresh is in
-    /// flight. Scoped to this view so the Library tab's own spinner isn't
-    /// tied to the pane being visible.
+    /// flight.
     @State private var isRescanning: Bool = false
 
-    /// Set after a successful Clear Cache to acknowledge the action — the
-    /// label fades back to normal after a short pause so the button doesn't
-    /// stick in a confirmation state forever.
+    /// Set after a successful Clear Cache to acknowledge the action.
     @State private var justCleared: Bool = false
+
+    /// The sort options offered as a default, per the issue's spec
+    /// (Name / Artist / Year / Date Added / Play Count / Random). These map
+    /// onto the existing `LibrarySortOrder` cases the Library header already
+    /// understands, so a chosen default is a real, applied sort — not a
+    /// parallel taxonomy.
+    private let defaultSortChoices: [LibrarySortOrder] = [
+        .nameAscending, .artist, .yearDescending, .recentlyAdded, .mostPlayed, .random,
+    ]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             header
+
+            PreferenceSection(
+                title: "Default Library",
+                footnote: "Lyrebird browses every music library you can see. A picker appears here once the server exposes more than one — until then there's nothing to choose between."
+            ) {
+                PreferenceRow(
+                    label: "Library",
+                    help: "All music libraries on \(model.session?.server.name ?? "your server")."
+                ) {
+                    Picker("", selection: .constant(0)) {
+                        Text("All Libraries").tag(0)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 200)
+                    .disabled(true)
+                    .accessibilityLabel("Default library")
+                }
+            }
+
+            PreferenceSection(
+                title: "Default Sort",
+                footnote: "Applied the first time you open each list in a session. You can still change the sort from the Library header at any time."
+            ) {
+                PreferenceRow(
+                    label: "Albums",
+                    help: "How the Albums list is ordered when you first open it."
+                ) {
+                    SortDefaultPicker(selection: $defaultAlbumSort, choices: defaultSortChoices)
+                        .accessibilityLabel("Default album sort")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Songs",
+                    help: "How the Songs list is ordered when you first open it."
+                ) {
+                    SortDefaultPicker(selection: $defaultSongSort, choices: defaultSortChoices)
+                        .accessibilityLabel("Default song sort")
+                }
+            }
+
+            PreferenceSection(
+                title: "Track Lists",
+                footnote: "Track numbers show as the leading column on album and playlist track rows. Play counts appear on the trailing edge when you hover a row."
+            ) {
+                PreferenceRow(
+                    label: "Show track numbers",
+                    help: showTrackNumbers
+                        ? "On — numbered rows show their position."
+                        : "Off — the number column is hidden."
+                ) {
+                    Toggle("", isOn: $showTrackNumbers)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Show track numbers")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Show play counts on hover",
+                    help: showPlayCountOnHover
+                        ? "On — hovering a track reveals how many times you've played it."
+                        : "Off — play counts stay hidden."
+                ) {
+                    Toggle("", isOn: $showPlayCountOnHover)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Show play counts on hover")
+                }
+            }
+
+            PreferenceSection(
+                title: "Sidebar Sections",
+                footnote: "Choose which rows appear under \"Your Library\" in the sidebar. Hidden sections are still reachable from search and detail pages."
+            ) {
+                sidebarToggle(label: "Favorites", isOn: $sidebarShowFavorites)
+                divider
+                sidebarToggle(label: "Albums", isOn: $sidebarShowAlbums)
+                divider
+                sidebarToggle(label: "Artists", isOn: $sidebarShowArtists)
+                divider
+                sidebarToggle(label: "Playlists", isOn: $sidebarShowPlaylists)
+            }
 
             PreferenceSection(
                 title: "Refresh",
@@ -113,16 +231,36 @@ struct PreferencesLibrary: View {
             Text("Library")
                 .font(Theme.font(28, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("Refresh server data and manage local caches.")
+            Text("Browsing defaults, sidebar sections, and local caches.")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }
     }
 
+    /// Shared divider used between rows inside a section.
+    private var divider: some View {
+        Divider()
+            .background(Theme.border)
+            .padding(.vertical, 10)
+    }
+
+    /// A single sidebar-section visibility toggle.
+    @ViewBuilder
+    private func sidebarToggle(label: String, isOn: Binding<Bool>) -> some View {
+        PreferenceRow(
+            label: label,
+            help: isOn.wrappedValue ? "Shown in the sidebar." : "Hidden from the sidebar."
+        ) {
+            Toggle("", isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel("Show \(label) in sidebar")
+        }
+    }
+
     // MARK: - Actions
 
-    /// Kick off the same refresh the Library tab uses. The pane disables the
-    /// button while it's in flight so repeat taps don't fan out.
+    /// Kick off the same refresh the Library tab uses.
     private func rescan() {
         guard !isRescanning else { return }
         isRescanning = true
@@ -132,15 +270,10 @@ struct PreferencesLibrary: View {
         }
     }
 
-    /// Evict the shared Nuke pipeline's memory + disk caches. `cache.removeAll`
-    /// sweeps every layer (image memory, encoded-image memory, and disk data)
-    /// in one call — equivalent to removing each cache individually.
+    /// Evict the shared Nuke pipeline's memory + disk caches.
     private func clearCache() {
         Artwork.pipeline.cache.removeAll()
         justCleared = true
-        // Give Nuke's background queue a moment to flush before we re-read
-        // the footprint. 0.6s is generous — the NSCache eviction is instant,
-        // disk removal is a few milliseconds in practice.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             refreshCacheSize()
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
@@ -150,20 +283,9 @@ struct PreferencesLibrary: View {
     }
 
     /// Read the artwork cache's current on-disk size and render it as
-    /// `4.3 MB` / `1.7 GB`. Uses `ByteCountFormatter` so the locale and unit
-    /// match every other size-of-thing in macOS.
-    ///
-    /// The pipeline's `dataCache` is typed as the `DataCaching` protocol so
-    /// callers can swap implementations; `totalSize` lives on the concrete
-    /// `Nuke.DataCache` Lyrebird actually uses (wired in
-    /// `Artwork.pipeline`). A failed downcast means someone swapped the
-    /// cache implementation, so we fall back to a dash rather than a zero.
-    ///
-    /// `totalSize` walks the cache index (read-after-index is O(n) on the
-    /// count of entries, not the bytes), so wrapping the read in a Task keeps
-    /// the view's first paint snappy even with a full 256 MB cache. The Task
-    /// stays on the main actor because `Artwork.pipeline` and `DataCache` are
-    /// both main-actor isolated in this module.
+    /// `4.3 MB` / `1.7 GB`. Wrapped in a Task so the index walk doesn't
+    /// block first paint. Stays on the main actor because `Artwork.pipeline`
+    /// and `DataCache` are both main-actor isolated in this module.
     private func refreshCacheSize() {
         Task { @MainActor in
             let cache = Artwork.pipeline.configuration.dataCache as? DataCache
@@ -176,6 +298,26 @@ struct PreferencesLibrary: View {
             }()
             cacheSizeLabel = label
         }
+    }
+}
+
+/// Menu picker for a default `LibrarySortOrder`. Renders only the curated
+/// `choices` (Name / Artist / Year / Date Added / Play Count / Random) so the
+/// default-sort menu stays a short, spec-shaped list rather than exposing all
+/// nine header sort modes.
+private struct SortDefaultPicker: View {
+    @Binding var selection: LibrarySortOrder
+    let choices: [LibrarySortOrder]
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(choices) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .frame(width: 160)
     }
 }
 

--- a/macos/Tests/LyrebirdTests/LibrarySortOrderPersistenceTests.swift
+++ b/macos/Tests/LyrebirdTests/LibrarySortOrderPersistenceTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Library-preferences persistence contract.
+///
+/// The default-sort preferences (`PreferencesLibrary`) persist a
+/// `LibrarySortOrder` via `@AppStorage`, which relies on the enum being
+/// `RawRepresentable` over *stable* String keys. If a raw value is ever
+/// renamed, every user's saved default silently resets — these tests pin the
+/// on-disk identifiers and the round-trip so that regression is caught here
+/// rather than in the field.
+final class LibrarySortOrderPersistenceTests: XCTestCase {
+    /// Every case round-trips through its raw value, so `@AppStorage` can
+    /// decode whatever it wrote.
+    func testRawValueRoundTrips() {
+        for order in LibrarySortOrder.allCases {
+            XCTAssertEqual(
+                LibrarySortOrder(rawValue: order.rawValue),
+                order,
+                "LibrarySortOrder.\(order) failed to round-trip through its raw value"
+            )
+        }
+    }
+
+    /// The stable on-disk identifiers. Renaming any of these is a breaking
+    /// change to persisted user defaults and must come with a migration.
+    func testStableRawValues() {
+        XCTAssertEqual(LibrarySortOrder.nameAscending.rawValue, "nameAscending")
+        XCTAssertEqual(LibrarySortOrder.nameDescending.rawValue, "nameDescending")
+        XCTAssertEqual(LibrarySortOrder.artist.rawValue, "artist")
+        XCTAssertEqual(LibrarySortOrder.recentlyAdded.rawValue, "recentlyAdded")
+        XCTAssertEqual(LibrarySortOrder.recentlyPlayed.rawValue, "recentlyPlayed")
+        XCTAssertEqual(LibrarySortOrder.mostPlayed.rawValue, "mostPlayed")
+        XCTAssertEqual(LibrarySortOrder.longest.rawValue, "longest")
+        XCTAssertEqual(LibrarySortOrder.shortest.rawValue, "shortest")
+        XCTAssertEqual(LibrarySortOrder.yearAscending.rawValue, "yearAscending")
+        XCTAssertEqual(LibrarySortOrder.yearDescending.rawValue, "yearDescending")
+        XCTAssertEqual(LibrarySortOrder.random.rawValue, "random")
+    }
+
+    /// An unknown raw value (e.g. a key written by a future build) decodes to
+    /// nil so the `@AppStorage` default kicks in rather than crashing.
+    func testUnknownRawValueDecodesToNil() {
+        XCTAssertNil(LibrarySortOrder(rawValue: "not-a-real-sort"))
+    }
+
+    /// Every case carries a non-empty menu label so the default-sort picker
+    /// never renders a blank row.
+    func testEveryCaseHasALabel() {
+        for order in LibrarySortOrder.allCases {
+            XCTAssertFalse(order.label.isEmpty, "LibrarySortOrder.\(order) has an empty label")
+        }
+    }
+
+    /// The Library-preferences storage keys are stable identifiers. These are
+    /// shared between `PreferencesLibrary` (writer) and the views that read
+    /// them; a drift here silently disconnects the setting from its effect.
+    func testLibraryDefaultsKeysAreStable() {
+        XCTAssertEqual(LibraryDefaults.albumSortKey, "library.defaultSort.albums")
+        XCTAssertEqual(LibraryDefaults.songSortKey, "library.defaultSort.songs")
+        XCTAssertEqual(LibraryDefaults.showTrackNumbersKey, "library.showTrackNumbers")
+        XCTAssertEqual(LibraryDefaults.showPlayCountOnHoverKey, "library.showPlayCountOnHover")
+        XCTAssertEqual(LibraryDefaults.sidebarShowFavoritesKey, "library.sidebar.showFavorites")
+        XCTAssertEqual(LibraryDefaults.sidebarShowAlbumsKey, "library.sidebar.showAlbums")
+        XCTAssertEqual(LibraryDefaults.sidebarShowArtistsKey, "library.sidebar.showArtists")
+        XCTAssertEqual(LibraryDefaults.sidebarShowPlaylistsKey, "library.sidebar.showPlaylists")
+    }
+}


### PR DESCRIPTION
Adds the Settings → Library surface so browsing defaults persist and reflect in the list views.

Closes #119

## What

- **Default sort** for the Albums and Songs chips (Name / Artist / Year / Date Added / Play Count / Random). `LibraryView` applies the persisted default the first time you enter each chip in a session; manual re-sorts from the header still win.
- **Sidebar sections**: show/hide toggles for each "Your Library" row (Favorites / Albums / Artists / Playlists). `Sidebar` hides the row and collapses the section header when everything is off.
- **Show track numbers** toggle — `TrackRow` hides the leading ordinal (keeping the play/equalizer affordance and column alignment) when off.
- **Show play counts on hover** toggle — `TrackRow` and `TrackListRow` reveal a "N plays" readout on hover when on.
- **Default library** picker is surfaced but inert: the core has no `libraries()` FFI yet (see `AppModel.playlistLibraryId`), so there is only the implicit all-libraries scope. The row documents this and activates once that FFI lands — no speculative core work added here.

Sort options reuse the existing `LibrarySortOrder` (now `String`-backed for `@AppStorage`; added `artist` + `random` cases wired through every `sorted*` branch) so a chosen default is a real applied sort. New keys are centralised in `LibraryDefaults` and shared between the writer (`PreferencesLibrary`) and readers.

## Tests

`LibrarySortOrderPersistenceTests` pins the stable raw values + storage keys and the round-trip the `@AppStorage` defaults depend on.

## pipeline

- fixer-session: feature-builder-119
- slice: macos / ux
- hotspots-claimed: none
- build-gate: cargo fmt --check + clippy -D warnings + core tests + `swift build` all green; new Swift tests pass
- diff-stat: 6 files, +357 / -61 (5 source, 1 test)