### PR TITLE
macos: add full-page Play Queue view (Cmd+U)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -48,6 +48,7 @@ final class AppModel {
         case playlist(String)
         case genre(Genre)
         case nowPlaying
+        case fullQueue
     }
 
     /// Drill stack for the current tab. Empty when the user is on the root
@@ -72,6 +73,14 @@ final class AppModel {
     /// the second press pops back rather than stacking another copy.
     var isShowingNowPlaying: Bool {
         navPath.last == .nowPlaying
+    }
+
+    /// True when the full-page Play Queue view is the top of the drill
+    /// stack. Used by the ⌘U menu toggle (see `LyrebirdApp.toggleFullQueue`)
+    /// so the second press pops back rather than stacking another copy. See
+    /// #81.
+    var isShowingFullQueue: Bool {
+        navPath.last == .fullQueue
     }
 
     /// Which chip is active on the Library screen. Driven by the sidebar's
@@ -384,6 +393,20 @@ final class AppModel {
     /// Show / hide the right-side queue inspector panel. Toggled by the
     /// Cmd+Opt+Q shortcut (#79).
     var isQueueInspectorOpen: Bool = false
+
+    /// Tracks played earlier in *this app session*, most-recent first. The
+    /// full-page Play Queue view (⌘U, #81) renders this above Now Playing as
+    /// a "Recently in this session" block so the user can re-queue something
+    /// they just heard. Distinct from `recentlyPlayed`, which is the server's
+    /// cross-device listening history — this is purely in-memory and resets
+    /// on sign-out. Capped at `sessionPlayHistoryLimit`; populated by the
+    /// status-poll track-change hook in `startPolling`.
+    var sessionPlayHistory: [Track] = []
+
+    /// Hard cap on `sessionPlayHistory`. The acceptance criteria call for the
+    /// last 50 played tracks; trimming on every append keeps the array (and
+    /// the view that renders it) bounded regardless of session length.
+    private let sessionPlayHistoryLimit = 50
 
     /// Contributors on the currently-playing track, sourced from Jellyfin's
     /// `Item.People` field. Populated by `fetchCurrentTrackDetails()` on
@@ -956,6 +979,7 @@ final class AppModel {
         currentTrackPeopleForId = nil
         currentLyrics = nil
         currentLyricsForId = nil
+        sessionPlayHistory = []
         resetPaginationState()
         stopPolling()
     }
@@ -1020,6 +1044,7 @@ final class AppModel {
         currentTrackPeopleForId = nil
         currentLyrics = nil
         currentLyricsForId = nil
+        sessionPlayHistory = []
         resetPaginationState()
         stopPolling()
     }
@@ -4894,7 +4919,8 @@ final class AppModel {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
-                let before = self.status.currentTrack?.id
+                let beforeTrack = self.status.currentTrack
+                let before = beforeTrack?.id
                 let beforeQueuePos = self.status.queuePosition
                 let beforeQueueLen = self.status.queueLength
                 self.status = self.core.status()
@@ -4904,6 +4930,13 @@ final class AppModel {
                 // media keys, or end-of-track auto-advance all get it
                 // for free.
                 if before != after {
+                    // Record the track we just left onto the in-session
+                    // history (#81). Only push real outgoing tracks — a
+                    // start-from-stopped transition (before == nil) has
+                    // nothing to record.
+                    if let outgoing = beforeTrack {
+                        self.recordSessionPlay(outgoing)
+                    }
                     if after == nil {
                         self.currentTrackPeople = []
                         self.currentTrackPeopleForId = nil
@@ -4947,6 +4980,32 @@ final class AppModel {
     /// keyboard shortcut via `MainShell`. See #79.
     func toggleQueueInspector() {
         isQueueInspectorOpen.toggle()
+    }
+
+    /// Push a track onto the in-session play history, most-recent first
+    /// (#81). De-duplicates against the current head so a track that loops
+    /// (e.g. repeat-one) doesn't flood the list with consecutive copies, and
+    /// trims to `sessionPlayHistoryLimit`. Called from the status-poll
+    /// track-change hook with the *outgoing* track.
+    func recordSessionPlay(_ track: Track) {
+        if sessionPlayHistory.first?.id == track.id { return }
+        sessionPlayHistory.insert(track, at: 0)
+        if sessionPlayHistory.count > sessionPlayHistoryLimit {
+            sessionPlayHistory.removeLast(sessionPlayHistory.count - sessionPlayHistoryLimit)
+        }
+    }
+
+    /// Toggle behaviour for the full-page Play Queue view (⌘U, #81): first
+    /// press pushes the queue page onto the drill stack, second press pops
+    /// it. Mirrors `LyrebirdApp.toggleNowPlaying` so either gesture (menu or
+    /// shortcut) behaves the same. Kept here so the ⌘U command and any future
+    /// in-app entry point (PlayerBar button) share one code path.
+    func toggleFullQueue() {
+        if isShowingFullQueue {
+            navPath.removeLast()
+        } else {
+            navPath.append(Route.fullQueue)
+        }
     }
 
     /// Reorder the user-added "Up Next" list. Uses the same `IndexSet` → Int

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -261,6 +261,15 @@ struct LyrebirdCommands: Commands {
             .keyboardShortcut("l", modifiers: .command)
             .disabled(model.session == nil)
 
+            // ⌘U opens the full-page Play Queue view and toggles back when
+            // pressed again (same reversible-drill feel as ⌘L Now Playing).
+            // See #81.
+            Button("menu.nav.play_queue") {
+                model.toggleFullQueue()
+            }
+            .keyboardShortcut("u", modifiers: .command)
+            .disabled(model.session == nil)
+
             // Command Palette (#305). Full-screen ⌘K overlay with library
             // search + static action verbs. Toggling the flag here and
             // letting `RootView` mount the overlay keeps the palette

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -757,6 +757,18 @@
         }
       }
     },
+    "menu.nav.play_queue" : {
+      "comment" : "View menu item: \"Play Queue\" (\u2318U) \u2014 opens the full-page Play Queue view.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play Queue"
+          }
+        }
+      }
+    },
     "menu.nav.command_palette" : {
       "comment" : "View menu item that opens the \u2318K Command Palette.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/FullQueueView.swift
+++ b/macos/Sources/Lyrebird/Screens/FullQueueView.swift
@@ -1,0 +1,390 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Full-page Play Queue view (⌘U, #81). A larger-format counterpart to the
+/// 320pt `QueueInspector` drawer, suited to bulk review of what's coming and
+/// what just played. Pushed onto `navPath` as `Route.fullQueue` and rendered
+/// by `MainShell`; ⌘U toggles it via `AppModel.toggleFullQueue`.
+///
+/// Layout (top → bottom):
+///   1. **Header** — title + "Save Queue as Playlist" action.
+///   2. **Recently in this session** — up to 50 tracks played earlier in
+///      *this app session* (newest first), drawn from `sessionPlayHistory`.
+///      Matches Spotify's "history above the now-playing line" affordance so
+///      the user can re-queue something they just heard.
+///   3. **Now Playing** — the currently-playing track.
+///   4. **Up Next** — the user-added queue (`upNextUserAdded`).
+///   5. **Playing From {source}** — the auto-queue tail (`upNextAutoQueue`).
+///
+/// Reorder / drag affordances stay in the inspector (#80); this page is a
+/// read-and-bulk-act surface, so rows are click-to-play with a context menu
+/// rather than draggable. "Save Queue as Playlist" reuses the same
+/// `AppModel.saveQueueAsPlaylist(name:)` path the inspector's Save uses, so
+/// error surfacing + the older-server top-up behaviour come for free.
+struct FullQueueView: View {
+    @Environment(AppModel.self) private var model
+
+    @State private var showSaveSheet = false
+    @State private var saveDraftName = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                header
+                if !model.sessionPlayHistory.isEmpty {
+                    sessionHistorySection
+                }
+                nowPlayingSection
+                upNextSection
+                playingFromSection
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 24)
+            .frame(maxWidth: 920, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.bg)
+        // Save-queue sheet. Mirrors the inspector's flow so the two Save
+        // entry points behave identically. Kept local to this view — the
+        // shared work is `saveQueueAsPlaylist(name:)` on the model.
+        .sheet(isPresented: $showSaveSheet, onDismiss: { saveDraftName = "" }) {
+            FullQueueSaveSheet(
+                name: $saveDraftName,
+                trackCount: saveTrackCount,
+                onCancel: { showSaveSheet = false },
+                onSave: {
+                    let trimmed = saveDraftName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    showSaveSheet = false
+                    Task { await model.saveQueueAsPlaylist(name: trimmed) }
+                }
+            )
+            .environment(model)
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Play Queue")
+                    .font(Theme.font(28, weight: .black))
+                    .foregroundStyle(Theme.ink)
+                Text(queueSummary)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+            }
+            Spacer()
+            Button(action: beginSave) {
+                HStack(spacing: 6) {
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Save Queue as Playlist")
+                        .font(Theme.font(12, weight: .semibold))
+                }
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Theme.surface))
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.border, lineWidth: 1))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(saveTrackCount == 0)
+            .accessibilityLabel("Save Queue as Playlist")
+            .accessibilityHint("Creates a new playlist from the current queue")
+        }
+    }
+
+    /// One-line summary of the queue size, e.g. "12 up next · 8 played this
+    /// session". Reads as a stable status line under the title.
+    private var queueSummary: String {
+        let upcoming = model.upNextUserAdded.count + model.upNextAutoQueue.count
+        let played = model.sessionPlayHistory.count
+        var parts: [String] = []
+        parts.append("\(upcoming) up next")
+        if played > 0 { parts.append("\(played) played this session") }
+        return parts.joined(separator: " \u{00B7} ")
+    }
+
+    // MARK: - Recently in this session (#81)
+
+    @ViewBuilder
+    private var sessionHistorySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Recently in this session")
+            VStack(spacing: 2) {
+                ForEach(Array(model.sessionPlayHistory.enumerated()), id: \.offset) { _, track in
+                    FullQueueTrackRow(track: track, queue: model.sessionPlayHistory)
+                }
+            }
+        }
+    }
+
+    // MARK: - Now Playing
+
+    @ViewBuilder
+    private var nowPlayingSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Now Playing")
+            if let track = model.status.currentTrack {
+                FullQueueTrackRow(track: track, queue: [track])
+            } else {
+                emptyRow("Nothing is playing.")
+            }
+        }
+    }
+
+    // MARK: - Up Next
+
+    @ViewBuilder
+    private var upNextSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Up Next")
+            if model.upNextUserAdded.isEmpty {
+                emptyRow("Nothing queued. Use \u{2318}-click \u{2192} Play Next on a track.")
+            } else {
+                VStack(spacing: 2) {
+                    ForEach(model.upNextUserAdded) { entry in
+                        FullQueueTrackRow(
+                            track: entry.track,
+                            queue: model.upNextUserAdded.map(\.track)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Playing From
+
+    @ViewBuilder
+    private var playingFromSection: some View {
+        if !model.upNextAutoQueue.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionHeader(playingFromTitle)
+                VStack(spacing: 2) {
+                    ForEach(model.upNextAutoQueue) { entry in
+                        FullQueueTrackRow(
+                            track: entry.track,
+                            queue: model.upNextAutoQueue.map(\.track)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var playingFromTitle: String {
+        if let name = model.currentContext?.name, !name.isEmpty {
+            return "Playing From \(name)"
+        }
+        return "Playing From Queue"
+    }
+
+    // MARK: - Actions
+
+    /// Number of tracks the Save action would write: current + user-added +
+    /// auto tail. Drives the disabled state and the sheet's count copy.
+    /// History is intentionally excluded — Save persists what's queued, not
+    /// what already played, matching the inspector's Save semantics.
+    private var saveTrackCount: Int {
+        let current = model.status.currentTrack == nil ? 0 : 1
+        return current + model.upNextUserAdded.count + model.upNextAutoQueue.count
+    }
+
+    private func beginSave() {
+        saveDraftName = defaultPlaylistName()
+        showSaveSheet = true
+    }
+
+    private func defaultPlaylistName() -> String {
+        if let name = model.currentContext?.name, !name.isEmpty {
+            return "\(name) + Up Next"
+        }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return "Queue \(formatter.string(from: Date()))"
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(Theme.font(11, weight: .bold))
+            .foregroundStyle(Theme.ink2)
+            .tracking(1.5)
+            .textCase(.uppercase)
+    }
+
+    @ViewBuilder
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .font(Theme.font(12, weight: .medium))
+            .foregroundStyle(Theme.ink3)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Row
+
+/// One track row in the full-page queue. Click plays the track in the
+/// context of its surrounding list (`queue`) so auto-advance continues
+/// naturally — the same contract `TopTrackRow` uses. Right-click surfaces
+/// the shared `TrackContextMenu` (Play Next / Add to Queue / favorite / …).
+private struct FullQueueTrackRow: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let track: Track
+    /// The list this row belongs to, passed to `play(tracks:startIndex:)` so
+    /// playback continues through the rest of the section.
+    let queue: [Track]
+
+    @State private var isHovering = false
+
+    private var isActive: Bool {
+        model.status.currentTrack?.id == track.id
+    }
+    private var isPlaying: Bool {
+        isActive && model.status.state == .playing
+    }
+
+    var body: some View {
+        Button(action: playFromHere) {
+            HStack(spacing: 12) {
+                ZStack {
+                    if isPlaying {
+                        EqualizerIcon()
+                            .foregroundStyle(Theme.accent)
+                    } else if isHovering {
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Theme.ink)
+                    } else {
+                        Artwork(
+                            url: model.imageURL(
+                                for: track.albumId ?? track.id,
+                                tag: track.imageTag,
+                                maxWidth: 120
+                            ),
+                            seed: track.albumName ?? track.name,
+                            size: 40,
+                            radius: 4
+                        )
+                        .frame(width: 40, height: 40)
+                    }
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(track.name)
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .lineLimit(1)
+                    Text(track.artistName)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                if let album = track.albumName, !album.isEmpty {
+                    Text(album)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .lineLimit(1)
+                        .frame(maxWidth: 220, alignment: .trailing)
+                }
+
+                Text(track.durationFormatted)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .monospacedDigit()
+                    .frame(minWidth: 42, alignment: .trailing)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.rowHover : .clear))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if reduceMotion {
+                isHovering = hovering
+            } else {
+                withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+            }
+        }
+        .contextMenu { TrackContextMenu(selection: [track]) }
+        .focusable(true)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(track.name) by \(track.artistName)")
+        .accessibilityHint("Plays this track")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Start playback at this row, handing the surrounding list to
+    /// `play(tracks:startIndex:)` so the rest of the section queues up.
+    private func playFromHere() {
+        guard let idx = queue.firstIndex(where: { $0.id == track.id }) else {
+            model.play(tracks: [track], startIndex: 0)
+            return
+        }
+        model.play(tracks: queue, startIndex: idx)
+    }
+}
+
+// MARK: - Save sheet
+
+/// Name-and-save sheet for the full-page queue. Functionally identical to
+/// the inspector's `SaveQueueSheet`, kept private here so the full-page view
+/// stays self-contained; both call `AppModel.saveQueueAsPlaylist(name:)`.
+private struct FullQueueSaveSheet: View {
+    @Binding var name: String
+    let trackCount: Int
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Save queue as playlist")
+                    .font(Theme.font(15, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                Text("Creates a new playlist with \(trackCount) \(trackCount == 1 ? "track" : "tracks").")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+            }
+
+            TextField("Playlist name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .font(Theme.font(12, weight: .medium))
+                .focused($focused)
+                .onSubmit { onSave() }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Save", action: onSave)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .onAppear { focused = true }
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -264,6 +264,8 @@ struct MainShell: View {
             GenreDetailView(genre: g)
         case .nowPlaying:
             NowPlayingView()
+        case .fullQueue:
+            FullQueueView()
         }
     }
 
@@ -393,6 +395,8 @@ struct MainShell: View {
             segments.append(g.name)
         case .nowPlaying?:
             segments.append("Now Playing")
+        case .fullQueue?:
+            segments.append("Play Queue")
         case .home?, .discover?, .library?, .favorites?, .search?, .settings?, nil:
             break
         }

--- a/macos/Sources/Lyrebird/System/AppShortcuts.swift
+++ b/macos/Sources/Lyrebird/System/AppShortcuts.swift
@@ -92,6 +92,8 @@ enum AppShortcuts {
 		         section: .view, key: "f", modifiers: .command),
 		Shortcut(id: "nav.now_playing", nameKeyString: "menu.nav.now_playing",
 		         section: .view, key: "l", modifiers: .command),
+		Shortcut(id: "nav.play_queue", nameKeyString: "menu.nav.play_queue",
+		         section: .view, key: "u", modifiers: .command),
 		Shortcut(id: "nav.command_palette", nameKeyString: "menu.nav.command_palette",
 		         section: .view, key: "k", modifiers: .command),
 		Shortcut(id: "view.mini_player", nameKeyString: "menu.view.mini_player",

--- a/macos/Tests/LyrebirdTests/SessionPlayHistoryTests.swift
+++ b/macos/Tests/LyrebirdTests/SessionPlayHistoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import LyrebirdCore
+
+@testable import Lyrebird
+
+/// Coverage for `AppModel.recordSessionPlay`, which backs the full Play Queue
+/// view's recent-history section (#81). Two invariants from the acceptance
+/// criteria: consecutive duplicates collapse, and the list is capped at 50
+/// entries (newest first).
+///
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore`; we redirect the
+/// core data dir to a throwaway temp dir via `XDG_DATA_HOME` so tests never
+/// touch the real database (mirrors `MiniPlayerStateTests`).
+@MainActor
+final class SessionPlayHistoryTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    func testInsertsNewestFirst() throws {
+        let model = try AppModel()
+        model.recordSessionPlay(makeTrack("a"))
+        model.recordSessionPlay(makeTrack("b"))
+        XCTAssertEqual(model.sessionPlayHistory.map(\.id), ["b", "a"])
+    }
+
+    func testConsecutiveDuplicateIsCollapsed() throws {
+        let model = try AppModel()
+        model.recordSessionPlay(makeTrack("a"))
+        model.recordSessionPlay(makeTrack("a"))
+        XCTAssertEqual(model.sessionPlayHistory.map(\.id), ["a"])
+    }
+
+    func testNonConsecutiveRepeatIsKept() throws {
+        let model = try AppModel()
+        model.recordSessionPlay(makeTrack("a"))
+        model.recordSessionPlay(makeTrack("b"))
+        model.recordSessionPlay(makeTrack("a"))
+        XCTAssertEqual(model.sessionPlayHistory.map(\.id), ["a", "b", "a"])
+    }
+
+    func testCapsAtFiftyKeepingMostRecent() throws {
+        let model = try AppModel()
+        for i in 0..<60 {
+            model.recordSessionPlay(makeTrack("t\(i)"))
+        }
+        XCTAssertEqual(model.sessionPlayHistory.count, 50)
+        XCTAssertEqual(model.sessionPlayHistory.first?.id, "t59", "newest retained at head")
+        XCTAssertEqual(model.sessionPlayHistory.last?.id, "t10", "oldest beyond the cap dropped")
+    }
+}


### PR DESCRIPTION
Adds a dedicated full-page Play Queue surface (Cmd+U) so the user can bulk-review history and what's coming in a larger format than the 320pt inspector drawer.

Closes #81

The page renders, top to bottom: a header with a "Save Queue as Playlist" action, "Recently in this session" (up to the last 50 tracks played this session, newest first), Now Playing, Up Next (user-added), and the "Playing From" auto-queue tail. Cmd+U toggles the page on/off via `AppModel.toggleFullQueue` (mirrors the `Cmd+L` Now Playing drill). Session history is purely in-memory, recorded from the existing status-poll track-change hook (no new sync FFI on the MainActor), capped at 50, and cleared on sign-out/disconnect. Save reuses the inspector's `saveQueueAsPlaylist(name:)` path so error surfacing comes for free.

pipeline:
- fixer-session: feature-builder-81
- slice: screens
- hotspots-claimed: none
- build-gate: pass (`cargo fmt --check`; `./macos/Scripts/build-core.sh`; `cd macos && swift build` — clean, only benign linker macOS-version warnings)
- diff-stat: 6 files changed, 477 insertions(+), 1 deletion(-)