### PR TITLE
macos: add Genre / Decade / Mood radio rows

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -1516,6 +1516,119 @@ impl JellyfinClient {
         })
     }
 
+    /// Audio tracks whose `ProductionYear` falls in the inclusive range
+    /// `[start_year, end_year]`. Powers the Radio page's "Decade Radio"
+    /// row — e.g. the '80s tile resolves to `1980..=1989`. Mirrors
+    /// [`Self::tracks_by_genre`]'s field projection so the returned
+    /// [`Track`]s carry artwork + user-data for the player.
+    pub async fn tracks_by_year_range(
+        &self,
+        start_year: u32,
+        end_year: u32,
+        paging: Paging,
+    ) -> Result<PaginatedTracks> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(LyrebirdError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            // Jellyfin's `Years` filter takes a CSV of discrete years; expand
+            // the inclusive range into that list. A decade is 10 entries —
+            // trivially short.
+            let years: Vec<String> = (start_year..=end_year).map(|y| y.to_string()).collect();
+            q.append_pair("Years", &years.join(","));
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            // Random order so repeat taps on the same decade tile don't always
+            // serve the same opening tracks — this is a "radio", not a catalog.
+            q.append_pair("SortBy", "Random");
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::AlbumId,
+                        ItemField::AlbumArtist,
+                        ItemField::Artists,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                        ItemField::RunTimeTicks,
+                    ],
+                    ItemField::as_str,
+                ),
+            );
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        let items: Vec<Track> = raw.items.into_iter().map(Track::from).collect();
+        Ok(PaginatedTracks {
+            items,
+            total_count: raw.total_record_count,
+        })
+    }
+
+    /// Audio tracks carrying the given free-text `tag`. Powers the Radio
+    /// page's "Mood Radio" row, where moods (chill / focus / workout /
+    /// sleep / party) are sourced from item tags when the library has them.
+    /// Returns an empty page (not an error) when no track carries the tag,
+    /// so the caller can gracefully hide an unpopulated mood tile.
+    pub async fn tracks_by_tag(&self, tag: &str, paging: Paging) -> Result<PaginatedTracks> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(LyrebirdError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Users/{user_id}/Items"))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("Tags", tag);
+            q.append_pair("Recursive", "true");
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
+            q.append_pair("Limit", &paging.limit.max(1).to_string());
+            q.append_pair("StartIndex", &paging.offset.to_string());
+            q.append_pair("SortBy", "Random");
+            q.append_pair("EnableUserData", "true");
+            q.append_pair("EnableImages", "true");
+            q.append_pair("ImageTypeLimit", "1");
+            q.append_pair(
+                "Fields",
+                &enums::csv(
+                    &[
+                        ItemField::MediaSources,
+                        ItemField::UserData,
+                        ItemField::ParentId,
+                        ItemField::AlbumId,
+                        ItemField::AlbumArtist,
+                        ItemField::Artists,
+                        ItemField::ProductionYear,
+                        ItemField::PrimaryImageAspectRatio,
+                        ItemField::RunTimeTicks,
+                    ],
+                    ItemField::as_str,
+                ),
+            );
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        let items: Vec<Track> = raw.items.into_iter().map(Track::from).collect();
+        Ok(PaginatedTracks {
+            items,
+            total_count: raw.total_record_count,
+        })
+    }
+
     /// Full artist record with biography, backdrops, and external links —
     /// extends [`JellyfinClient::fetch_item`] with an artist-focused field
     /// projection. Powers the artist detail header (bio + MusicBrainz /

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -512,7 +512,7 @@ impl LyrebirdCore {
 
     /// Audio tracks whose production year falls in the inclusive range
     /// `[start_year, end_year]`. Feeds the Radio page's "Decade Radio" row
-    /// (#256) — e.g. the '90s tile passes `1990, 1999`. Returns tracks in
+    /// — e.g. the '90s tile passes `1990, 1999`. Returns tracks in
     /// random order so the station varies between taps.
     pub fn tracks_by_year_range(
         &self,
@@ -531,7 +531,7 @@ impl LyrebirdCore {
     }
 
     /// Audio tracks carrying the given free-text tag. Feeds the Radio page's
-    /// "Mood Radio" row (#256), where moods come from item tags when present.
+    /// "Mood Radio" row, where moods come from item tags when present.
     /// Returns an empty page (not an error) when nothing carries the tag, so
     /// the caller can hide an unpopulated mood tile.
     pub fn tracks_by_tag(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -510,6 +510,42 @@ impl LyrebirdCore {
         })
     }
 
+    /// Audio tracks whose production year falls in the inclusive range
+    /// `[start_year, end_year]`. Feeds the Radio page's "Decade Radio" row
+    /// (#256) — e.g. the '90s tile passes `1990, 1999`. Returns tracks in
+    /// random order so the station varies between taps.
+    pub fn tracks_by_year_range(
+        &self,
+        start_year: u32,
+        end_year: u32,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime.block_on(c.tracks_by_year_range(
+                start_year,
+                end_year,
+                Paging::new(offset, limit),
+            ))
+        })
+    }
+
+    /// Audio tracks carrying the given free-text tag. Feeds the Radio page's
+    /// "Mood Radio" row (#256), where moods come from item tags when present.
+    /// Returns an empty page (not an error) when nothing carries the tag, so
+    /// the caller can hide an unpopulated mood tile.
+    pub fn tracks_by_tag(
+        &self,
+        tag: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedTracks, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.tracks_by_tag(&tag, Paging::new(offset, limit)))
+        })
+    }
+
     /// Full artist record with biography, backdrop image tags, and
     /// external links (MusicBrainz / Last.fm / Discogs). Feeds the artist
     /// detail header.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7873,3 +7873,95 @@ async fn album_tracks_parses_negative_bitrate_sentinel() {
     assert_eq!(tracks.len(), 1);
     assert_eq!(tracks[0].bitrate, Some(-1000));
 }
