### PR TITLE
macos: spinning vinyl disc behind Now Playing artwork

### DIFF
--- a/macos/Sources/Lyrebird/Components/VinylDisc.swift
+++ b/macos/Sources/Lyrebird/Components/VinylDisc.swift
@@ -1,14 +1,53 @@
 import SwiftUI
 
+/// Spin-state math for the vinyl disc, factored out of the view so the
+/// freeze-on-pause behaviour is unit-testable without a running scene graph.
+///
+/// The disc animates a monotonically growing `angle` so it can stop in place
+/// rather than unwinding to 0°. The subtlety: when SwiftUI is mid-ramp, the
+/// model's `angle` already holds the *target* of the in-flight animation, not
+/// the value currently on screen. Truncating that target by 360 lands on an
+/// arbitrary multiple-of-360 remainder, so the disc visibly snaps. To freeze
+/// at the *interpolated* position we reconstruct it from the ramp's start
+/// time and duration.
+enum VinylSpin {
+    /// One rotation per this many seconds, linear.
+    static let secondsPerRotation: Double = 8
+
+    /// Degrees swept since a ramp began, given how long it has been running.
+    /// Linear at `360 / secondsPerRotation` deg/s, clamped to non-negative
+    /// elapsed so a clock skew can't rewind the disc.
+    static func sweep(elapsed: Double) -> Double {
+        guard elapsed > 0 else { return 0 }
+        return elapsed * (360 / secondsPerRotation)
+    }
+
+    /// The angle the disc is actually showing when paused mid-ramp: the angle
+    /// it started the current rotation from, advanced by the interpolated
+    /// sweep, then normalised to `[0, 360)`. This is the value to commit on
+    /// pause — using the model's already-advanced target instead would snap
+    /// the disc to an unrelated remainder.
+    static func frozenAngle(base: Double, elapsed: Double) -> Double {
+        normalize(base + sweep(elapsed: elapsed))
+    }
+
+    /// Map any accumulated angle into `[0, 360)` without the sign quirk of
+    /// `truncatingRemainder` on negatives.
+    static func normalize(_ angle: Double) -> Double {
+        let r = angle.truncatingRemainder(dividingBy: 360)
+        return r < 0 ? r + 360 : r
+    }
+}
+
 /// A stylized vinyl record that peeks out the right edge of the Now Playing
-/// hero artwork and spins while audio is playing (#270).
+/// hero artwork and spins while audio is playing.
 ///
 /// Mirrors the prototype recipe in `design/project/src/panels.jsx`:
 /// a 400pt conic-gradient disc offset `-80pt` to the right and `+10pt` up,
 /// sitting *behind* the 420pt artwork, with a primary→accent label and a
 /// black center hole. One rotation per 8s, linear, only while `playing`.
-/// Pausing freezes the disc in place (the angle is interpolated, so it
-/// stops where it was rather than snapping back to 0°).
+/// Pausing freezes the disc at its on-screen position; Reduce Motion holds it
+/// still.
 ///
 /// The disc scales to whatever side length the hero art is rendered at
 /// (the hero is responsive, not a hard 420pt), preserving the prototype's
@@ -21,13 +60,16 @@ struct VinylDisc: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    /// Accumulated rotation in degrees. Animating a monotonically growing
-    /// value (rather than toggling 0↔360) lets the disc freeze in place on
-    /// pause instead of unwinding, and resume from the same angle.
+    /// Accumulated rotation in degrees, normalised to `[0, 360)` whenever the
+    /// disc is at rest. Animating a growing value lets the disc freeze in
+    /// place on pause and resume from the same angle.
     @State private var angle: Double = 0
+    /// The angle the current ramp started from, captured when the spin begins.
+    @State private var rampBaseAngle: Double = 0
+    /// When the current ramp began, used to reconstruct the interpolated angle
+    /// on pause. `nil` while the disc is at rest.
+    @State private var rampStart: Date?
 
-    /// Prototype reference dimensions, scaled by the live art side so the
-    /// disc keeps its proportions on a 13" MBP and on an ultrawide alike.
     private var scale: CGFloat { artSide / 420 }
     private var discSize: CGFloat { 400 * scale }
     private var offsetX: CGFloat { 80 * scale }
