### PR TITLE
macos: add menu-bar Now Playing extra with artwork + transport

### DIFF
--- a/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
+++ b/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
@@ -9,10 +9,9 @@ import SwiftUI
 /// explicit "Open Lyrebird" affordance that focuses the main window.
 ///
 /// Because a `MenuBarExtra` lives in the system menu bar, this surface stays
-/// reachable even when every Lyrebird window is closed or the app is hidden —
-/// the issue's "shows even when app is hidden" contract. When nothing is
-/// playing (or the user is signed out) it falls back to a minimal idle state
-/// so the panel never renders an empty box.
+/// reachable even when every Lyrebird window is closed or the app is hidden.
+/// When nothing is playing (or the user is signed out) it falls back to a
+/// minimal idle state so the panel never renders an empty box.
 ///
 /// All playback state + actions route through the same `AppModel` entry points
 /// the `PlayerBar` and `MiniPlayerView` use (`togglePlayPause`, `skipNext`,
@@ -23,7 +22,9 @@ struct MenuBarNowPlaying: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if let track = model.status.currentTrack {
+            if Self.showsNowPlaying(currentTrack: model.status.currentTrack),
+                let track = model.status.currentTrack
+            {
                 nowPlaying(track: track)
             } else {
                 idle
@@ -71,7 +72,7 @@ struct MenuBarNowPlaying: View {
                 model.skipPrevious()
             }
             Button(action: model.togglePlayPause) {
-                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                Image(systemName: Self.transportIcon(isPlaying: isPlaying))
                     .font(.system(size: 14))
                     .foregroundStyle(Theme.bg)
                     .frame(width: 34, height: 34)
@@ -129,6 +130,19 @@ struct MenuBarNowPlaying: View {
 
     private var isPlaying: Bool { model.status.state == .playing }
 
+    /// SF Symbol for the centre transport button given the play state. Pure so
+    /// the play↔pause icon swap can be verified without realizing the view.
+    static func transportIcon(isPlaying: Bool) -> String {
+        isPlaying ? "pause.fill" : "play.fill"
+    }
+
+    /// Whether the panel should show the rich now-playing card (`true`) or the
+    /// minimal idle fallback (`false`) for a given current track. Pure so the
+    /// idle-vs-playing branch is testable headlessly.
+    static func showsNowPlaying(currentTrack: Track?) -> Bool {
+        currentTrack != nil
+    }
+
     @ViewBuilder
     private func iconBtn(
         _ name: String,
@@ -154,7 +168,15 @@ struct MenuBarNowPlayingLabel: View {
     @Environment(AppModel.self) private var model
 
     var body: some View {
-        Image(systemName: model.status.state == .playing ? "waveform" : "music.note")
+        Image(systemName: Self.icon(for: model.status.state))
             .accessibilityLabel(Text("menu_bar.now_playing.label"))
+    }
+
+    /// SF Symbol for the status-bar label given the playback state: an animated
+    /// `waveform` while audio is running, the resting `music.note` otherwise.
+    /// Pure so the at-a-glance icon swap can be verified without a window
+    /// server.
+    static func icon(for state: PlaybackState) -> String {
+        state == .playing ? "waveform" : "music.note"
     }
 }

--- a/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
+++ b/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
@@ -1,0 +1,160 @@
+import AppKit
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Status-bar **Now Playing** panel — the content of the app's `MenuBarExtra`
+/// (declared in `LyrebirdApp`). Mirrors Apple Music's menu-bar mini transport
+/// and Spotify's status-bar widget: a compact card with artwork, the current
+/// track's title/artist, and prev / play-pause / next transport, plus an
+/// explicit "Open Lyrebird" affordance that focuses the main window.
+///
+/// Because a `MenuBarExtra` lives in the system menu bar, this surface stays
+/// reachable even when every Lyrebird window is closed or the app is hidden —
+/// the issue's "shows even when app is hidden" contract. When nothing is
+/// playing (or the user is signed out) it falls back to a minimal idle state
+/// so the panel never renders an empty box.
+///
+/// All playback state + actions route through the same `AppModel` entry points
+/// the `PlayerBar` and `MiniPlayerView` use (`togglePlayPause`, `skipNext`,
+/// `skipPrevious`, `status.*`), so the menu-bar panel can never disagree with
+/// the in-window transport — there is one writer.
+struct MenuBarNowPlaying: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let track = model.status.currentTrack {
+                nowPlaying(track: track)
+            } else {
+                idle
+            }
+            Divider()
+            openButton
+        }
+        .padding(14)
+        .frame(width: 280)
+    }
+
+    // MARK: - Now playing
+
+    @ViewBuilder
+    private func nowPlaying(track: Track) -> some View {
+        HStack(spacing: 12) {
+            Artwork(
+                url: model.imageURL(for: track.albumId ?? track.id, tag: track.imageTag, maxWidth: 120),
+                seed: track.name,
+                size: 56,
+                radius: 6
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.name)
+                    .font(Theme.font(13, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(track.artistName)
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 0)
+        }
+        transportRow
+    }
+
+    @ViewBuilder
+    private var transportRow: some View {
+        HStack(spacing: 18) {
+            Spacer(minLength: 0)
+            iconBtn("backward.fill", label: "menu_bar.now_playing.previous", size: 14) {
+                model.skipPrevious()
+            }
+            Button(action: model.togglePlayPause) {
+                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Theme.bg)
+                    .frame(width: 34, height: 34)
+                    .background(Circle().fill(Theme.ink))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text(isPlaying ? "menu_bar.now_playing.pause" : "menu_bar.now_playing.play"))
+            iconBtn("forward.fill", label: "menu_bar.now_playing.next", size: 14) {
+                model.skipNext()
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Idle (nothing playing / signed out)
+
+    @ViewBuilder
+    private var idle: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "music.note")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.ink3)
+            Text("player.nothing_playing")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Open the app
+
+    /// Focus the main window. Routes through the same `returnToFullWindow`
+    /// contract the mini player uses, which activates the app (raising the
+    /// main `WindowGroup` window) so the click works even when every Lyrebird
+    /// window is closed or the app is hidden.
+    @ViewBuilder
+    private var openButton: some View {
+        Button {
+            model.returnToFullWindow()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "macwindow")
+                    .font(.system(size: 12))
+                Text("menu_bar.now_playing.open")
+                    .font(Theme.font(12, weight: .semibold))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(Theme.ink2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text("menu_bar.now_playing.open"))
+    }
+
+    // MARK: - Derived
+
+    private var isPlaying: Bool { model.status.state == .playing }
+
+    @ViewBuilder
+    private func iconBtn(
+        _ name: String,
+        label: LocalizedStringKey,
+        size: CGFloat,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: name)
+                .font(.system(size: size))
+                .foregroundStyle(Theme.ink2)
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(label))
+    }
+}
+
+/// The menu-bar item's label (the icon shown in the system status bar). A
+/// small SF Symbol that reflects play state so the bar communicates whether
+/// audio is running at a glance, without opening the panel.
+struct MenuBarNowPlayingLabel: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        Image(systemName: model.status.state == .playing ? "waveform" : "music.note")
+            .accessibilityLabel(Text("menu_bar.now_playing.label"))
+    }
+}

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -108,6 +108,23 @@ struct LyrebirdApp: App {
         }
         .defaultSize(width: 480, height: 560)
         .windowResizability(.contentSize)
