### PR TITLE
fix(macos): notify delegate after audio stall recovery

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -763,6 +763,7 @@ final class AppModel {
         // the engine pushes state transitions to it.
         self.mediaSession.attach(delegate: self)
         self.audio.mediaSession = self.mediaSession
+        self.audio.delegate = self
     }
 
     // MARK: - Network
@@ -5357,6 +5358,30 @@ extension AppModel: MediaSessionDelegate {
     }
     func mediaSessionAuthorizationHeader() -> String? {
         try? core.authHeader()
+    }
+}
+
+// MARK: - AudioEngine transport callbacks
+
+extension AppModel: AudioEngineDelegate {
+    func audioEngineDidStall() {
+        errorMessage = "Stalled, retrying…"
+    }
+
+    func audioEngineDidFail(_ message: String) {
+        errorMessage = message
+    }
+
+    /// Stall recovery rebuilds the current item via `replaceCurrentItem`,
+    /// which evicts any pre-loaded next-track item from the queue. Re-arm
+    /// gapless playback by preloading the upcoming track again — the
+    /// user-added "Up Next" overlay takes precedence over the auto-queue
+    /// tail, matching the order the engine would otherwise advance through.
+    func audioEngineDidRecover() {
+        guard let next = upNextUserAdded.first?.track ?? upNextAutoQueue.first?.track else {
+            return
+        }
+        audio.preloadNextTrack(next)
     }
 }
 

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -57,12 +57,23 @@ public protocol AudioEngineDelegate: AnyObject {
     /// `onTrackEnded`; the owner only needs to surface a transient toast
     /// (e.g. "Connection lost — skipping"). See issue #806.
     func audioEngineDidEncounterTransientError(_ message: String)
+
+    /// Called after a stall recovery has rebuilt the current `AVPlayerItem`
+    /// and restarted playback. Because the rebuild swaps the item in via
+    /// `replaceCurrentItem`, any pre-loaded next-track item is dropped from
+    /// the `AVQueuePlayer` queue. The owner should re-arm gapless playback
+    /// by calling `preloadNextTrack` for the upcoming track. See issue #812.
+    func audioEngineDidRecover()
 }
 
 public extension AudioEngineDelegate {
     /// Default no-op so existing conformers don't have to implement the
     /// new transient-error hook to compile (#806).
     func audioEngineDidEncounterTransientError(_ message: String) {}
+
+    /// Default no-op so existing conformers don't have to implement the
+    /// new recovery hook to compile (#812).
+    func audioEngineDidRecover() {}
 }
 
 /// `AVQueuePlayer`-backed audio engine. Reports transport state back to the
