### PR TITLE
macos: inline lyrics snippet in Now Playing queue inspector

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -407,6 +407,14 @@ final class AppModel {
     /// `currentTrackPeopleForId`.
     private var currentLyricsForId: String?
 
+    /// One-shot request to land the Now Playing view on a specific tab when
+    /// it next appears. Set by `openLyrics()` (the inline lyrics snippet's
+    /// "open full lyrics" tap) and consumed — then cleared — by
+    /// `NowPlayingView.onAppear`. `nil` means "use the default tab". Kept as
+    /// a raw string rather than the view-local `Tab` enum so AppModel doesn't
+    /// take a dependency on a screen type. See #91.
+    var requestedNowPlayingTab: String?
+
     /// In-flight debounced VoiceOver track-change announcement (#342).
     /// Stored so a rapid next / next / next collapses to a single
     /// announcement: each call cancels the previous pending task before the
@@ -2794,6 +2802,19 @@ final class AppModel {
     /// and the command palette.
     func navigate(to route: Route) {
         navPath.append(route)
+    }
+
+    /// Open the full Now Playing view on its Lyrics tab. Wired to the inline
+    /// lyrics snippet in the Queue Inspector (#91) — tapping the snippet
+    /// promotes the compact 3-line preview to the full-screen synced lyrics.
+    /// Sets a one-shot `requestedNowPlayingTab` that `NowPlayingView` reads
+    /// and clears on appear, then pushes the route (or no-ops the push if
+    /// Now Playing is already on top so a second tap doesn't stack a copy).
+    func openLyrics() {
+        requestedNowPlayingTab = "Lyrics"
+        if !isShowingNowPlaying {
+            navigate(to: .nowPlaying)
+        }
     }
 
     /// Navigate to the Discover screen. See #248.

--- a/macos/Sources/Lyrebird/Components/InlineLyricsSnippet.swift
+++ b/macos/Sources/Lyrebird/Components/InlineLyricsSnippet.swift
@@ -72,9 +72,12 @@ struct InlineLyricsSnippet: View {
         .accessibilityHint("Opens the full lyrics view")
         .accessibilityAddTraits(.isButton)
         .onAppear { updateActiveLine() }
-        // 0.5s cadence (see type doc). Skip the recompute work when nothing
-        // is playing — a paused inspector shouldn't keep re-scanning.
+        // 0.5s cadence (see type doc). Skip the recompute while paused — a
+        // paused inspector's position is static, so the active line can't move.
+        // onAppear / onChange still re-anchor on visibility or track change so a
+        // paused track shows the right line.
         .onReceive(Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()) { _ in
+            guard model.status.state == .playing else { return }
             updateActiveLine()
         }
         // Re-anchor when the track changes (currentLyrics swaps wholesale).
@@ -129,12 +132,17 @@ struct InlineLyricsSnippet: View {
     /// timestamp-ordered lines; mutates `activeIndex` only on change so most
     /// ticks are no-ops.
     private func updateActiveLine() {
-        let lines = timedLines
-        guard !lines.isEmpty else {
-            if activeIndex != nil { activeIndex = nil }
-            return
+        let newActive = Self.activeLineIndex(in: timedLines, at: model.status.positionSeconds)
+        if newActive != activeIndex {
+            activeIndex = newActive
         }
-        let now = model.status.positionSeconds
+    }
+
+    /// Index of the line whose timestamp is the most recent at or before `now`,
+    /// or `nil` before the first timestamp. Lines are timestamp-ordered, so the
+    /// scan stops at the first cue in the future; lines without a timestamp are
+    /// skipped (they render but never auto-highlight).
+    static func activeLineIndex(in lines: [LyricLine], at now: Double) -> Int? {
         var newActive: Int? = nil
         for (idx, line) in lines.enumerated() {
             guard let ts = line.timestamp else { continue }
@@ -144,9 +152,7 @@ struct InlineLyricsSnippet: View {
                 break
             }
         }
-        if newActive != activeIndex {
-            activeIndex = newActive
-        }
+        return newActive
     }
 
     private func accessibilityLabel(for lines: [LyricLine]) -> String {

--- a/macos/Sources/Lyrebird/Components/InlineLyricsSnippet.swift
+++ b/macos/Sources/Lyrebird/Components/InlineLyricsSnippet.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+/// Compact, synced 3-line lyrics preview for the Queue Inspector (#91).
+///
+/// Sits below the Now Playing card and shows the previous, current
+/// (highlighted), and next lyric line so users who don't want the
+/// full-screen takeover still get a glanceable, in-sync read. Tapping it
+/// promotes to the full Lyrics tab via `AppModel.openLyrics()`.
+///
+/// Data + sync contract:
+///   * Reads `AppModel.currentLyrics` — the same parsed `[LyricLine]` the
+///     full `LyricsView` consumes, populated by `fetchCurrentTrackLyrics()`
+///     on every track change (polling loop), so the snippet is live even
+///     when the full player has never been opened.
+///   * Only renders for *timed* (LRC) lyrics. A 3-line synced window has no
+///     meaning for an untimed plain-text blob — there's no "current line"
+///     to track — so untimed / empty / nil all collapse to nothing. The
+///     Queue Inspector omits the whole section in that case (graceful
+///     omission per the issue's acceptance criteria).
+///   * A 0.5s ticker recomputes the active line index. Cheap: a backwards
+///     scan over a handful of lines + an index compare, mutating state only
+///     when the active line actually changes. The cadence is deliberately
+///     coarser than the full `LyricsView` (which uses 0.2s) — the inline
+///     preview doesn't need sub-second precision and the inspector is a
+///     persistent surface, so we keep idle wakes down (gap pattern #2).
+struct InlineLyricsSnippet: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Index of the active line within `timedLines`, or `nil` before the
+    /// first timestamp is reached. Driven by the ticker.
+    @State private var activeIndex: Int?
+
+    /// Timed lyric lines only. Drops untimed rows entirely — see the type
+    /// doc for why the snippet is synced-only.
+    private var timedLines: [LyricLine] {
+        (model.currentLyrics ?? []).filter { $0.timestamp != nil }
+    }
+
+    /// Whether there's anything to show. The Queue Inspector checks the
+    /// same condition to decide whether to mount the section header.
+    var hasContent: Bool { !timedLines.isEmpty }
+
+    var body: some View {
+        if hasContent {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let lines = timedLines
+        VStack(alignment: .leading, spacing: 6) {
+            row(for: relativeLine(offset: -1, in: lines), emphasis: .past)
+            row(for: relativeLine(offset: 0, in: lines), emphasis: .current)
+            row(for: relativeLine(offset: 1, in: lines), emphasis: .upcoming)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 10).fill(Theme.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10).stroke(Theme.border, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { model.openLyrics() }
+        .help("Open full lyrics")
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: lines))
+        .accessibilityHint("Opens the full lyrics view")
+        .accessibilityAddTraits(.isButton)
+        .onAppear { updateActiveLine() }
+        // 0.5s cadence (see type doc). Skip the recompute work when nothing
+        // is playing — a paused inspector shouldn't keep re-scanning.
+        .onReceive(Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()) { _ in
+            updateActiveLine()
+        }
+        // Re-anchor when the track changes (currentLyrics swaps wholesale).
+        .onChange(of: model.currentLyrics) { _, _ in
+            activeIndex = nil
+            updateActiveLine()
+        }
+    }
+
+    private enum Emphasis {
+        case past, current, upcoming
+    }
+
+    /// Resolve the line at `offset` rows from the active line. Returns `nil`
+    /// past either end so the surrounding/upcoming row renders empty (a
+    /// reserved blank line) rather than wrapping — that keeps the 3-line box
+    /// a stable height and stops the current line from jumping as the song
+    /// crosses the first/last lyric.
+    private func relativeLine(offset: Int, in lines: [LyricLine]) -> LyricLine? {
+        // Before the first timestamp, treat the upcoming first line as the
+        // "current" anchor so the preview shows what's about to start rather
+        // than an empty box during an intro.
+        let anchor = activeIndex ?? 0
+        let idx = anchor + offset
+        guard idx >= 0, idx < lines.count else { return nil }
+        return lines[idx]
+    }
+
+    @ViewBuilder
+    private func row(for line: LyricLine?, emphasis: Emphasis) -> some View {
+        let text = line?.text ?? " "
+        let isCurrent = emphasis == .current
+        Text(text)
+            .font(Theme.font(isCurrent ? 14 : 12, weight: isCurrent ? .bold : .medium))
+            .foregroundStyle(color(for: emphasis))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: text)
+    }
+
+    private func color(for emphasis: Emphasis) -> Color {
+        switch emphasis {
+        case .current: return Theme.ink
+        case .upcoming: return Theme.ink3
+        case .past: return Theme.ink3
+        }
+    }
+
+    /// Find the index of the line whose timestamp is the most recent one at
+    /// or before the current playback position. Walks backwards over the
+    /// timestamp-ordered lines; mutates `activeIndex` only on change so most
+    /// ticks are no-ops.
+    private func updateActiveLine() {
+        let lines = timedLines
+        guard !lines.isEmpty else {
+            if activeIndex != nil { activeIndex = nil }
+            return
+        }
+        let now = model.status.positionSeconds
+        var newActive: Int? = nil
+        for (idx, line) in lines.enumerated() {
+            guard let ts = line.timestamp else { continue }
+            if ts <= now {
+                newActive = idx
+            } else {
+                break
+            }
+        }
+        if newActive != activeIndex {
+            activeIndex = newActive
+        }
+    }
+
+    private func accessibilityLabel(for lines: [LyricLine]) -> String {
+        if let current = relativeLine(offset: 0, in: lines)?.text, !current.isEmpty {
+            return "Lyrics, now: \(current)"
+        }
+        return "Lyrics"
+    }
+}

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -71,6 +71,7 @@ struct QueueInspector: View {
                     VStack(alignment: .leading, spacing: 18) {
                         actionRow
                         nowPlayingCard
+                        lyricsSnippet
                         upNextSection
                         playingFromSection
                     }
@@ -425,6 +426,19 @@ struct QueueInspector: View {
                     .foregroundStyle(Theme.ink3)
                     .monospacedDigit()
             }
+        }
+    }
+
+    // MARK: - Inline lyrics snippet (#91)
+
+    /// Compact 3-line synced lyrics preview below the Now Playing card.
+    /// `InlineLyricsSnippet` renders nothing when the current track has no
+    /// timed lyrics, so the section gracefully omits itself — no spacer or
+    /// empty box is left behind. Only mounted while a track is playing.
+    @ViewBuilder
+    private var lyricsSnippet: some View {
+        if model.status.currentTrack != nil {
+            InlineLyricsSnippet()
         }
     }
 

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -54,6 +54,26 @@ struct NowPlayingView: View {
             await model.fetchCurrentTrackDetails()
             await model.fetchCurrentTrackLyrics()
         }
+        // Honor a one-shot tab request (#91): the inline lyrics snippet in
+        // the Queue Inspector taps `openLyrics()`, which sets
+        // `requestedNowPlayingTab`. Consume it here so the view lands on the
+        // Lyrics tab, then clear it so a later plain open still defaults to
+        // Queue.
+        .onAppear { consumeRequestedTab() }
+        // Also react while already on-screen: the inline lyrics snippet in
+        // the embedded Queue tab can call `openLyrics()` without re-pushing
+        // the route, so `.onAppear` wouldn't fire. Watch the request so an
+        // in-place tap still switches to the Lyrics tab.
+        .onChange(of: model.requestedNowPlayingTab) { _, _ in consumeRequestedTab() }
+    }
+
+    /// Apply and clear a one-shot `requestedNowPlayingTab` (#91).
+    private func consumeRequestedTab() {
+        if let requested = model.requestedNowPlayingTab,
+           let resolved = Tab(rawValue: requested) {
+            tab = resolved
+        }
+        model.requestedNowPlayingTab = nil
     }
 
     // MARK: - Main content

--- a/macos/Tests/LyrebirdTests/InlineLyricsSnippetTests.swift
+++ b/macos/Tests/LyrebirdTests/InlineLyricsSnippetTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the lyric active-line scan that drives the Now Playing inline
+/// snippet. The scan resolves the most-recent line at or before the playback
+/// position over a timestamp-ordered list.
+final class InlineLyricsSnippetTests: XCTestCase {
+    private func lines() -> [LyricLine] {
+        [
+            LyricLine(id: 0, timestamp: 0.0, text: "intro"),
+            LyricLine(id: 1, timestamp: 5.0, text: "verse"),
+            LyricLine(id: 2, timestamp: 10.0, text: "chorus"),
+            LyricLine(id: 3, timestamp: 15.0, text: "outro"),
+        ]
+    }
+
+    func testBeforeFirstTimestampReturnsNil() {
+        XCTAssertNil(InlineLyricsSnippet.activeLineIndex(in: lines(), at: -1.0))
+    }
+
+    func testExactTimestampSelectsThatLine() {
+        XCTAssertEqual(InlineLyricsSnippet.activeLineIndex(in: lines(), at: 10.0), 2)
+    }
+
+    func testBetweenTimestampsSelectsEarlierLine() {
+        XCTAssertEqual(InlineLyricsSnippet.activeLineIndex(in: lines(), at: 7.5), 1)
+    }
+
+    func testAfterLastTimestampSelectsLastLine() {
+        XCTAssertEqual(InlineLyricsSnippet.activeLineIndex(in: lines(), at: 999.0), 3)
+    }
+
+    func testEmptyListReturnsNil() {
+        XCTAssertNil(InlineLyricsSnippet.activeLineIndex(in: [], at: 3.0))
+    }
+
+    func testUntimedLinesAreSkipped() {
+        let mixed = [
+            LyricLine(id: 0, timestamp: nil, text: "[no timestamp]"),
+            LyricLine(id: 1, timestamp: 2.0, text: "timed"),
+            LyricLine(id: 2, timestamp: nil, text: "[no timestamp]"),
+        ]
+        XCTAssertEqual(InlineLyricsSnippet.activeLineIndex(in: mixed, at: 3.0), 1)
+        XCTAssertNil(InlineLyricsSnippet.activeLineIndex(in: mixed, at: 1.0))
+    }
+}


### PR DESCRIPTION
Gives users a glanceable, in-sync lyrics read without the full-screen takeover by adding a compact 3-line synced preview to the Queue Inspector.

Closes #91

The snippet (`InlineLyricsSnippet`) reads the same parsed `currentLyrics` the full `LyricsView` consumes, renders previous / current (highlighted) / next on a 0.5s ticker that skips work when nothing changes, and renders nothing for tracks without timed (LRC) lyrics so the section gracefully omits itself. Tapping it calls `openLyrics()`, which sets a one-shot `requestedNowPlayingTab` that `NowPlayingView` consumes on appear (and via `onChange` for the in-place embedded-queue case) to land on the Lyrics tab.

pipeline:
- fixer-session: feature-builder-91
- slice: screens (macos)
- hotspots-claimed: none
- build-gate: pass (`./macos/Scripts/build-core.sh --debug` then `cd macos && swift build` — Build complete; Swift-only diff, no Rust changes)
- diff-stat: 4 files changed, 213 insertions(+)
