### PR TITLE
macos: add Genre / Decade / Mood radio rows to Discover

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -2027,7 +2027,9 @@ final class AppModel {
         limit: UInt32,
         extraFields: [String],
         minDateLastSaved: String?,
-        parentId: String?
+        parentId: String?,
+        years: [Int]? = nil,
+        tags: [String]? = nil
     ) -> URLRequest? {
         guard let session = session,
               let baseURL = URL(string: session.server.url),
@@ -2058,6 +2060,14 @@ final class AppModel {
         }
         if let parentId, !parentId.isEmpty {
             queryItems.append(URLQueryItem(name: "ParentId", value: parentId))
+        }
+        if let years, !years.isEmpty {
+            queryItems.append(
+                URLQueryItem(name: "Years", value: years.map(String.init).joined(separator: ","))
+            )
+        }
+        if let tags, !tags.isEmpty {
+            queryItems.append(URLQueryItem(name: "Tags", value: tags.joined(separator: "|")))
         }
         comps?.queryItems = queryItems
         guard let url = comps?.url else { return nil }
@@ -4866,6 +4876,156 @@ final class AppModel {
                 }
                 errorMessage = "Couldn't load tracks for \(genre.name): \(error.localizedDescription)"
             }
+        }
+    }
+
+    // MARK: - Decade / Mood radio (#256)
+    //
+    // The Discover/Home "Radio" surface offers Genre, Decade, and Mood
+    // stations (per `06-screen-specs.md` §9). Genre radio reuses
+    // `startGenreRadio` (Instant Mix seeded by the genre). Decade and Mood
+    // have no Instant-Mix seed item, so they assemble a shuffled station out
+    // of a random page of audio tracks matching the decade's ten-year
+    // `Years` window / the mood `Tag`, then play it like any other queue.
+    // We go through the raw `/Items` query (the established
+    // `buildItemsQuery` pattern) rather than a new core FFI because the
+    // dimensions we need — `Years`, `Tags` — are just extra query params.
+
+    /// The fixed mood set the spec calls for, each backed by a Jellyfin tag.
+    /// `tag` is matched case-insensitively server-side; `label`/`symbol` drive
+    /// the tile. Only moods whose tag actually returns tracks are surfaced
+    /// (see `availableMoods`), so a library with no mood tags shows no row.
+    struct Mood: Identifiable, Hashable, Sendable {
+        let tag: String
+        let label: String
+        let symbol: String
+
+        var id: String { tag }
+
+        /// The five moods from `06-screen-specs.md` §9, in spec order.
+        static let all: [Mood] = [
+            Mood(tag: "chill", label: "Chill", symbol: "leaf"),
+            Mood(tag: "focus", label: "Focus", symbol: "scope"),
+            Mood(tag: "workout", label: "Workout", symbol: "figure.run"),
+            Mood(tag: "sleep", label: "Sleep", symbol: "moon.stars"),
+            Mood(tag: "party", label: "Party", symbol: "party.popper"),
+        ]
+    }
+
+    /// Subset of `Mood.all` whose tag returns at least one track in this
+    /// library. Empty until `probeAvailableMoods()` runs; the Mood radio row
+    /// hides itself while empty so a library with no mood tags doesn't render
+    /// a dead band. Moods are sourced from tags "if present" per the spec.
+    var availableMoods: [Mood] = []
+
+    /// Best-effort probe of which spec moods have any tagged tracks. Fires one
+    /// tiny (`limit: 1`) `/Items` HEAD-style fetch per mood concurrently and
+    /// keeps only the moods that came back non-empty. Idempotent and cheap;
+    /// safe to call on Discover/Home appearance. Failures (auth/network) leave
+    /// `availableMoods` unchanged rather than blanking an already-populated row.
+    func probeAvailableMoods() async {
+        guard session != nil else { return }
+        let present = await withTaskGroup(of: Mood?.self) { group in
+            for mood in Mood.all {
+                group.addTask { [weak self] in
+                    guard let self else { return nil }
+                    let hit = await self.moodHasTracks(tag: mood.tag)
+                    return hit ? mood : nil
+                }
+            }
+            var found: [Mood] = []
+            for await result in group {
+                if let mood = result { found.append(mood) }
+            }
+            return found
+        }
+        guard !present.isEmpty else { return }
+        // Re-order to the canonical spec order rather than completion order.
+        availableMoods = Mood.all.filter { mood in present.contains(mood) }
+    }
+
+    /// Does the given mood tag have at least one audio track? One `limit: 1`
+    /// `/Items` probe; returns false on auth/network/parse failure.
+    private func moodHasTracks(tag: String) async -> Bool {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "Audio",
+            sortBy: "Random",
+            sortOrder: "Ascending",
+            filters: nil,
+            limit: 1,
+            extraFields: [],
+            minDateLastSaved: nil,
+            parentId: nil,
+            tags: [tag]
+        ) else { return false }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return false
+            }
+            return !Self.parseTracksFromItems(data: data).isEmpty
+        } catch {
+            return false
+        }
+    }
+
+    /// Start a Decade Radio station — a shuffled queue of audio tracks whose
+    /// `ProductionYear` falls inside the decade's ten-year window. Replaces the
+    /// queue and plays from the top. Surfaces `errorMessage` when the decade
+    /// has no tracks (rather than silently no-op'ing).
+    func startDecadeRadio(startingYear start: Int) {
+        let years = Array(start...(start + 9))
+        Task {
+            let tracks = await fetchRadioTracks(years: years, tags: nil)
+            guard !tracks.isEmpty else {
+                errorMessage = "No tracks from the \(start)s in your library yet."
+                return
+            }
+            play(tracks: tracks, startIndex: 0)
+        }
+    }
+
+    /// Start a Mood Radio station — a shuffled queue of audio tracks carrying
+    /// the mood's Jellyfin tag. Replaces the queue and plays from the top.
+    func startMoodRadio(mood: Mood) {
+        Task {
+            let tracks = await fetchRadioTracks(years: nil, tags: [mood.tag])
+            guard !tracks.isEmpty else {
+                errorMessage = "No \(mood.label) tracks in your library yet."
+                return
+            }
+            play(tracks: tracks, startIndex: 0)
+        }
+    }
+
+    /// Fetch up to `limit` random audio tracks matching the given `Years`
+    /// window and/or `Tags`, already server-shuffled (`SortBy=Random`). Backs
+    /// the Decade and Mood radio stations. Returns `[]` on auth/network/parse
+    /// failure (the callers turn an empty result into a user-facing message).
+    private func fetchRadioTracks(years: [Int]?, tags: [String]?, limit: UInt32 = 100) async -> [Track] {
+        guard let request = buildItemsQuery(
+            includeItemTypes: "Audio",
+            sortBy: "Random",
+            sortOrder: "Ascending",
+            filters: nil,
+            limit: limit,
+            extraFields: [],
+            minDateLastSaved: nil,
+            parentId: nil,
+            years: years,
+            tags: tags
+        ) else { return [] }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            if let http = resp as? HTTPURLResponse, http.statusCode == 401 {
+                markAuthExpired()
+                return []
+            }
+            return Self.parseTracksFromItems(data: data)
+        } catch {
+            Log.net.error("fetchRadioTracks failed: \(error.localizedDescription, privacy: .public)")
+            return []
         }
     }
 

