### PR TITLE
macos: add Playlists-featuring-artist rail to Artist detail

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -837,6 +837,100 @@ impl JellyfinClient {
         self.user_playlists(playlist_library_id, paging).await
     }
 
+    /// Playlists in the user's Playlists library whose track list features the
+    /// given artist, capped at `limit` results.
+    ///
+    /// Jellyfin's `/Items` endpoint **ignores `ArtistIds` when the parent is a
+    /// playlist** (verified against a real server: the filter is silently
+    /// dropped and the full track list comes back), so we cannot push the
+    /// membership test server-side. Instead we walk each playlist's audio
+    /// items — requesting only `Fields=ArtistItems` to keep the payload small —
+    /// and match client-side against the track-level artist credits
+    /// (`ArtistItems`) plus the album-artist id. "Featured" therefore means the
+    /// artist appears anywhere in the track list, including guest features, not
+    /// just album-artist credits — which is what the Artist-detail rail wants.
+    ///
+    /// Cost: one playlist-list request plus one items request per playlist
+    /// scanned. We stop scanning as soon as `limit` matches are found, and cap
+    /// the playlists scanned at `MAX_PLAYLISTS_SCANNED` so a pathological
+    /// library can't turn this into an unbounded fan-out. Per-playlist we ask
+    /// for up to `PLAYLIST_TRACK_PROBE_LIMIT` items, which covers ordinary
+    /// playlists in a single round-trip; longer playlists are probed by their
+    /// leading window (a featured artist in a multi-hundred-track playlist is
+    /// overwhelmingly present in that window, and the rail is a discovery
+    /// affordance, not an exhaustive index).
+    pub async fn playlists_containing_artist(
+        &self,
+        playlist_library_id: &str,
+        artist_id: &str,
+        limit: u32,
+    ) -> Result<Vec<Playlist>> {
+        // Upper bounds that keep the fan-out predictable on large libraries.
+        const MAX_PLAYLISTS_SCANNED: u32 = 200;
+        const PLAYLIST_TRACK_PROBE_LIMIT: u32 = 500;
+
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(LyrebirdError::NotAuthenticated)?;
+
+        let candidates = self
+            .playlists_items(playlist_library_id, Paging::new(0, MAX_PLAYLISTS_SCANNED))
+            .await?;
+
+        let mut matches: Vec<Playlist> = Vec::new();
+        for raw in candidates.items {
+            if matches.len() as u32 >= limit {
+                break;
+            }
+            if self
+                .playlist_features_artist(&raw.id, user_id, artist_id, PLAYLIST_TRACK_PROBE_LIMIT)
+                .await?
+            {
+                matches.push(Playlist::from(raw));
+            }
+        }
+        Ok(matches)
+    }
+
+    /// Probe a single playlist for an artist credit. Returns `true` when any
+    /// audio item in the playlist's leading window credits `artist_id` at the
+    /// track level (`ArtistItems`) or as the album artist (`AlbumArtistId`).
+    /// Fetches only the artist fields to keep the per-playlist request cheap.
+    async fn playlist_features_artist(
+        &self,
+        playlist_id: &str,
+        user_id: &str,
+        artist_id: &str,
+        probe_limit: u32,
+    ) -> Result<bool> {
+        let mut url = self.endpoint("Items")?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("ParentId", playlist_id);
+            q.append_pair("UserId", user_id);
+            q.append_pair("IncludeItemTypes", ItemKind::Audio.as_str());
+            q.append_pair("Limit", &probe_limit.max(1).to_string());
+            q.append_pair("StartIndex", "0");
+            // Only the artist-credit fields — the rest of the track payload is
+            // irrelevant to the membership test and just inflates the response.
+            q.append_pair("Fields", "ArtistItems");
+        }
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let raw: RawItems<RawItem> = resp.json().await?;
+        let features = raw.items.iter().any(|item| {
+            item.album_artist_id.as_deref() == Some(artist_id)
+                || item.artist_items.iter().any(|a| a.id == artist_id)
+        });
+        Ok(features)
+    }
+
     /// Shared `GET /Items` request that returns all playlists under the
     /// given Playlists library view. `user_playlists` / `public_playlists`
     /// partition the result by `Path`. Returns the raw [`RawItems`] wrapper

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -619,6 +619,27 @@ impl LyrebirdCore {
         })
     }
 
