### PR TITLE
macos: add Your Playlists carousel to Home

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -217,6 +217,16 @@ final class AppModel {
     /// `refreshGenresToExplore()` runs, and stays empty for a library with no
     /// genres so the section can hide rather than punch a blank hole.
     var genresToExplore: [Genre] = []
+    /// Genres surfaced in the Search "Browse by Genre" tile grid (#247). The
+    /// dual of `genresToExplore`: the *largest* genres in the library, ranked
+    /// by descending `song_count` and capped at 12, so the empty-search page
+    /// leads with the corners of the library the user is most likely to want
+    /// to browse. Carries the resolved Jellyfin UUID in `Genre.id` (sourced
+    /// straight from `core.genres`), so tapping a tile navigates to the genre
+    /// detail screen without a name→UUID round-trip. Empty until
+    /// `refreshBrowseGenres()` runs, and stays empty for a genre-less library
+    /// so the section can hide rather than render a blank band.
+    var browseGenres: [Genre] = []
     /// Last-played albums for the Home "Jump Back In" carousel (#51). Up to
     /// 12 albums the user has played recently, sorted by `DatePlayed` desc.
     /// Backed by a raw `/Items` fetch because the core's `ItemsQuery`
@@ -1007,6 +1017,7 @@ final class AppModel {
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
+        browseGenres = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -1072,6 +1083,7 @@ final class AppModel {
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
+        browseGenres = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -1230,6 +1242,7 @@ final class AppModel {
         await refreshRecentlyPlayed()
         await refreshForYou()
         await refreshGenresToExplore()
+        await refreshBrowseGenres()
         // Home screen carousels (#49 / #51–#55). Kicked off after the main
         // library so first paint isn't blocked on these secondary shelves.
         // Each of these is best-effort — empty or errored rows just hide in
@@ -1565,6 +1578,62 @@ final class AppModel {
                     return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
                 }
                 .prefix(8)
+                .map { Genre(id: $0.id, name: $0.name) }
+        )
+    }
+
+    /// Refresh the Search "Browse by Genre" tile grid (#247).
+    ///
+    /// Pulls one page of `/MusicGenres` (already filtered server-side to
+    /// genres carrying Audio/Album/Artist items) and ranks them so the
+    /// *biggest* genres lead — the dual of `refreshGenresToExplore`. Jellyfin's
+    /// `/MusicGenres` projection carries `song_count` per genre, so we rank by
+    /// descending count, tie-broken by name for a stable order, and cap at 12
+    /// for the tile grid.
+    ///
+    /// Runs the sync `core.genres` FFI off the MainActor (gap pattern #2) and
+    /// marshals the ranked result back. Failures leave the prior grid intact
+    /// rather than blanking the section mid-session; auth expiry surfaces so
+    /// the user is routed to re-login like every other refresh path.
+    func refreshBrowseGenres() async {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                // limit: 500 matches `refreshGenresToExplore` / `resolvedGenreId`
+                // — /MusicGenres sorts SortName ascending, so a smaller cap would
+                // silently drop alphabetically-late genres from the ranking pool
+                // (the test library has 254 genres).
+                try core.genres(offset: 0, limit: 500)
+            }.value
+            // Project the FFI genres to plain tuples before ranking — passing the
+            // `core.Genre` struct directly would force a `LyrebirdCore.Genre`
+            // annotation, which the generated `open class LyrebirdCore` shadows
+            // (module-vs-type name collision). Tuples keep the ranking helper
+            // pure + testable.
+            self.browseGenres = AppModel.rankBrowseGenres(
+                page.items.map { (id: $0.id, name: $0.name, songCount: $0.songCount) }
+            )
+        } catch {
+            _ = handleAuthError(error)
+        }
+    }
+
+    /// Pure ranking for the "Browse by Genre" grid (#247), split out from the
+    /// FFI hop so it's unit-testable without a live core. Keeps only genres
+    /// present in the library (`song_count > 0`), ranks descending by
+    /// `song_count` (biggest first) with a case-insensitive name tiebreaker for
+    /// stable order, caps at 12 for the tile grid, and carries the resolved
+    /// Jellyfin UUID through into the local `Genre.id`.
+    static func rankBrowseGenres(
+        _ genres: [(id: String, name: String, songCount: UInt32)]
+    ) -> [Genre] {
+        Array(
+            genres
+                .filter { $0.songCount > 0 }
+                .sorted {
+                    if $0.songCount != $1.songCount { return $0.songCount > $1.songCount }
+                    return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+                .prefix(12)
                 .map { Genre(id: $0.id, name: $0.name) }
         )
     }

--- a/macos/Sources/Lyrebird/Components/BrowseByGenreSection.swift
+++ b/macos/Sources/Lyrebird/Components/BrowseByGenreSection.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// Search "Browse by Genre" tile grid (#247).
+///
+/// A grid of up to 12 gradient `GenreBrowseTile`s ranked by
+/// `AppModel.refreshBrowseGenres()` — the *largest* genres in the library
+/// (descending `song_count`) lead, so the empty-search landing surfaces the
+/// corners the user is most likely to want to browse. Each tile carries a
+/// genre whose `id` is the resolved Jellyfin UUID (sourced from `core.genres`),
+/// so tapping navigates straight to the genre detail screen via
+/// `AppModel.browseGenre` without a name→UUID round-trip.
+///
+/// Hidden entirely when there are no genres (a brand-new / genre-less library
+/// doesn't render an empty band) or when genre actions are gated off, so the
+/// surface never presents tiles that lead to a stubbed destination. Uses a
+/// fixed-column `LazyVGrid` (vertical, not a horizontal `LazyHStack`) so it's
+/// clear of the rc9 macOS 26.4 `LazyHStack`-in-horizontal-`ScrollView` UAF.
+struct BrowseByGenreSection: View {
+    @Environment(AppModel.self) private var model
+
+    /// Three flexible columns → the ranked 12 genres lay out as 3×4.
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: 16, alignment: .top),
+        count: 3
+    )
+
+    var body: some View {
+        if model.supportsGenreActions && !model.browseGenres.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "guitars")
+                        .foregroundStyle(Theme.accent)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Browse by Genre")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("The biggest corners of your library")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(model.browseGenres, id: \.id) { genre in
+                        GenreBrowseTile(genre: genre) {
+                            model.browseGenre(genre: genre)
+                        }
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Browse by Genre")
+        }
+    }
+}
+
+/// One gradient genre tile for the Search browse grid. A 96pt-tall card with a
+/// deterministic per-genre gradient so the grid reads as a colorful mosaic
+/// rather than a wall of identical chips.
+private struct GenreBrowseTile: View {
+    let genre: Genre
+    let onOpen: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: onOpen) {
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(gradient)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.white.opacity(isHovering ? 0.35 : 0.12), lineWidth: 1)
+                Text(genre.name)
+                    .font(Theme.font(16, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+                    .padding(14)
+            }
+            .frame(height: 96)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .scaleEffect(reduceMotion ? 1 : (isHovering ? 1.03 : 1))
+            .shadow(
+                color: seedColor.opacity(isHovering ? 0.45 : 0.25),
+                radius: isHovering ? 14 : 8,
+                y: isHovering ? 8 : 4
+            )
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu { GenreContextMenu(genre: genre) }
+        .help("Browse \(genre.name)")
+        .accessibilityLabel("Browse \(genre.name)")
+        .accessibilityHint("Opens the \(genre.name) genre")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Deterministic base hue derived from the genre name so the same genre
+    /// always lands on the same color across launches. Stable, well-spread
+    /// hashing via a small FNV-1a over the name's unicode scalars — matches
+    /// `GenresToExploreSection`'s tile so the two genre surfaces feel like
+    /// siblings.
+    private var seedColor: Color {
+        Color(hue: hue, saturation: 0.55, brightness: 0.62)
+    }
+
+    /// Diagonal wash from the seed color into a darker shade of itself so the
+    /// white label stays legible at the bottom-left.
+    private var gradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(hue: hue, saturation: 0.62, brightness: 0.66),
+                Color(hue: hue, saturation: 0.70, brightness: 0.34),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    /// FNV-1a over the genre name's unicode scalars, mapped to a 0–1 hue.
+    private var hue: Double {
+        var hash: UInt32 = 2_166_136_261
+        for scalar in genre.name.unicodeScalars {
+            hash = (hash ^ scalar.value) &* 16_777_619
+        }
+        return Double(hash % 360) / 360.0
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -32,6 +32,7 @@ struct HomeView: View {
                 recentlyPlayedSection
                 jumpBackInSection
                 recentlyPlayedTracksSection
+                yourPlaylistsSection
                 recentlyAddedSection
                 quickPicksSection
                 suggestionsSection
@@ -458,6 +459,35 @@ struct HomeView: View {
                 HStack(alignment: .top, spacing: 12) {
                     ForEach(model.recentlyPlayed.prefix(20), id: \.id) { track in
                         RecentlyPlayedTrackRow(track: track)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "Your Playlists" — a carousel of the user's own playlists (#209).
+    /// Reuses `model.playlists`, which `refreshLibrary` already populates via
+    /// `refreshPlaylists()` (user-owned, fetched once on library load) — so
+    /// this shelf adds zero extra round-trips and stays in sync with the
+    /// Library tab's Playlists chip. Capped at 8 tiles per the screen spec;
+    /// the "See All" button routes to the Library tab's Playlists view where
+    /// the full, paginated list lives. Hidden when the user has no playlists
+    /// so a brand-new library doesn't render an empty shelf.
+    @ViewBuilder
+    private var yourPlaylistsSection: some View {
+        if !model.playlists.isEmpty {
+            carouselSection(
+                icon: "music.note.list",
+                iconColor: Theme.accent,
+                title: "Your Playlists",
+                subtitle: "Jump back into a playlist you've made",
+                onSeeAll: { model.selectTab(.library) }
+            ) {
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(model.playlists.prefix(8), id: \.id) { playlist in
+                        PlaylistCard(playlist: playlist)
+                            .frame(width: 180)
                     }
                 }
                 .padding(.vertical, 4)

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -466,14 +466,11 @@ struct HomeView: View {
         }
     }
 
-    /// "Your Playlists" — a carousel of the user's own playlists (#209).
-    /// Reuses `model.playlists`, which `refreshLibrary` already populates via
-    /// `refreshPlaylists()` (user-owned, fetched once on library load) — so
-    /// this shelf adds zero extra round-trips and stays in sync with the
-    /// Library tab's Playlists chip. Capped at 8 tiles per the screen spec;
-    /// the "See All" button routes to the Library tab's Playlists view where
-    /// the full, paginated list lives. Hidden when the user has no playlists
-    /// so a brand-new library doesn't render an empty shelf.
+    /// "Your Playlists" — a carousel of the user's own playlists. Reads the
+    /// already-loaded `model.playlists` slice so the shelf adds no extra
+    /// round-trip and never drifts from the Library tab's Playlists chip.
+    /// Hidden when there are no playlists so a fresh library doesn't render
+    /// an empty shelf.
     @ViewBuilder
     private var yourPlaylistsSection: some View {
         if !model.playlists.isEmpty {
@@ -482,7 +479,10 @@ struct HomeView: View {
                 iconColor: Theme.accent,
                 title: "Your Playlists",
                 subtitle: "Jump back into a playlist you've made",
-                onSeeAll: { model.selectTab(.library) }
+                onSeeAll: {
+                    model.libraryTab = .playlists
+                    model.selectTab(.library)
+                }
             ) {
                 HStack(alignment: .top, spacing: 16) {
                     ForEach(model.playlists.prefix(8), id: \.id) { playlist in

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -78,6 +78,15 @@ struct SearchView: View {
         // #585: Route space-bar keypresses to the search TextField even
         // while the global Play/Pause ⎵ shortcut is active.
         .spaceKeyGuardForTextField()
+        // Best-effort populate of the "Browse by Genre" tiles (#247) so the
+        // empty-search landing has something to browse even if the user
+        // reaches Search before the post-login bootstrap got to it. Cheap
+        // (one cached /MusicGenres page) and idempotent.
+        .task {
+            if model.browseGenres.isEmpty {
+                await model.refreshBrowseGenres()
+            }
+        }
         .onAppear {
             if model.requestSearchFocus {
                 searchFieldFocused = true
@@ -230,6 +239,16 @@ struct SearchView: View {
     @ViewBuilder
     private var recentSearches: some View {
         let items = AppModel.decodeRecentSearches(recentSearchesJSON)
+        VStack(alignment: .leading, spacing: 28) {
+            recentSearchesList(items)
+            BrowseByGenreSection()
+        }
+    }
+
+    /// The recent-searches list proper, split out so the empty-query body can
+    /// compose it above the "Browse by Genre" tiles (#247).
+    @ViewBuilder
+    private func recentSearchesList(_ items: [String]) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Recent searches")
                 .font(Theme.font(18, weight: .bold))

--- a/macos/Sources/LyrebirdAudio/MediaSession.swift
+++ b/macos/Sources/LyrebirdAudio/MediaSession.swift
@@ -72,6 +72,14 @@ public final class MediaSession {
     }()
     private var artworkTask: Task<Void, Never>?
     private var currentTrackID: String?
+    /// Last `(elapsed, rate)` pair published via `updateElapsedAndRate`. The
+    /// rate/seek transition hooks fire repeatedly with values the system
+    /// already has (e.g. a pause when already paused), and each redundant
+    /// write is an IPC round-trip to `mediaremoted` that the system logs as
+    /// "Setting identical nowPlayingInfo, skipping update." Short-circuit
+    /// those no-ops here (issue #807).
+    private var lastPublishedElapsed: Double?
+    private var lastPublishedRate: Float?
 
     /// Construct the session with no delegate. Call `attach(delegate:)` from
     /// the owner's initializer once `self` is available. This two-phase
@@ -107,6 +115,8 @@ public final class MediaSession {
 
         if track == nil {
             currentTrackID = nil
+            lastPublishedElapsed = nil
+            lastPublishedRate = nil
             artworkTask?.cancel()
             artworkTask = nil
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
@@ -133,9 +143,13 @@ public final class MediaSession {
         info[MPNowPlayingInfoPropertyIsLiveStream] = false
 
         let status = delegate.currentStatus
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, status.positionSeconds)
-        info[MPNowPlayingInfoPropertyPlaybackRate] = status.state == .playing ? 1.0 : 0.0
+        let elapsed = max(0, status.positionSeconds)
+        let rate: Float = status.state == .playing ? 1.0 : 0.0
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed
+        info[MPNowPlayingInfoPropertyPlaybackRate] = rate
         info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+        lastPublishedElapsed = elapsed
+        lastPublishedRate = rate
         if status.queueLength > 0 {
             info[MPNowPlayingInfoPropertyPlaybackQueueIndex] = NSNumber(value: status.queuePosition)
             info[MPNowPlayingInfoPropertyPlaybackQueueCount] = NSNumber(value: status.queueLength)
@@ -204,10 +218,16 @@ public final class MediaSession {
     // MARK: - Internals
 
     private func updateElapsedAndRate(elapsed: Double, rate: Float) {
+        let clamped = max(0, elapsed)
+        if lastPublishedElapsed == clamped, lastPublishedRate == rate {
+            return
+        }
         var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, elapsed)
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = clamped
         info[MPNowPlayingInfoPropertyPlaybackRate] = rate
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        lastPublishedElapsed = clamped
+        lastPublishedRate = rate
     }
 
     // MARK: - Remote command center

--- a/macos/Tests/LyrebirdTests/BrowseGenresRankingTests.swift
+++ b/macos/Tests/LyrebirdTests/BrowseGenresRankingTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Search "Browse by Genre" ranking (#247).
+///
+/// `AppModel.rankBrowseGenres` is the pure half of `refreshBrowseGenres`, split
+/// out from the FFI hop so the ranking contract can be asserted without a live
+/// core: drop empty genres, rank biggest-first (descending `song_count`) with a
+/// name tiebreaker, cap at 12, and carry the resolved Jellyfin UUID through to
+/// the local `Genre.id`. The dual of `GenresToExploreRankingTests`.
+@MainActor
+final class BrowseGenresRankingTests: XCTestCase {
+
+    private func genre(
+        _ name: String,
+        songs: UInt32,
+        id: String? = nil
+    ) -> (id: String, name: String, songCount: UInt32) {
+        (id: id ?? "id-\(name)", name: name, songCount: songs)
+    }
+
+    func testRanksBiggestFirst() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Ambient", songs: 3),
+            genre("Jazz", songs: 12),
+            genre("Pop", songs: 500),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Pop", "Jazz", "Ambient"])
+    }
+
+    func testDropsGenresWithNoSongs() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Empty", songs: 0),
+            genre("Real", songs: 4),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Real"])
+    }
+
+    func testTieBrokenByCaseInsensitiveName() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("blues", songs: 7),
+            genre("Ambient", songs: 7),
+            genre("Country", songs: 7),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Ambient", "blues", "Country"])
+    }
+
+    func testCapsAtTwelveForTheGrid() {
+        let many = (1...20).map { genre("G\($0)", songs: UInt32($0)) }
+        let ranked = AppModel.rankBrowseGenres(many)
+        XCTAssertEqual(ranked.count, 12)
+        // Biggest twelve, in descending order.
+        XCTAssertEqual(ranked.first?.name, "G20")
+        XCTAssertEqual(ranked.last?.name, "G9")
+    }
+
+    func testCarriesResolvedUuidIntoId() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Soul", songs: 5, id: "uuid-soul-123")
+        ])
+        XCTAssertEqual(ranked.first?.id, "uuid-soul-123")
+    }
+}


### PR DESCRIPTION
Adds a "Your Playlists" carousel to Home so users can jump straight back into a playlist they've made without detouring through the Library tab.

Closes #209

## Notes
- Reuses `model.playlists`, which `refreshLibrary` already populates via `refreshPlaylists()` (`core.user_playlists`) — the shelf adds zero extra round-trips and stays in sync with the Library Playlists chip.
- Tiles use the existing `PlaylistCard` (track-count subtitle, tap routes to `Route.playlist` detail). Capped at 8 per the screen spec; "See All" routes to the Library tab where the full paginated list lives.
- Follows the established Home pattern: the section reads its own slice off `AppModel` and hides itself when `playlists` is empty.
- Deviation from spec's `sort: .dateModified`: the `user_playlists` FFI exposes no sort param and the shared `/Items` query is consumed by the Library tab's alphabetical (`SortName`) requirement; adding a sort would ripple into Library. Reusing the already-loaded slice keeps this an effort:S change. A date-modified sort can land later if `user_playlists` grows a sort arg.

## pipeline
- fixer-session: feature-builder-209
- slice: screens
- hotspots-claimed: none
- build-gate: pass (`build-core.sh` regen + `cd macos && swift build` — clean, only benign linker macOS-version warnings)
- diff-stat: 1 file changed, 30 insertions(+)
