### PR TITLE
macos: add Browse by Decade row deep-linking to year-filtered Library

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -90,6 +90,15 @@ final class AppModel {
     /// user-chip-change so the sidebar selection persists across navigation.
     var libraryTab: LibraryTab = .albums
 
+    /// One-shot inclusive release-year window the Library should pre-apply on
+    /// its next appearance. Set by `browseDecade(_:)` (the Discover "Browse by
+    /// Decade" row) so a tapped decade tile lands on the Library
+    /// pre-filtered to that ten-year span. `LibraryView` reads this on appear /
+    /// change and clears it via `consumePendingLibraryYearRange()` so the
+    /// filter isn't re-imposed when the user later returns to the Library by
+    /// other means.
+    var pendingLibraryYearRange: ClosedRange<Int>?
+
     /// Screen the app was on before the user opened the full Now Playing
     /// view. `NowPlayingView` offers a "Back" affordance that pops to this
     /// value rather than unconditionally routing to `.library`, so a user
@@ -2987,6 +2996,28 @@ final class AppModel {
     /// and the command palette.
     func navigate(to route: Route) {
         navPath.append(route)
+    }
+
+    /// Deep-link the Library to a decade. Stashes the inclusive
+    /// `[start, start+9]` release-year window on `pendingLibraryYearRange`,
+    /// forces the Albums chip (the only library tab whose items carry a year
+    /// the filter keys on), and switches to the Library tab. `LibraryView`
+    /// folds the pending window into its filter on appear and clears it, so
+    /// the constraint is applied exactly once. Wired by the Discover "Browse
+    /// by Decade" gradient tiles.
+    func browseDecade(startingYear start: Int) {
+        pendingLibraryYearRange = start...(start + 9)
+        libraryTab = .albums
+        selectTab(.library)
+    }
+
+    /// Read-and-clear the one-shot `pendingLibraryYearRange`. Returns the
+    /// window the caller should apply (or `nil` when none is pending) and
+    /// leaves the slot empty so a subsequent Library appearance doesn't
+    /// re-impose a decade the user already navigated away from.
+    func consumePendingLibraryYearRange() -> ClosedRange<Int>? {
+        defer { pendingLibraryYearRange = nil }
+        return pendingLibraryYearRange
     }
 
     /// Open the full Now Playing view on its Lyrics tab. Wired to the inline

--- a/macos/Sources/Lyrebird/Components/DecadeBrowseRow.swift
+++ b/macos/Sources/Lyrebird/Components/DecadeBrowseRow.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+/// Discover "Browse by Decade" row.
+///
+/// A horizontal strip of gradient tiles — '60s, '70s, '80s, '90s, '00s, '10s,
+/// '20s — each carrying a huge italic decade label over a deterministic
+/// per-decade wash. Tapping a tile deep-links to the Library pre-filtered to
+/// that decade's ten-year release-year window via `AppModel.browseDecade`.
+///
+/// The decade set is static (the catalogue's actual year coverage isn't known
+/// until the whole library is paged in, and the spec calls for the fixed
+/// '60s→'20s ramp), so the row always renders. A decade with no matching
+/// albums simply lands on an empty filtered Library, which the existing
+/// empty-grid affordance already covers.
+struct DecadeBrowseRow: View {
+	@Environment(AppModel.self) private var model
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 12) {
+			HStack(alignment: .firstTextBaseline, spacing: 8) {
+				Image(systemName: "calendar")
+					.foregroundStyle(Theme.primary)
+					.font(.system(size: 14, weight: .bold))
+				Text("Browse by Decade")
+					.font(Theme.font(18, weight: .bold))
+					.foregroundStyle(Theme.ink)
+				Text("Jump into a ten-year slice of your library")
+					.font(Theme.font(12, weight: .medium))
+					.foregroundStyle(Theme.ink3)
+			}
+			ScrollView(.horizontal, showsIndicators: false) {
+				HStack(spacing: 14) {
+					ForEach(Decade.all) { decade in
+						DecadeTile(decade: decade) {
+							model.browseDecade(startingYear: decade.startYear)
+						}
+					}
+				}
+				.padding(.vertical, 4)
+			}
+		}
+		.accessibilityElement(children: .contain)
+		.accessibilityLabel("Browse by Decade")
+	}
+}
+
+/// A single decade in the browse row. `startYear` is the inclusive lower bound
+/// of the ten-year window the Library filters to; `shortLabel` is the apostrophe
+/// form ("'80s") used on the tile face.
+struct Decade: Identifiable, Hashable {
+	let startYear: Int
+
+	var id: Int { startYear }
+
+	/// Two-digit apostrophe label — `1980 → "'80s"`, `2000 → "'00s"`.
+	var shortLabel: String {
+		let twoDigit = String(format: "%02d", startYear % 100)
+		return "'\(twoDigit)s"
+	}
+
+	/// VoiceOver-friendly spelled-out form — "the 1980s".
+	var spokenLabel: String { "the \(startYear)s" }
+
+	/// The fixed '60s→'20s ramp the Discover row renders, oldest first.
+	static let all: [Decade] = stride(from: 1960, through: 2020, by: 10).map(Decade.init)
+}
+
+/// One gradient decade tile. 150×120, continuous-corner card with a
+/// deterministic per-decade wash and an oversized italic label bottom-leading —
+/// the "default artwork gradient + huge italic decade text" the spec asks for.
+/// Mirrors the hover/scale/shadow vocabulary of `GenreExploreTile` so the
+/// Discover surface reads as one family.
+private struct DecadeTile: View {
+	let decade: Decade
+	let onOpen: () -> Void
+
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+	@State private var isHovering = false
+
+	var body: some View {
+		Button(action: onOpen) {
+			ZStack(alignment: .bottomLeading) {
+				RoundedRectangle(cornerRadius: 14, style: .continuous)
+					.fill(gradient)
+				RoundedRectangle(cornerRadius: 14, style: .continuous)
+					.stroke(.white.opacity(isHovering ? 0.35 : 0.12), lineWidth: 1)
+				Text(decade.shortLabel)
+					.font(Theme.font(40, weight: .black, italic: true))
+					.foregroundStyle(.white)
+					.shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+					.padding(14)
+			}
+			.frame(width: 150, height: 120)
+			.scaleEffect(reduceMotion ? 1 : (isHovering ? 1.03 : 1))
+			.shadow(
+				color: seedColor.opacity(isHovering ? 0.45 : 0.25),
+				radius: isHovering ? 14 : 8,
+				y: isHovering ? 8 : 4
+			)
+			.animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+			.contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+		}
+		.buttonStyle(.plain)
+		.onHover { isHovering = $0 }
+		.help("Browse \(decade.spokenLabel)")
+		.accessibilityLabel("Browse \(decade.spokenLabel)")
+		.accessibilityHint("Filters the Library to albums from \(decade.spokenLabel)")
+		.accessibilityAddTraits(.isButton)
+	}
+
+	/// Base hue spread evenly across the seven decades so the row reads as a
+	/// rainbow ramp rather than a wall of one color. Derived from the decade's
+	/// ordinal (0 for the '60s … 6 for the '20s) so the same decade always
+	/// lands on the same hue across launches.
+	private var hue: Double {
+		let ordinal = Double((decade.startYear - 1960) / 10)
+		return (ordinal / 7.0)
+	}
+
+	private var seedColor: Color {
+		Color(hue: hue, saturation: 0.55, brightness: 0.62)
+	}
+
+	/// Diagonal wash from the seed hue into a darker shade of itself so the
+	/// white italic label stays legible at the bottom-left.
+	private var gradient: LinearGradient {
+		LinearGradient(
+			colors: [
+				Color(hue: hue, saturation: 0.62, brightness: 0.66),
+				Color(hue: hue, saturation: 0.70, brightness: 0.34),
+			],
+			startPoint: .topLeading,
+			endPoint: .bottomTrailing
+		)
+	}
+}

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Discover — the "find something new" surface. Today: a header + Instant Mix
-/// CTA (#248), a horizontal "For You" carousel (#249), and a "Genres to
-/// Explore" grid (#250). Richer recommendations (recently added, more like
-/// this, etc.) land in follow-ups.
+/// CTA (#248), a horizontal "For You" carousel (#249), a "Browse by Decade"
+/// gradient-tile row, and a "Genres to Explore" grid (#250). Richer
+/// recommendations (recently added, more like this, etc.) land in follow-ups.
 ///
 /// Title is italic 34pt, subline 14pt `ink2`, right-aligned primary "Start
 /// Instant Mix" + ghost "Generate new mix" — per `06-screen-specs.md`.
