### PR TITLE
macos: Library track list density + multiselect

### DIFF
--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 @preconcurrency import LyrebirdCore
 
@@ -47,6 +48,20 @@ struct TrackListRow: View {
     /// matches the `AlbumDetailView.trackList` contract.
     let tracks: [Track]
     let index: Int
+    /// Whether this row is part of the caller's multi-selection. When `true`
+    /// the row paints a selection rail + tint regardless of hover / active
+    /// state. Callers that don't support multi-select leave this `false`.
+    var isSelected: Bool = false
+    /// Optional click router for multi-select hosts (#217). When non-nil the
+    /// row hands every click (with its modifier flags) to the caller instead
+    /// of playing immediately, so the host can resolve Cmd-toggle /
+    /// Shift-range / bare-click-plays. When nil the row plays on click exactly
+    /// as before — every existing single-select call site is unaffected.
+    var onSelect: ((NSEvent.ModifierFlags) -> Void)? = nil
+    /// Row density (#217). Bound by the Library Tracks tab to the user's
+    /// `appearance.density` preference; defaults to roomy so other call sites
+    /// keep their current look.
+    var density: AppearanceDensity = .roomy
     @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
     @State private var isHovering = false
     @FocusState private var isFocused: Bool
@@ -70,157 +85,91 @@ struct TrackListRow: View {
         return !directPlayContainers.contains(container)
     }
 
+    private var artworkSize: CGFloat { density.trackArtworkSize }
+
     var body: some View {
-        Button {
-            model.play(tracks: tracks, startIndex: index)
-        } label: {
-            HStack(spacing: 12) {
-                ZStack {
-                    Artwork(
-                        url: model.imageURL(
-                            for: track.albumId ?? track.id,
-                            tag: track.imageTag,
-                            maxWidth: 120
-                        ),
-                        seed: track.albumName ?? track.name,
-                        size: 40,
-                        radius: 4
-                    )
-                    if isPlaying {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.black.opacity(0.55))
-                            .frame(width: 40, height: 40)
-                        EqualizerIcon()
-                            .foregroundStyle(Theme.accent)
-                    } else if isHovering {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.black.opacity(0.45))
-                            .frame(width: 40, height: 40)
-                        Image(systemName: "play.fill")
-                            .foregroundStyle(.white)
-                            .font(.system(size: 13))
-                            .transition(.opacity)
-                    }
-                }
-                .frame(width: 40, height: 40)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 5) {
-                        Text(track.name)
-                            .font(Theme.font(13, weight: .semibold))
-                            .foregroundStyle(isActive ? Theme.accent : Theme.ink)
-                            .lineLimit(1)
-                        FormatBadge(track: track)
-                        if willTranscode {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.system(size: 10))
-                                .foregroundStyle(Theme.warning)
-                                .help("Transcoding required. Enable in Preferences → Playback.")
-                        }
-                    }
-                    Text(track.artistName)
-                        .font(Theme.font(11, weight: .medium))
-                        .foregroundStyle(Theme.ink2)
-                        .lineLimit(1)
-                }
-
-                Spacer()
-
-                if let album = track.albumName {
-                    Text(album)
-                        .font(Theme.font(12, weight: .medium))
-                        .foregroundStyle(Theme.ink3)
-                        .lineLimit(1)
-                        .frame(maxWidth: 240, alignment: .trailing)
-                }
-
-                let isFav = model.isFavorite(track: track)
-                if isFav || isHovering {
-                    Button {
-                        model.toggleFavorite(track: track)
-                    } label: {
-                        Image(systemName: isFav ? "heart.fill" : "heart")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
-                            .frame(width: 28, height: 28)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
-                }
-
-                Text(track.durationFormatted)
-                    .font(Theme.font(12, weight: .medium))
-                    .foregroundStyle(Theme.ink3)
-                    .monospacedDigit()
-                    .frame(minWidth: 48, alignment: .trailing)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+        rowContent
+            // When a selection host is wired up, route clicks (with modifier
+            // flags) to it; otherwise the inner Button handles the plain play
+            // tap as before. Gestures only attach on the multi-select path so
+            // the single-select path keeps the Button's full accessibility +
+            // hover behaviour untouched.
+            .modifier(SelectionClickModifier(onSelect: onSelect))
             .background(
                 RoundedRectangle(cornerRadius: 6)
                     .fill(rowBackground)
             )
+            .overlay(alignment: .leading) {
+                // Selection rail — 2pt accent bar on the leading edge so a
+                // multi-selected row reads at a glance even when it's also
+                // hovered. See #217.
+                if isSelected {
+                    Rectangle()
+                        .fill(Theme.accent)
+                        .frame(width: 2)
+                        .padding(.vertical, 2)
+                }
+            }
             .overlay(
                 // Subtle outline so focus-via-keyboard is visible even when
                 // the row is also hovered or active. See #105.
                 RoundedRectangle(cornerRadius: 6)
                     .stroke(isFocused ? Theme.accent.opacity(0.6) : .clear, lineWidth: 1)
             )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            if reduceMotion {
-                isHovering = hovering
-            } else {
-                withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+            .onHover { hovering in
+                if reduceMotion {
+                    isHovering = hovering
+                } else {
+                    withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+                }
             }
-        }
-        .contextMenu { TrackContextMenu(selection: [track]) }
-        // A single row should read as one VoiceOver element — the wrapping
-        // Button already carries a label, but we override it here to pull
-        // in the active state so playing rows announce "Now playing" and
-        // non-playing rows announce "Plays this track". `.combine` collapses
-        // the artwork and text sub-views so the rotor sees one button per
-        // row rather than several unlabelled children. See #588.
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(track.name) by \(track.artistName)")
-        .accessibilityHint(isPlaying ? "Now playing" : "Plays this track")
-        .accessibilityAddTraits(isPlaying ? [.isButton, .isSelected] : .isButton)
-        // MARK: Keyboard navigation (#105)
-        .focusable()
-        .focused($isFocused)
-        .onChange(of: isFocused) { _, nowFocused in
-            if nowFocused {
-                model.focusedTrackId = track.id
+            .contextMenu { TrackContextMenu(selection: [track]) }
+            // A single row should read as one VoiceOver element — the wrapping
+            // Button already carries a label, but we override it here to pull
+            // in the active state so playing rows announce "Now playing" and
+            // non-playing rows announce "Plays this track". `.combine` collapses
+            // the artwork and text sub-views so the rotor sees one button per
+            // row rather than several unlabelled children. See #588.
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(track.name) by \(track.artistName)")
+            .accessibilityHint(isPlaying ? "Now playing" : "Plays this track")
+            .accessibilityAddTraits(accessibilityTraits)
+            // MARK: Keyboard navigation (#105)
+            .focusable()
+            .focused($isFocused)
+            .onChange(of: isFocused) { _, nowFocused in
+                if nowFocused {
+                    model.focusedTrackId = track.id
+                }
             }
-        }
-        .onChange(of: model.focusedTrackId) { _, newId in
-            // Sibling rows observe the shared focus cursor; the one that
-            // matches pulls focus to itself. Without this the arrow keys
-            // would write the new id but no row would actually focus.
-            if newId == track.id && !isFocused {
-                isFocused = true
+            .onChange(of: model.focusedTrackId) { _, newId in
+                // Sibling rows observe the shared focus cursor; the one that
+                // matches pulls focus to itself. Without this the arrow keys
+                // would write the new id but no row would actually focus.
+                if newId == track.id && !isFocused {
+                    isFocused = true
+                }
             }
-        }
-        .onKeyPress(.upArrow) {
-            moveFocus(by: -1)
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            moveFocus(by: 1)
-            return .handled
-        }
-        .onKeyPress(.return) {
-            model.play(tracks: tracks, startIndex: index)
-            return .handled
-        }
-        .onKeyPress(.space) {
-            // Space toggles global play/pause regardless of focus target so
-            // "pause while scrolling" works from anywhere in the list.
-            model.togglePlayPause()
-            return .handled
-        }
+            .onKeyPress(.upArrow) {
+                moveFocus(by: -1)
+                return .handled
+            }
+            .onKeyPress(.downArrow) {
+                moveFocus(by: 1)
+                return .handled
+            }
+            .onKeyPress(.return) {
+                model.play(tracks: tracks, startIndex: index)
+                return .handled
+            }
+            .onKeyPress(.space) {
+                // Space toggles global play/pause regardless of focus target so
+                // "pause while scrolling" works from anywhere in the list.
+                model.togglePlayPause()
+                return .handled
+            }
         // TODO(#105): type-ahead search — buffer letter key presses for
         // ~500ms and move focus to the first row whose title starts with
         // the buffer. Needs either a shared FocusState container above the
@@ -229,7 +178,123 @@ struct TrackListRow: View {
         // timestamp. Out of scope for the first cut of keyboard nav.
     }
 
+    private var accessibilityTraits: AccessibilityTraits {
+        var traits: AccessibilityTraits = .isButton
+        if isPlaying || isSelected { traits.formUnion(.isSelected) }
+        return traits
+    }
+
+    /// The row's visual content. When `onSelect` is nil this is wrapped in a
+    /// play-on-tap `Button`; otherwise the host's gesture handler drives
+    /// playback / selection so the same markup serves both paths.
+    @ViewBuilder
+    private var rowContent: some View {
+        if onSelect == nil {
+            Button {
+                model.play(tracks: tracks, startIndex: index)
+            } label: {
+                rowLabel
+            }
+            .buttonStyle(.plain)
+        } else {
+            rowLabel
+        }
+    }
+
+    private var rowLabel: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Artwork(
+                    url: model.imageURL(
+                        for: track.albumId ?? track.id,
+                        tag: track.imageTag,
+                        maxWidth: 120
+                    ),
+                    seed: track.albumName ?? track.name,
+                    size: artworkSize,
+                    radius: 4
+                )
+                if isPlaying {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.black.opacity(0.55))
+                        .frame(width: artworkSize, height: artworkSize)
+                    EqualizerIcon()
+                        .foregroundStyle(Theme.accent)
+                } else if isHovering {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.black.opacity(0.45))
+                        .frame(width: artworkSize, height: artworkSize)
+                    Image(systemName: "play.fill")
+                        .foregroundStyle(.white)
+                        .font(.system(size: density == .compact ? 11 : 13))
+                        .transition(.opacity)
+                }
+            }
+            .frame(width: artworkSize, height: artworkSize)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 5) {
+                    Text(track.name)
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .lineLimit(1)
+                    FormatBadge(track: track)
+                    if willTranscode {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(Theme.warning)
+                            .help("Transcoding required. Enable in Preferences → Playback.")
+                    }
+                }
+                // Compact density drops the artist subline so the row can
+                // hit the 36pt target; the artist is still on the context
+                // menu / Track Info and stays on the roomy default.
+                if density != .compact {
+                    Text(track.artistName)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if let album = track.albumName {
+                Text(album)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .lineLimit(1)
+                    .frame(maxWidth: 240, alignment: .trailing)
+            }
+
+            let isFav = model.isFavorite(track: track)
+            if isFav || isHovering {
+                Button {
+                    model.toggleFavorite(track: track)
+                } label: {
+                    Image(systemName: isFav ? "heart.fill" : "heart")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
+            }
+
+            Text(track.durationFormatted)
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .monospacedDigit()
+                .frame(minWidth: 48, alignment: .trailing)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density == .compact ? 4 : 6)
+        .frame(minHeight: density.trackRowHeight)
+        .contentShape(Rectangle())
+    }
+
     private var rowBackground: Color {
+        if isSelected { return Theme.accent.opacity(0.18) }
         if isActive { return Theme.surface2 }
         if isFocused { return Theme.rowHover }
         if isHovering { return Theme.rowHover }
@@ -245,5 +310,32 @@ struct TrackListRow: View {
         let target = index + delta
         guard target >= 0, target < tracks.count else { return }
         model.focusedTrackId = tracks[target].id
+    }
+}
+
+/// Routes clicks to a multi-select host when one is wired up. When `onSelect`
+/// is nil the modifier is a no-op so the underlying play-on-tap `Button`
+/// drives interaction exactly as before. When present, three tap gestures
+/// disambiguate Cmd-toggle / Shift-range / bare-click and forward the
+/// modifier flags so the host can resolve the selection. Mirrors the gesture
+/// stack `PlaylistDetailView.SelectableTrackRow` uses (#74 / #217).
+private struct SelectionClickModifier: ViewModifier {
+    let onSelect: ((NSEvent.ModifierFlags) -> Void)?
+
+    func body(content: Content) -> some View {
+        if let onSelect {
+            content
+                .gesture(
+                    TapGesture().modifiers(.command).onEnded { onSelect(.command) }
+                )
+                .gesture(
+                    TapGesture().modifiers(.shift).onEnded { onSelect(.shift) }
+                )
+                .simultaneousGesture(
+                    TapGesture().onEnded { onSelect([]) }
+                )
+        } else {
+            content
+        }
     }
 }

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -279,6 +279,18 @@ struct TrackListRow: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(isFav ? "Unfavorite" : "Favorite")
+                // On the multi-select path the row carries a low-priority
+                // bare-tap `.gesture` that routes to `onSelect`. A bare tap on
+                // the heart must toggle the favorite *without* also triggering
+                // selection/playback, so we shadow it with a high-priority tap
+                // that wins the gesture arbitration and swallows the event
+                // before it reaches the row's selection gesture. On the
+                // single-select path (`onSelect == nil`) the row has no
+                // competing gesture, so the plain Button action is left to
+                // handle the tap on its own. See #217.
+                .modifier(FavoriteTapShield(onSelect: onSelect) {
+                    model.toggleFavorite(track: track)
+                })
             }
 
             Text(track.durationFormatted)
