### PR TITLE
fix(macos): breadcrumb resolves album/artist names past the paged cache

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -2429,6 +2429,18 @@ final class AppModel {
     /// its name instead of "…". Cleared on `logout()` / `forgetToken()`.
     var resolvedNameCache: [String: String] = [:]
 
+    /// Breadcrumb display name for an album id: the loaded `albums` page first,
+    /// then `resolvedNameCache` (seeded by `resolveAlbum` on drill-in), then nil
+    /// when neither knows the name so the caller can render an ellipsis.
+    func breadcrumbAlbumName(id: String) -> String? {
+        albums.first(where: { $0.id == id })?.name ?? resolvedNameCache[id]
+    }
+
+    /// Breadcrumb display name for an artist id, mirroring `breadcrumbAlbumName`.
+    func breadcrumbArtistName(id: String) -> String? {
+        artists.first(where: { $0.id == id })?.name ?? resolvedNameCache[id]
+    }
+
     /// Resolve an `Album` record by id — cache-first, falling back to
     /// `core.fetchItem` for libraries larger than the loaded `albums`
     /// page. Returns nil on error or missing id.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1029,6 +1029,7 @@ final class AppModel {
         artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
         artistDetailCache = [:]
+        resolvedNameCache = [:]
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
@@ -1096,6 +1097,7 @@ final class AppModel {
         artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
         artistDetailCache = [:]
+        resolvedNameCache = [:]
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
@@ -2377,8 +2379,12 @@ final class AppModel {
     /// "N albums · M songs" strip silently hides the zero-count lines
     /// rather than lying.
     func resolveArtist(id: String) async -> Artist? {
-        if let cached = artists.first(where: { $0.id == id }) { return cached }
+        if let cached = artists.first(where: { $0.id == id }) {
+            resolvedNameCache[id] = cached.name
+            return cached
+        }
         guard let detail = await artistDetail(artistId: id) else { return nil }
+        resolvedNameCache[id] = detail.name
         return Artist(
             id: detail.id,
             name: detail.name,
@@ -2416,6 +2422,13 @@ final class AppModel {
     /// Per-session cache for `artistDetail`. Cleared on `logout()` / `forgetToken()`.
     private var artistDetailCache: [String: ArtistDetail] = [:]
 
+    /// Album/artist id → display name, seeded by `resolveAlbum` / `resolveArtist`
+    /// when they resolve an id past the loaded library page. The breadcrumb
+    /// builder reads this so a drill destination reached from outside
+    /// `albums` / `artists` (recently played, discography, genre detail) shows
+    /// its name instead of "…". Cleared on `logout()` / `forgetToken()`.
+    var resolvedNameCache: [String: String] = [:]
+
     /// Resolve an `Album` record by id — cache-first, falling back to
     /// `core.fetchItem` for libraries larger than the loaded `albums`
     /// page. Returns nil on error or missing id.
@@ -2426,7 +2439,10 @@ final class AppModel {
     /// `ChildCount`; `AlbumDetailView` re-counts the loaded tracklist
     /// in that case.
     func resolveAlbum(id: String) async -> Album? {
-        if let cached = albums.first(where: { $0.id == id }) { return cached }
+        if let cached = albums.first(where: { $0.id == id }) {
+            resolvedNameCache[id] = cached.name
+            return cached
+        }
         do {
             let json = try await Task.detached(priority: .userInitiated) { [core] in
                 try core.fetchItem(
@@ -2434,7 +2450,9 @@ final class AppModel {
                     fields: ["PrimaryImageAspectRatio", "Genres", "ProductionYear", "ChildCount", "RunTimeTicks"]
                 )
             }.value
-            return Self.parseAlbum(from: json)
+            let album = Self.parseAlbum(from: json)
+            if let album { resolvedNameCache[id] = album.name }
+            return album
         } catch {
             _ = handleAuthError(error)
             return nil

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -368,6 +368,10 @@ struct MainShell: View {
             segments.append("Albums")
             if let album = model.albums.first(where: { $0.id == id }) {
                 segments.append(album.name)
+            } else if let name = model.resolvedNameCache[id] {
+                // The album was navigated to from outside the loaded library
+                // page; its name was seeded into the cache by `resolveAlbum`.
+                segments.append(name)
             } else {
                 // Ellipsis is more informative than a section-name-matching
                 // literal fallback ("Albums > Album") that reads like a bug.
@@ -378,6 +382,8 @@ struct MainShell: View {
             segments.append("Artists")
             if let artist = model.artists.first(where: { $0.id == id }) {
                 segments.append(artist.name)
+            } else if let name = model.resolvedNameCache[id] {
+                segments.append(name)
             } else {
                 segments.append("…")
             }

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -366,11 +366,7 @@ struct MainShell: View {
         case .album(let id)?:
             if model.screen != .library { segments.append("Library") }
             segments.append("Albums")
-            if let album = model.albums.first(where: { $0.id == id }) {
-                segments.append(album.name)
-            } else if let name = model.resolvedNameCache[id] {
-                // The album was navigated to from outside the loaded library
-                // page; its name was seeded into the cache by `resolveAlbum`.
+            if let name = model.breadcrumbAlbumName(id: id) {
                 segments.append(name)
             } else {
                 // Ellipsis is more informative than a section-name-matching
@@ -380,9 +376,7 @@ struct MainShell: View {
         case .artist(let id)?:
             if model.screen != .library { segments.append("Library") }
             segments.append("Artists")
-            if let artist = model.artists.first(where: { $0.id == id }) {
-                segments.append(artist.name)
-            } else if let name = model.resolvedNameCache[id] {
+            if let name = model.breadcrumbArtistName(id: id) {
                 segments.append(name)
             } else {
                 segments.append("…")

--- a/macos/Tests/LyrebirdTests/BreadcrumbNameResolutionTests.swift
+++ b/macos/Tests/LyrebirdTests/BreadcrumbNameResolutionTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the breadcrumb name-resolution chain (#938): the loaded
+/// `albums` / `artists` page first, then `resolvedNameCache` (seeded by
+/// `resolveAlbum` / `resolveArtist` on drill-in from outside that page), then
+/// nil so the trail renders an ellipsis. Before the fix a drill destination
+/// reached from recently-played / discography / genre detail dead-ended at "…".
+///
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore`; we redirect the
+/// core's data dir to a throwaway temp dir via `XDG_DATA_HOME` so the test
+/// never touches the real app database.
+@MainActor
+final class BreadcrumbNameResolutionTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeAlbum(id: String, name: String) -> Album {
+        Album(
+            id: id, name: name, artistName: "Artist", artistId: nil, year: nil,
+            trackCount: 0, runtimeTicks: 0, genres: [], imageTag: nil, userData: nil
+        )
+    }
+
+    private func makeArtist(id: String, name: String) -> Artist {
+        Artist(
+            id: id, name: name, albumCount: 0, songCount: 0, genres: [],
+            imageTag: nil, userData: nil
+        )
+    }
+
+    func testAlbumNamePrefersLoadedPage() throws {
+        let model = try AppModel()
+        model.albums = [makeAlbum(id: "a1", name: "Page Album")]
+        model.resolvedNameCache["a1"] = "Cache Album"
+
+        XCTAssertEqual(model.breadcrumbAlbumName(id: "a1"), "Page Album")
+    }
+
+    func testAlbumNameFallsBackToResolvedCache() throws {
+        let model = try AppModel()
+        // Empty page (the #938 case: album drilled into from outside page 1).
+        model.albums = []
+        model.resolvedNameCache["a2"] = "Cache Album"
+
+        XCTAssertEqual(model.breadcrumbAlbumName(id: "a2"), "Cache Album")
+    }
+
+    func testAlbumNameNilWhenUnknown() throws {
+        let model = try AppModel()
+        model.albums = []
+        model.resolvedNameCache = [:]
+
+        XCTAssertNil(model.breadcrumbAlbumName(id: "missing"))
+    }
+
+    func testArtistNamePrefersLoadedPage() throws {
+        let model = try AppModel()
+        model.artists = [makeArtist(id: "r1", name: "Page Artist")]
+        model.resolvedNameCache["r1"] = "Cache Artist"
+
+        XCTAssertEqual(model.breadcrumbArtistName(id: "r1"), "Page Artist")
+    }
+
+    func testArtistNameFallsBackToResolvedCache() throws {
+        let model = try AppModel()
+        model.artists = []
+        model.resolvedNameCache["r2"] = "Cache Artist"
+
+        XCTAssertEqual(model.breadcrumbArtistName(id: "r2"), "Cache Artist")
+    }
+
+    func testArtistNameNilWhenUnknown() throws {
+        let model = try AppModel()
+        model.artists = []
+        model.resolvedNameCache = [:]
+
+        XCTAssertNil(model.breadcrumbArtistName(id: "missing"))
+    }
+}

--- a/macos/Tests/LyrebirdTests/BreadcrumbNameResolutionTests.swift
+++ b/macos/Tests/LyrebirdTests/BreadcrumbNameResolutionTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Lyrebird
 @testable import LyrebirdCore
 
-/// Coverage for the breadcrumb name-resolution chain (#938): the loaded
+/// Coverage for the breadcrumb name-resolution chain: the loaded
 /// `albums` / `artists` page first, then `resolvedNameCache` (seeded by
 /// `resolveAlbum` / `resolveArtist` on drill-in from outside that page), then
 /// nil so the trail renders an ellipsis. Before the fix a drill destination
@@ -45,7 +45,7 @@ final class BreadcrumbNameResolutionTests: XCTestCase {
 
     func testAlbumNameFallsBackToResolvedCache() throws {
         let model = try AppModel()
-        // Empty page (the #938 case: album drilled into from outside page 1).
+        // Empty page (album drilled into from outside page 1).
         model.albums = []
         model.resolvedNameCache["a2"] = "Cache Album"
 


### PR DESCRIPTION
The breadcrumb trail dead-ended at "…" for any album or artist a user drilled into from outside the library's loaded first page (recently played, artist discography, genre detail), which is the common case on a 20k+-album library.

The breadcrumb builder resolved names via `model.albums.first` / `model.artists.first` — a cache-only scan of the in-memory page. This seeds a lightweight id→name cache in `resolveAlbum` / `resolveArtist` (already called on drill-in by `AlbumDetailView` / `ArtistDetailView`) and reads it as a fallback before the ellipsis. The cache is cleared on `logout()` / `forgetToken()`.

Closes #938

pipeline:
  fixer-session: wf_7dda2c5e-608-15
  slice: slice:screens
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 2 files changed, +24/-3