--- a/macos/Sources/Lyrebird/Components/RadioStationRows.swift
+++ b/macos/Sources/Lyrebird/Components/RadioStationRows.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+
+/// The Genre / Decade / Mood radio rows (#256, `06-screen-specs.md` §9).
+///
+/// Three horizontal rows of 4–6 gradient tiles. Each tile *starts a radio
+/// station* — it replaces the queue with a shuffled, station-style mix and
+/// plays from the top — as opposed to the Discover "Browse by Decade" /
+/// "Genres to Explore" rows, which deep-link into a filtered Library / genre
+/// detail. The two families share the gradient-tile vocabulary on purpose so
+/// the surfaces read as one design, but their *verbs* differ (radio vs.
+/// browse).
+///
+/// - Genre radio is seeded off the library's largest genres
+///   (`model.browseGenres`) via `startGenreRadio` (Instant Mix).
+/// - Decade radio assembles a shuffled queue from the decade's ten-year
+///   window via `startDecadeRadio`.
+/// - Mood radio is sourced from Jellyfin *tags* and only shows moods that are
+///   actually present in the library (`model.availableMoods`, populated by
+///   `probeAvailableMoods()`), so a library with no mood tags renders no row.
+///
+/// Each row hides itself when its data source is empty, so a brand-new or
+/// sparsely-tagged library never sees a blank band.
+struct RadioStationRows: View {
+	@Environment(AppModel.self) private var model
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 28) {
+			genreRadioRow
+			decadeRadioRow
+			moodRadioRow
+		}
+		// Populate the genre seed pool + probe which mood tags exist. Both are
+		// cheap + idempotent (the genre fetch is one cached /MusicGenres page;
+		// the mood probe is five limit:1 /Items HEADs) and only run when their
+		// backing data is still empty, so re-appearing the surface is free.
+		.task {
+			if model.browseGenres.isEmpty {
+				await model.refreshBrowseGenres()
+			}
+			if model.availableMoods.isEmpty {
+				await model.probeAvailableMoods()
+			}
+		}
+	}
+
+	// MARK: - Genre radio
+
+	@ViewBuilder
+	private var genreRadioRow: some View {
+		// Cap at 6 per the spec's "4–6 tiles" — browseGenres is the largest
+		// genres, already ranked, so the top 6 are the most useful stations.
+		let genres = Array(model.browseGenres.prefix(6))
+		if !genres.isEmpty {
+			RadioRow(
+				icon: "guitars",
+				iconColor: Theme.accent,
+				title: "Genre Radio",
+				subtitle: "Endless stations from your top genres"
+			) {
+				ForEach(genres, id: \.id) { genre in
+					RadioStationTile(
+						title: genre.name,
+						seed: genre.name,
+						symbol: "dot.radiowaves.left.and.right",
+						accessibilityVerb: "Start \(genre.name) radio"
+					) {
+						model.startGenreRadio(genre: genre)
+					}
+				}
+			}
+		}
+	}
+
+	// MARK: - Decade radio
+
+	private var decadeRadioRow: some View {
+		// The decade ramp is static ('60s→'20s); we surface the most recent 6
+		// so the row honors the "4–6 tiles" cap while leading with the decades
+		// a music library is most likely to be dense in.
+		let decades = Array(Decade.all.suffix(6).reversed())
+		return RadioRow(
+			icon: "calendar",
+			iconColor: Theme.primary,
+			title: "Decade Radio",
+			subtitle: "A shuffled trip through a ten-year slice"
+		) {
+			ForEach(decades) { decade in
+				RadioStationTile(
+					title: decade.shortLabel,
+					seed: "decade-\(decade.startYear)",
+					symbol: "dot.radiowaves.left.and.right",
+					titleFont: Theme.font(34, weight: .black, italic: true),
+					accessibilityVerb: "Start \(decade.spokenLabel) radio"
+				) {
+					model.startDecadeRadio(startingYear: decade.startYear)
+				}
+			}
+		}
+	}
+
+	// MARK: - Mood radio
+
+	@ViewBuilder
+	private var moodRadioRow: some View {
+		if !model.availableMoods.isEmpty {
+			RadioRow(
+				icon: "sparkles",
+				iconColor: Theme.teal,
+				title: "Mood Radio",
+				subtitle: "Stations for however you are feeling"
+			) {
+				ForEach(model.availableMoods) { mood in
+					RadioStationTile(
+						title: mood.label,
+						seed: "mood-\(mood.tag)",
+						symbol: mood.symbol,
+						accessibilityVerb: "Start \(mood.label) radio"
+					) {
+						model.startMoodRadio(mood: mood)
+					}
+				}
+			}
+		}
+	}
+}
+
+/// Shared chrome for a radio row: a labeled header + a horizontal scroller of
+/// tiles. Uses an eager `HStack` inside the horizontal `ScrollView` (not
+/// `LazyHStack`) to stay clear of the rc9 macOS 26.4 `LazyHStack` UAF noted in
+/// CLAUDE.md.
+private struct RadioRow<Content: View>: View {
+	let icon: String
+	let iconColor: Color
+	let title: String
+	let subtitle: String
+	@ViewBuilder let content: () -> Content
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 12) {
+			HStack(alignment: .firstTextBaseline, spacing: 8) {
+				Image(systemName: icon)
+					.foregroundStyle(iconColor)
+					.font(.system(size: 14, weight: .bold))
+				Text(title)
+					.font(Theme.font(18, weight: .bold))
+					.foregroundStyle(Theme.ink)
+				Text(subtitle)
+					.font(Theme.font(12, weight: .medium))
+					.foregroundStyle(Theme.ink3)
+			}
+			ScrollView(.horizontal, showsIndicators: false) {
+				HStack(spacing: 14) {
+					content()
+				}
+				.padding(.vertical, 4)
+			}
+		}
+		.accessibilityElement(children: .contain)
+		.accessibilityLabel(title)
+	}
+}
+
+/// One radio-station tile. A 150×120 continuous-corner gradient card (the same
+/// vocabulary as `DecadeBrowseRow`/`GenresToExploreSection`) with a station
+/// title and a radio glyph that brightens on hover so the tile reads as a
+/// "press to start a station" affordance rather than a passive label.
+private struct RadioStationTile: View {
+	let title: String
+	/// Deterministic color seed — the same seed always lands on the same hue
+	/// across launches, so a given station keeps its color.
+	let seed: String
+	let symbol: String
+	var titleFont: Font = Theme.font(20, weight: .bold)
+	let accessibilityVerb: String
+	let onStart: () -> Void
+
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+	@State private var isHovering = false
+
+	var body: some View {
+		Button(action: onStart) {
+			ZStack(alignment: .bottomLeading) {
+				RoundedRectangle(cornerRadius: 14, style: .continuous)
+					.fill(gradient)
+				RoundedRectangle(cornerRadius: 14, style: .continuous)
+					.stroke(.white.opacity(isHovering ? 0.35 : 0.12), lineWidth: 1)
+
+				// Radio glyph, top-trailing — the "this is a station" cue.
+				Image(systemName: symbol)
+					.font(.system(size: 16, weight: .bold))
+					.foregroundStyle(.white.opacity(isHovering ? 1 : 0.7))
+					.shadow(color: .black.opacity(0.35), radius: 3, y: 1)
+					.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+					.padding(12)
+
+				Text(title)
+					.font(titleFont)
+					.foregroundStyle(.white)
+					.lineLimit(2)
+					.multilineTextAlignment(.leading)
+					.shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+					.padding(14)
+			}
+			.frame(width: 150, height: 120)
+			.scaleEffect(reduceMotion ? 1 : (isHovering ? 1.03 : 1))
+			.shadow(
+				color: seedColor.opacity(isHovering ? 0.45 : 0.25),
+				radius: isHovering ? 14 : 8,
+				y: isHovering ? 8 : 4
+			)
+			.animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
+			.contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+		}
+		.buttonStyle(.plain)
+		.onHover { isHovering = $0 }
+		.help(accessibilityVerb)
+		.accessibilityLabel("\(title) Radio")
+		.accessibilityHint(accessibilityVerb)
+		.accessibilityAddTraits(.isButton)
+	}
+
+	/// Deterministic base hue via a small FNV-1a over the seed's scalars —
+	/// matches `GenreExploreTile` so the surfaces share one palette logic.
+	private var hue: Double {
+		var hash: UInt32 = 2_166_136_261
+		for scalar in seed.unicodeScalars {
+			hash = (hash ^ scalar.value) &* 16_777_619
+		}
+		return Double(hash % 360) / 360.0
+	}
+
+	private var seedColor: Color {
+		Color(hue: hue, saturation: 0.55, brightness: 0.62)
+	}
+
+	private var gradient: LinearGradient {
+		LinearGradient(
+			colors: [
+				Color(hue: hue, saturation: 0.62, brightness: 0.66),
+				Color(hue: hue, saturation: 0.70, brightness: 0.34),
+			],
+			startPoint: .topLeading,
+			endPoint: .bottomTrailing
+		)
+	}
+}

