### PR TITLE
macos: add Genres to Explore tiles to Discover (#250)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1446,22 +1446,28 @@ final class AppModel {
     /// marshals the ranked result back. Failures leave the prior grid intact
     /// rather than blanking the section mid-session.
     func refreshGenresToExplore() async {
-        let page = await Task.detached(priority: .userInitiated) { [core] in
-            // limit: 500 matches `resolvedGenreId`'s fetch — /MusicGenres sorts
-            // SortName ascending, so a smaller cap would silently drop
-            // alphabetically-late genres from the ranking pool (the test
-            // library has 254 genres).
-            try? core.genres(offset: 0, limit: 500)
-        }.value
-        guard let items = page?.items else { return }
-        // Project the FFI genres to plain tuples before ranking. Passing the
-        // `core.Genre` struct directly would force a `LyrebirdCore.Genre`
-        // annotation, which the generated `open class LyrebirdCore` shadows
-        // (module-vs-type name collision — same reason `resolvedGenreId`
-        // tuple-extracts). Tuples keep the ranking helper pure + testable.
-        self.genresToExplore = AppModel.rankGenresToExplore(
-            items.map { (id: $0.id, name: $0.name, songCount: $0.songCount) }
-        )
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                // limit: 500 matches `resolvedGenreId`'s fetch — /MusicGenres sorts
+                // SortName ascending, so a smaller cap would silently drop
+                // alphabetically-late genres from the ranking pool (the test
+                // library has 254 genres).
+                try core.genres(offset: 0, limit: 500)
+            }.value
+            // Project the FFI genres to plain tuples before ranking. Passing the
+            // `core.Genre` struct directly would force a `LyrebirdCore.Genre`
+            // annotation, which the generated `open class LyrebirdCore` shadows
+            // (module-vs-type name collision — same reason `resolvedGenreId`
+            // tuple-extracts). Tuples keep the ranking helper pure + testable.
+            self.genresToExplore = AppModel.rankGenresToExplore(
+                page.items.map { (id: $0.id, name: $0.name, songCount: $0.songCount) }
+            )
+        } catch {
+            // Auth expiry must surface so the user is routed to re-login, matching
+            // every other refresh path. Non-auth failures leave the prior grid
+            // intact rather than blanking the section mid-session.
+            _ = handleAuthError(error)
+        }
     }
 
     /// Pure ranking for the "Genres to Explore" grid (#250), split out from

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1447,7 +1447,11 @@ final class AppModel {
     /// rather than blanking the section mid-session.
     func refreshGenresToExplore() async {
         let page = await Task.detached(priority: .userInitiated) { [core] in
-            try? core.genres(offset: 0, limit: 200)
+            // limit: 500 matches `resolvedGenreId`'s fetch — /MusicGenres sorts
+            // SortName ascending, so a smaller cap would silently drop
+            // alphabetically-late genres from the ranking pool (the test
+            // library has 254 genres).
+            try? core.genres(offset: 0, limit: 500)
         }.value
         guard let items = page?.items else { return }
         // Project the FFI genres to plain tuples before ranking. Passing the

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -162,6 +162,16 @@ final class AppModel {
     /// follow-up on the core (no FFI exists yet; see `refreshForYou()` for
     /// the TODO).
     var forYou: [Track] = []
+    /// Genres surfaced in the Discover "Genres to Explore" grid (#250). A
+    /// 4×2 grid of up to 8 genres the user has explored the least, ranked by
+    /// ascending `song_count` — the smallest-but-present genres bubble up so
+    /// the surface nudges toward corners of the library the user hasn't dug
+    /// into. Carries the resolved Jellyfin UUID in `Genre.id` (sourced
+    /// straight from `core.genres`), so tapping a tile can navigate to the
+    /// genre detail screen without re-resolving the name. Empty until
+    /// `refreshGenresToExplore()` runs, and stays empty for a library with no
+    /// genres so the section can hide rather than punch a blank hole.
+    var genresToExplore: [Genre] = []
     /// Last-played albums for the Home "Jump Back In" carousel (#51). Up to
     /// 12 albums the user has played recently, sorted by `DatePlayed` desc.
     /// Backed by a raw `/Items` fetch because the core's `ItemsQuery`
@@ -920,6 +930,7 @@ final class AppModel {
         artistDetailCache = [:]
         recentlyPlayed = []
         forYou = []
+        genresToExplore = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -983,6 +994,7 @@ final class AppModel {
         artistDetailCache = [:]
         recentlyPlayed = []
         forYou = []
+        genresToExplore = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -1139,6 +1151,7 @@ final class AppModel {
         _ = await playlistsResult
         await refreshRecentlyPlayed()
         await refreshForYou()
+        await refreshGenresToExplore()
         // Home screen carousels (#49 / #51–#55). Kicked off after the main
         // library so first paint isn't blocked on these secondary shelves.
         // Each of these is best-effort — empty or errored rows just hide in
@@ -1416,6 +1429,56 @@ final class AppModel {
         // fetched. Capped at 20 so the carousel stays tight even if the core
         // later starts returning a longer list.
         self.forYou = Array(recentlyPlayed.prefix(20))
+    }
+
+    /// Refresh the Discover "Genres to Explore" grid (#250).
+    ///
+    /// Pulls one page of `/MusicGenres` (already filtered server-side to
+    /// genres that carry Audio/Album/Artist items), keeps only those present
+    /// in the library (`song_count > 0`), then ranks them so the *least*
+    /// explored bubble to the top. Jellyfin's `/MusicGenres` projection
+    /// carries no per-genre play count, so we approximate "least-played" with
+    /// ascending `song_count` (the smallest real genres are the ones a user
+    /// is least likely to have worked through), tie-broken by name for a
+    /// stable order. Capped at 8 to fill the 4×2 grid.
+    ///
+    /// Runs the sync `core.genres` FFI off the MainActor (gap pattern #2) and
+    /// marshals the ranked result back. Failures leave the prior grid intact
+    /// rather than blanking the section mid-session.
+    func refreshGenresToExplore() async {
+        let page = await Task.detached(priority: .userInitiated) { [core] in
+            try? core.genres(offset: 0, limit: 200)
+        }.value
+        guard let items = page?.items else { return }
+        // Project the FFI genres to plain tuples before ranking. Passing the
+        // `core.Genre` struct directly would force a `LyrebirdCore.Genre`
+        // annotation, which the generated `open class LyrebirdCore` shadows
+        // (module-vs-type name collision — same reason `resolvedGenreId`
+        // tuple-extracts). Tuples keep the ranking helper pure + testable.
+        self.genresToExplore = AppModel.rankGenresToExplore(
+            items.map { (id: $0.id, name: $0.name, songCount: $0.songCount) }
+        )
+    }
+
+    /// Pure ranking for the "Genres to Explore" grid (#250), split out from
+    /// the FFI hop so it's unit-testable without a live core. Keeps only
+    /// genres present in the library (`song_count > 0`), ranks ascending by
+    /// `song_count` (least-explored first) with a case-insensitive name
+    /// tiebreaker for stable order, caps at 8 for the 4×2 grid, and carries
+    /// the resolved Jellyfin UUID through into the local `Genre.id`.
+    static func rankGenresToExplore(
+        _ genres: [(id: String, name: String, songCount: UInt32)]
+    ) -> [Genre] {
+        Array(
+            genres
+                .filter { $0.songCount > 0 }
+                .sorted {
+                    if $0.songCount != $1.songCount { return $0.songCount < $1.songCount }
+                    return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+                .prefix(8)
+                .map { Genre(id: $0.id, name: $0.name) }
+        )
     }
 
     // MARK: - Home carousels (#49 / #51–#55)

--- a/macos/Sources/Lyrebird/Components/GenresToExploreSection.swift
+++ b/macos/Sources/Lyrebird/Components/GenresToExploreSection.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+/// Discover "Genres to Explore" grid (#250).
+///
+/// A 4×2 grid of large (120pt-tall) `GenreExploreTile`s ranked by
+/// `AppModel.refreshGenresToExplore()` — the least-explored genres present in
+/// the library bubble to the top. Each tile carries a genre whose `id` is the
+/// resolved Jellyfin UUID (sourced from `core.genres`), so tapping navigates
+/// straight to the genre detail screen without a name→UUID round-trip.
+///
+/// Hidden entirely when there are no genres so a brand-new / genre-less
+/// library doesn't render an empty band. Uses a fixed-column `LazyVGrid`
+/// (vertical, not a horizontal `LazyHStack`) so it's clear of the rc9 macOS
+/// 26.4 `LazyHStack`-in-horizontal-`ScrollView` UAF.
+struct GenresToExploreSection: View {
+    @Environment(AppModel.self) private var model
+
+    /// Four flexible columns → the ranked 8 genres lay out as 4×2.
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: 16, alignment: .top),
+        count: 4
+    )
+
+    var body: some View {
+        if !model.genresToExplore.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "square.grid.2x2")
+                        .foregroundStyle(Theme.teal)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Genres to Explore")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("Corners of your library you have barely touched")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(model.genresToExplore, id: \.id) { genre in
+                        GenreExploreTile(genre: genre) {
+                            model.navigate(to: .genre(genre))
+                        }
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Genres to Explore")
+        }
+    }
+}
+
+/// One large genre tile for the Discover grid. Bigger than the search-dropdown
+/// chip: a 120pt-tall card with a deterministic per-genre gradient so the grid
+/// reads as a colorful mosaic rather than a wall of identical chips.
+private struct GenreExploreTile: View {
+    let genre: Genre
+    let onOpen: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: onOpen) {
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(gradient)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.white.opacity(isHovering ? 0.35 : 0.12), lineWidth: 1)
+                Text(genre.name)
+                    .font(Theme.font(17, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+                    .padding(14)
+            }
+            .frame(height: 120)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .scaleEffect(reduceMotion ? 1 : (isHovering ? 1.03 : 1))
+            .shadow(
+                color: seedColor.opacity(isHovering ? 0.45 : 0.25),
+                radius: isHovering ? 14 : 8,
+                y: isHovering ? 8 : 4
+            )
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .help("Browse \(genre.name)")
+        .accessibilityLabel("Explore \(genre.name)")
+        .accessibilityHint("Opens the \(genre.name) genre")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Deterministic base hue derived from the genre name so the same genre
+    /// always lands on the same color across launches. Stable, well-spread
+    /// hashing via a small FNV-1a over the name's unicode scalars.
+    private var seedColor: Color {
+        var hash: UInt32 = 2_166_136_261
+        for scalar in genre.name.unicodeScalars {
+            hash = (hash ^ scalar.value) &* 16_777_619
+        }
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.55, brightness: 0.62)
+    }
+
+    /// Diagonal wash from the seed color into a darker shade of itself so the
+    /// white label stays legible at the bottom-left.
+    private var gradient: LinearGradient {
+        var hash: UInt32 = 2_166_136_261
+        for scalar in genre.name.unicodeScalars {
+            hash = (hash ^ scalar.value) &* 16_777_619
+        }
+        let hue = Double(hash % 360) / 360.0
+        return LinearGradient(
+            colors: [
+                Color(hue: hue, saturation: 0.62, brightness: 0.66),
+                Color(hue: hue, saturation: 0.70, brightness: 0.34),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Discover — the "find something new" surface. Today: a header + Instant Mix
-/// CTA (#248) and a horizontal "For You" carousel (#249). Richer
-/// recommendations (recently added, more like this, genre tiles, etc.) land
-/// in follow-ups.
+/// CTA (#248), a horizontal "For You" carousel (#249), and a "Genres to
+/// Explore" grid (#250). Richer recommendations (recently added, more like
+/// this, etc.) land in follow-ups.
 ///
 /// Title is italic 34pt, subline 14pt `ink2`, right-aligned primary "Start
 /// Instant Mix" + ghost "Generate new mix" — per `06-screen-specs.md`.
@@ -15,6 +15,7 @@ struct DiscoverView: View {
             VStack(alignment: .leading, spacing: 28) {
                 header
                 forYouSection
+                GenresToExploreSection()
                 Spacer(minLength: 24)
             }
             .padding(.horizontal, 32)
@@ -22,6 +23,15 @@ struct DiscoverView: View {
             .padding(.bottom, 32)
         }
         .background(backgroundWash)
+        // Best-effort refresh of the "Genres to Explore" grid (#250) so the
+        // tiles populate even if the user reaches Discover before the
+        // post-login bootstrap got to it. Cheap (one cached /MusicGenres
+        // page) and idempotent.
+        .task {
+            if model.genresToExplore.isEmpty {
+                await model.refreshGenresToExplore()
+            }
+        }
     }
 
     /// The "For You" recommendations carousel (#249). Today this mirrors

--- a/macos/Tests/LyrebirdTests/GenresToExploreRankingTests.swift
+++ b/macos/Tests/LyrebirdTests/GenresToExploreRankingTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Discover "Genres to Explore" ranking (#250).
+///
+/// `AppModel.rankGenresToExplore` is the pure half of `refreshGenresToExplore`,
+/// split out from the FFI hop so the ranking contract can be asserted without a
+/// live core: drop empty genres, rank least-explored (ascending `song_count`)
+/// first with a name tiebreaker, cap at 8, and carry the resolved Jellyfin UUID
+/// through to the local `Genre.id`.
+@MainActor
+final class GenresToExploreRankingTests: XCTestCase {
+
+    private func genre(
+        _ name: String,
+        songs: UInt32,
+        id: String? = nil
+    ) -> (id: String, name: String, songCount: UInt32) {
+        (id: id ?? "id-\(name)", name: name, songCount: songs)
+    }
+
+    func testRanksLeastPlayedFirst() {
+        let ranked = AppModel.rankGenresToExplore([
+            genre("Pop", songs: 500),
+            genre("Jazz", songs: 12),
+            genre("Ambient", songs: 3),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Ambient", "Jazz", "Pop"])
+    }
+
+    func testDropsGenresWithNoSongs() {
+        let ranked = AppModel.rankGenresToExplore([
+            genre("Empty", songs: 0),
+            genre("Real", songs: 4),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Real"])
+    }
+
+    func testTieBrokenByCaseInsensitiveName() {
+        let ranked = AppModel.rankGenresToExplore([
+            genre("blues", songs: 7),
+            genre("Ambient", songs: 7),
+            genre("Country", songs: 7),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Ambient", "blues", "Country"])
+    }
+
+    func testCapsAtEightForTheGrid() {
+        let many = (1...20).map { genre("G\($0)", songs: UInt32($0)) }
+        let ranked = AppModel.rankGenresToExplore(many)
+        XCTAssertEqual(ranked.count, 8)
+        // Least-explored eight, in ascending order.
+        XCTAssertEqual(ranked.first?.name, "G1")
+        XCTAssertEqual(ranked.last?.name, "G8")
+    }
+
+    func testCarriesResolvedUuidIntoId() {
+        let ranked = AppModel.rankGenresToExplore([
+            genre("Soul", songs: 5, id: "uuid-soul-123")
+        ])
+        XCTAssertEqual(ranked.first?.id, "uuid-soul-123")
+    }
+}


### PR DESCRIPTION
Surfaces a 4×2 grid of large genre tiles on Discover ranked by least-explored so users get nudged toward corners of their library they have barely touched.

Closes #250

- New `GenresToExploreSection` renders up to 8 genres in a fixed-column `LazyVGrid` (avoids the rc9 `LazyHStack` UAF), 120pt-tall tiles with deterministic per-genre gradients; the section hides entirely when there are no genres.
- `AppModel.refreshGenresToExplore()` runs the `core.genres` FFI off the `MainActor` (gap pattern #2) and leaves the prior grid intact on failure rather than blanking.
- `AppModel.rankGenresToExplore` is a pure, unit-tested helper: drops empty genres, ranks ascending `song_count`, case-insensitive name tiebreaker, caps at 8, and carries the resolved Jellyfin UUID into `Genre.id` so tapping navigates without a name→UUID round-trip.
- Wired into the post-login bootstrap and a best-effort `.task` refresh on `DiscoverView`.

pipeline:
- fixer-session: feat/250-genres-explore-tiles
- slice: screens
- hotspots-claimed: none
- build-gate: pass (swift build; swift test --filter GenresToExploreRankingTests → 5/5; no Rust/FFI change)
- diff-stat: 4 files, +265 / -3