+
+        // Status-bar "Now Playing" extra. A `MenuBarExtra` lives in the system
+        // menu bar, so this transport surface stays reachable even when every
+        // Lyrebird window is closed or the app is hidden (#320). The `.window`
+        // style lets the panel render artwork + a rich transport cluster rather
+        // than a flat text menu; the label reflects play state at a glance.
+        // Clicking "Open Lyrebird" routes through `returnToFullWindow`, which
+        // activates the app and raises the main window.
+        MenuBarExtra {
+            MenuBarNowPlaying()
+                .environment(model)
+                .preferredColorScheme(preferredColorScheme)
+        } label: {
+            MenuBarNowPlayingLabel()
+                .environment(model)
+        }
+        .menuBarExtraStyle(.window)
     }
 }
 

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -111,7 +111,7 @@ struct LyrebirdApp: App {
 
         // Status-bar "Now Playing" extra. A `MenuBarExtra` lives in the system
         // menu bar, so this transport surface stays reachable even when every
-        // Lyrebird window is closed or the app is hidden (#320). The `.window`
+        // Lyrebird window is closed or the app is hidden. The `.window`
         // style lets the panel render artwork + a rich transport cluster rather
         // than a flat text menu; the label reflects play state at a glance.
         // Clicking "Open Lyrebird" routes through `returnToFullWindow`, which

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1237,6 +1237,78 @@
         }
       }
     },
