### PR TITLE
macos: add Library filter popover (genre/year/format/duration)

### DIFF
--- a/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
@@ -1,0 +1,429 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Audio container formats the filter offers. Matching is done against the
+/// track's (lower/upper-mixed) `container` string, normalised to upper case.
+/// `ALAC` is shipped by Jellyfin in an `m4a`/`mp4` container, so its match set
+/// covers the common container spellings as well as the codec name itself.
+enum TrackFormat: String, CaseIterable, Identifiable, Hashable {
+	case flac = "FLAC"
+	case alac = "ALAC"
+	case mp3 = "MP3"
+
+	var id: String { rawValue }
+
+	var label: String { rawValue }
+
+	/// Upper-cased container tokens that count as this format.
+	private var containerTokens: Set<String> {
+		switch self {
+		case .flac: return ["FLAC"]
+		case .alac: return ["ALAC", "M4A", "MP4"]
+		case .mp3: return ["MP3", "MPEG"]
+		}
+	}
+
+	/// Whether a track's `container` string matches this format.
+	func matches(container raw: String?) -> Bool {
+		guard let token = raw?.trimmingCharacters(in: .whitespaces).uppercased(),
+			!token.isEmpty
+		else { return false }
+		return containerTokens.contains(token)
+	}
+}
+
+/// Coarse duration buckets the filter offers. Bounds are in seconds; matching a
+/// track means its runtime falls inside the half-open range.
+enum DurationBucket: String, CaseIterable, Identifiable, Hashable {
+	case short
+	case medium
+	case long
+
+	var id: String { rawValue }
+
+	var label: String {
+		switch self {
+		case .short: return "< 3m"
+		case .medium: return "3–6m"
+		case .long: return "> 6m"
+		}
+	}
+
+	/// Whether a runtime in seconds falls in this bucket.
+	func matches(seconds: Double) -> Bool {
+		switch self {
+		case .short: return seconds < 180
+		case .medium: return seconds >= 180 && seconds <= 360
+		case .long: return seconds > 360
+		}
+	}
+}
+
+/// Declarative, value-type description of the Library filter state. Lives on
+/// `LibraryView` as `@State`; the popover edits a working copy and commits it
+/// on "Apply". Filtering is applied client-side over the already-loaded
+/// `model.X` arrays (the same paged-cache scope the sort already operates on),
+/// so it composes with `LibrarySortOrder` without touching pagination
+/// accounting.
+struct LibraryFilter: Equatable {
+	/// Selected genre names. Empty = no genre constraint.
+	var genres: Set<String> = []
+	/// Inclusive `[lower, upper]` release-year window, or `nil` for no bound.
+	/// Stored separately from the slider's full range so a filter that spans
+	/// the whole catalogue reads as "inactive".
+	var yearRange: ClosedRange<Int>?
+	var onlyDownloaded = false
+	var onlyFavorited = false
+	/// Selected formats. Empty = no format constraint.
+	var formats: Set<TrackFormat> = []
+	/// Selected duration buckets. Empty = no duration constraint.
+	var durations: Set<DurationBucket> = []
+
+	/// Number of active filter groups — drives the pink dot / count badge on
+	/// the filter icon. A group counts once regardless of how many options
+	/// inside it are selected.
+	var activeGroupCount: Int {
+		var n = 0
+		if !genres.isEmpty { n += 1 }
+		if yearRange != nil { n += 1 }
+		if onlyDownloaded { n += 1 }
+		if onlyFavorited { n += 1 }
+		if !formats.isEmpty { n += 1 }
+		if !durations.isEmpty { n += 1 }
+		return n
+	}
+
+	var isActive: Bool { activeGroupCount > 0 }
+}
+
+/// 280pt popover anchored to the Library filter icon. Edits a working copy of
+/// the active `LibraryFilter` and only commits it to the bound value on
+/// "Apply"; "Clear all" resets the draft in place. Spec issue #214 / screen
+/// spec Issue 15.
+struct LibraryFilterPopover: View {
+	/// The committed filter the Library is rendering with. Bound from
+	/// `LibraryView`; only written on "Apply".
+	@Binding var filter: LibraryFilter
+	/// All genre names available across the loaded library, sorted A–Z.
+	let availableGenres: [String]
+	/// Release-year bounds discovered across the loaded library. Drives the
+	/// year slider's track. `nil` when no item carries a year.
+	let yearBounds: ClosedRange<Int>?
+	/// Whether the "Only downloaded" toggle should be shown. Gated on the
+	/// download engine (`AppModel.supportsDownloads`, #819) so the control
+	/// doesn't appear dead while downloads are unwired.
+	let showDownloaded: Bool
+	/// Dismiss handler — the host owns the `isPresented` binding.
+	let onClose: () -> Void
+
+	/// Working copy the popover mutates; committed to `filter` on Apply.
+	@State private var draft: LibraryFilter
+	/// Lower/upper year thumbs as doubles for the slider. Seeded from the
+	/// draft's `yearRange` or the discovered bounds.
+	@State private var yearLow: Double
+	@State private var yearHigh: Double
+
+	init(
+		filter: Binding<LibraryFilter>,
+		availableGenres: [String],
+		yearBounds: ClosedRange<Int>?,
+		showDownloaded: Bool,
+		onClose: @escaping () -> Void
+	) {
+		self._filter = filter
+		self.availableGenres = availableGenres
+		self.yearBounds = yearBounds
+		self.showDownloaded = showDownloaded
+		self.onClose = onClose
+		let initial = filter.wrappedValue
+		self._draft = State(initialValue: initial)
+		let lo = Double(initial.yearRange?.lowerBound ?? yearBounds?.lowerBound ?? 0)
+		let hi = Double(initial.yearRange?.upperBound ?? yearBounds?.upperBound ?? 0)
+		self._yearLow = State(initialValue: lo)
+		self._yearHigh = State(initialValue: hi)
+	}
+
+	var body: some View {
+		VStack(spacing: 0) {
+			ScrollView {
+				VStack(alignment: .leading, spacing: 18) {
+					if !availableGenres.isEmpty { genreGroup }
+					if yearBounds != nil { yearGroup }
+					if showDownloaded { downloadedGroup }
+					favoritedGroup
+					formatGroup
+					durationGroup
+				}
+				.padding(16)
+			}
+			Divider().overlay(Theme.border)
+			footer
+		}
+		.frame(width: 280)
+		.frame(maxHeight: 460)
+		.background(Theme.bgAlt)
+	}
+
+	// MARK: - Groups
+
+	private func groupHeader(_ title: String) -> some View {
+		Text(title.uppercased())
+			.font(Theme.font(10, weight: .bold))
+			.foregroundStyle(Theme.ink3)
+			.tracking(1.2)
+	}
+
+	private var genreGroup: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			groupHeader("Genre")
+			VStack(alignment: .leading, spacing: 6) {
+				ForEach(availableGenres, id: \.self) { genre in
+					checkRow(
+						label: genre,
+						isOn: draft.genres.contains(genre)
+					) {
+						toggle(genre, in: \.genres)
+					}
+				}
+			}
+		}
+	}
+
+	private var yearGroup: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			HStack {
+				groupHeader("Year")
+				Spacer()
+				Text("\(Int(yearLow))–\(Int(yearHigh))")
+					.font(Theme.font(11, weight: .semibold))
+					.foregroundStyle(Theme.ink2)
+			}
+			if let bounds = yearBounds {
+				RangeSlider(
+					low: $yearLow,
+					high: $yearHigh,
+					bounds: Double(bounds.lowerBound)...Double(bounds.upperBound)
+				)
+			}
+		}
+	}
+
+	private var downloadedGroup: some View {
+		toggleRow("Only downloaded", isOn: $draft.onlyDownloaded)
+	}
+
+	private var favoritedGroup: some View {
+		toggleRow("Only favorited", isOn: $draft.onlyFavorited)
+	}
+
+	private var formatGroup: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			groupHeader("Format")
+			VStack(alignment: .leading, spacing: 6) {
+				ForEach(TrackFormat.allCases) { format in
+					checkRow(
+						label: format.label,
+						isOn: draft.formats.contains(format)
+					) {
+						toggle(format, in: \.formats)
+					}
+				}
+			}
+		}
+	}
+
+	private var durationGroup: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			groupHeader("Duration")
+			VStack(alignment: .leading, spacing: 6) {
+				ForEach(DurationBucket.allCases) { bucket in
+					checkRow(
+						label: bucket.label,
+						isOn: draft.durations.contains(bucket)
+					) {
+						toggle(bucket, in: \.durations)
+					}
+				}
+			}
+		}
+	}
+
+	// MARK: - Footer
+
+	private var footer: some View {
+		HStack {
+			Button("Clear all") {
+				draft = LibraryFilter()
+				if let bounds = yearBounds {
+					yearLow = Double(bounds.lowerBound)
+					yearHigh = Double(bounds.upperBound)
+				}
+			}
+			.buttonStyle(.plain)
+			.font(Theme.font(12, weight: .semibold))
+			.foregroundStyle(Theme.ink2)
+			.disabled(!draftHasSelection)
+			.opacity(draftHasSelection ? 1 : 0.4)
+
+			Spacer()
+
+			Button("Apply") {
+				commit()
+				onClose()
+			}
+			.buttonStyle(.plain)
+			.font(Theme.font(12, weight: .bold))
+			.foregroundStyle(Theme.ink)
+			.padding(.horizontal, 16)
+			.padding(.vertical, 7)
+			.background(
+				RoundedRectangle(cornerRadius: 8).fill(Theme.primary)
+			)
+		}
+		.padding(.horizontal, 16)
+		.padding(.vertical, 12)
+	}
+
+	// MARK: - Reusable rows
+
+	private func checkRow(
+		label: String,
+		isOn: Bool,
+		toggle: @escaping () -> Void
+	) -> some View {
+		Button(action: toggle) {
+			HStack(spacing: 8) {
+				Image(systemName: isOn ? "checkmark.square.fill" : "square")
+					.font(.system(size: 13, weight: .semibold))
+					.foregroundStyle(isOn ? Theme.primary : Theme.ink3)
+				Text(label)
+					.font(Theme.font(12, weight: .medium))
+					.foregroundStyle(Theme.ink)
+					.lineLimit(1)
+				Spacer(minLength: 0)
+			}
+			.contentShape(Rectangle())
+		}
+		.buttonStyle(.plain)
+		.accessibilityAddTraits(isOn ? [.isSelected] : [])
+	}
+
+	private func toggleRow(_ label: String, isOn: Binding<Bool>) -> some View {
+		Toggle(isOn: isOn) {
+			Text(label)
+				.font(Theme.font(12, weight: .medium))
+				.foregroundStyle(Theme.ink)
+		}
+		.toggleStyle(.switch)
+		.tint(Theme.primary)
+	}
+
+	// MARK: - Helpers
+
+	private var draftHasSelection: Bool {
+		var working = draft
+		applyYearToDraft(&working)
+		return working.isActive
+	}
+
+	private func toggle<T: Hashable>(_ value: T, in keyPath: WritableKeyPath<LibraryFilter, Set<T>>) {
+		if draft[keyPath: keyPath].contains(value) {
+			draft[keyPath: keyPath].remove(value)
+		} else {
+			draft[keyPath: keyPath].insert(value)
+		}
+	}
+
+	/// Fold the slider thumbs into the draft's `yearRange`. A range that
+	/// covers the full discovered bounds reads as "no year filter" so the
+	/// group doesn't count as active when the user never moved a thumb.
+	private func applyYearToDraft(_ target: inout LibraryFilter) {
+		guard let bounds = yearBounds else {
+			target.yearRange = nil
+			return
+		}
+		let lo = Int(yearLow.rounded())
+		let hi = Int(yearHigh.rounded())
+		if lo <= bounds.lowerBound && hi >= bounds.upperBound {
+			target.yearRange = nil
+		} else {
+			target.yearRange = min(lo, hi)...max(lo, hi)
+		}
+	}
+
+	private func commit() {
+		var committed = draft
+		applyYearToDraft(&committed)
+		filter = committed
+	}
+}
+
+/// Minimal double-thumb range slider. SwiftUI ships no native range control,
+/// so this draws a track with two draggable thumbs over a `GeometryReader`.
+/// Used only by the year group of `LibraryFilterPopover`.
+struct RangeSlider: View {
+	@Binding var low: Double
+	@Binding var high: Double
+	let bounds: ClosedRange<Double>
+
+	private let thumbSize: CGFloat = 16
+	private let trackHeight: CGFloat = 4
+
+	var body: some View {
+		GeometryReader { geo in
+			let span = max(bounds.upperBound - bounds.lowerBound, 1)
+			let usable = max(geo.size.width - thumbSize, 1)
+			let lowX = CGFloat((low - bounds.lowerBound) / span) * usable
+			let highX = CGFloat((high - bounds.lowerBound) / span) * usable
+
+			ZStack(alignment: .leading) {
+				Capsule()
+					.fill(Theme.surface2)
+					.frame(height: trackHeight)
+					.frame(maxWidth: .infinity)
+					.padding(.horizontal, thumbSize / 2)
+
+				Capsule()
+					.fill(Theme.primary)
+					.frame(width: max(highX - lowX, 0), height: trackHeight)
+					.offset(x: lowX + thumbSize / 2)
+
+				thumb
+					.offset(x: lowX)
+					.gesture(drag(usable: usable, span: span, isLow: true))
+					.accessibilityLabel("Minimum year")
+					.accessibilityValue("\(Int(low))")
+
+				thumb
+					.offset(x: highX)
+					.gesture(drag(usable: usable, span: span, isLow: false))
+					.accessibilityLabel("Maximum year")
+					.accessibilityValue("\(Int(high))")
+			}
+			.frame(height: thumbSize)
+			.frame(maxHeight: .infinity)
+		}
+		.frame(height: 24)
+	}
+
+	private var thumb: some View {
+		Circle()
+			.fill(Theme.ink)
+			.frame(width: thumbSize, height: thumbSize)
+			.shadow(color: .black.opacity(0.3), radius: 2, y: 1)
+	}
+
+	private func drag(usable: CGFloat, span: Double, isLow: Bool) -> some Gesture {
+		DragGesture()
+			.onChanged { value in
+				let fraction = max(0, min(1, value.location.x / usable))
+				let raw = bounds.lowerBound + Double(fraction) * span
+				let clamped = max(bounds.lowerBound, min(bounds.upperBound, raw)).rounded()
+				if isLow {
+					low = min(clamped, high)
+				} else {
+					high = max(clamped, low)
+				}
+			}
+	}
+}

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -76,6 +76,11 @@ struct LibraryView: View {
     /// drives this. Defaults to alphabetical to match the order the server
     /// returns by default (`SortName` ascending).
     @State private var sortOrder: LibrarySortOrder = .nameAscending
+    /// Active client-side filter applied to the loaded library arrays before
+    /// sorting. Edited via the filter popover in the header. See #214.
+    @State private var filter = LibraryFilter()
+    /// Drives the filter popover's presentation. Anchored to the filter icon.
+    @State private var showFilter = false
 
     private let columns = [GridItem(.adaptive(minimum: 180, maximum: 220), spacing: 18)]
 
@@ -152,9 +157,56 @@ struct LibraryView: View {
             }
             Spacer()
             HStack(spacing: 8) {
+                filterButton
                 LibrarySortMenu(selection: $sortOrder)
                 LibraryViewToggle(mode: $viewMode)
             }
+        }
+    }
+
+    /// Filter icon that opens the 280pt filter popover. Carries a 10pt pink
+    /// dot when at least one filter group is active. See #214 / screen spec
+    /// Issue 15.
+    private var filterButton: some View {
+        Button {
+            showFilter = true
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(filter.isActive ? Theme.ink : Theme.ink2)
+                .frame(width: 30, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Theme.surface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Theme.border, lineWidth: 1)
+                        )
+                )
+                .overlay(alignment: .topTrailing) {
+                    if filter.isActive {
+                        Circle()
+                            .fill(Theme.accentHot)
+                            .frame(width: 10, height: 10)
+                            .offset(x: 3, y: -3)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Filter library")
+        .accessibilityValue(
+            filter.isActive
+                ? "\(filter.activeGroupCount) filters active"
+                : "No filters"
+        )
+        .popover(isPresented: $showFilter, arrowEdge: .bottom) {
+            LibraryFilterPopover(
+                filter: $filter,
+                availableGenres: availableGenres,
+                yearBounds: yearBounds,
+                showDownloaded: model.supportsDownloads,
+                onClose: { showFilter = false }
+            )
         }
     }
 
@@ -435,9 +487,114 @@ struct LibraryView: View {
         .background(Theme.bg)
     }
 
+    // MARK: - Filter
+
+    /// Genre names found across the loaded library, deduped and sorted A–Z.
+    /// Pulled from whichever item arrays are populated so the genre checklist
+    /// reflects what's actually loaded (the same paged-cache scope the rest of
+    /// the filter operates on). See #214.
+    private var availableGenres: [String] {
+        var set = Set<String>()
+        for album in model.albums { set.formUnion(album.genres) }
+        for artist in model.artists { set.formUnion(artist.genres) }
+        let cleaned = set
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return Array(Set(cleaned)).sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
+    /// Release-year bounds discovered across loaded albums + tracks. `nil`
+    /// when nothing carries a year, which hides the year group entirely.
+    private var yearBounds: ClosedRange<Int>? {
+        var years: [Int] = []
+        years.append(contentsOf: model.albums.compactMap { $0.year.map(Int.init) })
+        years.append(contentsOf: model.tracks.compactMap { $0.year.map(Int.init) })
+        let valid = years.filter { $0 > 0 }
+        guard let lo = valid.min(), let hi = valid.max(), lo < hi else { return nil }
+        return lo...hi
+    }
+
+    /// Whether an album passes the active filter. Genre, year, and favorited
+    /// apply to albums; format and duration are track-level and never exclude
+    /// an album. Downloaded is a no-op until the download engine lands.
+    private func passesFilter(_ album: Album) -> Bool {
+        if !filter.genres.isEmpty,
+            filter.genres.isDisjoint(with: Set(album.genres)) {
+            return false
+        }
+        if let range = filter.yearRange {
+            guard let year = album.year.map(Int.init), range.contains(year) else {
+                return false
+            }
+        }
+        if filter.onlyFavorited, !model.isFavorite(album: album) { return false }
+        return true
+    }
+
+    /// Whether an artist passes the active filter. Only genre and favorited
+    /// apply to artists; year/format/duration are not artist-level.
+    private func passesFilter(_ artist: Artist) -> Bool {
+        if !filter.genres.isEmpty,
+            filter.genres.isDisjoint(with: Set(artist.genres)) {
+            return false
+        }
+        if filter.onlyFavorited, !model.isFavorite(artist: artist) { return false }
+        return true
+    }
+
+    /// Whether a track passes the active filter. Tracks carry every filter
+    /// dimension except genre (not projected on the track payload), so genre
+    /// is skipped here.
+    private func passesFilter(_ track: Track) -> Bool {
+        if let range = filter.yearRange {
+            guard let year = track.year.map(Int.init), range.contains(year) else {
+                return false
+            }
+        }
+        if filter.onlyFavorited, !model.isFavorite(track: track) { return false }
+        if !filter.formats.isEmpty {
+            guard filter.formats.contains(where: { $0.matches(container: track.container) })
+            else { return false }
+        }
+        if !filter.durations.isEmpty {
+            let seconds = Double(track.runtimeTicks) / 10_000_000
+            guard filter.durations.contains(where: { $0.matches(seconds: seconds) })
+            else { return false }
+        }
+        return true
+    }
+
+    /// Whether a playlist passes the active filter. Only favorited applies.
+    private func passesFilter(_ playlist: Playlist) -> Bool {
+        if filter.onlyFavorited, !model.isFavorite(playlist: playlist) { return false }
+        return true
+    }
+
     // MARK: - Sort
 
-    /// `model.albums` re-ordered for the current `sortOrder`. The underlying
+    /// Loaded arrays narrowed to the active filter. Sorting operates on these
+    /// so the displayed list is `filter → sort`; the raw `model.X` arrays stay
+    /// untouched so pagination accounting (`loaded` vs `total`) is unaffected.
+    /// When no filter is active these return the full arrays unchanged.
+    private var filteredAlbums: [Album] {
+        filter.isActive ? model.albums.filter(passesFilter) : model.albums
+    }
+
+    private var filteredArtists: [Artist] {
+        filter.isActive ? model.artists.filter(passesFilter) : model.artists
+    }
+
+    private var filteredTracks: [Track] {
+        filter.isActive ? model.tracks.filter(passesFilter) : model.tracks
+    }
+
+    private var filteredPlaylists: [Playlist] {
+        filter.isActive ? model.playlists.filter(passesFilter) : model.playlists
+    }
+
+    /// `filteredAlbums` re-ordered for the current `sortOrder`. The underlying
     /// model array is left untouched so pagination accounting (`loaded` vs
     /// `total`, threshold math) keeps working unchanged. Sort keys that
     /// don't apply to albums (`mostPlayed` for an album with no
@@ -447,11 +604,11 @@ struct LibraryView: View {
     private var sortedAlbums: [Album] {
         switch sortOrder {
         case .nameAscending:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         case .nameDescending:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
         case .recentlyAdded:
@@ -459,9 +616,9 @@ struct LibraryView: View {
             // preserve the server's load order (which is `SortName` asc by
             // default). Acts as a no-op fallback rather than a misleading
             // "newest first" promise.
-            return model.albums
+            return filteredAlbums
         case .recentlyPlayed:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 let lhsDate = lhs.userData?.lastPlayedAt ?? ""
                 let rhsDate = rhs.userData?.lastPlayedAt ?? ""
                 if lhsDate == rhsDate {
@@ -470,7 +627,7 @@ struct LibraryView: View {
                 return lhsDate > rhsDate
             }
         case .mostPlayed:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 let lhsCount = lhs.userData?.playCount ?? 0
                 let rhsCount = rhs.userData?.playCount ?? 0
                 if lhsCount == rhsCount {
@@ -479,21 +636,21 @@ struct LibraryView: View {
                 return lhsCount > rhsCount
             }
         case .longest:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks > rhs.runtimeTicks
             }
         case .shortest:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks < rhs.runtimeTicks
             }
         case .yearAscending:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 let lhsYear = lhs.year ?? Int32.max
                 let rhsYear = rhs.year ?? Int32.max
                 if lhsYear == rhsYear {
@@ -502,7 +659,7 @@ struct LibraryView: View {
                 return lhsYear < rhsYear
             }
         case .yearDescending:
-            return model.albums.sorted { lhs, rhs in
+            return filteredAlbums.sorted { lhs, rhs in
                 let lhsYear = lhs.year ?? Int32.min
                 let rhsYear = rhs.year ?? Int32.min
                 if lhsYear == rhsYear {
@@ -519,11 +676,11 @@ struct LibraryView: View {
     private var sortedArtists: [Artist] {
         switch sortOrder {
         case .nameDescending:
-            return model.artists.sorted { lhs, rhs in
+            return filteredArtists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
         case .recentlyPlayed:
-            return model.artists.sorted { lhs, rhs in
+            return filteredArtists.sorted { lhs, rhs in
                 let lhsDate = lhs.userData?.lastPlayedAt ?? ""
                 let rhsDate = rhs.userData?.lastPlayedAt ?? ""
                 if lhsDate == rhsDate {
@@ -532,7 +689,7 @@ struct LibraryView: View {
                 return lhsDate > rhsDate
             }
         case .mostPlayed:
-            return model.artists.sorted { lhs, rhs in
+            return filteredArtists.sorted { lhs, rhs in
                 let lhsCount = lhs.userData?.playCount ?? 0
                 let rhsCount = rhs.userData?.playCount ?? 0
                 if lhsCount == rhsCount {
@@ -542,10 +699,10 @@ struct LibraryView: View {
             }
         case .recentlyAdded:
             // No per-item date on the artist payload — keep server order.
-            return model.artists
+            return filteredArtists
         case .nameAscending, .longest, .shortest, .yearAscending, .yearDescending:
             // Year and runtime aren't carried for artists; treat as alpha asc.
-            return model.artists.sorted { lhs, rhs in
+            return filteredArtists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         }
@@ -557,17 +714,17 @@ struct LibraryView: View {
     private var sortedTracks: [Track] {
         switch sortOrder {
         case .nameAscending:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         case .nameDescending:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
         case .recentlyAdded:
-            return model.tracks
+            return filteredTracks
         case .recentlyPlayed:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 let lhsDate = lhs.userData?.lastPlayedAt ?? ""
                 let rhsDate = rhs.userData?.lastPlayedAt ?? ""
                 if lhsDate == rhsDate {
@@ -576,28 +733,28 @@ struct LibraryView: View {
                 return lhsDate > rhsDate
             }
         case .mostPlayed:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 if lhs.playCount == rhs.playCount {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.playCount > rhs.playCount
             }
         case .longest:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks > rhs.runtimeTicks
             }
         case .shortest:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks < rhs.runtimeTicks
             }
         case .yearAscending:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 let lhsYear = lhs.year ?? Int32.max
                 let rhsYear = rhs.year ?? Int32.max
                 if lhsYear == rhsYear {
@@ -606,7 +763,7 @@ struct LibraryView: View {
                 return lhsYear < rhsYear
             }
         case .yearDescending:
-            return model.tracks.sorted { lhs, rhs in
+            return filteredTracks.sorted { lhs, rhs in
                 let lhsYear = lhs.year ?? Int32.min
                 let rhsYear = rhs.year ?? Int32.min
                 if lhsYear == rhsYear {
@@ -623,27 +780,27 @@ struct LibraryView: View {
     private var sortedPlaylists: [Playlist] {
         switch sortOrder {
         case .nameDescending:
-            return model.playlists.sorted { lhs, rhs in
+            return filteredPlaylists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedDescending
             }
         case .longest:
-            return model.playlists.sorted { lhs, rhs in
+            return filteredPlaylists.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks > rhs.runtimeTicks
             }
         case .shortest:
-            return model.playlists.sorted { lhs, rhs in
+            return filteredPlaylists.sorted { lhs, rhs in
                 if lhs.runtimeTicks == rhs.runtimeTicks {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 }
                 return lhs.runtimeTicks < rhs.runtimeTicks
             }
         case .recentlyAdded:
-            return model.playlists
+            return filteredPlaylists
         case .nameAscending, .recentlyPlayed, .mostPlayed, .yearAscending, .yearDescending:
-            return model.playlists.sorted { lhs, rhs in
+            return filteredPlaylists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         }

--- a/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
+++ b/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the pure value logic behind the Library filter popover (#214):
+/// format-container matching, duration bucketing, and the active-group count
+/// that drives the pink dot on the filter icon. These are deliberately
+/// `AppModel`-free — the per-item `passesFilter` predicates that consult the
+/// model live on `LibraryView`; here we lock down the standalone primitives.
+final class LibraryFilterTests: XCTestCase {
+
+    // MARK: - TrackFormat
+
+    func testFlacMatchesOnlyFlacContainer() {
+        XCTAssertTrue(TrackFormat.flac.matches(container: "flac"))
+        XCTAssertTrue(TrackFormat.flac.matches(container: "FLAC"))
+        XCTAssertFalse(TrackFormat.flac.matches(container: "mp3"))
+        XCTAssertFalse(TrackFormat.flac.matches(container: nil))
+        XCTAssertFalse(TrackFormat.flac.matches(container: "  "))
+    }
+
+    func testAlacMatchesM4aAndMp4Containers() {
+        // Jellyfin ships ALAC inside an m4a/mp4 container, so both spellings
+        // plus the codec name itself must count.
+        XCTAssertTrue(TrackFormat.alac.matches(container: "m4a"))
+        XCTAssertTrue(TrackFormat.alac.matches(container: "MP4"))
+        XCTAssertTrue(TrackFormat.alac.matches(container: "alac"))
+        XCTAssertFalse(TrackFormat.alac.matches(container: "flac"))
+    }
+
+    func testMp3MatchesMpegSpelling() {
+        XCTAssertTrue(TrackFormat.mp3.matches(container: "mp3"))
+        XCTAssertTrue(TrackFormat.mp3.matches(container: "MPEG"))
+        XCTAssertFalse(TrackFormat.mp3.matches(container: "aac"))
+    }
+
+    // MARK: - DurationBucket
+
+    func testDurationBucketBoundaries() {
+        // < 3m
+        XCTAssertTrue(DurationBucket.short.matches(seconds: 179))
+        XCTAssertFalse(DurationBucket.short.matches(seconds: 180))
+        // 3–6m inclusive on both ends
+        XCTAssertTrue(DurationBucket.medium.matches(seconds: 180))
+        XCTAssertTrue(DurationBucket.medium.matches(seconds: 360))
+        XCTAssertFalse(DurationBucket.medium.matches(seconds: 179))
+        XCTAssertFalse(DurationBucket.medium.matches(seconds: 361))
+        // > 6m
+        XCTAssertTrue(DurationBucket.long.matches(seconds: 361))
+        XCTAssertFalse(DurationBucket.long.matches(seconds: 360))
+    }
+
+    func testDurationBucketsArePartition() {
+        // Every positive runtime falls in exactly one bucket.
+        for seconds in stride(from: 0.0, through: 1200.0, by: 7.0) {
+            let hits = DurationBucket.allCases.filter { $0.matches(seconds: seconds) }
+            XCTAssertEqual(hits.count, 1, "seconds=\(seconds) hit \(hits.count) buckets")
+        }
+    }
+
+    // MARK: - LibraryFilter.activeGroupCount
+
+    func testEmptyFilterIsInactive() {
+        let f = LibraryFilter()
+        XCTAssertFalse(f.isActive)
+        XCTAssertEqual(f.activeGroupCount, 0)
+    }
+
+    func testActiveGroupCountCountsEachGroupOnce() {
+        var f = LibraryFilter()
+        f.genres = ["Rock", "Jazz"]   // one group despite two selections
+        f.formats = [.flac, .mp3]     // one group despite two selections
+        XCTAssertEqual(f.activeGroupCount, 2)
+        XCTAssertTrue(f.isActive)
+
+        f.onlyFavorited = true
+        f.yearRange = 1990...2000
+        f.durations = [.short]
+        XCTAssertEqual(f.activeGroupCount, 5)
+    }
+}


### PR DESCRIPTION
Adds the Library filter popover so users can narrow the loaded library by genre, release year, format, duration, and favorited state — matching screen-spec Issue 15.

Closes #214

## What's here
- New `LibraryFilterPopover` (280pt, anchored to a filter `IconBtn`-style button in the Library header) with groups: Genre (checklist of loaded genres), Year (double-thumb `RangeSlider`), Only favorited (toggle), Format (FLAC / ALAC / MP3 checkboxes), Duration (< 3m / 3–6m / > 6m). "Only downloaded" is gated behind `AppModel.supportsDownloads` so it doesn't render as a dead control while the download engine is unwired.
- "Clear all" + "Apply" footer; the popover edits a working-copy draft and only commits on Apply. A 10pt pink dot (`Theme.accentHot`) shows on the filter icon when any filter group is active.
- `LibraryView` applies the filter client-side over the already-loaded `model.X` arrays (the same paged-cache scope the sort already uses) before sorting, so it composes with `LibrarySortOrder` and leaves pagination accounting untouched.
- Filter predicates are favorite-cache-aware via `model.isFavorite(album:)` / `(artist:)` / `(track:)` / `(playlist:)`.

Pure SwiftUI — no FFI change; all backing fields (`genres`, `year`, `container`, `runtimeTicks`, `userData.isFavorite`) already exist on the committed core models.

## pipeline
- fixer-session: feature-builder-214
- slice: screens (Library)
- hotspots-claimed: none
- build-gate: `swift build` clean; `swift test --filter LibraryFilterTests` 7/7 green; no Rust diff (`cargo fmt --all -- --check` clean)
- diff-stat: 3 files, +696 / -29