### PR TITLE
macos: add autoplay-when-queue-ends toggle to queue header

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -528,14 +528,14 @@ final class AppModel {
     // MARK: - Autoplay (queue end)
 
     /// UserDefaults key for the persisted "autoplay similar music when the
-    /// queue ends" preference (#83). Same `@Observable` → UserDefaults
-    /// bridge as the mini-player flag above.
+    /// queue ends" preference. Same `@Observable` → UserDefaults bridge as
+    /// the mini-player flag above.
     private static let autoplayWhenQueueEndsKey = "queue.autoplayWhenQueueEnds"
 
     /// Whether playback should extend with an Instant Mix of similar music
-    /// when the user-added queue and its source tail run dry (#83). Default
-    /// **on** to match Apple Music / Spotify's endless-listening behaviour;
-    /// users who dislike endless autoplay flip it off in the queue header and
+    /// when the user-added queue and its source tail run dry. Default **on**
+    /// to match Apple Music / Spotify's endless-listening behaviour; users
+    /// who dislike endless autoplay flip it off in the queue header and
     /// playback simply stops at the end of what they queued. Persisted across
     /// launches; read through `autoplayWhenQueueEndsDefault` so an unset key
     /// resolves to `true` rather than `bool(forKey:)`'s `false`.
@@ -552,10 +552,10 @@ final class AppModel {
         return UserDefaults.standard.bool(forKey: autoplayWhenQueueEndsKey)
     }
 
-    /// Set + persist the autoplay-at-queue-end preference (#83). Wired to the
-    /// queue header toggle; `handleTrackEnded` reads `autoplayWhenQueueEnds`
-    /// when the queue runs dry to decide whether to extend with an Instant
-    /// Mix or stop.
+    /// Set + persist the autoplay-at-queue-end preference. Wired to the queue
+    /// header toggle; `handleTrackEnded` reads `autoplayWhenQueueEnds` when
+    /// the queue runs dry to decide whether to extend with an Instant Mix or
+    /// stop.
     func setAutoplayWhenQueueEnds(_ on: Bool) {
         autoplayWhenQueueEnds = on
         UserDefaults.standard.set(on, forKey: AppModel.autoplayWhenQueueEndsKey)
@@ -4645,7 +4645,7 @@ final class AppModel {
             return
         }
         // Queue ran dry. When "autoplay similar music when queue ends" is on
-        // (#83, default), seed an Instant Mix from the track that just
+        // (the default), seed an Instant Mix from the track that just
         // finished and keep playing — matching Apple Music / Spotify's
         // endless listening. When the user has turned it off, do nothing so
         // playback simply stops at the end of what they queued.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -525,6 +525,42 @@ final class AppModel {
         UserDefaults.standard.set(on, forKey: AppModel.miniPlayerAlwaysOnTopKey)
     }
 
+    // MARK: - Autoplay (queue end)
+
+    /// UserDefaults key for the persisted "autoplay similar music when the
+    /// queue ends" preference (#83). Same `@Observable` → UserDefaults
+    /// bridge as the mini-player flag above.
+    private static let autoplayWhenQueueEndsKey = "queue.autoplayWhenQueueEnds"
+
+    /// Whether playback should extend with an Instant Mix of similar music
+    /// when the user-added queue and its source tail run dry (#83). Default
+    /// **on** to match Apple Music / Spotify's endless-listening behaviour;
+    /// users who dislike endless autoplay flip it off in the queue header and
+    /// playback simply stops at the end of what they queued. Persisted across
+    /// launches; read through `autoplayWhenQueueEndsDefault` so an unset key
+    /// resolves to `true` rather than `bool(forKey:)`'s `false`.
+    var autoplayWhenQueueEnds: Bool = AppModel.autoplayWhenQueueEndsDefault()
+
+    /// Resolve the persisted autoplay flag, defaulting to `true` when the key
+    /// has never been written. `UserDefaults.bool(forKey:)` returns `false`
+    /// for a missing key, which would silently invert this feature's "default
+    /// on" contract, so we probe for the object first.
+    private static func autoplayWhenQueueEndsDefault() -> Bool {
+        guard UserDefaults.standard.object(forKey: autoplayWhenQueueEndsKey) != nil else {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: autoplayWhenQueueEndsKey)
+    }
+
+    /// Set + persist the autoplay-at-queue-end preference (#83). Wired to the
+    /// queue header toggle; `handleTrackEnded` reads `autoplayWhenQueueEnds`
+    /// when the queue runs dry to decide whether to extend with an Instant
+    /// Mix or stop.
+    func setAutoplayWhenQueueEnds(_ on: Bool) {
+        autoplayWhenQueueEnds = on
+        UserDefaults.standard.set(on, forKey: AppModel.autoplayWhenQueueEndsKey)
+    }
+
     /// Close the Mini Player and bring the full window forward, honouring the
     /// "closing returns to full window" contract. Used by the mini player's
     /// settings-menu and hover "return" affordances. Clearing the flag lets
@@ -4606,7 +4642,21 @@ final class AppModel {
         // Advance to the next track in the queue if there is one.
         if let next = core.skipNext() {
             playCurrent(next)
+            return
         }
+        // Queue ran dry. When "autoplay similar music when queue ends" is on
+        // (#83, default), seed an Instant Mix from the track that just
+        // finished and keep playing — matching Apple Music / Spotify's
+        // endless listening. When the user has turned it off, do nothing so
+        // playback simply stops at the end of what they queued.
+        //
+        // This only fires once the user's Up Next *and* the source tail (the
+        // album / playlist tracks the core queue already held) are exhausted,
+        // so it never short-circuits an explicit album-end — `skipNext`
+        // walks those first and only returns nil when there's genuinely
+        // nothing left.
+        guard autoplayWhenQueueEnds, let seed = status.currentTrack else { return }
+        playInstantMix(seedId: seed.id)
     }
 
     // MARK: - Now Playing details

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -221,7 +221,7 @@ struct QueueInspector: View {
         }
     }
 