--- a/macos/Sources/Lyrebird/Screens/DiscoverView.swift
+++ b/macos/Sources/Lyrebird/Screens/DiscoverView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 /// Discover — the "find something new" surface. Today: a header + Instant Mix
-/// CTA (#248), a horizontal "For You" carousel (#249), a "Browse by Decade"
-/// gradient-tile row, and a "Genres to Explore" grid (#250). Richer
-/// recommendations (recently added, more like this, etc.) land in follow-ups.
+/// CTA (#248), a horizontal "For You" carousel (#249), the Genre / Decade /
+/// Mood radio rows (#256), a "Browse by Decade" gradient-tile row, and a
+/// "Genres to Explore" grid (#250). Richer recommendations (recently added,
+/// more like this, etc.) land in follow-ups.
 ///
 /// Title is italic 34pt, subline 14pt `ink2`, right-aligned primary "Start
 /// Instant Mix" + ghost "Generate new mix" — per `06-screen-specs.md`.
@@ -15,6 +16,7 @@ struct DiscoverView: View {
             VStack(alignment: .leading, spacing: 28) {
                 header
                 forYouSection
+                RadioStationRows()
                 DecadeBrowseRow()
                 GenresToExploreSection()
                 Spacer(minLength: 24)

--- a/macos/Tests/LyrebirdTests/MoodRadioTests.swift
+++ b/macos/Tests/LyrebirdTests/MoodRadioTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Mood radio model (#256).
+///
+/// The mood set is pure value logic sourced from `06-screen-specs.md` §9
+/// ("chill, focus, workout, sleep, party"), and `availableMoods` must start
+/// empty so the Mood radio row hides itself on a library that hasn't been
+/// probed / has no mood tags.
+@MainActor
+final class MoodRadioTests: XCTestCase {
+
+	override class func setUp() {
+		super.setUp()
+		let dir = NSTemporaryDirectory() + "lyrebird-mood-\(UUID().uuidString)"
+		setenv("XDG_DATA_HOME", dir, 1)
+	}
+
+	func testMoodSetMatchesSpecTagsInOrder() {
+		XCTAssertEqual(
+			AppModel.Mood.all.map(\.tag),
+			["chill", "focus", "workout", "sleep", "party"],
+			"the mood row carries the five spec moods, in spec order"
+		)
+	}
+
+	func testEachMoodHasADistinctLabelAndSymbol() {
+		let labels = AppModel.Mood.all.map(\.label)
+		let symbols = AppModel.Mood.all.map(\.symbol)
+		XCTAssertEqual(Set(labels).count, labels.count, "labels are distinct")
+		XCTAssertEqual(Set(symbols).count, symbols.count, "tile glyphs are distinct")
+		XCTAssertFalse(symbols.contains(where: \.isEmpty), "every mood carries a glyph")
+	}
+
+	func testAvailableMoodsStartsEmptySoTheRowHidesUntilProbed() throws {
+		let model = try AppModel()
+		XCTAssertTrue(
+			model.availableMoods.isEmpty,
+			"no moods are surfaced until probeAvailableMoods() confirms tagged tracks exist"
+		)
+	}
+}


### PR DESCRIPTION
Adds the §9 Radio station rows to Discover so users can launch Genre, Decade, and Mood stations directly instead of only browsing.

Closes #256

Three new rows of gradient station tiles on Discover (`RadioStationRows`), each starting a station that replaces the queue and plays shuffled from the top:
- **Genre Radio** — top 6 library genres (`browseGenres`) via `startGenreRadio` (Instant Mix).
- **Decade Radio** — most recent 6 decades; `startDecadeRadio` fetches a random page of audio tracks in the decade's ten-year `Years` window and plays it shuffled.
- **Mood Radio** — the five spec moods (chill, focus, workout, sleep, party) sourced from Jellyfin `Tags`. `probeAvailableMoods()` does a tiny `limit:1` probe per mood and surfaces only moods that actually have tagged tracks, so a library with no mood tags renders no row (verified against the real test server, which has 0 mood-tagged tracks → row stays hidden).

`buildItemsQuery` gained additive optional `years` / `tags` params (existing callers unchanged). Decade/Mood fetches run off the `MainActor` via `URLSession`, and empty results surface a user-facing `errorMessage` rather than a silent no-op. Rows hide when their data source is empty.

Tiles reuse the existing `DecadeBrowseRow` / `GenreExploreTile` gradient vocabulary; the rows use eager `HStack` (not `LazyHStack`) per the rc9 macOS 26.4 UAF note. No core/FFI changes.

pipeline:
- fixer-session: feature-builder-256
- slice: screens
- hotspots-claimed: none
- build-gate: pass (swift build + `swift test --filter MoodRadioTests`, 3/3)
- diff-stat: 4 files, +366/-4 (AppModel.swift, DiscoverView.swift, RadioStationRows.swift new, MoodRadioTests.swift new)