@@ -331,9 +343,40 @@ private struct SelectionClickModifier: ViewModifier {
                 .gesture(
                     TapGesture().modifiers(.shift).onEnded { onSelect(.shift) }
                 )
-                .simultaneousGesture(
+                // Bare-tap routes to selection at *normal* priority (not
+                // `.simultaneousGesture`) so an interactive subview — the
+                // favorite heart — can claim a tap that lands on it via a
+                // `.highPriorityGesture` and stop it bubbling to selection.
+                // A `.simultaneousGesture` here would always co-fire and
+                // re-introduce the heart-tap-clears-selection regression
+                // (#217 review). The reference `SelectableTrackRow` can use
+                // `.simultaneousGesture` only because it has no interactive
+                // subviews.
+                .gesture(
                     TapGesture().onEnded { onSelect([]) }
                 )
+        } else {
+            content
+        }
+    }
+}
+
+/// Lets the favorite-heart `Button` win the gesture arbitration against the
+/// row's bare-tap selection gesture on the multi-select path. When `onSelect`
+/// is non-nil the row owns a normal-priority bare-tap `.gesture`; attaching a
+/// `.highPriorityGesture` here makes the heart consume taps that land on it,
+/// so toggling a favorite never also clears the selection or starts playback.
+/// When `onSelect` is nil there is no competing row gesture, so this is a
+/// no-op and the plain `Button` action handles the tap unchanged. See #217.
+private struct FavoriteTapShield: ViewModifier {
+    let onSelect: ((NSEvent.ModifierFlags) -> Void)?
+    let toggle: () -> Void
+
+    func body(content: Content) -> some View {
+        if onSelect != nil {
+            content.highPriorityGesture(
+                TapGesture().onEnded { toggle() }
+            )
         } else {
             content
         }

--- a/macos/Sources/Lyrebird/Components/TrackSelectionBanner.swift
+++ b/macos/Sources/Lyrebird/Components/TrackSelectionBanner.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Bottom-anchored action bar for a multi-track selection (#217). Slides in
+/// over the content while at least one row is selected and exposes the
+/// spec's batch actions:
+///
+///     "{n} selected — Play / Queue / Favorite / Add to playlist / Remove"
+///
+/// `Remove` only appears when `onRemove` is supplied (e.g. a playlist
+/// surface); the Library Tracks tab leaves it nil since you can't remove a
+/// track from the whole library. All actions route through `AppModel`'s
+/// existing selection-aware methods (`play(tracks:)`, `addToQueue(tracks:)`,
+/// `toggleFavorite(tracks:)`, `addTracksToPlaylist(tracks:playlist:)`), so
+/// the banner is pure presentation.
+struct TrackSelectionBanner: View {
+    @Environment(AppModel.self) private var model
+
+    /// The currently-selected tracks, in list order.
+    let selection: [Track]
+    /// Clears the host's selection. Wired to the trailing ✕ and fired after
+    /// any terminal action so the banner dismisses itself.
+    let onClear: () -> Void
+    /// Optional remove handler — present only on surfaces where "remove from
+    /// this collection" is meaningful (playlists). Library callers leave it
+    /// nil and the Remove button is hidden.
+    var onRemove: (() -> Void)? = nil
+
+    private var count: Int { selection.count }
+
+    private var allFavorited: Bool {
+        !selection.isEmpty && selection.allSatisfy { model.isFavorite(track: $0) }
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text("\(count) selected")
+                .font(Theme.font(13, weight: .bold))
+                .foregroundStyle(Theme.ink)
+                .monospacedDigit()
+                .accessibilityLabel("\(count) tracks selected")
+
+            Text("—")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .accessibilityHidden(true)
+
+            actionButton("Play", systemImage: "play.fill") {
+                model.play(tracks: selection, startIndex: 0)
+                onClear()
+            }
+            actionButton("Queue", systemImage: "text.append") {
+                model.addToQueue(tracks: selection)
+                onClear()
+            }
+            actionButton(
+                allFavorited ? "Unfavorite" : "Favorite",
+                systemImage: allFavorited ? "heart.slash" : "heart"
+            ) {
+                model.toggleFavorite(tracks: selection)
+            }
+
+            Menu {
+                AddToPlaylistSubmenu { playlist in
+                    model.addTracksToPlaylist(tracks: selection, playlist: playlist)
+                    onClear()
+                }
+            } label: {
+                bannerLabel("Add to playlist", systemImage: "text.badge.plus")
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .accessibilityLabel("Add \(count) tracks to a playlist")
+
+            if let onRemove {
+                actionButton("Remove", systemImage: "trash", role: .destructive) {
+                    onRemove()
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Button(action: onClear) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.escape, modifiers: [])
+            .accessibilityLabel("Clear selection")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Theme.bgAlt.opacity(0.85))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.border, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.35), radius: 16, y: 6)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func actionButton(
+        _ title: String,
+        systemImage: String,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(role: role, action: action) {
+            bannerLabel(title, systemImage: systemImage, destructive: role == .destructive)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(title) \(count) selected tracks")
+    }
+
+    private func bannerLabel(
+        _ title: String,
+        systemImage: String,
+        destructive: Bool = false
+    ) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .semibold))
+            Text(title)
+                .font(Theme.font(12, weight: .bold))
+        }
+        .foregroundStyle(destructive ? Theme.danger : Theme.ink)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(destructive ? Theme.danger.opacity(0.18) : Theme.surface2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(destructive ? Theme.danger.opacity(0.6) : Theme.border, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -163,6 +163,12 @@ struct LibraryView: View {
             // it referenced are no longer on screen. See #217.
             clearSelection()
         }
+        // `anchorIndex` is a positional cursor into the displayed list; a sort
+        // or filter change reorders that list, so a stale anchor would extend a
+        // Shift+Click range from the wrong row. The ID-based `selectedTrackIds`
+        // survives the reorder, so only the anchor needs clearing. See #217.
+        .onChange(of: sortOrder) { _, _ in anchorIndex = nil }
+        .onChange(of: filter) { _, _ in anchorIndex = nil }
     }
 
     /// The selected tracks resolved against the currently-sorted list, in

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -182,28 +182,23 @@ struct LibraryView: View {
     /// modifier state. Cmd toggles the hit row; Shift extends a contiguous
     /// range from the anchor; a bare click plays the row and resets the
     /// selection. Mirrors `PlaylistDetailView.handleRowClick`. See #217.
+    ///
+    /// The pure selection arithmetic lives in `TrackSelectionResolver.resolve`
+    /// so it can be unit-tested without a View or an `AppModel`; this method is
+    /// only the thin glue that applies the result to `@State` and fires the
+    /// play side effect.
     private func handleTrackClick(index: Int, in tracks: [Track], modifiers: NSEvent.ModifierFlags) {
-        guard tracks.indices.contains(index) else { return }
-        let track = tracks[index]
-        if modifiers.contains(.command) {
-            if selectedTrackIds.contains(track.id) {
-                selectedTrackIds.remove(track.id)
-            } else {
-                selectedTrackIds.insert(track.id)
-            }
-            anchorIndex = index
-        } else if modifiers.contains(.shift) {
-            let from = anchorIndex ?? index
-            let range = from <= index ? from...index : index...from
-            var next = selectedTrackIds
-            for i in range where tracks.indices.contains(i) {
-                next.insert(tracks[i].id)
-            }
-            selectedTrackIds = next
-            anchorIndex = index
-        } else {
-            clearSelection()
-            anchorIndex = index
+        let outcome = TrackSelectionResolver.resolve(
+            clickedIndex: index,
+            trackIds: tracks.map(\.id),
+            currentSelection: selectedTrackIds,
+            anchorIndex: anchorIndex,
+            modifiers: modifiers
+        )
+        guard let outcome else { return }
+        selectedTrackIds = outcome.selection
+        anchorIndex = outcome.anchorIndex
+        if outcome.shouldPlay {
             model.play(tracks: tracks, startIndex: index)
         }
     }
@@ -1161,5 +1156,62 @@ struct LibrarySortMenu: View {
         .fixedSize()
         .accessibilityLabel("Sort library")
         .accessibilityValue(selection.label)
+    }
+}
+
+/// Pure selection arithmetic for the Library Tracks tab multi-select (#217).
+///
+/// Extracted out of `LibraryView.handleTrackClick` so the Cmd-toggle /
+/// Shift-range / bare-click-plays logic can be exercised by unit tests without
+/// standing up a SwiftUI scene graph or an `AppModel`. The View layer keeps
+/// only the `@State` mutation + the `model.play(...)` side effect.
+enum TrackSelectionResolver {
+    /// The next selection state plus whether the caller should start playback.
+    struct Outcome: Equatable {
+        var selection: Set<String>
+        var anchorIndex: Int?
+        var shouldPlay: Bool
+    }
+
+    /// Resolve a click on `clickedIndex` within `trackIds` given the current
+    /// selection, anchor, and modifier flags.
+    ///
+    /// - Cmd: toggle the hit row in/out of the selection; re-anchor to it.
+    /// - Shift: insert the contiguous range between the anchor (or the hit row
+    ///   if there is no anchor) and the hit row; re-anchor to the hit row.
+    /// - No modifier: clear the selection, anchor the hit row, and signal that
+    ///   playback should start at it.
+    ///
+    /// Returns `nil` when `clickedIndex` is out of bounds, so the caller does
+    /// nothing — matching the previous guard.
+    static func resolve(
+        clickedIndex: Int,
+        trackIds: [String],
+        currentSelection: Set<String>,
+        anchorIndex: Int?,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Outcome? {
+        guard trackIds.indices.contains(clickedIndex) else { return nil }
+        let clickedId = trackIds[clickedIndex]
+
+        if modifiers.contains(.command) {
+            var next = currentSelection
+            if next.contains(clickedId) {
+                next.remove(clickedId)
+            } else {
+                next.insert(clickedId)
+            }
+            return Outcome(selection: next, anchorIndex: clickedIndex, shouldPlay: false)
+        } else if modifiers.contains(.shift) {
+            let from = anchorIndex ?? clickedIndex
+            let range = from <= clickedIndex ? from...clickedIndex : clickedIndex...from
+            var next = currentSelection
+            for i in range where trackIds.indices.contains(i) {
+                next.insert(trackIds[i])
+            }
+            return Outcome(selection: next, anchorIndex: clickedIndex, shouldPlay: false)
+        } else {
+            return Outcome(selection: [], anchorIndex: clickedIndex, shouldPlay: true)
+        }
     }
 }

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 @preconcurrency import LyrebirdCore
 
@@ -81,29 +82,65 @@ struct LibraryView: View {
     @State private var filter = LibraryFilter()
     /// Drives the filter popover's presentation. Anchored to the filter icon.
     @State private var showFilter = false
+    /// Row density for the Tracks tab, bound to the Appearance preference
+    /// (#217). 48pt roomy / 36pt compact — see `AppearanceDensity`.
+    @AppStorage(AppearanceKeys.density) private var densityRaw: String = AppearanceDensity.roomy.rawValue
+    /// Track ids in the user's multi-selection on the Tracks tab. Empty means
+    /// no selection; the selection banner is shown whenever it's non-empty.
+    /// Cleared on Esc, on a bare click, and on switching chips. See #217.
+    @State private var selectedTrackIds: Set<String> = []
+    /// Anchor row index for Shift+Click range extension. Mirrors the pattern
+    /// in `PlaylistDetailView`.
+    @State private var anchorIndex: Int? = nil
+
+    private var density: AppearanceDensity {
+        AppearanceDensity(rawValue: densityRaw) ?? .roomy
+    }
 
     private let columns = [GridItem(.adaptive(minimum: 180, maximum: 220), spacing: 18)]
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                header
-                chipRow
-                if model.isLoadingLibrary && model.albums.isEmpty {
-                    ProgressView()
-                        .tint(Theme.ink2)
-                        .padding(.top, 40)
-                        .frame(maxWidth: .infinity)
-                } else {
-                    content
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    chipRow
+                    if model.isLoadingLibrary && model.albums.isEmpty {
+                        ProgressView()
+                            .tint(Theme.ink2)
+                            .padding(.top, 40)
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        content
+                    }
+                    Spacer(minLength: 24)
                 }
-                Spacer(minLength: 24)
+                .padding(.horizontal, 32)
+                .padding(.top, 28)
+                // Leave room for the floating selection banner so the last
+                // rows aren't occluded while a selection is active.
+                .padding(.bottom, selectedTracks.isEmpty ? 32 : 88)
             }
-            .padding(.horizontal, 32)
-            .padding(.top, 28)
-            .padding(.bottom, 32)
+            .background(backgroundWash)
+
+            if !selectedTracks.isEmpty {
+                TrackSelectionBanner(
+                    selection: selectedTracks,
+                    onClear: clearSelection
+                )
+                .padding(.horizontal, 32)
+                .padding(.bottom, 20)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
-        .background(backgroundWash)
+        .animation(.easeInOut(duration: 0.2), value: selectedTrackIds.isEmpty)
+        // Esc clears the selection from anywhere in the view (the banner's ✕
+        // also has the .escape shortcut for when it holds focus). See #217.
+        .onKeyPress(.escape) {
+            guard !selectedTrackIds.isEmpty else { return .ignored }
+            clearSelection()
+            return .handled
+        }
         .environment(
             \.libraryHoverID,
             LibraryHoverBinding(id: $hoverID, isActive: true)
@@ -122,6 +159,52 @@ struct LibraryView: View {
             if model.libraryTab != newValue {
                 model.libraryTab = newValue
             }
+            // Switching chips abandons any track multi-selection — the rows
+            // it referenced are no longer on screen. See #217.
+            clearSelection()
+        }
+    }
+
+    /// The selected tracks resolved against the currently-sorted list, in
+    /// display order. Used by the selection banner so its batch actions run
+    /// on the same ordering the user sees.
+    private var selectedTracks: [Track] {
+        guard !selectedTrackIds.isEmpty else { return [] }
+        return sortedTracks.filter { selectedTrackIds.contains($0.id) }
+    }
+
+    private func clearSelection() {
+        selectedTrackIds = []
+        anchorIndex = nil
+    }
+
+    /// Resolve a click on `index` within the sorted tracks list given the
+    /// modifier state. Cmd toggles the hit row; Shift extends a contiguous
+    /// range from the anchor; a bare click plays the row and resets the
+    /// selection. Mirrors `PlaylistDetailView.handleRowClick`. See #217.
+    private func handleTrackClick(index: Int, in tracks: [Track], modifiers: NSEvent.ModifierFlags) {
+        guard tracks.indices.contains(index) else { return }
+        let track = tracks[index]
+        if modifiers.contains(.command) {
+            if selectedTrackIds.contains(track.id) {
+                selectedTrackIds.remove(track.id)
+            } else {
+                selectedTrackIds.insert(track.id)
+            }
+            anchorIndex = index
+        } else if modifiers.contains(.shift) {
+            let from = anchorIndex ?? index
+            let range = from <= index ? from...index : index...from
+            var next = selectedTrackIds
+            for i in range where tracks.indices.contains(i) {
+                next.insert(tracks[i].id)
+            }
+            selectedTrackIds = next
+            anchorIndex = index
+        } else {
+            clearSelection()
+            anchorIndex = index
+            model.play(tracks: tracks, startIndex: index)
         }
     }
 
@@ -305,10 +388,19 @@ struct LibraryView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     LazyVStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(items.enumerated()), id: \.element.id) { idx, track in
-                            TrackListRow(track: track, tracks: items, index: idx)
-                                .onAppear {
-                                    triggerLoadMoreTracksIfNeeded(atIndex: idx)
-                                }
+                            TrackListRow(
+                                track: track,
+                                tracks: items,
+                                index: idx,
+                                isSelected: selectedTrackIds.contains(track.id),
+                                onSelect: { modifiers in
+                                    handleTrackClick(index: idx, in: items, modifiers: modifiers)
+                                },
+                                density: density
+                            )
+                            .onAppear {
+                                triggerLoadMoreTracksIfNeeded(atIndex: idx)
+                            }
                         }
                     }
                     if model.isLoadingMoreTracks {

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
@@ -78,6 +78,26 @@ enum AppearanceDensity: String, CaseIterable, Identifiable {
         case .compact: return "Compact"
         }
     }
+
+    /// Target row height for track lists, per the screen spec (#217): 48pt
+    /// roomy / 36pt compact. Row content sizes its artwork + vertical
+    /// padding off this so the two densities read distinctly without the
+    /// caller having to special-case anything.
+    var trackRowHeight: CGFloat {
+        switch self {
+        case .roomy: return 48
+        case .compact: return 36
+        }
+    }
+
+    /// Square artwork edge inside a track row. Shrinks in compact so the
+    /// row can hit the 36pt target without clipping.
+    var trackArtworkSize: CGFloat {
+        switch self {
+        case .roomy: return 40
+        case .compact: return 28
+        }
+    }
 }
 
 /// Sidebar visibility. UI-only today; the sidebar chrome lives in

--- a/macos/Tests/LyrebirdTests/TrackSelectionResolverTests.swift
+++ b/macos/Tests/LyrebirdTests/TrackSelectionResolverTests.swift
@@ -1,0 +1,134 @@
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// Pure-logic coverage for the Library Tracks tab multi-select state machine
+/// (#217). Exercises every branch of `TrackSelectionResolver.resolve` — the
+/// Cmd-toggle / Shift-range / bare-click-plays arithmetic that drives
+/// `LibraryView.handleTrackClick` — without a SwiftUI scene graph or an
+/// `AppModel`.
+final class TrackSelectionResolverTests: XCTestCase {
+	private let ids = ["a", "b", "c", "d", "e"]
+
+	// MARK: - Bare click
+
+	func testBareClickClearsSelectionAnchorsAndPlays() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 2,
+			trackIds: ids,
+			currentSelection: ["a", "b"],
+			anchorIndex: 0,
+			modifiers: []
+		)
+		XCTAssertEqual(outcome, .init(selection: [], anchorIndex: 2, shouldPlay: true))
+	}
+
+	// MARK: - Cmd toggle
+
+	func testCommandClickAddsRowWithoutPlaying() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 1,
+			trackIds: ids,
+			currentSelection: ["a"],
+			anchorIndex: 0,
+			modifiers: .command
+		)
+		XCTAssertEqual(outcome, .init(selection: ["a", "b"], anchorIndex: 1, shouldPlay: false))
+	}
+
+	func testCommandClickRemovesAlreadySelectedRow() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 1,
+			trackIds: ids,
+			currentSelection: ["a", "b"],
+			anchorIndex: 0,
+			modifiers: .command
+		)
+		XCTAssertEqual(outcome, .init(selection: ["a"], anchorIndex: 1, shouldPlay: false))
+	}
+
+	// MARK: - Shift range
+
+	func testShiftClickExtendsRangeForwardFromAnchor() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 3,
+			trackIds: ids,
+			currentSelection: ["a"],
+			anchorIndex: 1,
+			modifiers: .shift
+		)
+		// Anchor 1 (b) through 3 (d) inclusive, unioned with the prior "a".
+		XCTAssertEqual(outcome, .init(selection: ["a", "b", "c", "d"], anchorIndex: 3, shouldPlay: false))
+	}
+
+	func testShiftClickExtendsRangeBackwardFromAnchor() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 1,
+			trackIds: ids,
+			currentSelection: [],
+			anchorIndex: 3,
+			modifiers: .shift
+		)
+		XCTAssertEqual(outcome, .init(selection: ["b", "c", "d"], anchorIndex: 1, shouldPlay: false))
+	}
+
+	func testShiftClickWithoutAnchorSelectsOnlyHitRow() {
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 2,
+			trackIds: ids,
+			currentSelection: [],
+			anchorIndex: nil,
+			modifiers: .shift
+		)
+		XCTAssertEqual(outcome, .init(selection: ["c"], anchorIndex: 2, shouldPlay: false))
+	}
+
+	// MARK: - Guards & edge cases
+
+	func testOutOfBoundsIndexReturnsNil() {
+		XCTAssertNil(
+			TrackSelectionResolver.resolve(
+				clickedIndex: 99,
+				trackIds: ids,
+				currentSelection: ["a"],
+				anchorIndex: 0,
+				modifiers: []
+			)
+		)
+		XCTAssertNil(
+			TrackSelectionResolver.resolve(
+				clickedIndex: -1,
+				trackIds: ids,
+				currentSelection: [],
+				anchorIndex: nil,
+				modifiers: []
+			)
+		)
+	}
+
+	func testEmptyListReturnsNil() {
+		XCTAssertNil(
+			TrackSelectionResolver.resolve(
+				clickedIndex: 0,
+				trackIds: [],
+				currentSelection: [],
+				anchorIndex: nil,
+				modifiers: []
+			)
+		)
+	}
+
+	func testCommandTakesPrecedenceOverShiftWhenBothHeld() {
+		// AppKit reports both flags; the resolver checks `.command` first, so a
+		// Cmd+Shift click toggles a single row rather than extending a range.
+		let outcome = TrackSelectionResolver.resolve(
+			clickedIndex: 4,
+			trackIds: ids,
+			currentSelection: ["a"],
+			anchorIndex: 0,
+			modifiers: [.command, .shift]
+		)
+		XCTAssertEqual(outcome, .init(selection: ["a", "e"], anchorIndex: 4, shouldPlay: false))
+	}
+}