+    "menu_bar.now_playing.label" : {
+      "comment" : "Accessibility label for the menu-bar Now Playing status item.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Now Playing"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.next" : {
+      "comment" : "Accessibility label for the menu-bar Now Playing next button.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.open" : {
+      "comment" : "Button in the menu-bar Now Playing panel that focuses the main Lyrebird window.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Lyrebird"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.pause" : {
+      "comment" : "Accessibility label for the menu-bar Now Playing pause button.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.play" : {
+      "comment" : "Accessibility label for the menu-bar Now Playing play button.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.previous" : {
+      "comment" : "Accessibility label for the menu-bar Now Playing previous button.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous"
+          }
+        }
+      }
+    },
     "mini_player.window.title" : {
       "comment" : "Window title for the detached Mini Player (not shown — the window is borderless — but used by the window list / accessibility).",
       "extractionState" : "manual",

--- a/macos/Tests/LyrebirdTests/MenuBarNowPlayingTests.swift
+++ b/macos/Tests/LyrebirdTests/MenuBarNowPlayingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the menu-bar Now Playing rendering decisions: the
+/// idle-vs-playing panel branch, the centre transport play↔pause icon swap,
+/// and the status-bar label's at-a-glance icon.
+///
+/// Each decision is exercised through a pure static helper
+/// (`MenuBarNowPlaying.showsNowPlaying`, `MenuBarNowPlaying.transportIcon`,
+/// `MenuBarNowPlayingLabel.icon(for:)`) so the precedence is verified without
+/// realizing a live SwiftUI view or a window-server connection, which a
+/// headless test run doesn't have.
+final class MenuBarNowPlayingTests: XCTestCase {
+
+    private func makeTrack(name: String = "Song") -> Track {
+        Track(
+            id: "t1",
+            name: name,
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - Idle vs. now-playing panel
+
+    func testShowsIdleWhenNoTrack() {
+        XCTAssertFalse(
+            MenuBarNowPlaying.showsNowPlaying(currentTrack: nil),
+            "with no current track the panel must fall back to the idle state"
+        )
+    }
+
+    func testShowsNowPlayingWhenTrackPresent() {
+        XCTAssertTrue(
+            MenuBarNowPlaying.showsNowPlaying(currentTrack: makeTrack()),
+            "a current track must render the rich now-playing card"
+        )
+    }
+
+    // MARK: - Centre transport icon
+
+    func testTransportIconShowsPauseWhilePlaying() {
+        XCTAssertEqual(
+            MenuBarNowPlaying.transportIcon(isPlaying: true),
+            "pause.fill",
+            "while playing, the centre button offers pause"
+        )
+    }
+
+    func testTransportIconShowsPlayWhilePaused() {
+        XCTAssertEqual(
+            MenuBarNowPlaying.transportIcon(isPlaying: false),
+            "play.fill",
+            "while not playing, the centre button offers play"
+        )
+    }
+
+    // MARK: - Status-bar label icon
+
+    func testLabelIconIsWaveformWhilePlaying() {
+        XCTAssertEqual(
+            MenuBarNowPlayingLabel.icon(for: .playing),
+            "waveform",
+            "the label animates a waveform while audio is running"
+        )
+    }
+
+    func testLabelIconIsRestingNoteWhenNotPlaying() {
+        for state: PlaybackState in [.idle, .loading, .paused, .stopped, .ended] {
+            XCTAssertEqual(
+                MenuBarNowPlayingLabel.icon(for: state),
+                "music.note",
+                "the label rests on music.note for the non-playing state \(state)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Adds a status-bar Now Playing surface so playback stays controllable when every Lyrebird window is closed or the app is hidden.

A `MenuBarExtra` (`.window` style) renders the current track's artwork, title, and artist plus prev / play-pause / next transport; its label icon reflects play state at a glance. The "Open Lyrebird" button focuses the main window through the existing `returnToFullWindow` contract (which activates the app and raises the main `WindowGroup`). All actions route through the same `AppModel` writers (`togglePlayPause` / `skipNext` / `skipPrevious` / `status.*`) the `PlayerBar` and `MiniPlayerView` use, so the menu-bar panel can never disagree with the in-window transport. When nothing is playing it falls back to a minimal idle state.

Closes #320

pipeline:
- fixer-session: feature-builder-320
- slice: ux
- hotspots-claimed: none
- build-gate: pass (build-core.sh debug regen + `rm -rf macos/.build && swift build`; no core/Rust changes, so Rust gates N/A)
- diff-stat: 3 files, +245/-0 (new `MenuBarNowPlaying.swift`, `MenuBarExtra` scene in `LyrebirdApp.swift`, 6 localization keys)