+
+#[tokio::test]
+async fn tracks_by_year_range_builds_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "t1", "Name": "Disco Inferno", "Type": "Audio", "ProductionYear": 1976 }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .tracks_by_year_range(1970, 1979, Paging::new(0, 100))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 1);
+    assert_eq!(page.items[0].id, "t1");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    // Inclusive range expanded into the CSV `Years` filter (URL-encoded comma).
+    assert!(q.contains("Years=1970%2C1971%2C1972"), "query: {q}");
+    assert!(
+        q.contains("Years=1970%2C1971%2C1972%2C1973%2C1974%2C1975%2C1976%2C1977%2C1978%2C1979"),
+        "query: {q}"
+    );
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("Limit=100"), "query: {q}");
+    assert!(q.contains("SortBy=Random"), "query: {q}");
+}
+
+#[tokio::test]
+async fn tracks_by_tag_builds_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [],
+            "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    // Empty result is a valid page, not an error — lets the UI hide an
+    // unpopulated mood tile gracefully.
+    let page = client
+        .tracks_by_tag("chill", Paging::new(0, 100))
+        .await
+        .unwrap();
+    assert_eq!(page.total_count, 0);
+    assert!(page.items.is_empty());
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("Tags=chill"), "query: {q}");
+    assert!(q.contains("IncludeItemTypes=Audio"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("SortBy=Random"), "query: {q}");
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4851,7 +4851,7 @@ final class AppModel {
         PinnedStationsStore.save(stations)
     }
 
-    // MARK: - Decade / Mood radio (Radio page rows, #256)
+    // MARK: - Decade / Mood radio (Radio page rows)
     //
     // Genre Radio already routes through `startGenreRadio` (Instant Mix on a
     // resolved genre UUID). Decade and Mood don't have a single seed item to
@@ -4862,7 +4862,7 @@ final class AppModel {
 
     /// Start a "decade radio" — plays a randomized page of tracks whose
     /// production year falls in `[startYear, endYear]`. Backs the Decade
-    /// Radio tile row on the Radio page (#256). The FFI runs off the
+    /// Radio tile row on the Radio page. The FFI runs off the
     /// MainActor per CLAUDE.md gap pattern #2.
     func startDecadeRadio(startYear: UInt32, endYear: UInt32, label: String) {
         Task {
@@ -4892,7 +4892,7 @@ final class AppModel {
 
     /// Start a "mood radio" — plays a randomized page of tracks carrying the
     /// given tag (chill / focus / workout / sleep / party). Backs the Mood
-    /// Radio tile row on the Radio page (#256). Surfaces a friendly message
+    /// Radio tile row on the Radio page. Surfaces a friendly message
     /// when the library has no tracks tagged with the mood rather than
     /// silently doing nothing. The FFI runs off the MainActor per CLAUDE.md
     /// gap pattern #2.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4851,6 +4851,72 @@ final class AppModel {
         PinnedStationsStore.save(stations)
     }
 
+    // MARK: - Decade / Mood radio (Radio page rows, #256)
+    //
+    // Genre Radio already routes through `startGenreRadio` (Instant Mix on a
+    // resolved genre UUID). Decade and Mood don't have a single seed item to
+    // hand to Instant Mix, so they query a track set directly
+    // (`tracksByYearRange` / `tracksByTag`), then play it. Both FFIs return
+    // server-randomized pages, so the station varies between taps without a
+    // client-side shuffle.
+
+    /// Start a "decade radio" — plays a randomized page of tracks whose
+    /// production year falls in `[startYear, endYear]`. Backs the Decade
+    /// Radio tile row on the Radio page (#256). The FFI runs off the
+    /// MainActor per CLAUDE.md gap pattern #2.
+    func startDecadeRadio(startYear: UInt32, endYear: UInt32, label: String) {
+        Task {
+            do {
+                let page = try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.tracksByYearRange(
+                        startYear: startYear,
+                        endYear: endYear,
+                        offset: 0,
+                        limit: 100
+                    )
+                }.value
+                guard !page.items.isEmpty else {
+                    errorMessage = "No tracks found for \(label)"
+                    return
+                }
+                play(tracks: page.items, startIndex: 0)
+            } catch {
+                if handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = "Couldn't start \(label) radio: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Start a "mood radio" — plays a randomized page of tracks carrying the
+    /// given tag (chill / focus / workout / sleep / party). Backs the Mood
+    /// Radio tile row on the Radio page (#256). Surfaces a friendly message
+    /// when the library has no tracks tagged with the mood rather than
+    /// silently doing nothing. The FFI runs off the MainActor per CLAUDE.md
+    /// gap pattern #2.
+    func startMoodRadio(tag: String, label: String) {
+        Task {
+            do {
+                let page = try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.tracksByTag(tag: tag, offset: 0, limit: 100)
+                }.value
+                guard !page.items.isEmpty else {
+                    errorMessage = "No \(label) tracks tagged in your library"
+                    return
+                }
+                play(tracks: page.items, startIndex: 0)
+            } catch {
+                if handleAuthError(error) { return }
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+                errorMessage = "Couldn't start \(label) radio: \(error.localizedDescription)"
+            }
+        }
+    }
+
     func pause() { audio.pause() }
     func resume() { audio.resume() }
     func stop() { audio.stop() }

--- a/macos/Sources/Lyrebird/Components/RadioStationTile.swift
+++ b/macos/Sources/Lyrebird/Components/RadioStationTile.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// A gradient station tile used by the Genre / Decade / Mood radio rows on
-/// the Radio / Home screen (#256). Unlike `ArtistRadioTile` (a circular
+/// the Radio / Home screen. Unlike `ArtistRadioTile` (a circular
 /// artwork thumb), these stations have no single seed image — they're
 /// abstract "play me this slice of the library" presets — so the tile leans
 /// on a per-tile gradient + a huge italic label, matching the screen-spec

--- a/macos/Sources/Lyrebird/Components/RadioStationTile.swift
+++ b/macos/Sources/Lyrebird/Components/RadioStationTile.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// A gradient station tile used by the Genre / Decade / Mood radio rows on
+/// the Radio / Home screen (#256). Unlike `ArtistRadioTile` (a circular
+/// artwork thumb), these stations have no single seed image — they're
+/// abstract "play me this slice of the library" presets — so the tile leans
+/// on a per-tile gradient + a huge italic label, matching the screen-spec
+/// treatment ("default artwork gradient + huge italic text"). A radio glyph
+/// reveals on hover so the tile reads as an action, not a static label.
+///
+/// Tapping invokes `action`, which the caller wires to the corresponding
+/// `AppModel` radio starter (`startGenreRadio` / `startDecadeRadio` /
+/// `startMoodRadio`).
+struct RadioStationTile: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Large italic label, e.g. "Jazz", "'80s", "Chill".
+    let label: String
+    /// Small uppercase eyebrow, e.g. "GENRE", "DECADE", "MOOD".
+    let eyebrow: String
+    /// Stable seed used to derive the gradient hue so a given station always
+    /// renders the same color (e.g. the genre name / decade string).
+    let seed: String
+    let action: () -> Void
+
+    var size: CGFloat = 150
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            ZStack(alignment: .bottomLeading) {
+                gradient
+                // Radio glyph, top-trailing, revealed on hover.
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .padding(12)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                    .opacity(isHovering ? 1 : 0)
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(eyebrow)
+                        .font(Theme.font(10, weight: .bold))
+                        .tracking(1.2)
+                        .foregroundStyle(.white.opacity(0.75))
+                    Text(label)
+                        .font(Theme.font(26, weight: .black, italic: true))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
+                .padding(14)
+            }
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(isHovering ? Theme.accent : Theme.border, lineWidth: isHovering ? 2 : 1)
+            )
+            .shadow(color: isHovering ? Theme.accent.opacity(0.3) : .clear, radius: 12)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .help("Start \(label) Radio")
+        .accessibilityLabel("\(label) Radio")
+        .accessibilityHint("Starts a radio station seeded by \(label)")
+    }
+
+    /// Deterministic two-stop gradient derived from `seed` so each station
+    /// gets a distinct but stable hue. Saturation/brightness are pinned so
+    /// every tile stays in the same "deep, music-forward" register as the
+    /// rest of the UI rather than going neon.
+    private var gradient: some View {
+        let hue = Double(abs(seed.hashValue) % 360) / 360.0
+        let top = Color(hue: hue, saturation: 0.55, brightness: 0.42)
+        let bottom = Color(hue: (hue + 0.08).truncatingRemainder(dividingBy: 1.0),
+                           saturation: 0.7, brightness: 0.24)
+        return LinearGradient(
+            colors: [top, bottom],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -270,7 +270,7 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Genre / Decade / Mood radio rows (#256)
+    // MARK: - Genre / Decade / Mood radio rows
 
     /// The three station rows from the Radio screen spec (§9, Issue 57):
     /// Genre Radio, Decade Radio, and Mood Radio. Each is a horizontal row of

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -41,6 +41,7 @@ struct HomeView: View {
                 // does nothing. Re-enable once the real pin infrastructure
                 // lands (#144, #253).
                 artistRadioRow
+                radioStationsSection
                 Spacer(minLength: 24)
             }
             .padding(.horizontal, 32)
@@ -268,6 +269,137 @@ struct HomeView: View {
             }
         }
     }
+
+    // MARK: - Genre / Decade / Mood radio rows (#256)
+
+    /// The three station rows from the Radio screen spec (§9, Issue 57):
+    /// Genre Radio, Decade Radio, and Mood Radio. Each is a horizontal row of
+    /// gradient `RadioStationTile`s. Tapping a tile starts the corresponding
+    /// station via `AppModel`. The Genre row only renders when the library
+    /// has surfaced genres to explore; Decade and Mood are static presets and
+    /// always render (the AppModel starters surface a friendly message if a
+    /// given decade/mood has no tracks).
+    @ViewBuilder
+    private var radioStationsSection: some View {
+        if !genreRadioStations.isEmpty {
+            radioRow(
+                title: "Genre Radio",
+                subtitle: "Stations from your library",
+                tiles: genreRadioStations,
+                eyebrow: "GENRE"
+            ) { genre in
+                model.startGenreRadio(genre: genre)
+            } labelFor: { genre in
+                (label: genre.name, seed: "genre-\(genre.name)")
+            }
+        }
+
+        radioRow(
+            title: "Decade Radio",
+            subtitle: "Travel through the years",
+            tiles: Self.decadeStations,
+            eyebrow: "DECADE"
+        ) { decade in
+            model.startDecadeRadio(
+                startYear: decade.startYear,
+                endYear: decade.endYear,
+                label: decade.label
+            )
+        } labelFor: { decade in
+            (label: decade.label, seed: "decade-\(decade.label)")
+        }
+
+        radioRow(
+            title: "Mood Radio",
+            subtitle: "Tagged by feel",
+            tiles: Self.moodStations,
+            eyebrow: "MOOD"
+        ) { mood in
+            model.startMoodRadio(tag: mood.tag, label: mood.label)
+        } labelFor: { mood in
+            (label: mood.label, seed: "mood-\(mood.tag)")
+        }
+    }
+
+    /// Shared layout for a radio station row: shelf header + a horizontal
+    /// strip of `RadioStationTile`s. Generic over the tile model so Genre /
+    /// Decade / Mood can share one implementation.
+    @ViewBuilder
+    private func radioRow<Item: Hashable>(
+        title: String,
+        subtitle: String,
+        tiles: [Item],
+        eyebrow: String,
+        action: @escaping (Item) -> Void,
+        labelFor: @escaping (Item) -> (label: String, seed: String)
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .foregroundStyle(Theme.accent)
+                    .font(.system(size: 14, weight: .bold))
+                Text(title)
+                    .font(Theme.font(18, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                Text(subtitle)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(tiles, id: \.self) { tile in
+                        let info = labelFor(tile)
+                        RadioStationTile(
+                            label: info.label,
+                            eyebrow: eyebrow,
+                            seed: info.seed,
+                            action: { action(tile) }
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// Genre stations — drawn from the same ranked "genres to explore" signal
+    /// the Discover screen uses, capped to the spec's 4–6 tiles.
+    private var genreRadioStations: [Genre] {
+        Array(model.genresToExplore.prefix(6))
+    }
+
+    /// Static decade presets (§9 Issue 52/57). `endYear` is inclusive.
+    struct DecadeStation: Hashable {
+        let label: String
+        let startYear: UInt32
+        let endYear: UInt32
+    }
+
+    static let decadeStations: [DecadeStation] = [
+        DecadeStation(label: "'60s", startYear: 1960, endYear: 1969),
+        DecadeStation(label: "'70s", startYear: 1970, endYear: 1979),
+        DecadeStation(label: "'80s", startYear: 1980, endYear: 1989),
+        DecadeStation(label: "'90s", startYear: 1990, endYear: 1999),
+        DecadeStation(label: "'00s", startYear: 2000, endYear: 2009),
+        DecadeStation(label: "'10s", startYear: 2010, endYear: 2019),
+    ]
+
+    /// Static mood presets sourced from item tags when present (§9 Issue 57).
+    /// The AppModel starter surfaces a friendly message when a mood has no
+    /// tagged tracks, so showing the tile costs nothing if the library is
+    /// untagged.
+    struct MoodStation: Hashable {
+        let label: String
+        let tag: String
+    }
+
+    static let moodStations: [MoodStation] = [
+        MoodStation(label: "Chill", tag: "chill"),
+        MoodStation(label: "Focus", tag: "focus"),
+        MoodStation(label: "Workout", tag: "workout"),
+        MoodStation(label: "Sleep", tag: "sleep"),
+        MoodStation(label: "Party", tag: "party"),
+    ]
 
     /// Pinned Stations row (#253). A user-curated shelf of station "presets"
     /// — artist radios, playlists, moods. The real pin infrastructure (server


### PR DESCRIPTION
Adds the three station rows from the Radio screen spec (§9, Issue 57) so users can start a station from a genre, decade, or mood without leaving Home.

Closes #256

- **Genre Radio** reuses the existing `startGenreRadio` (Instant Mix on a resolved genre UUID), sourced from the same ranked genres-to-explore signal Discover uses.
- **Decade Radio** ('60s–'10s) and **Mood Radio** (chill / focus / workout / sleep / party, sourced from item tags) are backed by two new core FFIs — `tracks_by_year_range` and `tracks_by_tag` — modeled on `tracks_by_genre`, returning server-randomized pages so a station varies between taps. Empty pages surface a friendly `errorMessage` rather than failing silently (verified against the real server: the test library has no mood tags, so Mood tiles message gracefully; Decade returns 3737 tracks for the '90s).
- New `RadioStationTile` is a gradient preset tile (deterministic hue per seed) with a hover-revealed radio glyph; FFI calls run off the MainActor per the gap-pattern playbook.

pipeline:
- fixer-session: feature-builder-256
- slice: screens
- hotspots-claimed: none
- build-gate: cargo fmt + clippy (-D warnings) + 218 tests green; `rm -rf macos/.build && swift build` green; xcframework + bindings regenerated via build-core.sh (gitignored — CI regenerates from Rust source)
- diff-stat: 6 files, +525