### PR DESCRIPTION
Wires the Library **Tracks** tab to the Appearance density preference and adds Cmd/Shift/Esc multi-selection with a bottom action banner so batch operations on tracks match the Apple Music / Spotify bar.

Closes #217

### What changed
- **Density** — `AppearanceDensity` now vends `trackRowHeight` (48pt roomy / 36pt compact) and `trackArtworkSize`; `TrackListRow` reads a `density` param (defaults to roomy so all other call sites are unaffected) and the Tracks tab binds it to `@AppStorage("appearance.density")`. Compact drops the artist subline to hit 36pt.
- **Multiselect** — `TrackListRow` gains an optional `onSelect` click router (only attaches gestures when non-nil, so single-select surfaces keep the play-on-tap `Button` + full a11y). `LibraryView` resolves Cmd-toggle / Shift-range / bare-click-plays exactly like `PlaylistDetailView`, and Esc clears.
- **Selection banner** — new `TrackSelectionBanner` slides in at the bottom: `"{n} selected — Play / Queue / Favorite / Add to playlist"`, routing through the existing selection-aware `AppModel` methods. `Remove` is gated behind an optional `onRemove` (nil in the library, since you can't remove from the whole catalog).

No FFI / Rust changes — all batch actions already existed on `AppModel`. The `xcframework` + bindings were regenerated locally only to build Swift; they stay gitignored.

pipeline:
- fixer-session: feat/217-tracklist-density-multiselect
- slice: components / macos
- hotspots-claimed: none
- build-gate: cargo fmt --check clean; cargo clippy -D warnings clean; swift build clean (FFI untouched)
- diff-stat: 4 files, +508 / -156 (1 new file: TrackSelectionBanner.swift)