+    /// Playlists in the user's Playlists library whose track list features the
+    /// given artist, capped at `limit`. Powers the "Playlists featuring this
+    /// artist" rail on the Artist detail screen. Matching is track-level
+    /// (guest features count), scanned client-side because Jellyfin ignores
+    /// `ArtistIds` under a playlist parent — see
+    /// [`JellyfinClient::playlists_containing_artist`] for the cost bounds.
+    pub fn playlists_containing_artist(
+        &self,
+        playlist_library_id: String,
+        artist_id: String,
+        limit: u32,
+    ) -> std::result::Result<Vec<Playlist>, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime.block_on(c.playlists_containing_artist(
+                &playlist_library_id,
+                &artist_id,
+                limit,
+            ))
+        })
+    }
+
     /// Tracks on a playlist, in the server's playlist order. Pass `offset`
     /// and `limit` for paging; the underlying `/Items` request does NOT sort
     /// server-side so the playlist's stored order is preserved. The

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7873,3 +7873,128 @@ async fn album_tracks_parses_negative_bitrate_sentinel() {
     assert_eq!(tracks.len(), 1);
     assert_eq!(tracks[0].bitrate, Some(-1000));
 }
+
+/// `playlists_containing_artist` walks every playlist in the library
+/// view and keeps only those whose track list credits the target artist at
+/// the track level (`ArtistItems`) or as album artist. The membership test is
+/// client-side because Jellyfin ignores `ArtistIds` under a playlist parent.
+#[tokio::test]
+async fn playlists_containing_artist_filters_by_track_credit() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // Library view: three playlists.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "lib-pl"))
+        .and(query_param("IncludeItemTypes", "Playlist"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                { "Id": "pl-a", "Name": "Has Artist", "Type": "Playlist", "ChildCount": 2 },
+                { "Id": "pl-b", "Name": "No Artist", "Type": "Playlist", "ChildCount": 1 },
+                { "Id": "pl-c", "Name": "Album Artist", "Type": "Playlist", "ChildCount": 1 }
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+    // pl-a — artist credited at the track level via ArtistItems.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "pl-a"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(query_param("Fields", "ArtistItems"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t1", "Name": "Some Other", "Type": "Audio",
+                    "ArtistItems": [ { "Id": "other", "Name": "Other" } ]
+                },
+                {
+                    "Id": "t2", "Name": "Guest Feature", "Type": "Audio",
+                    "ArtistItems": [
+                        { "Id": "other2", "Name": "Other Two" },
+                        { "Id": "artist-x", "Name": "Artist X" }
+                    ]
+                }
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+    // pl-b — no credit for the artist anywhere.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "pl-b"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t3", "Name": "Unrelated", "Type": "Audio",
+                    "ArtistItems": [ { "Id": "nope", "Name": "Nope" } ]
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // pl-c — artist credited only as album artist (AlbumArtistId) still counts.
+    Mock::given(method("GET"))
+        .and(path("/Items"))
+        .and(query_param("ParentId", "pl-c"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "t4", "Name": "Album Track", "Type": "Audio",
+                    "AlbumArtistId": "artist-x",
+                    "ArtistItems": []
+                }
+            ],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let result = client
+        .playlists_containing_artist("lib-pl", "artist-x", 6)
+        .await
+        .unwrap();
+
+    let ids: Vec<&str> = result.iter().map(|p| p.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["pl-a", "pl-c"],
+        "only playlists crediting the artist (track-level or album-artist) are returned"
+    );
+}
+
+/// A zero `limit` short-circuits without issuing any HTTP request.
+#[tokio::test]
+async fn playlists_containing_artist_zero_limit_is_empty() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let result = client
+        .playlists_containing_artist("lib-pl", "artist-x", 0)
+        .await
+        .unwrap();
+    assert!(result.is_empty());
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -199,6 +199,11 @@ final class AppModel {
     /// `loadSimilarArtists(artistId:)` when the Artist detail screen opens.
     /// Held for the session; cleared on logout. See #146.
     var artistSimilarCache: [String: [Artist]] = [:]  // artistID → similar artists
+    /// Cache of playlists that feature a given artist in their track list.
+    /// Populated on demand by `loadPlaylistsFeaturingArtist(artistId:)` when
+    /// the Artist detail screen opens. Held for the session; cleared on
+    /// logout.
+    var artistPlaylistsCache: [String: [Playlist]] = [:]  // artistID → featuring playlists
     var recentlyPlayed: [Track] = []
     /// Tracks surfaced in the Discover "For You" carousel (#249). Today this
     /// is a best-effort fallback to the first 20 `recentlyPlayed` tracks. A
@@ -1012,6 +1017,7 @@ final class AppModel {
         playlistPendingDelete = nil
         artistTopTracks = [:]
         artistSimilarCache = [:]
+        artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
         artistDetailCache = [:]
         recentlyPlayed = []
@@ -1078,6 +1084,7 @@ final class AppModel {
         playlistPendingDelete = nil
         artistTopTracks = [:]
         artistSimilarCache = [:]
+        artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
         artistDetailCache = [:]
         recentlyPlayed = []
@@ -2609,6 +2616,40 @@ final class AppModel {
         } catch {
             // Silent fallback — don't surface errors for a secondary widget.
             Log.app.notice("loadSimilarArtists failed artist=\(artistId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            if handleAuthError(error) { return [] }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            return []
+        }
+    }
+
+    /// Fetch the playlists whose track list features `artistId`, for the
+    /// "Playlists featuring this artist" rail on the Artist detail screen.
+    /// Backed by `core.playlistsContainingArtist`, which walks each
+    /// playlist and matches the artist at the track level (guest features
+    /// count). Cached for the session in `artistPlaylistsCache`, cleared on
+    /// logout. Mirrors `loadSimilarArtists` — detached FFI call, silent
+    /// fallback (the rail collapses when empty so an error reads as "no
+    /// featuring playlists" rather than a broken section).
+    @discardableResult
+    func loadPlaylistsFeaturingArtist(artistId: String, limit: UInt32 = 6) async -> [Playlist] {
+        if let cached = artistPlaylistsCache[artistId] { return cached }
+        let libraryId = await ensurePlaylistLibraryId()
+        do {
+            let playlists = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.playlistsContainingArtist(
+                    playlistLibraryId: libraryId,
+                    artistId: artistId,
+                    limit: limit
+                )
+            }.value
+            artistPlaylistsCache[artistId] = playlists
+            serverReachability.noteSuccess()
+            return playlists
+        } catch {
+            // Silent fallback — don't surface errors for a secondary widget.
+            Log.app.notice("loadPlaylistsFeaturingArtist failed artist=\(artistId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             if handleAuthError(error) { return [] }
             if ServerReachability.shouldCount(error: error) {
                 serverReachability.noteFailure()

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -44,6 +44,9 @@ struct ArtistDetailView: View {
     @State private var fetchedArtist: Artist?
     @State private var isBioExpanded = false
     @State private var similarArtistsState: [Artist] = []
+    /// Playlists whose track list features this artist. Populated by
+    /// the `.task(id:)` block; the rail collapses silently when empty.
+    @State private var featuringPlaylists: [Playlist] = []
     /// Plain-text biography, HTML-stripped from `ArtistDetail.overview`.
     /// `nil` until the detail fetch resolves; empty/whitespace-only overviews
     /// collapse to `nil` so the About section hides entirely.
@@ -89,6 +92,7 @@ struct ArtistDetailView: View {
                 transportBar
                 topSongsSection
                 discographySection
+                featuringPlaylistsSection
                 similarArtistsSection
                 aboutSection
                 footer
@@ -113,6 +117,7 @@ struct ArtistDetailView: View {
             bioOverview = nil
             isBioExpanded = false
             scopedQuery = ""
+            featuringPlaylists = []
             isLoadingTopTracks = true
             if model.artists.first(where: { $0.id == artistID }) == nil {
                 fetchedArtist = await model.resolveArtist(id: artistID)
@@ -125,6 +130,7 @@ struct ArtistDetailView: View {
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
             isLoadingTopTracks = false
             similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
+            featuringPlaylists = await model.loadPlaylistsFeaturingArtist(artistId: artistID)
             // Biography is independent of the lists above so a missing or slow
             // detail fetch never blocks the rest of the page. The server
             // overview may carry HTML, so it is stripped to plain text before
@@ -646,6 +652,35 @@ struct ArtistDetailView: View {
         let albums: [Album]
     }
 
+    // MARK: - Playlists featuring artist
+
+    /// Horizontal carousel of playlists whose track list features this
+    /// artist. Mirrors the discography carousel's shape with 160pt playlist
+    /// tiles. Hidden entirely when the artist appears in no playlists so the
+    /// section never reads as a broken empty shelf. Data comes from
+    /// `featuringPlaylists`, populated by the `.task(id:)` block.
+    @ViewBuilder
+    private var featuringPlaylistsSection: some View {
+        if !featuringPlaylists.isEmpty, let artist = artist {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeader(eyebrow: "APPEARS ON", title: "Featuring \(artist.name)")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    // Eager `HStack` (not `LazyHStack`) for the same macOS 26.4
+                    // recycle-UAF reason documented in `discographyGroup`. The
+                    // rail is capped at six tiles, so eager rendering is free.
+                    HStack(alignment: .top, spacing: 16) {
+                        ForEach(featuringPlaylists, id: \.id) { playlist in
+                            FeaturingPlaylistTile(playlist: playlist)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 32)
+        }
+    }
+
     // MARK: - Similar Artists (#232)
 
     /// Horizontal carousel of 140pt circular artist tiles, mirroring
@@ -1019,5 +1054,78 @@ private struct SimilarArtistTile: View {
         .contextMenu { ArtistContextMenu(artist: artist) }
         .accessibilityLabel("\(artist.name), similar artist")
         .accessibilityHint("Opens artist detail")
+    }
+}
+
+// MARK: - Featuring-playlist tile
+
+/// Compact 160pt square playlist tile used in the "Featuring <artist>" rail
+/// on the Artist detail screen. Mirrors `ArtistDiscographyTile`'s shape
+/// so the two artist-page carousels read consistently; tapping opens the
+/// playlist detail, the hover play button plays the playlist, and the subline
+/// is the track count.
+private struct FeaturingPlaylistTile: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let playlist: Playlist
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            model.navPath.append(AppModel.Route.playlist(playlist.id))
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                ZStack(alignment: .bottomTrailing) {
+                    Artwork(
+                        url: model.imageURL(for: playlist.id, tag: playlist.imageTag, maxWidth: 400),
+                        seed: playlist.name,
+                        size: 160,
+                        radius: 6
+                    )
+                    .frame(width: 160, height: 160)
+
+                    Button { model.play(playlist: playlist) } label: {
+                        Image(systemName: "play.fill")
+                            .foregroundStyle(.white)
+                            .font(.system(size: 14))
+                            .frame(width: 36, height: 36)
+                            .background(Circle().fill(Theme.primary))
+                            .shadow(color: Theme.primary.opacity(0.5), radius: 8, y: 3)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .opacity(isHovering ? 1 : 0)
+                    .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+                    .accessibilityLabel("Play \(playlist.name)")
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(playlist.name)
+                        .font(Theme.font(12, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .lineLimit(1)
+                }
+                .frame(width: 160, alignment: .leading)
+            }
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .contextMenu { PlaylistContextMenu(playlist: playlist) }
+        .accessibilityLabel("\(playlist.name), \(subtitle)")
+        .accessibilityHint("Opens playlist detail")
+    }
+
+    /// "42 tracks" / "1 track" / "Empty" — matches `PlaylistCard`'s subline.
+    private var subtitle: String {
+        switch playlist.trackCount {
+        case 0: return "Empty"
+        case 1: return "1 track"
+        default: return "\(playlist.trackCount) tracks"
+        }
     }
 }


### PR DESCRIPTION
Surfaces the playlists a given artist appears in as an "APPEARS ON" carousel on the Artist detail screen, so listeners can jump from an artist to the curated/community playlists that feature them.

Closes #233

## Notes
- New core FFI `playlists_containing_artist(playlist_library_id, artist_id, limit)`. Jellyfin **ignores `ArtistIds` under a playlist parent** (verified against a live server — the filter is silently dropped), so membership is matched client-side over each playlist's track-level `ArtistItems` credits (guest features count) plus the album-artist id. Fan-out is bounded (<=200 playlists scanned, <=500 items probed per playlist, early-exit once `limit` matches found).
- `AppModel.loadPlaylistsFeaturingArtist(artistId:)` mirrors `loadSimilarArtists`: detached FFI off the MainActor, session cache (`artistPlaylistsCache`, cleared on logout), silent fallback so the rail collapses rather than erroring.
- `ArtistDetailView` gains a `featuringPlaylistsSection` (eager `HStack` carousel, matching the discography rail's macOS 26.4 recycle-UAF workaround) and a `FeaturingPlaylistTile`. The section hides entirely when the artist is in no playlists.

## pipeline
- fixer-session: feature-builder-233
- slice: screens
- hotspots-claimed: none
- build-gate: pass (cargo fmt/clippy/test green; clean swift build green; xcframework + bindings are gitignored and regenerated by CI via build-core.sh)
- diff-stat: 5 files, +389