### PR TITLE
fix(macos): resolve PlaybackInfo off-main in AudioEngine.play

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3556,8 +3556,15 @@ final class AppModel {
         do {
             _ = try core.setQueue(tracks: tracks, startIndex: UInt32(startIndex))
             guard let first = tracks[safe: startIndex] else { return }
-            try audio.play(track: first)
-            errorMessage = nil
+            Task {
+                do {
+                    try await audio.play(track: first)
+                    errorMessage = nil
+                } catch {
+                    if handleAuthError(error) { return }
+                    errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
+                }
+            }
         } catch {
             if handleAuthError(error) { return }
             errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
@@ -5051,11 +5058,13 @@ final class AppModel {
     }
 
     private func playCurrent(_ track: Track) {
-        do {
-            try audio.play(track: track)
-        } catch {
-            if handleAuthError(error) { return }
-            errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
+        Task {
+            do {
+                try await audio.play(track: track)
+            } catch {
+                if handleAuthError(error) { return }
+                errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
+            }
         }
     }
 

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -201,7 +201,14 @@ public final class AudioEngine: NSObject {
     /// ahead of stream-URL construction. Both are `nil` on error so the
     /// caller falls back to the server's default source and an
     /// opportunistic (uncorrelated) session — the URL is still playable.
-    private func resolvePlaybackSource(for trackId: String) -> (mediaSourceId: String?, playSessionId: String?) {
+    ///
+    /// The `core.playbackInfo` call crosses the FFI into Rust and blocks the
+    /// calling thread on the core's `block_on` for the full `POST
+    /// /Items/{id}/PlaybackInfo` round-trip (50–500 ms local, unbounded on a
+    /// slow link). It runs off the main actor so `play(track:)` never beach-
+    /// balls the UI for the duration of that request (#936).
+    private func resolvePlaybackSource(for trackId: String) async -> (mediaSourceId: String?, playSessionId: String?) {
+        let core = self.core
         let opts = PlaybackInfoOpts(
             userId: nil,
             startTimeTicks: nil,
@@ -213,10 +220,12 @@ public final class AudioEngine: NSObject {
             autoOpenLiveStream: nil,
             deviceProfile: nil
         )
-        guard let info = try? core.playbackInfo(itemId: trackId, opts: opts) else {
-            return (nil, nil)
-        }
-        return (info.mediaSources.first?.id, info.playSessionId)
+        return await Task.detached {
+            guard let info = try? core.playbackInfo(itemId: trackId, opts: opts) else {
+                return (nil, nil)
+            }
+            return (info.mediaSources.first?.id, info.playSessionId)
+        }.value
     }
 
     /// The currently-reporting session, captured at the last
@@ -325,13 +334,15 @@ public final class AudioEngine: NSObject {
 
     // MARK: - Public
 
-    public func play(track: Track) throws {
+    public func play(track: Track) async throws {
         // Resolve media source + play session id via PlaybackInfo so the
         // server picks the right source for multi-version items and can
         // correlate subsequent /Sessions/Playing* reports with the stream.
         // Falling back to nil is harmless — the server just picks its
-        // default source and correlation stays opportunistic.
-        let (mediaSourceId, playSessionId) = resolvePlaybackSource(for: track.id)
+        // default source and correlation stays opportunistic. The resolution
+        // runs off the main actor (#936) so the network POST never blocks the
+        // UI; everything below resumes on the main actor.
+        let (mediaSourceId, playSessionId) = await resolvePlaybackSource(for: track.id)
         let urlString = try core.streamUrl(
             trackId: track.id,
             mediaSourceId: mediaSourceId,

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -202,11 +202,9 @@ public final class AudioEngine: NSObject {
     /// caller falls back to the server's default source and an
     /// opportunistic (uncorrelated) session — the URL is still playable.
     ///
-    /// The `core.playbackInfo` call crosses the FFI into Rust and blocks the
-    /// calling thread on the core's `block_on` for the full `POST
-    /// /Items/{id}/PlaybackInfo` round-trip (50–500 ms local, unbounded on a
-    /// slow link). It runs off the main actor so `play(track:)` never beach-
-    /// balls the UI for the duration of that request (#936).
+    /// Runs off the main actor: the `core.playbackInfo` FFI blocks the calling
+    /// thread on the full `POST /Items/{id}/PlaybackInfo` round-trip, which
+    /// would beach-ball the UI if taken on the main actor.
     private func resolvePlaybackSource(for trackId: String) async -> (mediaSourceId: String?, playSessionId: String?) {
         let core = self.core
         let opts = PlaybackInfoOpts(
@@ -339,9 +337,7 @@ public final class AudioEngine: NSObject {
         // server picks the right source for multi-version items and can
         // correlate subsequent /Sessions/Playing* reports with the stream.
         // Falling back to nil is harmless — the server just picks its
-        // default source and correlation stays opportunistic. The resolution
-        // runs off the main actor (#936) so the network POST never blocks the
-        // UI; everything below resumes on the main actor.
+        // default source and correlation stays opportunistic.
         let (mediaSourceId, playSessionId) = await resolvePlaybackSource(for: track.id)
         let urlString = try core.streamUrl(
             trackId: track.id,

--- a/macos/Sources/SmokeTest/main.swift
+++ b/macos/Sources/SmokeTest/main.swift
@@ -95,7 +95,7 @@ struct SmokeTest {
         // ─── Step 1: play ────────────────────────────────────────────────
         do {
             _ = try core.setQueue(tracks: tracks, startIndex: 0)
-            try engine.play(track: first)
+            try await engine.play(track: first)
         } catch {
             fputs("play: \(error)\n", stderr); exit(1)
         }
@@ -168,7 +168,7 @@ struct SmokeTest {
         if tracks.count >= 2 {
             let beforeId = core.status().currentTrack?.id
             if let next = core.skipNext() {
-                try? engine.play(track: next)
+                try? await engine.play(track: next)
                 // Poll instead of sleeping — AudioEngine.play() schedules
                 // the AVPlayer item replacement asynchronously, which on a
                 // headless runner can take longer than a fixed 1.5s.


### PR DESCRIPTION
`AudioEngine.resolvePlaybackSource(for:)` issued a synchronous `POST /Items/{id}/PlaybackInfo` across the UniFFI boundary on the main actor for every `play(track:)`, so the UI hung for the full network round-trip (50-500 ms local, unbounded on a slow link) on each user-initiated play. This moves that resolution off the main actor — mirroring the existing `preloadNextTrack` pattern — so playback start no longer beach-balls the main thread.

`resolvePlaybackSource` now runs the blocking FFI inside a `Task.detached` and returns its value; `play(track:)` becomes `async` and awaits it, resuming the cheap AVQueuePlayer setup back on the `MainActor`. The two AppModel call sites and the SmokeTest harness are updated to await accordingly.

Closes #936

pipeline:
  fixer-session: wf_7dda2c5e-608-17
  slice: slice:audio
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 3 files changed, +37/-17