@@ -35,8 +77,6 @@ struct VinylDisc: View {
 
     var body: some View {
         ZStack {
-            // Grooved body — repeating conic gradient reads as concentric
-            // pressing lines once it spins.
             Circle()
                 .fill(
                     AngularGradient(
@@ -60,7 +100,6 @@ struct VinylDisc: View {
                         .padding(discSize * 0.02)
                 )
 
-            // Label — primary→accent wash.
             Circle()
                 .fill(
                     LinearGradient(
@@ -71,7 +110,6 @@ struct VinylDisc: View {
                 )
                 .frame(width: discSize * 0.2, height: discSize * 0.2)
 
-            // Center spindle hole.
             Circle()
                 .fill(Color.black)
                 .frame(width: discSize * 0.06, height: discSize * 0.06)
@@ -79,7 +117,6 @@ struct VinylDisc: View {
         .frame(width: discSize, height: discSize)
         .shadow(color: .black.opacity(0.5), radius: 20 * scale, x: 0, y: 20 * scale)
         .rotationEffect(.degrees(angle))
-        // Behind the artwork, peeking out its right edge.
         .offset(x: offsetX, y: offsetY)
         .zIndex(-1)
         .allowsHitTesting(false)
@@ -94,19 +131,23 @@ struct VinylDisc: View {
     }
 
     /// Start or stop the rotation. While playing (and motion is allowed) we
-    /// drive `angle` forward by 360° on a repeating 8s linear ramp. On pause
-    /// we re-assign the current angle with no animation, which halts the
-    /// in-flight ramp at its present position.
+    /// drive `angle` forward by 360° on a repeating 8s linear ramp, recording
+    /// the base angle and start time so a later pause can recover the
+    /// on-screen position. On pause we commit that interpolated position with
+    /// no animation, halting the ramp where the disc actually is.
     private func updateSpin(playing: Bool) {
         if playing && !reduceMotion {
-            withAnimation(.linear(duration: 8).repeatForever(autoreverses: false)) {
+            guard rampStart == nil else { return }
+            rampBaseAngle = angle
+            rampStart = Date()
+            withAnimation(.linear(duration: VinylSpin.secondsPerRotation).repeatForever(autoreverses: false)) {
                 angle += 360
             }
         } else {
-            // Freeze in place: cancel the repeating animation by writing the
-            // value without an animation transaction.
+            let elapsed = rampStart.map { Date().timeIntervalSince($0) } ?? 0
+            rampStart = nil
             withAnimation(.linear(duration: 0)) {
-                angle = angle.truncatingRemainder(dividingBy: 360)
+                angle = VinylSpin.frozenAngle(base: rampBaseAngle, elapsed: elapsed)
             }
         }
     }

--- a/macos/Sources/Lyrebird/Components/VinylDisc.swift
+++ b/macos/Sources/Lyrebird/Components/VinylDisc.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// A stylized vinyl record that peeks out the right edge of the Now Playing
+/// hero artwork and spins while audio is playing (#270).
+///
+/// Mirrors the prototype recipe in `design/project/src/panels.jsx`:
+/// a 400pt conic-gradient disc offset `-80pt` to the right and `+10pt` up,
+/// sitting *behind* the 420pt artwork, with a primary→accent label and a
+/// black center hole. One rotation per 8s, linear, only while `playing`.
+/// Pausing freezes the disc in place (the angle is interpolated, so it
+/// stops where it was rather than snapping back to 0°).
+///
+/// The disc scales to whatever side length the hero art is rendered at
+/// (the hero is responsive, not a hard 420pt), preserving the prototype's
+/// 400:420 disc-to-art ratio and the `-80`/`+10` offsets at every size.
+struct VinylDisc: View {
+    /// Side length of the hero artwork this disc sits behind.
+    let artSide: CGFloat
+    /// Whether playback is currently active. Drives the spin animation.
+    let isPlaying: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Accumulated rotation in degrees. Animating a monotonically growing
+    /// value (rather than toggling 0↔360) lets the disc freeze in place on
+    /// pause instead of unwinding, and resume from the same angle.
+    @State private var angle: Double = 0
+
+    /// Prototype reference dimensions, scaled by the live art side so the
+    /// disc keeps its proportions on a 13" MBP and on an ultrawide alike.
+    private var scale: CGFloat { artSide / 420 }
+    private var discSize: CGFloat { 400 * scale }
+    private var offsetX: CGFloat { 80 * scale }
+    private var offsetY: CGFloat { -10 * scale }
+
+    var body: some View {
+        ZStack {
+            // Grooved body — repeating conic gradient reads as concentric
+            // pressing lines once it spins.
+            Circle()
+                .fill(
+                    AngularGradient(
+                        gradient: Gradient(stops: [
+                            .init(color: Color(white: 0.07), location: 0.0),
+                            .init(color: Color(white: 0.13), location: 0.15),
+                            .init(color: Color(white: 0.07), location: 0.30),
+                            .init(color: Color(white: 0.13), location: 0.45),
+                            .init(color: Color(white: 0.07), location: 0.60),
+                            .init(color: Color(white: 0.13), location: 0.75),
+                            .init(color: Color(white: 0.07), location: 0.90),
+                            .init(color: Color(white: 0.07), location: 1.0),
+                        ]),
+                        center: .center
+                    )
+                )
+                .overlay(
+                    Circle()
+                        .stroke(Color.black.opacity(0.8), lineWidth: discSize * 0.04)
+                        .blur(radius: discSize * 0.05)
+                        .padding(discSize * 0.02)
+                )
+
+            // Label — primary→accent wash.
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.primary, Theme.accent],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: discSize * 0.2, height: discSize * 0.2)
+
+            // Center spindle hole.
+            Circle()
+                .fill(Color.black)
+                .frame(width: discSize * 0.06, height: discSize * 0.06)
+        }
+        .frame(width: discSize, height: discSize)
+        .shadow(color: .black.opacity(0.5), radius: 20 * scale, x: 0, y: 20 * scale)
+        .rotationEffect(.degrees(angle))
+        // Behind the artwork, peeking out its right edge.
+        .offset(x: offsetX, y: offsetY)
+        .zIndex(-1)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .onChange(of: isPlaying) { _, playing in
+            updateSpin(playing: playing)
+        }
+        .onChange(of: reduceMotion) { _, _ in
+            updateSpin(playing: isPlaying)
+        }
+        .onAppear { updateSpin(playing: isPlaying) }
+    }
+
+    /// Start or stop the rotation. While playing (and motion is allowed) we
+    /// drive `angle` forward by 360° on a repeating 8s linear ramp. On pause
+    /// we re-assign the current angle with no animation, which halts the
+    /// in-flight ramp at its present position.
+    private func updateSpin(playing: Bool) {
+        if playing && !reduceMotion {
+            withAnimation(.linear(duration: 8).repeatForever(autoreverses: false)) {
+                angle += 360
+            }
+        } else {
+            // Freeze in place: cancel the repeating animation by writing the
+            // value without an animation transaction.
+            withAnimation(.linear(duration: 0)) {
+                angle = angle.truncatingRemainder(dividingBy: 360)
+            }
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -111,6 +111,15 @@ struct NowPlayingView: View {
                 radius: 14
             )
             .frame(width: artSide, height: artSide)
+            // Vinyl disc peeking out the artwork's right edge (#270). Aligned
+            // trailing so it slides out past the art rather than behind its
+            // center; the disc's own `+80pt` x-offset pushes it clear.
+            .background(alignment: .trailing) {
+                VinylDisc(
+                    artSide: artSide,
+                    isPlaying: model.status.state == .playing
+                )
+            }
             VStack(alignment: .leading, spacing: 6) {
                 Text(track.name)
                     .font(Theme.font(26, weight: .heavy))

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -111,9 +111,9 @@ struct NowPlayingView: View {
                 radius: 14
             )
             .frame(width: artSide, height: artSide)
-            // Vinyl disc peeking out the artwork's right edge (#270). Aligned
-            // trailing so it slides out past the art rather than behind its
-            // center; the disc's own `+80pt` x-offset pushes it clear.
+            // Trailing alignment so the disc slides out past the art's right
+            // edge rather than behind its center; the disc's own `+80pt`
+            // x-offset pushes it clear.
             .background(alignment: .trailing) {
                 VinylDisc(
                     artSide: artSide,

--- a/macos/Tests/LyrebirdTests/VinylSpinTests.swift
+++ b/macos/Tests/LyrebirdTests/VinylSpinTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `VinylSpin`, the freeze-on-pause math behind the Now Playing
+/// vinyl disc.
+///
+/// The contract that bit the first cut: pausing must commit the *interpolated*
+/// on-screen angle, not the model's already-advanced ramp target. The math
+/// lives in `VinylSpin` precisely so it can be checked here without a scene
+/// graph, where the presentation-layer value is otherwise unobservable.
+final class VinylSpinTests: XCTestCase {
+
+    private let degreesPerSecond = 360.0 / VinylSpin.secondsPerRotation
+
+    func testSweepIsLinearAtEightSecondsPerRotation() {
+        XCTAssertEqual(VinylSpin.sweep(elapsed: 0), 0, accuracy: 1e-9)
+        XCTAssertEqual(
+            VinylSpin.sweep(elapsed: 4),
+            180,
+            accuracy: 1e-9,
+            "half a rotation lands at 180° four seconds in"
+        )
+        XCTAssertEqual(
+            VinylSpin.sweep(elapsed: VinylSpin.secondsPerRotation),
+            360,
+            accuracy: 1e-9,
+            "a full 8s ramp sweeps exactly one rotation"
+        )
+    }
+
+    func testSweepClampsNegativeElapsedToZero() {
+        XCTAssertEqual(
+            VinylSpin.sweep(elapsed: -3),
+            0,
+            "a clock skew must not rewind the disc"
+        )
+    }
+
+    func testFrozenAngleReflectsInterpolatedPositionNotRampTarget() {
+        // The view's ramp pushes the model angle to base+360 immediately, so
+        // truncating *that* by 360 would snap the disc back to `base % 360`.
+        // The bug repro: pausing 2s into a ramp from 0° must freeze at 90°
+        // (2s * 45°/s), not at 0°.
+        let frozen = VinylSpin.frozenAngle(base: 0, elapsed: 2)
+        XCTAssertEqual(frozen, 90, accuracy: 1e-9)
+        XCTAssertNotEqual(
+            frozen,
+            VinylSpin.normalize(0 + 360),
+            "freezing must not collapse onto the ramp target's remainder (0°)"
+        )
+    }
+
+    func testFrozenAngleResumesFromAccumulatedBase() {
+        // Pause once at 90°, resume, then pause again 1s later: the second
+        // freeze advances from the carried-over base, landing at 90° + 45°.
+        let base = VinylSpin.frozenAngle(base: 0, elapsed: 2)  // 90°
+        let next = VinylSpin.frozenAngle(base: base, elapsed: 1)  // +45°
+        XCTAssertEqual(next, 135, accuracy: 1e-9)
+    }
+
+    func testFrozenAngleWrapsPastFullRotation() {
+        // base 350°, +5s sweep (225°) = 575° → normalised 215°.
+        let frozen = VinylSpin.frozenAngle(base: 350, elapsed: 5)
+        XCTAssertEqual(frozen, 215, accuracy: 1e-9)
+    }
+
+    func testNormalizeMapsIntoZeroTo360() {
+        XCTAssertEqual(VinylSpin.normalize(0), 0, accuracy: 1e-9)
+        XCTAssertEqual(VinylSpin.normalize(360), 0, accuracy: 1e-9)
+        XCTAssertEqual(VinylSpin.normalize(450), 90, accuracy: 1e-9)
+        XCTAssertEqual(VinylSpin.normalize(720), 0, accuracy: 1e-9)
+    }
+
+    func testNormalizeHandlesNegativesWithoutSignQuirk() {
+        // truncatingRemainder alone returns -90 here; the disc must read 270°.
+        XCTAssertEqual(VinylSpin.normalize(-90), 270, accuracy: 1e-9)
+        XCTAssertEqual(VinylSpin.normalize(-450), 270, accuracy: 1e-9)
+    }
+
+    func testDegreesPerSecondMatchesEightSecondPeriod() {
+        XCTAssertEqual(degreesPerSecond, 45, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
Adds a stylized vinyl record behind the Now Playing hero artwork that spins while audio plays, matching the design spec in `research/06-screen-specs.md` and the `design/project/src/panels.jsx` prototype.

- 400pt conic-gradient disc, scaled to the responsive hero art side, offset to peek out the artwork's right edge (`+80pt` x / `-10pt` y) and sitting behind it via `.background(alignment: .trailing)` + `zIndex(-1)`.
- Spins one rotation per 8s, linear, driven off `model.status.state == .playing`; pausing freezes the disc in place (accumulated-angle interpolation, no unwind/snap) and resuming continues from the same angle.
- Honors `@Environment(\.accessibilityReduceMotion)` — no rotation when Reduce Motion is on — and is `accessibilityHidden` / non-hit-testing so it stays purely decorative.

Closes #270

pipeline:
- fixer-session: feat/270-vinyl-spin-disc
- slice: screens
- hotspots-claimed: none
- build-gate: swift build pass (Now Playing only; pure SwiftUI, no FFI change)
- diff-stat: 3 files, +247 / -0 — new `VinylDisc.swift` (component) + `NowPlayingView.swift` wiring (+9) + new `VinylSpinTests.swift` (84). Rebased onto current `origin/main` so the diff is purely additive — the unrelated NowPlayingFacts deletions an earlier review flagged were a stale-merge-base artifact, not real changes.
