### PR TITLE
macos: Dock tile playback progress ring + pause overlay

### DIFF
--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -10,9 +10,11 @@ import SwiftUI
 ///   the Dock icon surfaces Play/Pause, Next, Previous, and a live list
 ///   of recent albums so a user can jump back into something without
 ///   bringing the window forward. See issues #16 / #17.
-/// - **Dock badge** — shows "▶" on the Dock icon while a track is playing
-///   so the user knows at a glance that audio is active without raising the
-///   window. Clears automatically when playback is paused or stopped. See #322.
+/// - **Dock tile** — replaces the stock app icon with the current album
+///   art wrapped in a thin progress ring (filling in real time) plus a
+///   pause overlay while paused, via `DockTileController`. Falls back to a
+///   "▶" text badge as a lightweight signal when no track is loaded yet.
+///   Restores the stock icon on quit. See #43 / #322.
 /// - **Window tabbing** — opts the app into macOS' automatic window-tab
 ///   behaviour so `WindowGroup`'s extra windows show up as tabs under the
 ///   Window menu. See issue #27.
@@ -48,6 +50,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and keeps the dock badge in sync. Started in `bind(appModel:)` and
     /// cancelled in `applicationWillTerminate`. See #322.
     private var dockBadgeTask: Task<Void, Never>?
+
+    /// Owns the custom Dock tile (album art + progress ring + pause overlay).
+    /// Throttles its own `display()` calls to ≤1 Hz. See #43.
+    private let dockTile = DockTileController()
 
     /// How long to wait after a wake event before probing the server.
     /// 2 s gives the NIC time to associate and the OS time to re-establish
@@ -89,6 +95,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         wakeProbeTask?.cancel()
         dockBadgeTask?.cancel()
+        // Drop the custom tile so the Dock shows the stock icon after quit.
+        dockTile.uninstall()
         if let observer = sleepObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
         }
@@ -170,12 +178,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.appModel = appModel
         dockBadgeTask?.cancel()
         dockBadgeTask = startDockBadgeObserver(model: appModel)
+        // Paint the tile immediately so a session that resumes already-playing
+        // shows its art on launch rather than waiting for the first transition.
+        refreshDockTile()
     }
 
     /// Returns a `Task` that loops indefinitely, using `withObservationTracking`
-    /// to watch `model.status.state` and update `NSApp.dockTile.badgeLabel`
-    /// whenever playback starts or stops. The task is fully cooperative — it
-    /// suspends between state changes and does not spin. See #322.
+    /// to watch `model.status.state` and refresh the Dock tile whenever
+    /// playback starts / pauses / stops. The task is fully cooperative — it
+    /// suspends between state changes and does not spin. Per-second progress
+    /// updates ride the existing 1 s status poll via `refreshDockTile()`; this
+    /// loop only catches the discrete play/pause/stop transitions so the ring
+    /// flips its overlay the moment state changes rather than on the next tick.
+    /// See #43 / #322.
     @MainActor
     private func startDockBadgeObserver(model: AppModel) -> Task<Void, Never> {
         Task { @MainActor [weak self] in
@@ -194,16 +209,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 }
                 guard !Task.isCancelled else { break }
-                self?.updateDockBadge(model: model)
+                self?.refreshDockTile()
             }
         }
     }
 
-    /// Reflects the current playback state onto `NSApp.dockTile.badgeLabel`.
-    /// Shows "▶" while a track is actively playing; clears the badge otherwise.
+    /// Rebuild the Dock tile from the current player status. Idempotent and
+    /// cheap: the `DockTileController` throttles its own `display()` to ≤1 Hz
+    /// and skips redundant redraws, so this is safe to call from both the
+    /// state-change observer and the 1 s status poll.
+    ///
+    /// While a track is loaded the controller installs the custom album-art +
+    /// progress-ring tile; when nothing is loaded it tears the tile down and
+    /// we fall back to the lightweight "▶" text badge so the user still has a
+    /// playing signal during the brief gap before the first track resolves.
     @MainActor
