### PR TITLE
macos: add Browse by Genre tiles to empty Search page (top 12 by track count)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -217,6 +217,16 @@ final class AppModel {
     /// `refreshGenresToExplore()` runs, and stays empty for a library with no
     /// genres so the section can hide rather than punch a blank hole.
     var genresToExplore: [Genre] = []
+    /// Genres surfaced in the Search "Browse by Genre" tile grid (#247). The
+    /// dual of `genresToExplore`: the *largest* genres in the library, ranked
+    /// by descending `song_count` and capped at 12, so the empty-search page
+    /// leads with the corners of the library the user is most likely to want
+    /// to browse. Carries the resolved Jellyfin UUID in `Genre.id` (sourced
+    /// straight from `core.genres`), so tapping a tile navigates to the genre
+    /// detail screen without a name→UUID round-trip. Empty until
+    /// `refreshBrowseGenres()` runs, and stays empty for a genre-less library
+    /// so the section can hide rather than render a blank band.
+    var browseGenres: [Genre] = []
     /// Last-played albums for the Home "Jump Back In" carousel (#51). Up to
     /// 12 albums the user has played recently, sorted by `DatePlayed` desc.
     /// Backed by a raw `/Items` fetch because the core's `ItemsQuery`
@@ -1007,6 +1017,7 @@ final class AppModel {
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
+        browseGenres = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -1072,6 +1083,7 @@ final class AppModel {
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
+        browseGenres = []
         jumpBackIn = []
         recentlyAdded = []
         recentlyAddedDates = [:]
@@ -1230,6 +1242,7 @@ final class AppModel {
         await refreshRecentlyPlayed()
         await refreshForYou()
         await refreshGenresToExplore()
+        await refreshBrowseGenres()
         // Home screen carousels (#49 / #51–#55). Kicked off after the main
         // library so first paint isn't blocked on these secondary shelves.
         // Each of these is best-effort — empty or errored rows just hide in
@@ -1565,6 +1578,62 @@ final class AppModel {
                     return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
                 }
                 .prefix(8)
+                .map { Genre(id: $0.id, name: $0.name) }
+        )
+    }
+
+    /// Refresh the Search "Browse by Genre" tile grid (#247).
+    ///
+    /// Pulls one page of `/MusicGenres` (already filtered server-side to
+    /// genres carrying Audio/Album/Artist items) and ranks them so the
+    /// *biggest* genres lead — the dual of `refreshGenresToExplore`. Jellyfin's
+    /// `/MusicGenres` projection carries `song_count` per genre, so we rank by
+    /// descending count, tie-broken by name for a stable order, and cap at 12
+    /// for the tile grid.
+    ///
+    /// Runs the sync `core.genres` FFI off the MainActor (gap pattern #2) and
+    /// marshals the ranked result back. Failures leave the prior grid intact
+    /// rather than blanking the section mid-session; auth expiry surfaces so
+    /// the user is routed to re-login like every other refresh path.
+    func refreshBrowseGenres() async {
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                // limit: 500 matches `refreshGenresToExplore` / `resolvedGenreId`
+                // — /MusicGenres sorts SortName ascending, so a smaller cap would
+                // silently drop alphabetically-late genres from the ranking pool
+                // (the test library has 254 genres).
+                try core.genres(offset: 0, limit: 500)
+            }.value
+            // Project the FFI genres to plain tuples before ranking — passing the
+            // `core.Genre` struct directly would force a `LyrebirdCore.Genre`
+            // annotation, which the generated `open class LyrebirdCore` shadows
+            // (module-vs-type name collision). Tuples keep the ranking helper
+            // pure + testable.
+            self.browseGenres = AppModel.rankBrowseGenres(
+                page.items.map { (id: $0.id, name: $0.name, songCount: $0.songCount) }
+            )
+        } catch {
+            _ = handleAuthError(error)
+        }
+    }
+
+    /// Pure ranking for the "Browse by Genre" grid (#247), split out from the
+    /// FFI hop so it's unit-testable without a live core. Keeps only genres
+    /// present in the library (`song_count > 0`), ranks descending by
+    /// `song_count` (biggest first) with a case-insensitive name tiebreaker for
+    /// stable order, caps at 12 for the tile grid, and carries the resolved
+    /// Jellyfin UUID through into the local `Genre.id`.
+    static func rankBrowseGenres(
+        _ genres: [(id: String, name: String, songCount: UInt32)]
+    ) -> [Genre] {
+        Array(
+            genres
+                .filter { $0.songCount > 0 }
+                .sorted {
+                    if $0.songCount != $1.songCount { return $0.songCount > $1.songCount }
+                    return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+                .prefix(12)
                 .map { Genre(id: $0.id, name: $0.name) }
         )
     }

--- a/macos/Sources/Lyrebird/Components/BrowseByGenreSection.swift
+++ b/macos/Sources/Lyrebird/Components/BrowseByGenreSection.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// Search "Browse by Genre" tile grid (#247).
+///
+/// A grid of up to 12 gradient `GenreBrowseTile`s ranked by
+/// `AppModel.refreshBrowseGenres()` — the *largest* genres in the library
+/// (descending `song_count`) lead, so the empty-search landing surfaces the
+/// corners the user is most likely to want to browse. Each tile carries a
+/// genre whose `id` is the resolved Jellyfin UUID (sourced from `core.genres`),
+/// so tapping navigates straight to the genre detail screen via
+/// `AppModel.browseGenre` without a name→UUID round-trip.
+///
+/// Hidden entirely when there are no genres (a brand-new / genre-less library
+/// doesn't render an empty band) or when genre actions are gated off, so the
+/// surface never presents tiles that lead to a stubbed destination. Uses a
+/// fixed-column `LazyVGrid` (vertical, not a horizontal `LazyHStack`) so it's
+/// clear of the rc9 macOS 26.4 `LazyHStack`-in-horizontal-`ScrollView` UAF.
+struct BrowseByGenreSection: View {
+    @Environment(AppModel.self) private var model
+
+    /// Three flexible columns → the ranked 12 genres lay out as 3×4.
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: 16, alignment: .top),
+        count: 3
+    )
+
+    var body: some View {
+        if model.supportsGenreActions && !model.browseGenres.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "guitars")
+                        .foregroundStyle(Theme.accent)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Browse by Genre")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("The biggest corners of your library")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(model.browseGenres, id: \.id) { genre in
+                        GenreBrowseTile(genre: genre) {
+                            model.browseGenre(genre: genre)
+                        }
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Browse by Genre")
+        }
+    }
+}
+
+/// One gradient genre tile for the Search browse grid. A 96pt-tall card with a
+/// deterministic per-genre gradient so the grid reads as a colorful mosaic
+/// rather than a wall of identical chips.
+private struct GenreBrowseTile: View {
+    let genre: Genre
+    let onOpen: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: onOpen) {
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(gradient)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.white.opacity(isHovering ? 0.35 : 0.12), lineWidth: 1)
+                Text(genre.name)
+                    .font(Theme.font(16, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+                    .padding(14)
+            }
+            .frame(height: 96)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .scaleEffect(reduceMotion ? 1 : (isHovering ? 1.03 : 1))
+            .shadow(
+                color: seedColor.opacity(isHovering ? 0.45 : 0.25),
+                radius: isHovering ? 14 : 8,
+                y: isHovering ? 8 : 4
+            )
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu { GenreContextMenu(genre: genre) }
+        .help("Browse \(genre.name)")
+        .accessibilityLabel("Browse \(genre.name)")
+        .accessibilityHint("Opens the \(genre.name) genre")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Deterministic base hue derived from the genre name so the same genre
+    /// always lands on the same color across launches. Stable, well-spread
+    /// hashing via a small FNV-1a over the name's unicode scalars — matches
+    /// `GenresToExploreSection`'s tile so the two genre surfaces feel like
+    /// siblings.
+    private var seedColor: Color {
+        Color(hue: hue, saturation: 0.55, brightness: 0.62)
+    }
+
+    /// Diagonal wash from the seed color into a darker shade of itself so the
+    /// white label stays legible at the bottom-left.
+    private var gradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(hue: hue, saturation: 0.62, brightness: 0.66),
+                Color(hue: hue, saturation: 0.70, brightness: 0.34),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    /// FNV-1a over the genre name's unicode scalars, mapped to a 0–1 hue.
+    private var hue: Double {
+        var hash: UInt32 = 2_166_136_261
+        for scalar in genre.name.unicodeScalars {
+            hash = (hash ^ scalar.value) &* 16_777_619
+        }
+        return Double(hash % 360) / 360.0
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -78,6 +78,15 @@ struct SearchView: View {
         // #585: Route space-bar keypresses to the search TextField even
         // while the global Play/Pause ⎵ shortcut is active.
         .spaceKeyGuardForTextField()
+        // Best-effort populate of the "Browse by Genre" tiles (#247) so the
+        // empty-search landing has something to browse even if the user
+        // reaches Search before the post-login bootstrap got to it. Cheap
+        // (one cached /MusicGenres page) and idempotent.
+        .task {
+            if model.browseGenres.isEmpty {
+                await model.refreshBrowseGenres()
+            }
+        }
         .onAppear {
             if model.requestSearchFocus {
                 searchFieldFocused = true
@@ -230,6 +239,16 @@ struct SearchView: View {
     @ViewBuilder
     private var recentSearches: some View {
         let items = AppModel.decodeRecentSearches(recentSearchesJSON)
+        VStack(alignment: .leading, spacing: 28) {
+            recentSearchesList(items)
+            BrowseByGenreSection()
+        }
+    }
+
+    /// The recent-searches list proper, split out so the empty-query body can
+    /// compose it above the "Browse by Genre" tiles (#247).
+    @ViewBuilder
+    private func recentSearchesList(_ items: [String]) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Recent searches")
                 .font(Theme.font(18, weight: .bold))

--- a/macos/Tests/LyrebirdTests/BrowseGenresRankingTests.swift
+++ b/macos/Tests/LyrebirdTests/BrowseGenresRankingTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Search "Browse by Genre" ranking (#247).
+///
+/// `AppModel.rankBrowseGenres` is the pure half of `refreshBrowseGenres`, split
+/// out from the FFI hop so the ranking contract can be asserted without a live
+/// core: drop empty genres, rank biggest-first (descending `song_count`) with a
+/// name tiebreaker, cap at 12, and carry the resolved Jellyfin UUID through to
+/// the local `Genre.id`. The dual of `GenresToExploreRankingTests`.
+@MainActor
+final class BrowseGenresRankingTests: XCTestCase {
+
+    private func genre(
+        _ name: String,
+        songs: UInt32,
+        id: String? = nil
+    ) -> (id: String, name: String, songCount: UInt32) {
+        (id: id ?? "id-\(name)", name: name, songCount: songs)
+    }
+
+    func testRanksBiggestFirst() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Ambient", songs: 3),
+            genre("Jazz", songs: 12),
+            genre("Pop", songs: 500),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Pop", "Jazz", "Ambient"])
+    }
+
+    func testDropsGenresWithNoSongs() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Empty", songs: 0),
+            genre("Real", songs: 4),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Real"])
+    }
+
+    func testTieBrokenByCaseInsensitiveName() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("blues", songs: 7),
+            genre("Ambient", songs: 7),
+            genre("Country", songs: 7),
+        ])
+        XCTAssertEqual(ranked.map(\.name), ["Ambient", "blues", "Country"])
+    }
+
+    func testCapsAtTwelveForTheGrid() {
+        let many = (1...20).map { genre("G\($0)", songs: UInt32($0)) }
+        let ranked = AppModel.rankBrowseGenres(many)
+        XCTAssertEqual(ranked.count, 12)
+        // Biggest twelve, in descending order.
+        XCTAssertEqual(ranked.first?.name, "G20")
+        XCTAssertEqual(ranked.last?.name, "G9")
+    }
+
+    func testCarriesResolvedUuidIntoId() {
+        let ranked = AppModel.rankBrowseGenres([
+            genre("Soul", songs: 5, id: "uuid-soul-123")
+        ])
+        XCTAssertEqual(ranked.first?.id, "uuid-soul-123")
+    }
+}


### PR DESCRIPTION
Surfaces a gradient `GenreBrowseTile` grid on the empty-query Search page so users can dive into their library's biggest genres without typing a query.

The grid ranks `core.genres()` by descending `song_count` (the dual of the Discover "Genres to Explore" grid, which ranks ascending), keeps only genres present in the library, caps at 12, and carries the resolved Jellyfin UUID through into each tile so a tap routes straight to the genre detail screen via `AppModel.browseGenre` — no name→UUID round-trip. The FFI hop runs off the `MainActor` (gap pattern #2); the section hides entirely for a genre-less library or when genre actions are gated off, so it never renders a blank band or a tile that leads to a stub.

Closes #247

pipeline:
- fixer-session: feature-builder-247
- slice: screens
- hotspots-claimed: none
- build-gate: `./macos/Scripts/build-core.sh` (debug) + `swift build --package-path macos` (Build complete) + `swift test --filter BrowseGenresRankingTests` (5/5 pass) + `cargo fmt --all -- --check` (clean; no Rust changed)
- diff-stat: 2 files modified, 2 new (BrowseByGenreSection.swift + BrowseGenresRankingTests.swift), +88 in tracked diff plus the two new files