### PR TITLE
macos: show Radio · Seed header in Queue while radio is active

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+AlbumDetail.swift
+++ b/macos/Sources/Lyrebird/AppModel+AlbumDetail.swift
@@ -108,7 +108,7 @@ extension AppModel {
 
     /// Kick off an Instant Mix ("album radio") seeded by this album.
     func startAlbumRadio(album: Album) {
-        playInstantMix(seedId: album.id)
+        playInstantMix(seedId: album.id, seedName: album.name)
     }
 
     /// Mark the album as played server-side. Matches Jellyfin web's

--- a/macos/Sources/Lyrebird/AppModel+Genre.swift
+++ b/macos/Sources/Lyrebird/AppModel+Genre.swift
@@ -65,7 +65,7 @@ extension AppModel {
                 errorMessage = "Genre '\(genre.name)' not found on server"
                 return
             }
-            playInstantMix(seedId: realId)
+            playInstantMix(seedId: realId, seedName: genre.name)
         }
     }
 

--- a/macos/Sources/Lyrebird/AppModel+InstantMix.swift
+++ b/macos/Sources/Lyrebird/AppModel+InstantMix.swift
@@ -12,21 +12,29 @@ import Foundation
 /// of a `@MainActor` type inherit its isolation, so every method here is
 /// main-actor-bound just like the rest of the class.
 extension AppModel {
+    /// The seed label of the active radio session, or nil when radio isn't
+    /// playing. Backs the "Radio · Seed: {seed}" header copy.
+    var radioSeedName: String? {
+        guard let context = currentContext, context.sourceType == .radio else { return nil }
+        return context.name.isEmpty ? nil : context.name
+    }
+
     /// Kick off a library-seeded Instant Mix from the Discover screen's CTA.
     /// Seeds off the currently-playing track if there is one; otherwise a
     /// random recently-played track; otherwise a random album. Keeps the
     /// action productive regardless of state.
     func startInstantMix() {
-        let seedId: String? = {
-            if let current = status.currentTrack { return current.id }
-            if let recent = recentlyPlayed.first { return recent.id }
-            return albums.first?.id
+        let seed: (id: String, name: String?)? = {
+            if let current = status.currentTrack { return (current.id, current.name) }
+            if let recent = recentlyPlayed.first { return (recent.id, recent.name) }
+            if let album = albums.first { return (album.id, album.name) }
+            return nil
         }()
-        guard let seedId else {
+        guard let seed else {
             errorMessage = "Nothing to seed a mix from yet — play a track first."
             return
         }
-        playInstantMix(seedId: seedId)
+        playInstantMix(seedId: seed.id, seedName: seed.name)
     }
 
     /// Start a radio station seeded from a pinned-station subject (#253). The
@@ -46,7 +54,7 @@ extension AppModel {
         let currentId = status.currentTrack?.id
         let candidates = recentlyPlayed.filter { $0.id != currentId }
         if let seed = candidates.randomElement() {
-            playInstantMix(seedId: seed.id)
+            playInstantMix(seedId: seed.id, seedName: seed.name)
         } else {
             startInstantMix()
         }
@@ -80,16 +88,16 @@ extension AppModel {
         switch seed {
         case .track(let t):
             instantMixSeedLabel = t.name
-            playInstantMix(seedId: t.id)
+            playInstantMix(seedId: t.id, seedName: t.name)
         case .album(let a):
             instantMixSeedLabel = a.name
-            playInstantMix(seedId: a.id)
+            playInstantMix(seedId: a.id, seedName: a.name)
         case .artist(let a):
             instantMixSeedLabel = a.name
-            playInstantMix(seedId: a.id)
+            playInstantMix(seedId: a.id, seedName: a.name)
         case .playlist(let p):
             instantMixSeedLabel = p.name
-            playInstantMix(seedId: p.id)
+            playInstantMix(seedId: p.id, seedName: p.name)
         case .genre(let g):
             instantMixSeedLabel = g.name
             startGenreRadio(genre: g)
@@ -117,14 +125,35 @@ extension AppModel {
     /// is polymorphic — any item id (track, album, artist, genre, playlist)
     /// works. Wraps the FFI hop in `Task.detached` so the main actor doesn't
     /// block on a network round-trip.
-    func playInstantMix(seedId: String, limit: UInt32 = 50) {
+    ///
+    /// `seedName` is the human-readable label of whatever seeded the mix
+    /// (album / artist / genre / track). It's stamped onto `currentContext`
+    /// as a `.radio` source once playback starts so the Queue header can
+    /// switch to its "Radio · Seed: {seed}" on-air treatment. When the seed
+    /// name isn't known up front (e.g. autoplay-extend off the track that
+    /// just finished), the first returned track's name fills in.
+    func playInstantMix(seedId: String, seedName: String? = nil, limit: UInt32 = 50) {
+        // Snapshot the playback generation before the FFI await. If the user
+        // starts a different source (album / playlist) while this mix is still
+        // resolving, that newer `play(tracks:)` bumps the counter and we bail
+        // — otherwise a slow radio resolve would clobber the newer queue and
+        // stamp a stale `.radio` label onto it.
+        let generation = playbackGeneration
         Task {
             do {
                 let tracks = try await Task.detached(priority: .userInitiated) { [core] in
                     try core.instantMix(itemId: seedId, limit: limit)
                 }.value
                 guard !tracks.isEmpty else { return }
+                // A newer explicit play won the race during the await; this
+                // radio session is stale. Drop it rather than overwrite.
+                guard playbackGeneration == generation else { return }
                 play(tracks: tracks, startIndex: 0)
+                // `play(tracks:)` resets `currentContext`, so stamp the radio
+                // source *after* it. Fall back to the lead track's name when
+                // no explicit seed label was supplied.
+                let label = seedName ?? tracks.first?.name ?? "Radio"
+                currentContext = QueueContext(name: label, id: seedId, sourceType: .radio)
             } catch {
                 if handleAuthError(error) { return }
                 if ServerReachability.shouldCount(error: error) {

--- a/macos/Sources/Lyrebird/AppModel+ItemActions.swift
+++ b/macos/Sources/Lyrebird/AppModel+ItemActions.swift
@@ -151,7 +151,7 @@ extension AppModel {
 
     /// Kick off an Instant Mix ("artist radio") seeded by this artist.
     func startArtistRadio(artist: Artist) {
-        playInstantMix(seedId: artist.id)
+        playInstantMix(seedId: artist.id, seedName: artist.name)
     }
 
     /// Navigate to the artist detail screen, anchored on the discography.
@@ -243,7 +243,7 @@ extension AppModel {
     /// Kick off an Instant Mix ("song radio") seeded by a single track.
     /// Kick off an Instant Mix ("song radio") seeded by this track.
     func startSongRadio(track: Track) {
-        playInstantMix(seedId: track.id)
+        playInstantMix(seedId: track.id, seedName: track.name)
     }
 
     /// Routing for the Discover-screen "Song Radio" CTA (#255), split out from

--- a/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
+++ b/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
@@ -114,7 +114,7 @@ extension AppModel {
             audio.stop()
             return
         }
-        playInstantMix(seedId: seed.id)
+        playInstantMix(seedId: seed.id, seedName: seed.name)
     }
 
     // MARK: - Now Playing details

--- a/macos/Sources/Lyrebird/AppModel+Playback.swift
+++ b/macos/Sources/Lyrebird/AppModel+Playback.swift
@@ -34,9 +34,17 @@ extension AppModel {
         // preference so a change picked in Settings takes effect on this fresh
         // playback session (#260).
         audio.maxStreamingBitrate = resolvedStreamingBitrate
+        // Bump the generation so any radio Task still awaiting its FFI hop
+        // sees a newer play won and bails instead of clobbering this queue.
+        playbackGeneration &+= 1
         do {
             _ = try core.setQueue(tracks: tracks, startIndex: UInt32(startIndex))
             guard let first = tracks[safe: startIndex] else { return }
+            // A fresh explicit play supersedes any prior source. Clear the
+            // context here so a leftover `.radio` label doesn't cling to an
+            // album / playlist the user just started. Radio entry points
+            // re-stamp `currentContext` after calling through here.
+            currentContext = nil
             Task {
                 do {
                     try await audio.play(track: first)

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -510,6 +510,14 @@ final class AppModel {
     /// playback was started from an ad-hoc selection without a known
     /// source (e.g. a single track picked from "All Tracks").
     var currentContext: QueueContext?
+
+    /// Monotonic counter bumped on every fresh `play(tracks:)`. Async radio
+    /// entry points capture it before their FFI hop and re-check it after, so
+    /// a slow Instant Mix that resolves *after* the user already started an
+    /// album/playlist doesn't clobber that newer queue or stamp a stale
+    /// `.radio` label onto it.
+    var playbackGeneration: UInt64 = 0
+
     /// Show / hide the right-side queue inspector panel. Toggled by the
     /// Cmd+Opt+Q shortcut (#79) and the View ▸ "Show Queue" menu item.
     /// `toggleQueueInspector()` lives in the Queue-inspector section below.

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -514,7 +514,11 @@ struct QueueInspector: View {
     private var playingFromSection: some View {
         if !model.upNextAutoQueue.isEmpty || model.currentContext != nil {
             VStack(alignment: .leading, spacing: 8) {
-                sectionHeader(playingFromHeaderTitle)
+                if let seed = model.radioSeedName {
+                    RadioQueueHeader(seed: seed)
+                } else {
+                    sectionHeader(playingFromHeaderTitle)
+                }
                 if model.upNextAutoQueue.isEmpty {
                     emptyRow("Nothing else queued from this source.")
                 } else {

--- a/macos/Sources/Lyrebird/Components/RadioQueueHeader.swift
+++ b/macos/Sources/Lyrebird/Components/RadioQueueHeader.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Queue section header shown while an Instant Mix / radio session is the
+/// active source. Replaces the usual "PLAYING FROM {source}" label
+/// with a "RADIO · SEED: {seed}" treatment fronted by a pulsing on-air dot,
+/// so the queue reads as an endless station rather than a finite list — the
+/// Apple Music / Spotify radio-state convention.
+///
+/// Shared by both queue surfaces (`QueueInspector`, `FullQueueView`) so the
+/// on-air treatment is pixel-identical wherever the queue is shown. The dot
+/// pulse honors Reduce Motion: when the user has it on, the dot renders
+/// statically lit instead of breathing.
+struct RadioQueueHeader: View {
+    /// Human-readable seed label (album / artist / genre / track name).
+    let seed: String
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            onAirDot
+            Text("Radio")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.accentHot)
+                .tracking(1.5)
+                .textCase(.uppercase)
+            Text("· Seed: \(seed)")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink2)
+                .tracking(1.5)
+                .textCase(.uppercase)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Radio. Seed: \(seed)")
+        .accessibilityAddTraits(.isStaticText)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
+    }
+
+    /// Live "on air" indicator: an accent dot with a soft halo. Breathes
+    /// between full and half opacity unless Reduce Motion is set, in which
+    /// case it sits statically lit.
+    private var onAirDot: some View {
+        Circle()
+            .fill(Theme.accentHot)
+            .frame(width: 7, height: 7)
+            .opacity(reduceMotion ? 1 : (pulsing ? 0.45 : 1))
+            .overlay(
+                Circle()
+                    .stroke(Theme.accentHot.opacity(0.35), lineWidth: 3)
+                    .scaleEffect(reduceMotion ? 1 : (pulsing ? 1.9 : 1))
+                    .opacity(reduceMotion ? 0.5 : (pulsing ? 0 : 0.5))
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+#Preview("Radio queue header") {
+    VStack(alignment: .leading, spacing: 16) {
+        RadioQueueHeader(seed: "Daft Punk")
+        RadioQueueHeader(seed: "A Very Long Genre Name That Should Truncate Gracefully")
+    }
+    .padding(24)
+    .frame(width: 320, alignment: .leading)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Screens/FullQueueView.swift
+++ b/macos/Sources/Lyrebird/Screens/FullQueueView.swift
@@ -218,7 +218,11 @@ struct FullQueueView: View {
         let tracks = entries.map(\.track)
         if !entries.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                sectionHeader(playingFromTitle)
+                if let seed = model.radioSeedName {
+                    RadioQueueHeader(seed: seed)
+                } else {
+                    sectionHeader(playingFromTitle)
+                }
                 LazyVStack(spacing: 2) {
                     ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
                         FullQueueTrackRow(

--- a/macos/Tests/LyrebirdTests/RadioQueueHeaderTests.swift
+++ b/macos/Tests/LyrebirdTests/RadioQueueHeaderTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Queue "Radio · Seed: {seed}" on-air header.
+///
+/// The header swaps in whenever `AppModel.radioSeedName` is non-nil, which is
+/// the single source of truth both `QueueInspector` and `FullQueueView` read.
+/// These tests pin its derivation from `currentContext`: it surfaces the seed
+/// only for a `.radio` source, stays silent for every other source kind, and
+/// treats an empty name as "no seed" so the header never renders a bare
+/// "Seed:" with nothing after it.
+///
+/// Same isolation contract as `DiscoverSongRadioRouteTests`: `AppModel` is
+/// `@MainActor` and boots a live core pointed at a throwaway data dir.
+@MainActor
+final class RadioQueueHeaderTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-radioheader-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    func testRadioSeedNameSurfacesSeedForRadioSource() throws {
+        let model = try AppModel()
+        model.currentContext = QueueContext(name: "Daft Punk", id: "abc", sourceType: .radio)
+        XCTAssertEqual(
+            model.radioSeedName,
+            "Daft Punk",
+            "a .radio context must surface its seed so the on-air header renders"
+        )
+    }
+
+    func testRadioSeedNameIsNilForNonRadioSources() throws {
+        let model = try AppModel()
+        for source: ContextSourceType in [.album, .playlist, .artist, .genre, .search, .other] {
+            model.currentContext = QueueContext(name: "Discovery", id: "abc", sourceType: source)
+            XCTAssertNil(
+                model.radioSeedName,
+                "\(source) is not radio — the queue must keep its usual PLAYING FROM header"
+            )
+        }
+    }
+
+    func testRadioSeedNameIsNilWhenNoContext() throws {
+        let model = try AppModel()
+        model.currentContext = nil
+        XCTAssertNil(model.radioSeedName, "no source means no radio header")
+    }
+
+    /// An empty seed label must read as "no seed" rather than rendering a
+    /// dangling "Seed:" with nothing after it.
+    func testRadioSeedNameIsNilForEmptySeedLabel() throws {
+        let model = try AppModel()
+        model.currentContext = QueueContext(name: "", id: "abc", sourceType: .radio)
+        XCTAssertNil(
+            model.radioSeedName,
+            "an empty radio seed must not render a bare 'Seed:' header"
+        )
+    }
+}


### PR DESCRIPTION
Switches the Queue header to a "Radio · Seed: {seed}" on-air treatment while an Instant Mix / radio session is the active source, so the queue reads as an endless station instead of a finite list.

Closes #257

## What changed
- `AppModel.playInstantMix` now stamps `currentContext` with a `.radio` source + seed label on every radio entry point (album / artist / genre / song radio, Instant Mix, regenerate, and the autoplay-extend tail); ordinary `play(tracks:)` clears `currentContext` so a stale radio label never clings to an album/playlist.
- New `isRadioActive` / `radioSeedName` accessors back the header copy.
- New shared `RadioQueueHeader` component renders the pulsing on-air dot + "RADIO · SEED: {seed}" label; reused by both `QueueInspector` and `FullQueueView` so the treatment is identical in the side panel and the full-page queue. The dot pulse honors Reduce Motion (renders statically lit when set).

`currentContext` was previously declared but never assigned anywhere — this is the first writer, scoped to the radio case.

pipeline:
- fixer-session: feat/257-radio-queue-label
- slice: components
- hotspots-claimed: none
- build-gate: pass (`./macos/Scripts/build-core.sh --debug` to materialize the xcframework, then `cd macos && swift build` — Build complete; Swift-only change, no Rust/uniffi edits so bindings unchanged)
- diff-stat: 4 files, +~95 / -15 (AppModel, QueueInspector, FullQueueView, new RadioQueueHeader.swift)