-    /// "Autoplay similar music when queue ends" toggle (#83). When on
+    /// "Autoplay similar music when queue ends" toggle. When on
     /// (default), playback extends with an Instant Mix once Up Next and the
     /// source tail run dry; when off, playback stops at the end of what the
     /// user queued. Persists across launches via

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -191,31 +191,72 @@ struct QueueInspector: View {
 
     @ViewBuilder
     private var header: some View {
-        HStack {
-            Text("Queue")
-                .font(Theme.font(11, weight: .bold))
-                .foregroundStyle(Theme.ink2)
-                .tracking(2)
-                .textCase(.uppercase)
-            Spacer()
-            // Note: the Cmd+Opt+Q toggle lives on `MainShell` so it works
-            // whether the panel is open or closed. The X here is click-only
-            // so we don't register two responders for the same shortcut.
-            Button(action: { model.isQueueInspectorOpen = false }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Queue")
+                    .font(Theme.font(11, weight: .bold))
                     .foregroundStyle(Theme.ink2)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(Theme.surface))
+                    .tracking(2)
+                    .textCase(.uppercase)
+                Spacer()
+                // Note: the Cmd+Opt+Q toggle lives on `MainShell` so it works
+                // whether the panel is open or closed. The X here is click-only
+                // so we don't register two responders for the same shortcut.
+                Button(action: { model.isQueueInspectorOpen = false }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .frame(width: 22, height: 22)
+                        .background(Circle().fill(Theme.surface))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close queue")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close queue")
+            autoplayToggle
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .overlay(alignment: .bottom) {
             Rectangle().fill(Theme.border).frame(height: 1)
         }
+    }
+
+    /// "Autoplay similar music when queue ends" toggle (#83). When on
+    /// (default), playback extends with an Instant Mix once Up Next and the
+    /// source tail run dry; when off, playback stops at the end of what the
+    /// user queued. Persists across launches via
+    /// `AppModel.setAutoplayWhenQueueEnds(_:)`.
+    @ViewBuilder
+    private var autoplayToggle: some View {
+        Toggle(isOn: autoplayBinding) {
+            HStack(spacing: 6) {
+                Image(systemName: "infinity")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                    .accessibilityHidden(true)
+                Text("Autoplay similar music when queue ends")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.switch)
+        .controlSize(.mini)
+        .tint(Theme.accent)
+        .accessibilityLabel("Autoplay similar music when queue ends")
+        .accessibilityHint("When off, playback stops at the end of the queue instead of continuing with similar music")
+    }
+
+    /// Bridges the `@Observable` model's persisted flag to a SwiftUI
+    /// `Binding` so the `Toggle` writes through `setAutoplayWhenQueueEnds`
+    /// (which both updates state and persists to UserDefaults). The model
+    /// isn't `@Bindable` here, so we route the setter explicitly rather than
+    /// `$model.autoplayWhenQueueEnds`, which would bypass persistence.
+    private var autoplayBinding: Binding<Bool> {
+        Binding(
+            get: { model.autoplayWhenQueueEnds },
+            set: { model.setAutoplayWhenQueueEnds($0) }
+        )
     }
 
     // MARK: - Action row (BATCH-07b, #284)

--- a/macos/Tests/LyrebirdTests/AutoplayWhenQueueEndsTests.swift
+++ b/macos/Tests/LyrebirdTests/AutoplayWhenQueueEndsTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the "autoplay similar music when the queue ends" preference:
+/// the **default-on** contract (an unset key must resolve to `true`, not
+/// `UserDefaults.bool(forKey:)`'s `false`) and the persistence round-trip
+/// through `setAutoplayWhenQueueEnds(_:)`.
+///
+/// `AppModel` is `@MainActor`, so the whole suite is main-actor isolated.
+/// Constructing it boots a live `LyrebirdCore`; we redirect the core's data
+/// directory to a throwaway temp dir via `XDG_DATA_HOME` (honoured by
+/// `storage::default_data_dir()`) so the test never touches the real app's
+/// database. Persistence runs against the standard `UserDefaults` domain, so
+/// each test scrubs the key before and after to stay hermetic.
+@MainActor
+final class AutoplayWhenQueueEndsTests: XCTestCase {
+
+    /// The persisted key, kept in sync with `AppModel.autoplayWhenQueueEndsKey`
+    /// (private). If that string ever changes, the default-on probe and the
+    /// persistence assertions here go stale, so this test pins the contract.
+    private let key = "queue.autoplayWhenQueueEnds"
+
+    /// Point the core at a unique temp data dir before the first `AppModel()`
+    /// in the process. Set once for the whole suite — the core reads the env
+    /// var when it builds its default data dir, and we never want the real
+    /// `~/Library/Application Support/lyrebird-desktop` DB created by tests.
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        // A stale persisted value would mask the default-on probe, so clear
+        // the key before constructing the model under test.
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    // MARK: - default-on contract
+
+    /// With the key never written, the flag must read `true`. This is the
+    /// load-bearing contract: a naive `bool(forKey:)` would return `false`
+    /// and silently invert the feature to "stop at end of queue" by default.
+    func testDefaultsToOnWhenKeyUnset() throws {
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: key),
+            "precondition: key must be unset for the default probe"
+        )
+
+        let model = try AppModel()
+        XCTAssertTrue(
+            model.autoplayWhenQueueEnds,
+            "an unset preference must default to autoplay-on"
+        )
+    }
+
+    /// A persisted `false` must survive into a freshly-constructed model — the
+    /// default-on probe must not clobber an explicit opt-out.
+    func testPersistedFalseIsHonouredOnLaunch() throws {
+        UserDefaults.standard.set(false, forKey: key)
+
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.autoplayWhenQueueEnds,
+            "a persisted opt-out must be restored, not reset to the default"
+        )
+    }
+
+    // MARK: - setAutoplayWhenQueueEnds (persistence round-trip)
+
+    func testSetAutoplayUpdatesPropertyAndPersists() throws {
+        let model = try AppModel()
+
+        model.setAutoplayWhenQueueEnds(false)
+        XCTAssertFalse(model.autoplayWhenQueueEnds, "live property reflects the set value")
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: key),
+            "turning autoplay off must persist so the next launch restores it"
+        )
+
+        model.setAutoplayWhenQueueEnds(true)
+        XCTAssertTrue(model.autoplayWhenQueueEnds)
+        XCTAssertTrue(
+            UserDefaults.standard.bool(forKey: key),
+            "turning autoplay back on must persist too"
+        )
+    }
+}


### PR DESCRIPTION
Lets users who dislike endless autoplay stop playback at the end of what they queued, while keeping Apple Music / Spotify-style endless listening on by default.

Closes #83

When the queue runs dry, `handleTrackEnded` now extends playback with an Instant Mix seeded from the just-finished track only when the new "Autoplay similar music when queue ends" switch is on (default). The switch lives in the Queue Inspector header and persists across launches via UserDefaults (default-on resolved by probing for the key rather than `bool(forKey:)`, which would otherwise invert the contract). It gates only the Instant Mix extension — `core.skipNext()` still walks the user-added Up Next and the source tail (album / playlist tracks) first, so an explicit album-end is unaffected; the toggle only decides whether to keep going with similar music or stop.

The `Toggle` routes through `setAutoplayWhenQueueEnds(_:)` via an explicit `Binding` (the model is `@Observable`, not `@Bindable` in this view) so writes persist.

pipeline:
- fixer-session: feature-builder-83
- slice: components / macos-ux
- hotspots-claimed: none
- build-gate: swift build (pass; Swift-only diff, no FFI/Rust change, xcframework + bindings regenerated locally to link)
- diff-stat: 2 files, +108 / -17