### PR TITLE
macos: ambient palette wash from artwork on Now Playing

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1206,6 +1206,30 @@ impl LyrebirdCore {
             .save_shuffle_repeat(status.shuffle, mode);
     }
 
+    /// Persist a per-album ambient palette so the macOS Now Playing wash can
+    /// paint the artwork-derived colors instantly on re-open instead of
+    /// re-sampling the image every time (issue #271). `value` is an opaque
+    /// string the caller defines — the macOS side packs the two dominant hex
+    /// colors. Backed by the SQLite `settings` table via a `palette:<id>` key.
+    ///
+    /// Errors are swallowed: a failed palette write only costs a re-sample on
+    /// the next open, never a user-visible failure, so callers don't have to
+    /// thread a Result through a purely-cosmetic cache.
+    pub fn cache_album_palette(&self, album_id: String, value: String) {
+        let _ = self.inner.lock().db.set_album_palette(&album_id, &value);
+    }
+
+    /// Read the cached ambient palette for an album, or `None` when one has
+    /// not been sampled yet. Counterpart to [`Self::cache_album_palette`].
+    pub fn cached_album_palette(&self, album_id: String) -> Option<String> {
+        self.inner
+            .lock()
+            .db
+            .get_album_palette(&album_id)
+            .ok()
+            .flatten()
+    }
+
     pub fn stop(&self) {
         self.stop_heartbeat();
         self.player.clear();

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -158,8 +158,15 @@ impl Database {
     /// Stored as a single `settings` row under the `palette:<album_id>` key;
     /// the value is an opaque, caller-defined encoding (the macOS side packs
     /// two hex colors). Keyed under the existing settings table rather than a
-    /// new schema so it rides the same migration and `clear_user_data`
-    /// lifecycle.
+    /// new schema so it rides the same migration lifecycle.
+    ///
+    /// Note: `palette:*` rows are deliberately **not** removed by
+    /// [`Self::clear_user_data`] — they survive logout and server switches.
+    /// A palette is derived purely from public album artwork (no user-scoped
+    /// data), is content-addressed by album id, and is cheap to regenerate,
+    /// so keeping it across sessions just avoids needless re-sampling. If a
+    /// future change makes palettes user-scoped, add the `palette:` prefix to
+    /// `clear_user_data`'s deletion set.
     pub fn set_album_palette(&self, album_id: &str, value: &str) -> Result<()> {
         self.set_setting(&format!("palette:{album_id}"), value)
     }

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -153,6 +153,23 @@ impl Database {
         Ok(())
     }
 
+    /// Persist an ambient palette derived from an album's artwork so the
+    /// macOS Now Playing wash doesn't re-sample the image on every open.
+    /// Stored as a single `settings` row under the `palette:<album_id>` key;
+    /// the value is an opaque, caller-defined encoding (the macOS side packs
+    /// two hex colors). Keyed under the existing settings table rather than a
+    /// new schema so it rides the same migration and `clear_user_data`
+    /// lifecycle.
+    pub fn set_album_palette(&self, album_id: &str, value: &str) -> Result<()> {
+        self.set_setting(&format!("palette:{album_id}"), value)
+    }
+
+    /// Read back a cached album palette written by [`Self::set_album_palette`].
+    /// Returns `None` when no palette has been sampled for this album yet.
+    pub fn get_album_palette(&self, album_id: &str) -> Result<Option<String>> {
+        self.get_setting(&format!("palette:{album_id}"))
+    }
+
     pub fn record_play(&self, track_id: &str, played_at: i64) -> Result<()> {
         self.conn.lock().execute(
             "INSERT INTO play_history (track_id, played_at) VALUES (?1, ?2)",

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7873,3 +7873,35 @@ async fn album_tracks_parses_negative_bitrate_sentinel() {
     assert_eq!(tracks.len(), 1);
     assert_eq!(tracks[0].bitrate, Some(-1000));
 }
+
+/// #271 — the per-album ambient palette cache round-trips through SQLite.
+/// A fresh album id reads back `None`; after `cache_album_palette` the same id
+/// returns the exact stored value, and a re-cache overwrites in place.
+#[test]
+fn album_palette_cache_round_trips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+
+    assert!(
+        core.cached_album_palette("album-1".into()).is_none(),
+        "unsampled album must read back None"
+    );
+
+    core.cache_album_palette("album-1".into(), "0C0622,887BFF".into());
+    assert_eq!(
+        core.cached_album_palette("album-1".into()).as_deref(),
+        Some("0C0622,887BFF"),
+        "cached palette must round-trip verbatim"
+    );
+
+    // Distinct albums don't alias each other.
+    assert!(core.cached_album_palette("album-2".into()).is_none());
+
+    // Re-cache overwrites rather than appending a second row.
+    core.cache_album_palette("album-1".into(), "140B30,FF066F".into());
+    assert_eq!(
+        core.cached_album_palette("album-1".into()).as_deref(),
+        Some("140B30,FF066F"),
+        "re-cache must overwrite the prior palette"
+    );
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3478,6 +3478,49 @@ final class AppModel {
         return result
     }
 
+    // MARK: - Ambient palette (#271)
+
+    /// In-process palette cache keyed by album id. The per-album palette is
+    /// deterministic for a given cover, so once sampled (or read back from
+    /// the SQLite cache) we never cross the FFI boundary or re-decode the
+    /// image again this session.
+    private var ambientPaletteCache: [String: AmbientPalette] = [:]
+
+    /// Resolve the ambient wash palette for an album, sampled from its
+    /// artwork (#271). Resolution order, cheapest first:
+    ///   1. this session's in-memory cache,
+    ///   2. the core's per-album SQLite palette cache (`cachedAlbumPalette`),
+    ///   3. a fresh `CIAreaAverage` sample of the Nuke-cached artwork, which
+    ///      is then written back to both caches.
+    ///
+    /// The FFI reads/writes are wrapped in `Task.detached` and the Core Image
+    /// sampling runs off the main actor (gap pattern #2 — never sample or take
+    /// the `Inner` mutex on the MainActor per open). Returns `nil` when there
+    /// is no artwork URL or extraction fails; callers fall back to the theme
+    /// wash, so a miss is never user-visible as a failure.
+    func ambientPalette(forAlbumId albumId: String, imageURL: URL?) async -> AmbientPalette? {
+        if let cached = ambientPaletteCache[albumId] { return cached }
+
+        // SQLite cache read — off the MainActor so the `Inner` mutex isn't
+        // taken on the main thread.
+        if let encoded = await Task.detached(priority: .utility, operation: { [core] in
+            core.cachedAlbumPalette(albumId: albumId)
+        }).value, let palette = AmbientPalette(encoded: encoded) {
+            ambientPaletteCache[albumId] = palette
+            return palette
+        }
+
+        guard let imageURL else { return nil }
+        guard let palette = await PaletteSampler.sample(from: imageURL) else { return nil }
+
+        ambientPaletteCache[albumId] = palette
+        let encoded = palette.encoded
+        Task.detached(priority: .utility) { [core] in
+            core.cacheAlbumPalette(albumId: albumId, value: encoded)
+        }
+        return palette
+    }
+
     // MARK: - Playback
 
     func play(tracks: [Track], startIndex: Int = 0) {

--- a/macos/Sources/Lyrebird/Components/AmbientWash.swift
+++ b/macos/Sources/Lyrebird/Components/AmbientWash.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+import AppKit
+import CoreImage
+import Nuke
+
+/// Two artwork-derived colors used to paint the Now Playing ambient wash
+/// (#271). Replaces the theme-default `primary`/`accent` pair so the player
+/// background picks up the mood of whatever is on screen.
+///
+/// The pair is packed to / from a compact `RRGGBB,RRGGBB` hex string so it
+/// round-trips through the core's per-album SQLite palette cache
+/// (`cacheAlbumPalette` / `cachedAlbumPalette`) without a bespoke codable
+/// surface across the FFI boundary.
+struct AmbientPalette: Equatable {
+    let top: Color
+    let bottom: Color
+
+    /// The two hex triples backing `top` / `bottom`, kept so the palette can
+    /// be re-serialized for the cache without round-tripping through
+    /// `NSColor` component extraction (which is lossy across color spaces).
+    private let topHex: UInt32
+    private let bottomHex: UInt32
+
+    init(topHex: UInt32, bottomHex: UInt32) {
+        self.topHex = topHex
+        self.bottomHex = bottomHex
+        self.top = Color(hex: topHex)
+        self.bottom = Color(hex: bottomHex)
+    }
+
+    /// `"RRGGBB,RRGGBB"` — the cache encoding written via
+    /// `core.cacheAlbumPalette`.
+    var encoded: String {
+        String(format: "%06X,%06X", topHex, bottomHex)
+    }
+
+    /// Parse a `"RRGGBB,RRGGBB"` string produced by `encoded`. Returns `nil`
+    /// on any malformed input so a stale / corrupt cache row falls back to a
+    /// fresh sample rather than rendering garbage.
+    init?(encoded: String) {
+        let parts = encoded.split(separator: ",")
+        guard parts.count == 2,
+              let t = UInt32(parts[0], radix: 16),
+              let b = UInt32(parts[1], radix: 16)
+        else { return nil }
+        self.init(topHex: t, bottomHex: b)
+    }
+}
+
+/// Off-main sampler that pulls two dominant colors from album artwork via
+/// Core Image's `CIAreaAverage` — no third-party Vibrant dependency. The
+/// image is split top/bottom and each half is averaged, which gives a pair
+/// that reads as a gentle vertical gradient matching the artwork's overall
+/// light-to-dark fall rather than two near-identical full-frame averages.
+///
+/// Each averaged color is nudged toward the dark surface palette (clamped
+/// luminance, modest saturation floor) so the wash never blows out to a flat
+/// white or a muddy gray on monochrome covers — it stays a *wash*, legible
+/// behind white type, per the screen spec's "ambient" intent.
+enum PaletteSampler {
+    /// Shared CIContext — creating one per sample is expensive (it spins up a
+    /// Metal/GL pipeline). `nonisolated(unsafe)` because `CIContext` is
+    /// internally thread-safe for rendering and we only ever read it.
+    nonisolated(unsafe) private static let ciContext = CIContext(options: [.workingColorSpace: NSNull()])
+
+    /// Extract an `AmbientPalette` from a decoded `CGImage`. Runs the Core
+    /// Image reductions synchronously; callers invoke it off the main actor
+    /// (see `AppModel.ambientPalette`).
+    static func palette(from cgImage: CGImage) -> AmbientPalette? {
+        let ci = CIImage(cgImage: cgImage)
+        let extent = ci.extent
+        guard extent.width >= 2, extent.height >= 2 else { return nil }
+
+        let topRect = CGRect(
+            x: extent.minX, y: extent.midY,
+            width: extent.width, height: extent.height / 2
+        )
+        let bottomRect = CGRect(
+            x: extent.minX, y: extent.minY,
+            width: extent.width, height: extent.height / 2
+        )
+
+        guard let topHex = averageHex(of: ci, in: topRect),
+              let bottomHex = averageHex(of: ci, in: bottomRect)
+        else { return nil }
+
+        return AmbientPalette(topHex: topHex, bottomHex: bottomHex)
+    }
+
+    /// Average the pixels of `image` inside `rect` with `CIAreaAverage`, then
+    /// render the resulting 1×1 image to a single RGBA8 pixel and tone-map it
+    /// for the dark wash.
+    private static func averageHex(of image: CIImage, in rect: CGRect) -> UInt32? {
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [
+            kCIInputImageKey: image,
+            kCIInputExtentKey: CIVector(cgRect: rect),
+        ]), let output = filter.outputImage else { return nil }
+
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        ciContext.render(
+            output,
+            toBitmap: &bitmap,
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
+
+        return toneMappedHex(r: bitmap[0], g: bitmap[1], b: bitmap[2])
+    }
+
+    /// Clamp an averaged color into the band that reads well as a dark wash:
+    /// floor a little saturation so pure-gray covers don't yield a dead gray,
+    /// and cap luminance so a bright cover doesn't wash out the white type.
+    private static func toneMappedHex(r: UInt8, g: UInt8, b: UInt8) -> UInt32 {
+        var h: CGFloat = 0, s: CGFloat = 0, v: CGFloat = 0
+        let color = NSColor(
+            srgbRed: CGFloat(r) / 255.0,
+            green: CGFloat(g) / 255.0,
+            blue: CGFloat(b) / 255.0,
+            alpha: 1.0
+        )
+        color.getHue(&h, saturation: &s, brightness: &v, alpha: nil)
+
+        // Keep some chroma so monochrome covers don't flatten to gray, but
+        // hold brightness in a mid-dark band so the wash stays behind type.
+        let mappedS = max(0.18, min(s, 0.85))
+        let mappedV = max(0.22, min(v, 0.55))
+        let mapped = NSColor(hue: h, saturation: mappedS, brightness: mappedV, alpha: 1.0)
+
+        guard let srgb = mapped.usingColorSpace(.sRGB) else { return 0 }
+        let ri = UInt32((srgb.redComponent * 255).rounded())
+        let gi = UInt32((srgb.greenComponent * 255).rounded())
+        let bi = UInt32((srgb.blueComponent * 255).rounded())
+        return (ri << 16) | (gi << 8) | bi
+    }
+}
+
+/// Full-bleed ambient background painted from an `AmbientPalette` (#271).
+/// Two radial gradients — one anchored top-leading in the palette's top
+/// color, one bottom-trailing in the bottom color — layered over the base
+/// `Theme.bg`, then blurred 20pt so it reads as a soft wash rather than two
+/// hard spotlights. Mirrors the prototype's twin-radial pattern but sources
+/// the colors from artwork instead of the static theme primary/accent.
+///
+/// When `palette` is `nil` (pre-sample, or extraction failed) it falls back
+/// to the theme `primary`/`accent` pair, so the player is never bare.
+struct AmbientWash: View {
+    let palette: AmbientPalette?
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        let top = palette?.top ?? Theme.primary
+        let bottom = palette?.bottom ?? Theme.accent
+
+        ZStack {
+            Theme.bg
+            if !reduceTransparency {
+                GeometryReader { geo in
+                    let side = max(geo.size.width, geo.size.height)
+                    ZStack {
+                        RadialGradient(
+                            colors: [top.opacity(0.55), .clear],
+                            center: .topLeading,
+                            startRadius: 0,
+                            endRadius: side * 0.9
+                        )
+                        RadialGradient(
+                            colors: [bottom.opacity(0.55), .clear],
+                            center: .bottomTrailing,
+                            startRadius: 0,
+                            endRadius: side * 0.9
+                        )
+                    }
+                    .blur(radius: 20)
+                }
+                // A faint scrim keeps white type legible over a bright wash.
+                Theme.bg.opacity(0.25)
+            }
+        }
+        .ignoresSafeArea()
+        .animation(.easeInOut(duration: 0.45), value: palette)
+    }
+}
+
+// MARK: - Nuke image fetch (palette source)
+
+extension PaletteSampler {
+    /// Pull the decoded artwork for `url` out of Nuke's shared pipeline —
+    /// reusing the same cache the on-screen `Artwork` already populated, so
+    /// sampling never triggers a second network fetch when the art is
+    /// already visible — and hand its `CGImage` to the sampler.
+    ///
+    /// Returns `nil` when the image can't be loaded or decoded; callers treat
+    /// that as "no palette" and fall back to the theme wash.
+    static func sample(from url: URL) async -> AmbientPalette? {
+        let request = ImageRequest(url: url)
+        let image: PlatformImage
+        do {
+            image = try await Artwork.pipeline.image(for: request)
+        } catch {
+            return nil
+        }
+        guard let cgImage = image.cgImageForPalette() else { return nil }
+        return palette(from: cgImage)
+    }
+}
+
+private extension PlatformImage {
+    /// Best-effort `CGImage` for sampling. `NSImage` may be backed by a vector
+    /// or multi-rep source, so go through `cgImage(forProposedRect:)` which
+    /// rasterizes the best representation at native size.
+    func cgImageForPalette() -> CGImage? {
+        var rect = CGRect(origin: .zero, size: size)
+        return cgImage(forProposedRect: &rect, context: nil, hints: nil)
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -29,6 +29,12 @@ struct NowPlayingView: View {
     @State private var tab: Tab = .queue
     @State private var resolvedAlbum: Album?
 
+    /// Artwork-derived ambient wash for the player background (#271). `nil`
+    /// until the current track's palette is sampled / read from cache; the
+    /// `AmbientWash` view falls back to the theme primary/accent pair in the
+    /// meantime so the screen is never bare.
+    @State private var ambientPalette: AmbientPalette?
+
     enum Tab: String, CaseIterable, Identifiable {
         case queue = "Queue"
         case lyrics = "Lyrics"
@@ -46,13 +52,28 @@ struct NowPlayingView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Theme.bg)
+        .background(AmbientWash(palette: ambientPalette))
         // Re-fetch the People array + lyrics on open and on track change.
         // The polling loop in AppModel already handles mid-session
         // transitions; this keeps the open-from-cold path honest too.
         .task(id: model.status.currentTrack?.id) {
             await model.fetchCurrentTrackDetails()
             await model.fetchCurrentTrackLyrics()
+        }
+        // Sample the ambient palette from the current track's album artwork
+        // (#271). Keyed on the album id so it only re-samples on a genuine
+        // album change, not on every metadata refresh; cleared to nil first
+        // so the wash cross-fades from the theme fallback into the new colors.
+        .task(id: model.status.currentTrack?.albumId ?? model.status.currentTrack?.id) {
+            ambientPalette = nil
+            guard let track = model.status.currentTrack else { return }
+            let albumId = track.albumId ?? track.id
+            let url = model.imageURL(
+                for: albumId,
+                tag: track.imageTag,
+                maxWidth: 480
+            )
+            ambientPalette = await model.ambientPalette(forAlbumId: albumId, imageURL: url)
         }
         // Honor a one-shot tab request (#91): the inline lyrics snippet in
         // the Queue Inspector taps `openLyrics()`, which sets

--- a/macos/Tests/LyrebirdTests/AmbientPaletteTests.swift
+++ b/macos/Tests/LyrebirdTests/AmbientPaletteTests.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// #271 — coverage for `AmbientPalette`'s string codec, the Swift half of the
+/// per-album ambient-wash cache. The Rust side already round-trips the opaque
+/// `"RRGGBB,RRGGBB"` value through SQLite verbatim
+/// (`album_palette_cache_round_trips`); what that test can't reach is the
+/// *decoder contract* on the Swift side — that a cached string bridges back to
+/// the correct `Color` values, and that a malformed / stale row is rejected so
+/// the wash falls back to a fresh sample instead of rendering garbage.
+///
+/// These tests pin that bridge: `init?(encoded:)` parsing, the hex→`Color`
+/// mapping (resolved through sRGB components, the same technique
+/// `AccessibleThemeTests` uses), `encoded` symmetry, and the full set of
+/// rejection cases.
+final class AmbientPaletteTests: XCTestCase {
+
+    /// An sRGB byte triple, made `Equatable` so `XCTAssertEqual` can compare a
+    /// whole color in one assertion (raw tuples aren't `Equatable`).
+    private struct RGB: Equatable {
+        let r: Int
+        let g: Int
+        let b: Int
+    }
+
+    /// Resolve a SwiftUI `Color` to its sRGB byte triple so we can assert the
+    /// decoded palette landed on the exact channels the hex string encoded.
+    private func rgb(_ color: Color) -> RGB {
+        let ns = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return RGB(
+            r: Int((ns.redComponent * 255).rounded()),
+            g: Int((ns.greenComponent * 255).rounded()),
+            b: Int((ns.blueComponent * 255).rounded())
+        )
+    }
+
+    // MARK: - Decode contract
+
+    /// A well-formed cache string decodes, and each half bridges to the exact
+    /// `Color` the hex triple names — this is the contract the Rust round-trip
+    /// test cannot observe (it only proves the bytes survive SQLite).
+    func testDecodesWellFormedStringToCorrectColors() {
+        guard let palette = AmbientPalette(encoded: "0C0622,887BFF") else {
+            return XCTFail("well-formed palette string must decode")
+        }
+
+        let top = rgb(palette.top)
+        XCTAssertEqual(top.r, 0x0C)
+        XCTAssertEqual(top.g, 0x06)
+        XCTAssertEqual(top.b, 0x22)
+
+        let bottom = rgb(palette.bottom)
+        XCTAssertEqual(bottom.r, 0x88)
+        XCTAssertEqual(bottom.g, 0x7B)
+        XCTAssertEqual(bottom.b, 0xFF)
+    }
+
+    /// The decoded palette's `top`/`bottom` must match the canonical
+    /// `Color(hex:)` constructor for the same triples — i.e. the codec path and
+    /// the direct constructor agree, so a cached value renders identically to a
+    /// freshly sampled one.
+    func testDecodedColorsMatchCanonicalHexInitializer() {
+        guard let palette = AmbientPalette(encoded: "140B30,FF066F") else {
+            return XCTFail("well-formed palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), rgb(Color(hex: 0x140B30)))
+        XCTAssertEqual(rgb(palette.bottom), rgb(Color(hex: 0xFF066F)))
+    }
+
+    /// Pure black / white extremes must survive the decode without channel
+    /// truncation or overflow.
+    func testDecodesBlackAndWhiteExtremes() {
+        guard let palette = AmbientPalette(encoded: "000000,FFFFFF") else {
+            return XCTFail("extreme palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0, g: 0, b: 0))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 255, g: 255, b: 255))
+    }
+
+    /// `UInt32(_:radix:)` accepts lowercase hex, so a cache row that was written
+    /// (or hand-edited) in lowercase must still decode to the same colors.
+    func testDecodesLowercaseHex() {
+        guard let palette = AmbientPalette(encoded: "0c0622,887bff") else {
+            return XCTFail("lowercase palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0x0C, g: 0x06, b: 0x22))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 0x88, g: 0x7B, b: 0xFF))
+    }
+
+    // MARK: - encode/decode symmetry
+
+    /// `encoded` re-serializes to the canonical uppercase form, and that form
+    /// decodes back to an equal palette — closing the loop the cache relies on.
+    func testEncodeDecodeRoundTrip() {
+        let original = AmbientPalette(topHex: 0x0C0622, bottomHex: 0x887BFF)
+        XCTAssertEqual(original.encoded, "0C0622,887BFF")
+
+        guard let restored = AmbientPalette(encoded: original.encoded) else {
+            return XCTFail("re-encoded palette must decode")
+        }
+        XCTAssertEqual(restored, original)
+    }
+
+    /// Decoding a lowercase string then re-encoding yields the canonical
+    /// uppercase form, so the cache self-heals casing on re-write.
+    func testReEncodeNormalizesCasing() {
+        let palette = AmbientPalette(encoded: "0c0622,887bff")
+        XCTAssertEqual(palette?.encoded, "0C0622,887BFF")
+    }
+
+    // MARK: - Rejection of malformed / stale cache rows
+
+    func testRejectsMalformedStrings() {
+        let bad = [
+            "",                  // empty
+            "0C0622",            // single color, no comma
+            "0C0622,887BFF,FF0", // three colors
+            "0C0622887BFF",      // missing separator
+            "ZZZZZZ,887BFF",     // non-hex in first half
+            "0C0622,ZZZZZZ",     // non-hex in second half
+            "0C0622,",           // trailing empty half
+            ",887BFF",           // leading empty half
+            "  0C0622,887BFF",   // stray whitespace breaks hex parse
+        ]
+        for input in bad {
+            XCTAssertNil(
+                AmbientPalette(encoded: input),
+                "malformed cache row \"\(input)\" must decode to nil so the wash re-samples"
+            )
+        }
+    }
+
+    /// A value with more than six hex digits per half still *parses* as a
+    /// `UInt32` but names a color outside the 0xRRGGBB space; the high bits are
+    /// simply ignored by `Color(hex:)`, so we assert the documented masking
+    /// behavior rather than a crash. This pins that an over-wide stale row
+    /// degrades gracefully (low 24 bits win) instead of trapping.
+    func testOverWideHexMasksToLow24Bits() {
+        guard let palette = AmbientPalette(encoded: "FF887BFF,00000000") else {
+            return XCTFail("parseable-but-wide hex should still decode")
+        }
+        // 0xFF887BFF & 0xFFFFFF == 0x887BFF
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0x88, g: 0x7B, b: 0xFF))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 0, g: 0, b: 0))
+    }
+}


### PR DESCRIPTION
Paints the Now Playing screen with an ambient wash sampled from the current album's artwork instead of the static theme colors, so the player background takes on the mood of whatever is playing.

Closes #271

What it does:
- `PaletteSampler` (new `Components/AmbientWash.swift`) extracts two dominant colors from the artwork with Core Image `CIAreaAverage` over the top/bottom halves — no Vibrant dependency. Each color is tone-mapped into a mid-dark band so the wash stays legible behind white type and never blows out on bright/monochrome covers.
- `AmbientWash` renders the twin-radial-gradient pattern (top-leading + bottom-trailing), blurred 20pt over `Theme.bg`, and falls back to the theme `primary`/`accent` pair until the sample lands. It honors `accessibilityReduceTransparency`.
- `AppModel.ambientPalette(forAlbumId:imageURL:)` resolves cheapest-first: in-memory cache, then the core's per-album SQLite cache, then a fresh sample written back to both. The image is pulled from Nuke's shared pipeline (reusing the cache `Artwork` already populated), and both the FFI cache reads/writes and the Core Image work run off the MainActor (gap pattern #2).
- Core: new `cacheAlbumPalette` / `cachedAlbumPalette` FFI backed by the existing SQLite settings table under a `palette:<albumId>` key.
- `NowPlayingView` samples on album-id change and cross-fades the wash in.

The property wrappers touched are `State` and `Environment`; the resolver uses `Task.detached` for off-actor FFI.

pipeline:
- fixer-session: feature-builder-271
- slice: design
- hotspots-claimed: none
- build-gate: pass (cargo fmt --check, clippy -D warnings, cargo test 217 passed incl. new `album_palette_cache_round_trips`; macos clean `rm -rf .build && swift build`)
- diff-stat: 6 files, +355 / -1
