### PR TITLE
test(macos): cover capability-gated palette ids in PaletteRow coverage gate

### DIFF
--- a/macos/Tests/LyrebirdTests/PaletteRowCoverageTests.swift
+++ b/macos/Tests/LyrebirdTests/PaletteRowCoverageTests.swift
@@ -7,11 +7,19 @@ import XCTest
 /// `PaletteRow` labels and icons each action by id through two hand-maintained
 /// static maps (`actionTitleById` / `actionSymbolById`), kept in sync with the
 /// roster emitted by `AppModel.paletteActions`. A drift between the two renders
-/// the raw id string and a generic bolt icon (the key-miss fallbacks) — exactly
-/// the `nav.favorites` regression in #937. This gate fails if any registered
-/// action id is missing from either map.
+/// the raw id string and a generic bolt icon (the key-miss fallbacks) — a
+/// `nav.favorites` row showing its raw id is the regression this guards. This
+/// gate fails if any registered action id is missing from either map.
 @MainActor
 final class PaletteRowCoverageTests: XCTestCase {
+
+	/// Action ids that `paletteActions` only appends behind a capability flag
+	/// (`supportsDownloads`, etc.), so the default `AppModel` roster never
+	/// surfaces them. They still need map entries because the row renders the
+	/// same way once the flag flips, so cover them explicitly.
+	private static let conditionalActionIds: Set<String> = [
+		"download.current"
+	]
 
 	override class func setUp() {
 		super.setUp()
@@ -22,6 +30,7 @@ final class PaletteRowCoverageTests: XCTestCase {
 	func testEveryPaletteActionHasATitleAndSymbolEntry() throws {
 		let model = try AppModel()
 		let actionIds = Set(model.paletteActions.map(\.id))
+			.union(Self.conditionalActionIds)
 
 		let titleKeys = Set(PaletteRow.actionTitleById.keys)
 		XCTAssertTrue(


### PR DESCRIPTION
Follow-up to the palette-favorites fix: the coverage gate only asserted against the default `AppModel` roster, which omits capability-gated actions, so the gated `download.current` row's map entries were never verified; this closes that gap and drops a stale task-number reference from the doc comment.

PR #942 (the original `nav.favorites` fix) squash-merged to main before the reviewer's requested changes could land on its branch, so this carries those two changes forward.

Addresses reviewer findings on #942:
- doc comment no longer references a task number by id
- gate now unions the capability-gated action ids (`download.current`) into the asserted set, so their `actionTitleById`/`actionSymbolById` entries are actually covered regardless of the runtime `supportsDownloads` gate

pipeline:
  fixer-session: wf_7dda2c5e-608-40
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 1 file changed, +12/-3