@@ -15,6 +15,7 @@ struct DiscoverView: View {
             VStack(alignment: .leading, spacing: 28) {
                 header
                 forYouSection
+                DecadeBrowseRow()
                 GenresToExploreSection()
                 Spacer(minLength: 24)
             }

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -166,9 +166,16 @@ struct LibraryView: View {
         .onAppear {
             selectedTab = model.libraryTab
             applyDefaultSort(for: selectedTab)
+            applyPendingDecadeFilter()
         }
         .onChange(of: model.libraryTab) { _, newValue in
             selectedTab = newValue
+        }
+        // A decade tile tapped while the Library is already on screen flips
+        // `pendingLibraryYearRange` without re-running `.onAppear`; pick it up
+        // here so the year filter still lands.
+        .onChange(of: model.pendingLibraryYearRange) { _, _ in
+            applyPendingDecadeFilter()
         }
         .onChange(of: selectedTab) { _, newValue in
             // Write-back so the sidebar's highlighted chip stays in sync.
@@ -711,6 +718,19 @@ struct LibraryView: View {
 
     private var filteredPlaylists: [Playlist] {
         filter.isActive ? model.playlists.filter(passesFilter) : model.playlists
+    }
+
+    /// Consume the one-shot decade window deep-linked from the Discover
+    /// "Browse by Decade" row and fold it into the active filter. Forces
+    /// the Albums chip (album items carry the `year` the filter keys on) and
+    /// replaces any prior year constraint with the decade's `[start, start+9]`
+    /// span. Other filter groups (genre, favorited, …) are preserved so the
+    /// decade composes with whatever the user already had set. No-op when no
+    /// window is pending, so an ordinary Library visit is untouched.
+    private func applyPendingDecadeFilter() {
+        guard let range = model.consumePendingLibraryYearRange() else { return }
+        selectedTab = .albums
+        filter.yearRange = range
     }
 
     /// Apply the persisted default sort for `tab` the first time the user

--- a/macos/Tests/LyrebirdTests/DecadeBrowseTests.swift
+++ b/macos/Tests/LyrebirdTests/DecadeBrowseTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Discover "Browse by Decade" deep-link.
+///
+/// Two contracts: the static `Decade` ramp and its label formatting are pure
+/// value logic, and `AppModel.browseDecade(_:)` must stash a one-shot
+/// `[start, start+9]` year window, force the Albums chip, switch to the Library,
+/// and surrender that window exactly once via `consumePendingLibraryYearRange()`.
+///
+/// Same isolation contract as `DiscoverSongRadioRouteTests`: `AppModel` is
+/// `@MainActor` and boots a live core pointed at a throwaway data dir.
+@MainActor
+final class DecadeBrowseTests: XCTestCase {
+
+	override class func setUp() {
+		super.setUp()
+		let dir = NSTemporaryDirectory() + "lyrebird-decade-\(UUID().uuidString)"
+		setenv("XDG_DATA_HOME", dir, 1)
+	}
+
+	func testDecadeRampCoversSixtiesThroughTwenties() {
+		XCTAssertEqual(
+			Decade.all.map(\.startYear),
+			[1960, 1970, 1980, 1990, 2000, 2010, 2020],
+			"the row renders the fixed '60s→'20s ramp, oldest first"
+		)
+	}
+
+	func testShortLabelUsesTwoDigitApostropheForm() {
+		XCTAssertEqual(Decade(startYear: 1980).shortLabel, "'80s")
+		XCTAssertEqual(Decade(startYear: 2000).shortLabel, "'00s")
+		XCTAssertEqual(Decade(startYear: 2020).shortLabel, "'20s")
+	}
+
+	func testBrowseDecadeStashesInclusiveTenYearWindowAndRoutesToLibrary() throws {
+		let model = try AppModel()
+		model.libraryTab = .artists
+
+		model.browseDecade(startingYear: 1990)
+
+		XCTAssertEqual(
+			model.pendingLibraryYearRange,
+			1990...1999,
+			"a decade tile must stash the inclusive [start, start+9] window"
+		)
+		XCTAssertEqual(
+			model.libraryTab, .albums,
+			"the decade filter keys on album years, so the Albums chip is forced"
+		)
+		XCTAssertEqual(model.screen, .library, "tapping a decade routes to the Library")
+		XCTAssertTrue(model.navPath.isEmpty, "the drill stack is reset on tab switch")
+	}
+
+	func testConsumePendingYearRangeIsOneShot() throws {
+		let model = try AppModel()
+
+		model.browseDecade(startingYear: 2010)
+
+		XCTAssertEqual(
+			model.consumePendingLibraryYearRange(),
+			2010...2019,
+			"the first consume hands back the pending window"
+		)
+		XCTAssertNil(
+			model.consumePendingLibraryYearRange(),
+			"the window is cleared after one read so a later Library visit isn't re-filtered"
+		)
+		XCTAssertNil(model.pendingLibraryYearRange)
+	}
+}


### PR DESCRIPTION
Adds the Discover "Browse by Decade" row from the screen spec: a horizontal strip of gradient tiles ('60s→'20s) with oversized italic decade labels that deep-link into the Library pre-filtered to that ten-year release-year window.

Closes #251

### How it works
- `DecadeBrowseRow` (new component) renders the fixed '60s→'20s ramp as gradient tiles, mirroring `GenreExploreTile`'s hover/scale/shadow vocabulary so Discover reads as one family. Tapping a tile calls `AppModel.browseDecade(startingYear:)`.
- `browseDecade` stashes the inclusive `[start, start+9]` window on a new one-shot `pendingLibraryYearRange`, forces the Albums chip (album items carry the `year` the existing filter keys on), and switches to the Library tab.
- `LibraryView` consumes the pending window on `.onAppear` (fresh entry) and on `.onChange` of `pendingLibraryYearRange` (tapped while Library already on screen), folding it into the existing `LibraryFilter.yearRange` and clearing it via `consumePendingLibraryYearRange()` so an ordinary later Library visit isn't re-filtered. Other filter groups are preserved so the decade composes with whatever was already set.

Reuses the existing client-side year filter — no new FFI, no Rust change.

### pipeline
- fixer-session: feature-builder-251
- slice: screens
- hotspots-claimed: none
- build-gate: pass — `swift build` clean, `swift test --filter DecadeBrowseTests` 4/4 green (no Rust touched, so Rust gates N/A)
- diff-stat: 5 files, +264 / -3