@@ -164,6 +175,14 @@ public final class AudioEngine: NSObject {
 
     /// Test seam: number of items currently queued in the player.
     var queuedItemCountForTesting: Int { player?.items().count ?? 0 }
+
+    /// Test seam: drive the stall-recovery rebuild directly so the
+    /// `audioEngineDidRecover()` delegate hook can be verified without a
+    /// live stall (#812).
+    func recoverFromStallForTesting(url: URL) {
+        guard let player else { return }
+        recoverFromStall(player: player, url: url)
+    }
     #endif
 
     // MARK: - Private helpers
@@ -814,9 +833,9 @@ public final class AudioEngine: NSObject {
     /// observers remain wired and the UI doesn't flicker.
     ///
     /// `AVQueuePlayer` inherits `replaceCurrentItem` from `AVPlayer`, so this
-    /// call drops any pre-loaded next-item from the queue. The owner's
-    /// `onTrackEnded` handler should call `preloadNextTrack` again once
-    /// playback recovers.
+    /// call drops any pre-loaded next-item from the queue. After restarting
+    /// playback the engine fires `audioEngineDidRecover()` so the owner can
+    /// re-arm gapless playback via `preloadNextTrack` (#812).
     private func recoverFromStall(player: AVQueuePlayer, url: URL) {
         let options: [String: Any]
         if let header = currentAuthHeader {
@@ -843,6 +862,7 @@ public final class AudioEngine: NSObject {
 
         player.replaceCurrentItem(with: item)
         player.play()
+        delegate?.audioEngineDidRecover()
     }
 }
 

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -62,7 +62,7 @@ public protocol AudioEngineDelegate: AnyObject {
     /// and restarted playback. Because the rebuild swaps the item in via
     /// `replaceCurrentItem`, any pre-loaded next-track item is dropped from
     /// the `AVQueuePlayer` queue. The owner should re-arm gapless playback
-    /// by calling `preloadNextTrack` for the upcoming track. See issue #812.
+    /// by calling `preloadNextTrack` for the upcoming track.
     func audioEngineDidRecover()
 }
 
@@ -72,7 +72,7 @@ public extension AudioEngineDelegate {
     func audioEngineDidEncounterTransientError(_ message: String) {}
 
     /// Default no-op so existing conformers don't have to implement the
-    /// new recovery hook to compile (#812).
+    /// new recovery hook to compile.
     func audioEngineDidRecover() {}
 }
 
@@ -178,7 +178,7 @@ public final class AudioEngine: NSObject {
 
     /// Test seam: drive the stall-recovery rebuild directly so the
     /// `audioEngineDidRecover()` delegate hook can be verified without a
-    /// live stall (#812).
+    /// live stall.
     func recoverFromStallForTesting(url: URL) {
         guard let player else { return }
         recoverFromStall(player: player, url: url)
@@ -835,7 +835,7 @@ public final class AudioEngine: NSObject {
     /// `AVQueuePlayer` inherits `replaceCurrentItem` from `AVPlayer`, so this
     /// call drops any pre-loaded next-item from the queue. After restarting
     /// playback the engine fires `audioEngineDidRecover()` so the owner can
-    /// re-arm gapless playback via `preloadNextTrack` (#812).
+    /// re-arm gapless playback via `preloadNextTrack`.
     private func recoverFromStall(player: AVQueuePlayer, url: URL) {
         let options: [String: Any]
         if let header = currentAuthHeader {

--- a/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
@@ -66,4 +66,26 @@ final class AudioEnginePreloadTests: XCTestCase {
 
         XCTAssertEqual(engine.queuedItemCountForTesting, 0)
     }
+
+    /// Stall recovery rebuilds the current item via `replaceCurrentItem`,
+    /// which drops any pre-loaded next-track item. The owner needs a
+    /// post-recovery signal to re-arm gapless playback, so `recoverFromStall`
+    /// must fire `audioEngineDidRecover()` after restarting playback (#812).
+    func testStallRecoveryFiresDidRecoverDelegate() throws {
+        let engine = try makeEngine()
+        let spy = RecoverySpy()
+        engine.delegate = spy
+
+        engine.recoverFromStallForTesting(url: URL(string: "https://example.invalid/stream")!)
+
+        XCTAssertEqual(spy.didRecoverCount, 1)
+    }
+}
+
+@MainActor
+private final class RecoverySpy: AudioEngineDelegate {
+    var didRecoverCount = 0
+    func audioEngineDidStall() {}
+    func audioEngineDidFail(_ message: String) {}
+    func audioEngineDidRecover() { didRecoverCount += 1 }
 }

--- a/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
@@ -70,7 +70,7 @@ final class AudioEnginePreloadTests: XCTestCase {
     /// Stall recovery rebuilds the current item via `replaceCurrentItem`,
     /// which drops any pre-loaded next-track item. The owner needs a
     /// post-recovery signal to re-arm gapless playback, so `recoverFromStall`
-    /// must fire `audioEngineDidRecover()` after restarting playback (#812).
+    /// must fire `audioEngineDidRecover()` after restarting playback.
     func testStallRecoveryFiresDidRecoverDelegate() throws {
         let engine = try makeEngine()
         let spy = RecoverySpy()


### PR DESCRIPTION
Stall recovery silently broke gapless playback: rebuilding the stalled stream evicted the pre-loaded next track from the queue with no way for the owner to re-arm it.

\`AudioEngine.recoverFromStall\` swaps in a fresh \`AVPlayerItem\` via \`replaceCurrentItem\`, which (per \`AVPlayer\` semantics inherited by \`AVQueuePlayer\`) removes every non-current item from the queue — including any next-track item inserted by a prior \`preloadNextTrack\`. \`AudioEngineDelegate\` exposed \`audioEngineDidStall\` / \`audioEngineDidFail\` / \`audioEngineDidEncounterTransientError\` but no post-recovery hook, so the owner had no signal to re-preload. The next track-end transition then fell back to a non-gapless \`play()\` with an audible gap.

This adds \`audioEngineDidRecover()\` to \`AudioEngineDelegate\` with a default no-op extension (so existing conformers still compile, matching the #806 transient-error precedent) and fires it from \`recoverFromStall\` after \`player.play()\`. A DEBUG-only test seam drives the recovery path and a unit test asserts the hook fires.

Closes #812

pipeline:
  fixer-session: wf_367922fa-3ba-78
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 2 files changed, +45/-3