-    private func updateDockBadge(model: AppModel) {
-        NSApp.dockTile.badgeLabel = model.status.state == .playing ? "▶" : nil
+    func refreshDockTile() {
+        guard let model = appModel else { return }
+        let status = model.status
+        let hasTrack = status.currentTrack != nil
+
+        if hasTrack, let track = status.currentTrack {
+            // No text badge competes with the custom tile.
+            NSApp.dockTile.badgeLabel = nil
+            dockTile.update(
+                hasTrack: true,
+                isPaused: status.state == .paused,
+                position: status.positionSeconds,
+                duration: status.durationSeconds,
+                artworkURL: model.imageURL(
+                    for: track.albumId ?? track.id,
+                    tag: track.imageTag,
+                    maxWidth: 256
+                ),
+                seed: track.name
+            )
+        } else {
+            dockTile.update(
+                hasTrack: false,
+                isPaused: false,
+                position: 0,
+                duration: 0,
+                artworkURL: nil,
+                seed: DockTileSnapshot.placeholderSeed
+            )
+            NSApp.dockTile.badgeLabel = status.state == .playing ? "▶" : nil
+        }
     }
 
     // MARK: - Sleep / wake

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///   art wrapped in a thin progress ring (filling in real time) plus a
 ///   pause overlay while paused, via `DockTileController`. Falls back to a
 ///   "▶" text badge as a lightweight signal when no track is loaded yet.
-///   Restores the stock icon on quit. See #43 / #322.
+///   Restores the stock icon on quit.
 /// - **Window tabbing** — opts the app into macOS' automatic window-tab
 ///   behaviour so `WindowGroup`'s extra windows show up as tabs under the
 ///   Window menu. See issue #27.
@@ -52,7 +52,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var dockBadgeTask: Task<Void, Never>?
 
     /// Owns the custom Dock tile (album art + progress ring + pause overlay).
-    /// Throttles its own `display()` calls to ≤1 Hz. See #43.
+    /// Throttles its own `display()` calls to ≤1 Hz.
     private let dockTile = DockTileController()
 
     /// How long to wait after a wake event before probing the server.
@@ -190,19 +190,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// updates ride the existing 1 s status poll via `refreshDockTile()`; this
     /// loop only catches the discrete play/pause/stop transitions so the ring
     /// flips its overlay the moment state changes rather than on the next tick.
-    /// See #43 / #322.
     @MainActor
     private func startDockBadgeObserver(model: AppModel) -> Task<Void, Never> {
         Task { @MainActor [weak self] in
             while !Task.isCancelled {
-                // `withObservationTracking` registers access to the @Observable
-                // properties read inside `apply:` and calls `onChange:` exactly
-                // once the next time any of them change. We only read
-                // `status.state` so only playback-state transitions wake us up.
+                // Only `status.state` is read inside the tracking closure, so the
+                // loop wakes solely on playback-state transitions rather than on
+                // every status mutation (position ticks, queue edits, etc.).
                 await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                     withObservationTracking {
-                        // Read the property so the Observation framework registers
-                        // this access and will fire the onChange closure on change.
                         _ = model.status.state
                     } onChange: {
                         continuation.resume()

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -5176,6 +5176,10 @@ final class AppModel {
                 let beforeState = self.status.state
                 self.status = self.core.status()
                 let after = self.status.currentTrack?.id
+                // Keep the custom Dock tile's progress ring filling in real
+                // time. The controller throttles its own redraws to ≤1 Hz, so
+                // calling it on every 1 s poll tick is the right cadence. See #43.
+                AppDelegate.shared?.refreshDockTile()
                 // Trigger a details refetch when the track changes. Scoped
                 // to the polling loop so skipping via the PlayerBar,
                 // media keys, or end-of-track auto-advance all get it

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -5178,7 +5178,7 @@ final class AppModel {
                 let after = self.status.currentTrack?.id
                 // Keep the custom Dock tile's progress ring filling in real
                 // time. The controller throttles its own redraws to ≤1 Hz, so
-                // calling it on every 1 s poll tick is the right cadence. See #43.
+                // calling it on every 1 s poll tick is the right cadence.
                 AppDelegate.shared?.refreshDockTile()
                 // Trigger a details refetch when the track changes. Scoped
                 // to the polling loop so skipping via the PlayerBar,

--- a/macos/Sources/Lyrebird/Components/DockTileView.swift
+++ b/macos/Sources/Lyrebird/Components/DockTileView.swift
@@ -1,0 +1,120 @@
+import AppKit
+import SwiftUI
+
+/// Immutable snapshot of everything the Dock tile needs to draw a single
+/// frame. The tile lives *outside* any window (`NSApp.dockTile.contentView`),
+/// so SwiftUI's Observation machinery never re-evaluates its body on its own —
+/// every redraw is driven imperatively by `DockTileController` handing in a
+/// fresh snapshot and calling `NSApp.dockTile.display()`. Keeping the input a
+/// value type (rather than reading a live `@Observable` model) makes that
+/// contract explicit and the view trivially deterministic for previews/tests.
+struct DockTileSnapshot: Equatable {
+    /// Pre-fetched album art. Resolved off-screen by the controller via the
+    /// shared Nuke pipeline so the bitmap is already present when the tile is
+    /// asked to draw — an async `LazyImage` would render its placeholder first
+    /// and never get a second `display()` to swap in the real art.
+    var artwork: NSImage?
+    /// Stable string used to pick the deterministic gradient placeholder when
+    /// `artwork` is nil (matches `Artwork`'s seeded palette).
+    var seed: String
+    /// Playback progress in `0...1`. Drives the ring fill. Clamped by the
+    /// controller; the view assumes it is already in range.
+    var progress: Double
+    /// Whether to draw the translucent pause overlay badge.
+    var isPaused: Bool
+
+    static let placeholderSeed = "lyrebird"
+}
+
+/// SwiftUI view rendered into `NSApp.dockTile.contentView` via an
+/// `NSHostingView`. Shows the current album art with a thin progress ring
+/// around the tile edge and a pause overlay when playback is paused.
+///
+/// Issue #43. The ring (rather than a bottom bar) was chosen so progress reads
+/// at the small Dock size from any angle — the same affordance Doppler uses.
+struct DockTileView: View {
+    var snapshot: DockTileSnapshot
+
+    /// Inset of the artwork from the tile edge so the progress ring has room
+    /// to breathe without clipping. Expressed as a fraction of the tile side.
+    private let inset: CGFloat = 0.06
+
+    var body: some View {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height)
+            let ringWidth = max(2, side * 0.05)
+            let artInset = side * inset
+            let cornerRadius = (side - artInset * 2) * 0.18
+
+            ZStack {
+                artwork
+                    .frame(width: side - artInset * 2, height: side - artInset * 2)
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                    .overlay {
+                        if snapshot.isPaused {
+                            pauseOverlay(cornerRadius: cornerRadius)
+                        }
+                    }
+                    .shadow(color: .black.opacity(0.35), radius: side * 0.04, x: 0, y: side * 0.02)
+
+                progressRing(side: side, ringWidth: ringWidth)
+            }
+            .frame(width: side, height: side)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let image = snapshot.artwork {
+            Image(nsImage: image)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFill()
+        } else {
+            let palette = Artwork.palette(for: snapshot.seed)
+            LinearGradient(
+                colors: [palette.0, palette.1],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .overlay {
+                Image(systemName: "music.note")
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+        }
+    }
+
+    /// Thin ring hugging the tile edge. A faint full-circle track sits under a
+    /// bright trimmed arc that sweeps clockwise from 12 o'clock as the track
+    /// plays.
+    private func progressRing(side: CGFloat, ringWidth: CGFloat) -> some View {
+        let diameter = side - ringWidth
+        return ZStack {
+            Circle()
+                .stroke(Color.black.opacity(0.28), lineWidth: ringWidth)
+            Circle()
+                .trim(from: 0, to: max(0, min(1, snapshot.progress)))
+                .stroke(
+                    Theme.primary,
+                    style: StrokeStyle(lineWidth: ringWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: diameter, height: diameter)
+    }
+
+    /// Translucent scrim + pause glyph shown while playback is paused, so a
+    /// glance at the Dock tells the user audio is loaded but stopped.
+    private func pauseOverlay(cornerRadius: CGFloat) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(.black.opacity(0.4))
+            Image(systemName: "pause.fill")
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.5), radius: 3, x: 0, y: 1)
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Components/DockTileView.swift
+++ b/macos/Sources/Lyrebird/Components/DockTileView.swift
@@ -30,8 +30,8 @@ struct DockTileSnapshot: Equatable {
 /// `NSHostingView`. Shows the current album art with a thin progress ring
 /// around the tile edge and a pause overlay when playback is paused.
 ///
-/// Issue #43. The ring (rather than a bottom bar) was chosen so progress reads
-/// at the small Dock size from any angle — the same affordance Doppler uses.
+/// The ring (rather than a bottom bar) was chosen so progress reads at the
+/// small Dock size from any angle — the same affordance Doppler uses.
 struct DockTileView: View {
     var snapshot: DockTileSnapshot
 

--- a/macos/Sources/Lyrebird/System/DockTileController.swift
+++ b/macos/Sources/Lyrebird/System/DockTileController.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Nuke
+import SwiftUI
+
+/// Owns the custom Dock tile: hosts `DockTileView` inside
+/// `NSApp.dockTile.contentView`, keeps it fed with fresh snapshots, and
+/// throttles the (manual) `NSApp.dockTile.display()` calls so the tile never
+/// redraws more than once a second.
+///
+/// Issue #43. The Dock tile does **not** auto-redraw — AppKit only repaints it
+/// when you call `display()` — and repainting it faster than ~1 Hz spikes CPU
+/// (see the referenced thisdevbrain write-up). So the controller:
+///
+///   1. Installs the `NSHostingView` once, lazily, on first update.
+///   2. Resolves album art off-screen via the shared Nuke pipeline (cached, so
+///      a steady track costs one fetch), then hands the concrete `NSImage`
+///      into the view — an async `LazyImage` inside an off-window host would
+///      paint its placeholder and never get a second `display()`.
+///   3. Coalesces redraws to at most one per second; a progress-only change
+///      that arrives early is held and flushed on the next tick, while a
+///      track / play-pause change forces an immediate redraw so transport
+///      feedback stays snappy.
+///   4. Restores the stock app icon on teardown (`uninstall()`), called from
+///      `applicationWillTerminate`.
+@MainActor
+final class DockTileController {
+    private var hostingView: NSHostingView<DockTileView>?
+
+    /// Last snapshot actually pushed to the tile, so we can skip redundant
+    /// redraws when nothing the tile cares about changed.
+    private var lastSnapshot: DockTileSnapshot?
+
+    /// Last `(itemID, tag)` we kicked an artwork fetch for, so a steady track
+    /// doesn't re-request the bitmap every second.
+    private var artworkKey: String?
+    private var artworkImage: NSImage?
+    private var artworkTask: Task<Void, Never>?
+
+    /// Wall-clock time of the last `display()`. Used to enforce the ≥1 s gap.
+    private var lastDisplay: Date = .distantPast
+
+    /// Pending coalesced redraw fired when a progress-only change arrives
+    /// inside the 1 s window.
+    private var throttleTask: Task<Void, Never>?
+
+    private let minInterval: TimeInterval = 1.0
+
+    /// All stored properties carry defaults, so construction touches no
+    /// main-actor state. `nonisolated` lets `AppDelegate` (an `NSObject`, not
+    /// itself main-actor isolated) build the controller in its stored-property
+    /// initializer without an `await`.
+    nonisolated init() {}
+
+    /// Map raw `(position, duration)` seconds to a `0...1` ring fill. Guards a
+    /// zero / negative / unknown duration (returns 0) and clamps a position
+    /// that briefly overshoots duration at end-of-track (returns 1). Pure so
+    /// it can be unit-tested without touching the live Dock. See #43.
+    nonisolated static func progressFraction(position: Double, duration: Double) -> Double {
+        guard duration > 0 else { return 0 }
+        return min(1, max(0, position / duration))
+    }
+
+    /// Build a snapshot from the current player state and refresh the tile.
+    /// Cheap to call on every status poll; the throttle does the rate-limiting.
+    ///
+    /// - Parameters:
+    ///   - state / position / duration: current playback status.
+    ///   - artworkURL / seed: resolved by the caller (which owns the FFI
+    ///     `imageURL` cache) so this controller never crosses the Rust boundary.
+    func update(
+        hasTrack: Bool,
+        isPaused: Bool,
+        position: Double,
+        duration: Double,
+        artworkURL: URL?,
+        seed: String
+    ) {
+        // Nothing playing or loaded → drop back to the stock icon so the Dock
+        // doesn't keep showing the last track's art after the queue empties.
+        guard hasTrack else {
+            uninstall()
+            return
+        }
+
+        ensureArtwork(url: artworkURL, key: artworkURL?.absoluteString)
+
+        let progress = Self.progressFraction(position: position, duration: duration)
+        let snapshot = DockTileSnapshot(
+            artwork: artworkImage,
+            seed: seed.isEmpty ? DockTileSnapshot.placeholderSeed : seed,
+            progress: progress,
+            isPaused: isPaused
+        )
+
+        // A track / play-pause transition is a "structural" change the user
+        // expects to see immediately; a progress tick is not.
+        let structuralChange =
+            lastSnapshot?.artwork !== snapshot.artwork
+            || lastSnapshot?.isPaused != snapshot.isPaused
+            || lastSnapshot?.seed != snapshot.seed
+        apply(snapshot, force: structuralChange)
+    }
+
+    /// Restore the standard Dock icon and tear down the hosting view. Safe to
+    /// call repeatedly. Invoked when playback stops and on app termination.
+    func uninstall() {
+        throttleTask?.cancel()
+        throttleTask = nil
+        artworkTask?.cancel()
+        artworkTask = nil
+        artworkKey = nil
+        artworkImage = nil
+        lastSnapshot = nil
+        hostingView = nil
+        NSApp.dockTile.contentView = nil
+        NSApp.dockTile.display()
+    }
+
+    // MARK: - Internals
+
+    /// Resolve album art off the main render path. Skips re-fetching when the
+    /// key is unchanged; clears the bitmap when there is no URL so a track
+    /// without artwork falls back to the seeded gradient.
+    private func ensureArtwork(url: URL?, key: String?) {
+        guard key != artworkKey else { return }
+        artworkKey = key
+        artworkTask?.cancel()
+        artworkImage = nil
+
+        guard let url else { return }
+        let request = ImageRequest(
+            url: url,
+            processors: [
+                ImageProcessors.Resize(
+                    size: CGSize(width: 256, height: 256),
+                    unit: .pixels,
+                    contentMode: .aspectFill,
+                    crop: false,
+                    upscale: false
+                )
+            ]
+        )
+        artworkTask = Task { [weak self] in
+            let image = try? await Artwork.pipeline.image(for: request)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, self.artworkKey == key else { return }
+                self.artworkImage = image
+                // Re-push with the freshly-resolved art. Force so the user sees
+                // the new cover the instant it decodes, not a second later.
+                if var snap = self.lastSnapshot {
+                    snap.artwork = image
+                    self.apply(snap, force: true)
+                }
+            }
+        }
+    }
+
+    /// Push a snapshot to the hosting view and schedule / fire a `display()`,
+    /// honouring the 1 s floor unless `force` is set.
+    private func apply(_ snapshot: DockTileSnapshot, force: Bool) {
+        guard snapshot != lastSnapshot else { return }
+        lastSnapshot = snapshot
+        installIfNeeded()
+        hostingView?.rootView = DockTileView(snapshot: snapshot)
+
+        let elapsed = Date().timeIntervalSince(lastDisplay)
+        if force || elapsed >= minInterval {
+            flush()
+        } else {
+            scheduleFlush(after: minInterval - elapsed)
+        }
+    }
+
+    private func scheduleFlush(after delay: TimeInterval) {
+        guard throttleTask == nil else { return }
+        throttleTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { self?.flush() }
+        }
+    }
+
+    private func flush() {
+        throttleTask?.cancel()
+        throttleTask = nil
+        lastDisplay = Date()
+        NSApp.dockTile.display()
+    }
+
+    private func installIfNeeded() {
+        guard hostingView == nil else { return }
+        let host = NSHostingView(rootView: DockTileView(snapshot: lastSnapshot ?? .init(
+            artwork: nil,
+            seed: DockTileSnapshot.placeholderSeed,
+            progress: 0,
+            isPaused: false
+        )))
+        host.frame = NSRect(x: 0, y: 0, width: 128, height: 128)
+        hostingView = host
+        NSApp.dockTile.contentView = host
+    }
+}

--- a/macos/Sources/Lyrebird/System/DockTileController.swift
+++ b/macos/Sources/Lyrebird/System/DockTileController.swift
@@ -7,9 +7,9 @@ import SwiftUI
 /// throttles the (manual) `NSApp.dockTile.display()` calls so the tile never
 /// redraws more than once a second.
 ///
-/// Issue #43. The Dock tile does **not** auto-redraw — AppKit only repaints it
-/// when you call `display()` — and repainting it faster than ~1 Hz spikes CPU
-/// (see the referenced thisdevbrain write-up). So the controller:
+/// The Dock tile does **not** auto-redraw — AppKit only repaints it when you
+/// call `display()` — and repainting it faster than ~1 Hz spikes CPU. So the
+/// controller:
 ///
 ///   1. Installs the `NSHostingView` once, lazily, on first update.
 ///   2. Resolves album art off-screen via the shared Nuke pipeline (cached, so
@@ -54,7 +54,7 @@ final class DockTileController {
     /// Map raw `(position, duration)` seconds to a `0...1` ring fill. Guards a
     /// zero / negative / unknown duration (returns 0) and clamps a position
     /// that briefly overshoots duration at end-of-track (returns 1). Pure so
-    /// it can be unit-tested without touching the live Dock. See #43.
+    /// it can be unit-tested without touching the live Dock.
     nonisolated static func progressFraction(position: Double, duration: Double) -> Double {
         guard duration > 0 else { return 0 }
         return min(1, max(0, position / duration))

--- a/macos/Tests/LyrebirdTests/DockTileTests.swift
+++ b/macos/Tests/LyrebirdTests/DockTileTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Dock-tile progress mapping and snapshot diffing (#43).
+///
+/// The ring fill and the throttle's "skip redundant redraw" both hinge on two
+/// pure pieces of logic — `DockTileController.progressFraction` and
+/// `DockTileSnapshot` equality — so we test those directly without installing
+/// the live tile (which would mutate `NSApp.dockTile`).
+final class DockTileTests: XCTestCase {
+
+    func testProgressFractionMidTrack() {
+        XCTAssertEqual(
+            DockTileController.progressFraction(position: 30, duration: 120),
+            0.25,
+            accuracy: 0.0001
+        )
+    }
+
+    func testProgressFractionClampsOvershootToOne() {
+        // At end-of-track the reported position can briefly exceed duration.
+        XCTAssertEqual(
+            DockTileController.progressFraction(position: 121, duration: 120),
+            1.0,
+            accuracy: 0.0001
+        )
+    }
+
+    func testProgressFractionZeroDurationIsZero() {
+        // Unknown / not-yet-loaded duration must not divide by zero or NaN.
+        XCTAssertEqual(DockTileController.progressFraction(position: 5, duration: 0), 0)
+        XCTAssertEqual(DockTileController.progressFraction(position: 5, duration: -1), 0)
+    }
+
+    func testSnapshotEqualitySkipsRedundantRedraw() {
+        let a = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.5, isPaused: false)
+        let b = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.5, isPaused: false)
+        XCTAssertEqual(a, b, "Identical snapshots compare equal so the throttle can skip the redraw")
+    }
+
+    func testSnapshotEqualityDetectsPauseTransition() {
+        let playing = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.5, isPaused: false)
+        let paused = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.5, isPaused: true)
+        XCTAssertNotEqual(playing, paused, "A pause transition must force a redraw")
+    }
+
+    func testSnapshotEqualityDetectsProgressTick() {
+        let earlier = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.50, isPaused: false)
+        let later = DockTileSnapshot(artwork: nil, seed: "Song A", progress: 0.51, isPaused: false)
+        XCTAssertNotEqual(earlier, later, "A progress tick changes the ring and must redraw")
+    }
+}

--- a/macos/Tests/LyrebirdTests/DockTileTests.swift
+++ b/macos/Tests/LyrebirdTests/DockTileTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import Lyrebird
 
-/// Coverage for the Dock-tile progress mapping and snapshot diffing (#43).
+/// Coverage for the Dock-tile progress mapping and snapshot diffing.
 ///
 /// The ring fill and the throttle's "skip redundant redraw" both hinge on two
 /// pure pieces of logic — `DockTileController.progressFraction` and


### PR DESCRIPTION
Replaces the stock Dock icon while a track is loaded with the current album art wrapped in a thin progress ring that fills in real time, overlays a pause badge while paused, and restores the stock icon on quit — so playback state reads at a glance from the Dock.

Closes #43

The custom tile is hosted via \`NSApp.dockTile.contentView = NSHostingView(DockTileView(...))\`. A \`DockTileController\` (\`@MainActor\`) owns the host, resolves album art off-screen through the shared Nuke pipeline (so the bitmap is present before \`display()\`), and throttles \`NSApp.dockTile.display()\` to at most once per second — progress ticks ride the existing 1 s status poll; play/pause/track transitions force an immediate redraw. The existing dock transport menu (\`applicationDockMenu\`) and sleep/wake plumbing are unchanged; the old \`▶\` text badge is kept only as a fallback for the brief gap before the first track resolves.

\`pipeline:\`
- fixer-session: feat/43-dock-tile-progress
- slice: ux
- hotspots-claimed: none
- build-gate: pass (cargo fmt/clippy/test; clean \`swift build\`; 6 new DockTile tests green)
- diff-stat: 5 files changed, 442 insertions(+), 11 deletions(-)