### PR TITLE
fix(macos): dedupe redundant MPNowPlayingInfoCenter elapsed/rate writes

### DIFF
--- a/macos/Sources/LyrebirdAudio/MediaSession.swift
+++ b/macos/Sources/LyrebirdAudio/MediaSession.swift
@@ -72,6 +72,14 @@ public final class MediaSession {
     }()
     private var artworkTask: Task<Void, Never>?
     private var currentTrackID: String?
+    /// Last `(elapsed, rate)` pair published via `updateElapsedAndRate`. The
+    /// rate/seek transition hooks fire repeatedly with values the system
+    /// already has (e.g. a pause when already paused), and each redundant
+    /// write is an IPC round-trip to `mediaremoted` that the system logs as
+    /// "Setting identical nowPlayingInfo, skipping update." Short-circuit
+    /// those no-ops here (issue #807).
+    private var lastPublishedElapsed: Double?
+    private var lastPublishedRate: Float?
 
     /// Construct the session with no delegate. Call `attach(delegate:)` from
     /// the owner's initializer once `self` is available. This two-phase
@@ -107,6 +115,8 @@ public final class MediaSession {
 
         if track == nil {
             currentTrackID = nil
+            lastPublishedElapsed = nil
+            lastPublishedRate = nil
             artworkTask?.cancel()
             artworkTask = nil
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
@@ -133,9 +143,13 @@ public final class MediaSession {
         info[MPNowPlayingInfoPropertyIsLiveStream] = false
 
         let status = delegate.currentStatus
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, status.positionSeconds)
-        info[MPNowPlayingInfoPropertyPlaybackRate] = status.state == .playing ? 1.0 : 0.0
+        let elapsed = max(0, status.positionSeconds)
+        let rate: Float = status.state == .playing ? 1.0 : 0.0
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed
+        info[MPNowPlayingInfoPropertyPlaybackRate] = rate
         info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+        lastPublishedElapsed = elapsed
+        lastPublishedRate = rate
         if status.queueLength > 0 {
             info[MPNowPlayingInfoPropertyPlaybackQueueIndex] = NSNumber(value: status.queuePosition)
             info[MPNowPlayingInfoPropertyPlaybackQueueCount] = NSNumber(value: status.queueLength)
@@ -204,10 +218,16 @@ public final class MediaSession {
     // MARK: - Internals
 
     private func updateElapsedAndRate(elapsed: Double, rate: Float) {
+        let clamped = max(0, elapsed)
+        if lastPublishedElapsed == clamped, lastPublishedRate == rate {
+            return
+        }
         var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, elapsed)
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = clamped
         info[MPNowPlayingInfoPropertyPlaybackRate] = rate
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        lastPublishedElapsed = clamped
+        lastPublishedRate = rate
     }
 
     // MARK: - Remote command center


### PR DESCRIPTION
Cuts unnecessary IPC round-trips to `mediaremoted`: the rate/seek transition hooks repeatedly republished an elapsed/rate pair the now-playing center already held, which the system absorbed but logged as "Setting identical nowPlayingInfo, skipping update."

`MediaSession` is the single writer of `MPNowPlayingInfoCenter.nowPlayingInfo`. It now tracks the last-published `(elapsed, rate)` pair and short-circuits `updateElapsedAndRate` when both are unchanged. `trackChanged` records the new baseline when it writes the full payload (and resets it when the track clears), so a subsequent same-value rate/seek call is correctly recognized as a no-op. Full-payload writes (track change, queue change, artwork) are untouched — those genuinely change the dictionary.

## Test coverage

Manual-verification-only. The dedup short-circuit gates writes to `MPNowPlayingInfoCenter.default()`, an uninjectable system singleton with no public read-back contract suitable for assertion; `MediaSession` writes to it directly rather than through an injectable sink. Adding a unit test would require refactoring `MediaSession` to route now-playing writes through an injected closure — a change outside the scope of this fix. Verified manually: with the app paused, repeated pause/seek/skip transitions no longer emit the "Setting identical nowPlayingInfo, skipping update." log line, while track changes, queue changes, and artwork updates still publish.

Closes #807

pipeline:
  fixer-session: wf_500a742e-e1a-38
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +23/-3
