### PR TITLE
docs: agentic-pipeline playbook + track workflow scripts

### DIFF
--- a/.claude/agents/area-auditor.md
+++ b/.claude/agents/area-auditor.md
@@ -79,6 +79,8 @@ Use `gh issue create` with body that follows the bug.yml template structure. Req
 - `effort:S` | `effort:M` | `effort:L`
 - `source:auto-audit` (mandatory — provenance marker)
 
+**Escape `@` in prose.** Swift property wrappers / attributes (`@State`, `@Environment`, `@MainActor`, `@AppStorage`, `@Published`, `@escaping`, etc.) MUST be backticked (`` `@State` ``) in the issue body — bare `@State` becomes a GitHub `@username` mention. In the issue **title** (no backticks possible), drop the `@`: e.g. "dead State tick", not "dead @State tick".
+
 ## Output format to your dispatcher
 
 After your run, emit a one-block summary:

--- a/.claude/agents/area-fixer.md
+++ b/.claude/agents/area-fixer.md
@@ -77,6 +77,7 @@ You commit directly on your `fix/*` branch (sub-agent commits are squash-merged 
 - **Never** add `Co-Authored-By` lines.
 - **Never** mention Claude / AI / AI tooling in commit messages, PR descriptions, or comments.
 - Author commits as the user (skalthoff). The squash-merge resigns the merge commit with the user's GPG key.
+- **Escape `@` in prose.** Swift property wrappers and attributes (`@State`, `@Environment`, `@MainActor`, `@AppStorage`, `@Published`, `@escaping`, `@preconcurrency`, etc.) MUST be wrapped in backticks (`` `@State` ``) anywhere they appear in a PR/issue body or comment — bare `@State` is rendered by GitHub as a `@username` mention (broken link + phantom notification). In **titles** (which can't use backticks), drop the `@`: write "State" / "MainActor", not "@State".
 
 PR body must include:
 - One sentence on the *why* (not the *what*).

--- a/.claude/workflows/drive-lyrebird-desktop.js
+++ b/.claude/workflows/drive-lyrebird-desktop.js
@@ -1,0 +1,639 @@
+export const meta = {
+	name: 'drive-lyrebird-desktop',
+	description:
+		'Aggressively drive lyrebird-desktop toward shippable: each wave resolves open agent PRs, drains the real open backlog (bugs p0→p2, then M3 features), periodically audits for regressions, then builds → adversarial-reviews (2 refix rounds) → auto-merges. Loops until the backlog drains / POLISH_TARGETS passes / token budget / wave cap.',
+	whenToUse:
+		'When the owner wants the app driven hard end-to-end: clears stalled PRs, fixes the open bug backlog, implements M3 features, and keeps the audit safety-net running. Hotspot-safe, worktree-isolated, auto-merge on approval.',
+	phases: [
+		{ title: 'Preflight', detail: 'POLISH gate + open-work census + open agent-PR list' },
+		{ title: 'Resolve PRs', detail: 'review → refix(≤2) → merge/flag every open agent PR' },
+		{ title: 'Audit', detail: '8 auditors on wave 1 + every Nth wave (regression net)' },
+		{ title: 'Triage', detail: 'fresh audit findings → bug manifest' },
+		{ title: 'Backlog', detail: 'select prioritized open issues without a PR (bugs then M3 feats)' },
+		{ title: 'Build', detail: 'area-fixer (bugs) + feature-builder (feats), worktree-isolated, ≤1/hotspot' },
+		{ title: 'Review', detail: 'adversarial-reviewer per PR; Opus on dispute; 2 refix rounds; auto-merge' },
+		{ title: 'Release gate', detail: 'M4 release-readiness verification (no live signing)' },
+		{ title: 'Report', detail: 'final polish-gate + run summary' },
+	],
+}
+
+// ---------------------------------------------------------------------------
+// CONFIG
+// ---------------------------------------------------------------------------
+const cfg = {
+	autoMerge: args && args.autoMerge != null ? args.autoMerge : true,
+	maxWaves: args && args.maxWaves != null ? args.maxWaves : null,
+	auditEvery: args && args.auditEvery != null ? args.auditEvery : 4, // audit on wave 1 and every Nth wave
+	backlogBatch: args && args.backlogBatch != null ? args.backlogBatch : 16, // candidate items pulled per wave
+	buildCeiling: args && args.buildCeiling != null ? args.buildCeiling : 10, // max PRs opened per wave (runtime caps concurrency at min(16,cores-2))
+	refixRounds: args && args.refixRounds != null ? args.refixRounds : 2, // in-wave request-changes retries
+	featMilestone: args && args.featMilestone ? args.featMilestone : 'M3 — macOS polish',
+	includeDist: args && args.includeDist != null ? args.includeDist : true,
+	// Model for code-authoring agents (builders + in-place PR refixers). Default opus for max code quality.
+	builderModel: args && args.builderModel ? args.builderModel : 'opus',
+	// Escalate the adversarial first-pass reviewer to this model too (default sonnet — anti-anchoring + opus-on-dispute is intentional).
+	reviewModel: args && args.reviewModel ? args.reviewModel : 'sonnet',
+	// HYPER / CI-gated mode: builders SKIP the slow CPU-bound local cargo/swift compile and
+	// rely on GitHub Actions (runs fmt/clippy/test/swift-build on every PR) as the authoritative
+	// build gate. Auto-merge only lands on green CI, so correctness is preserved while the local
+	// box stops being the bottleneck. They still do FAST local sanity (fmt --check, grep) before push.
+	ciGated: args && args.ciGated != null ? args.ciGated : false,
+}
+
+const WAVE_TOKEN_COST = 1300000 // observed ~1.27M/wave on the first full run
+const DRAIN_CEILING = cfg.ciGated ? 24 : 10 // CI-gated mode tolerates a much deeper open-PR queue (cloud runners gate, not the local box)
+
+const MAX_WAVES =
+	cfg.maxWaves != null
+		? cfg.maxWaves
+		: budget.total
+			? Math.max(1, Math.min(12, Math.floor(budget.total / WAVE_TOKEN_COST)))
+			: 6
+
+// ---------------------------------------------------------------------------
+// SCHEMAS
+// ---------------------------------------------------------------------------
+const PREFLIGHT_SCHEMA = {
+	type: 'object',
+	properties: {
+		polished: { type: 'boolean' },
+		polishChecks: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { name: { type: 'string' }, pass: { type: 'boolean' }, detail: { type: 'string' } },
+				required: ['name', 'pass'],
+			},
+		},
+		openP0: { type: 'integer' },
+		openBugs: { type: 'integer' },
+		openFeatM3: { type: 'integer' },
+		openAgentPRs: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					number: { type: 'integer' },
+					head: { type: 'string' },
+					title: { type: 'string' },
+					isDraft: { type: 'boolean' },
+				},
+				required: ['number'],
+			},
+		},
+		openFixPRs: { type: 'integer' },
+		notes: { type: 'string' },
+	},
+	required: ['polished', 'openP0', 'notes'],
+	additionalProperties: true,
+}
+
+const AUDIT_SCHEMA = {
+	type: 'object',
+	properties: {
+		slice: { type: 'string' },
+		candidatesFound: { type: 'integer' },
+		issuesFiled: { type: 'integer' },
+		issueNumbers: { type: 'array', items: { type: 'integer' } },
+		autoDowngrade: { type: 'boolean' },
+		notes: { type: 'string' },
+	},
+	required: ['slice', 'issuesFiled', 'notes'],
+	additionalProperties: true,
+}
+
+const TRIAGE_SCHEMA = {
+	type: 'object',
+	properties: {
+		manifest: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					issue: { type: 'integer' },
+					slice: { type: 'string' },
+					hotspot: { type: 'string' },
+					priority: { type: 'string' },
+					effort: { type: 'string' },
+				},
+				required: ['issue', 'hotspot'],
+			},
+		},
+		rejected: { type: 'array', items: { type: 'object', properties: { issue: { type: 'integer' }, reason: { type: 'string' } } } },
+		notes: { type: 'string' },
+	},
+	required: ['manifest'],
+	additionalProperties: true,
+}
+
+const SELECT_SCHEMA = {
+	type: 'object',
+	properties: {
+		items: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					issue: { type: 'integer' },
+					slice: { type: 'string' },
+					hotspot: { type: 'string' },
+					title: { type: 'string' },
+					kind: { type: 'string' },
+					builder: { type: 'string' },
+				},
+				required: ['issue', 'hotspot', 'builder'],
+			},
+		},
+		notes: { type: 'string' },
+	},
+	required: ['items'],
+	additionalProperties: true,
+}
+
+const BUILD_SCHEMA = {
+	type: 'object',
+	properties: {
+		issue: { type: 'integer' },
+		prOpened: { type: ['integer', 'null'] },
+		branch: { type: 'string' },
+		hotspotsClaimed: { type: 'array', items: { type: 'string' } },
+		buildGate: { type: 'string', enum: ['pass', 'fail', 'skipped'] },
+		resolved: { type: 'boolean' },
+		notes: { type: 'string' },
+	},
+	required: ['issue', 'prOpened', 'buildGate', 'resolved', 'notes'],
+	additionalProperties: true,
+}
+
+const REVIEW_SCHEMA = {
+	type: 'object',
+	properties: {
+		pr: { type: ['integer', 'null'] },
+		outcome: { type: 'string', enum: ['approve', 'request-changes', 'dispute-needs-opus', 'close', 'no-pr', 'error'] },
+		checklistViolations: { type: 'integer' },
+		merged: { type: 'boolean' },
+		hotspotReleased: { type: ['string', 'null'] },
+		notes: { type: 'string' },
+	},
+	required: ['outcome', 'notes'],
+	additionalProperties: true,
+}
+
+const RELEASE_GATE_SCHEMA = {
+	type: 'object',
+	properties: {
+		checks: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { name: { type: 'string' }, pass: { type: 'boolean' }, detail: { type: 'string' } },
+				required: ['name', 'pass'],
+			},
+		},
+		releaseReady: { type: 'boolean' },
+		blockers: { type: 'array', items: { type: 'string' } },
+		notes: { type: 'string' },
+	},
+	required: ['releaseReady', 'notes'],
+	additionalProperties: true,
+}
+
+// ---------------------------------------------------------------------------
+// SLICES + helpers
+// ---------------------------------------------------------------------------
+const SLICES = [
+	'slice:client',
+	'slice:models',
+	'slice:state',
+	'slice:tests',
+	'slice:screens',
+	'slice:components',
+	'slice:audio',
+	'slice:scaffold',
+]
+
+function hotspotOf(item) {
+	const h = (item && item.hotspot ? String(item.hotspot) : '').toLowerCase()
+	if (h.includes('client')) return 'client'
+	if (h.includes('test')) return 'tests'
+	if (h.includes('appmodel') || h.includes('scaffold') || h.includes('lyrebirdapp')) return 'appmodel'
+	if (h && h !== 'none') return 'none'
+	const s = (item && item.slice ? String(item.slice) : '').toLowerCase()
+	if (s.includes('client')) return 'client'
+	if (s.includes('tests')) return 'tests'
+	if (s.includes('scaffold')) return 'appmodel'
+	return 'none'
+}
+
+function pickWork(allItems, ceiling) {
+	const seen = new Set()
+	const selected = []
+	const deferred = []
+	const seenIssue = new Set()
+	for (const it of allItems) {
+		if (seenIssue.has(it.issue)) continue // de-dup same issue from multiple sources
+		seenIssue.add(it.issue)
+		const h = hotspotOf(it)
+		if (selected.length >= ceiling) {
+			deferred.push(it)
+			continue
+		}
+		if (h !== 'none' && seen.has(h)) {
+			deferred.push(it)
+			continue
+		}
+		if (h !== 'none') seen.add(h)
+		selected.push({ ...it, _hotspot: h })
+	}
+	return { selected, deferred }
+}
+
+function builderAgentType(item) {
+	return item.builder === 'area-fixer' ? 'area-fixer' : 'claude'
+}
+
+// Build-gate directive — swapped by cfg.ciGated. In CI-gated (HYPER) mode the local box does
+// NOT run the slow CPU-bound cargo clippy/test + swift build (those serialize and are the real
+// bottleneck on this 10-core machine); GitHub Actions runs the full gate on every PR in the cloud,
+// and auto-merge only lands on green CI. Builders still run FAST local checks so they don't push
+// obviously-broken diffs and waste a CI cycle.
+const BUILD_GATE_DIRECTIVE = cfg.ciGated
+	? `BUILD GATE — CI-GATED (HYPER) MODE: Do NOT run the slow local build (\`cargo clippy\`/\`cargo test\`/\`swift build\`) — GitHub Actions CI is the authoritative gate and runs fmt+clippy+test+swift-build on your PR in the cloud; auto-merge only lands on green CI. DO run these FAST local checks before pushing so you don't burn a CI cycle on a trivial error: (a) \`cargo fmt --all\` (auto-format, then \`--check\` clean) for Rust; (b) \`swift format\`/visual scan + confirm braces/imports balance for Swift; (c) re-read your full \`git diff\` for syntax. For FFI-adjacent changes (core/src/lib.rs or uniffi Record/Enum in models.rs) you MUST still regenerate the xcframework + lyrebird_core.swift bindings locally and commit them in the SAME commit (CI consumes the committed xcframework; stale bindings = red CI). After you push and open the PR, you MAY return immediately — do not block locally waiting for CI; the reviewer checks the CI result. Never \`--no-verify\`/\`--no-gpg-sign\`. Ignore Scripts/wave-budget.sh.`
+	: `BUILD GATE: Run the full gates before pushing — Rust → \`cargo fmt --all -- --check\` + \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` + \`cargo test --workspace --exclude lyrebird-desktop --all-features --no-fail-fast\`; Swift → \`cd macos && swift build\` (FFI-adjacent: \`rm -rf macos/.build && swift build --package-path macos\`, and regenerate xcframework + bindings in the SAME commit). Never \`--no-verify\`/\`--no-gpg-sign\`. Ignore Scripts/wave-budget.sh.`
+
+// ---------------------------------------------------------------------------
+// PROMPTS
+// ---------------------------------------------------------------------------
+function preflightPrompt(w) {
+	return `Preflight for wave ${w} of the lyrebird-desktop DRIVE pipeline. Read-only — do NOT file issues, open PRs, or change code. Run and report:
+
+1. POLISH gate: read POLISH_TARGETS.md; for every target whose \`check:\` line is a real shell command (not a placeholder comment), RUN it. A target passes iff exit 0. Report {name, pass, detail} each. \`polished\` = every runnable check passed.
+2. Census via \`gh\`: openP0 (open priority:p0), openBugs (open kind:bug), openFeatM3 (open kind:feat in milestone "${cfg.featMilestone}").
+3. Open agent PRs: \`gh pr list --state open --json number,headRefName,title,isDraft\`. Return openAgentPRs = those whose head branch starts with \`fix/\` or \`feat/\` (EXCLUDE dependabot/* and any human branch). Also openFixPRs = count of head:fix/.
+
+Do NOT use Scripts/wave-budget.sh — the orchestrator governs the budget. Return the structured PREFLIGHT object.`
+}
+
+function auditPrompt(slice, w) {
+	return `You are auditing ${slice}. Wave ${w} of the lyrebird-desktop DRIVE pipeline (regression net). Read CLAUDE.md fully and follow .claude/agents/area-auditor.md EXACTLY. Default verdict: findings: []. De-dup against ALL open issues with \`gh issue list --state open --search "<keyword>"\` before filing — most real bugs are already tracked; do not refile them. Honor the five-part falsifiability gate and auto-downgrade rule. Ignore Scripts/wave-budget.sh. File only genuinely NEW confirmed defects with \`gh issue create\` (+ \`source:auto-audit\`). Return the structured AUDIT summary.`
+}
+
+function triagePrompt(w, filedNumbers) {
+	return `You are the problem-triager for wave ${w}. Follow .claude/agents/problem-triager.md EXACTLY. Do NOT write code or open PRs. Ignore Scripts/wave-budget.sh — treat budget as ample; never emit an empty manifest due to budget.
+
+Issues filed by auditors this wave: ${filedNumbers.length ? filedNumbers.map((n) => '#' + n).join(', ') : '(none)'}. Reject kind:feat, re-check falsifiability, reconcile priority/effort labels, tag hotspots (client.rs / tests.rs / AppModel.swift+LyrebirdApp.swift). Build the ordered fix manifest (priority desc, effort asc, non-hotspot first, ≤1/hotspot, cap 6). Return the structured TRIAGE object.`
+}
+
+function backlogPrompt(w, n, milestone, excludeNote) {
+	return `You are the BACKLOG SELECTOR for wave ${w}. Read-only + \`gh\`. Do NOT write code. Pick up to ${n} of the highest-value OPEN issues to drive next.
+
+Be AMBITIOUS — fill the entire batch (${n} items) if that much real work exists. The orchestrator runs up to 10 builders in parallel, so favor a DIVERSE SPREAD across the 8 slices and keep at most ONE item per hotspot (client.rs / tests.rs / AppModel.swift+LyrebirdApp.swift) so the batch parallelizes without collisions.
+
+Priority order:
+1. Open \`kind:bug\` — priority p0 > p1 > p2 (confirmed defects; fix first).
+2. Open \`kind:feat\` in milestone "${milestone}" — priority p0 > p1 > p2, then effort S > M > L. INCLUDE effort:L features when they are well-scoped and self-contained (do not skip a feature just for being L), and INCLUDE p0 features. Aim high — these features are the actual product.
+3. Open \`area:dist\` / M4 work that needs NO Apple credentials (CI yaml, entitlements plist, packaging/appcast scripts).
+
+HARD requirements for every pick:
+- SKIP any issue that already has an OPEN PR (search \`gh pr list --state open\` and match by "Closes #n" in bodies or by topic). ${excludeNote || ''}
+- SKIP kind:feat blocked on unlanded core FFI (read CLAUDE.md "Deferred / known-open work").
+- SKIP issues that are already implemented (verify by reading the cited code) — a no-op PR wastes a review cycle.
+- For each pick set: \`slice\` (one of the 8 slice labels, infer from area/topic), \`hotspot\` (client | tests | appmodel | none — appmodel = touches AppModel.swift/LyrebirdApp.swift), \`builder\` ("area-fixer" for kind:bug/chore/polish, "feature-builder" for kind:feat), \`kind\`, \`title\`.
+
+Return the structured SELECT object. If nothing actionable remains, return items: [].`
+}
+
+function fixerPrompt(item, w) {
+	const hs = item._hotspot === 'none' ? '[]' : `[${item._hotspot}]`
+	return `slice: ${item.slice || '(infer from issue labels)'}
+issues: [#${item.issue}]
+hotspots-required: ${hs}
+wave: ${w}
+
+Follow .claude/agents/area-fixer.md EXACTLY — EXCEPT do NOT abort on the wave-budget gate (ignore Scripts/wave-budget.sh; the orchestrator governs budget; treat remaining as ample). Pre-flight: \`git branch --show-current\`; if on main/claude/*, create \`fix/${item.issue}-<slug>\` off \`origin/main\`. Make the MINIMAL change that closes #${item.issue} — nothing else. If a required hotspot is already locked by another agent, abort cleanly (prOpened:null).
+
+${BUILD_GATE_DIRECTIVE}
+
+No AI attribution, no banned comments. Open a PR with \`Closes #${item.issue}\` + the \`pipeline:\` block; the PR TITLE must be a single conventional-commit line (e.g. \`fix(macos): <what>\`) — never internal notes, questions, or monologue. ESCAPE \`@\` IN PROSE: backtick Swift property wrappers/attributes (\`@State\`, \`@Environment\`, \`@MainActor\`, \`@escaping\`, …) in the PR/commit body so GitHub doesn't render them as @username mentions; in the TITLE drop the @ entirely (write "State", not "@State"). Return the structured BUILD object.`
+}
+
+function featureBuilderPrompt(item, w) {
+	const hs = item._hotspot === 'none' ? 'none' : item._hotspot
+	return `You implement ONE feature for lyrebird-desktop — a NATIVE desktop Jellyfin client (Rust \`core/\` via UniFFI; \`macos/\` SwiftUI app consuming LyrebirdCore). Wave ${w}. You OWN the design quality: match the Apple Music / Spotify / Doppler bar in ROADMAP.md.
+
+Issue: #${item.issue} — "${item.title || ''}" (${item.slice || 'unknown'}, kind:${item.kind || 'feat'}). Hotspot: ${hs}.
+
+Discipline:
+1. \`git branch --show-current\`; if on main/claude/*, create \`feat/${item.issue}-<slug>\` off \`origin/main\`.
+2. Read the issue (\`gh issue view ${item.issue}\`) and the cited code. Read CLAUDE.md "Runtime gaps — common patterns" (sync FFI on MainActor, paged-cache-only resolution, optimistic-UI-without-echo, tuple-destructure awaits) and the build-gate section. VERIFY the feature isn't already implemented — if it is, abort (prOpened:null, resolved:false) rather than ship a no-op.
+3. If hotspot != none, claim it: \`Scripts/area-lock.sh claim ${hs} pending feature-builder-${item.issue}\`; if LOCKED, abort cleanly (no waiting).
+4. Implement the smallest CORRECT version that satisfies the issue's acceptance criteria, following existing patterns (resolveArtist/resolveAlbum cache-miss fallback, Log.app.notice over print, errorMessage + rollback for mutations). No speculative scope. If a missing core FFI is in scope, add it in \`core/\` and regenerate the xcframework + \`lyrebird_core.swift\` bindings in the SAME commit (\`./macos/Scripts/build-core.sh --arm64-only\`; then \`cd macos && rm -rf .build && swift build\`).
+5. ${BUILD_GATE_DIRECTIVE}
+6. Add a focused test only if it directly verifies new behavior. No AI attribution anywhere (commits/PR/comments); author as the user.
+7. Open a PR: TITLE must be a single conventional-commit line (e.g. \`macos: <what>\`) — never internal notes/questions/monologue. ESCAPE \`@\` IN PROSE: backtick Swift property wrappers/attributes (\`@State\`, \`@Environment\`, \`@MainActor\`, …) in the body so GitHub doesn't make them @username mentions; in the TITLE drop the @ (write "State", not "@State"). Body = one-sentence WHY, \`Closes #${item.issue}\`, \`pipeline:\` block (fixer-session, slice, hotspots-claimed, build-gate, diff-stat). Name any claimed hotspot for release on merge.
+
+Return the structured BUILD object (prOpened = PR number, or null if aborted).`
+}
+
+function reviewPrompt(pr, w) {
+	const mergeLine = cfg.autoMerge
+		? 'On `approve`: `gh pr review --approve` THEN `gh pr merge ' + pr + ' --squash --auto --delete-branch`. Release any claimed hotspot lock after queuing the merge.'
+		: 'On `approve`: `gh pr review --approve` only. Do NOT merge.'
+	const ciLine = cfg.ciGated
+		? '\n\nCI-GATED MODE: builders did NOT compile locally — GitHub Actions is the build gate. Check the PR\'s CI status with `gh pr checks ' + pr + '` (or `gh pr view ' + pr + ' --json statusCheckRollup`). If CI is still pending, that is fine — `--squash --auto` waits for green before merging, so you may approve a code-correct PR while CI runs. If CI has already FAILED, do NOT approve: return `request-changes` citing the failing job (fmt/clippy/test/swift-build) so the builder fixes it. A PR is only mergeable when the diff is correct AND CI is (or will go) green.'
+		: ''
+	return `Review PR #${pr}. Wave ${w}. NOTE: .claude/agents/adversarial-reviewer.md says "approving is the exception" and "emit one finding per category" — for THIS feature-drive pipeline that calibration is OVERRIDDEN by the rules below (it caused 7/7 false rejections of correct PRs). Use the def's 8 risk categories only as a LENS, not as a quota. Anti-anchoring: read the DIFF and its callers BEFORE the PR description/issue (error-swallowing, MainActor-blocking FFI, paged-cache-only resolution, optimistic-UI-without-echo, hotspot growth, missing test for changed behavior, speculative scope, banned comments).
+
+CALIBRATION — this is the important part. Your job is to catch REAL defects, NOT to manufacture findings. You are NOT required to emit a finding per category; a clean diff legitimately has zero. **APPROVE when ALL of these hold:** (1) the diff correctly does what the linked issue asks, (2) scope is locked to that issue (no unrelated churn), (3) CI is green or pending (\`gh pr checks ${pr}\`), and (4) you cannot name a CONCRETE defect — a specific line that swallows a real error, blocks the MainActor in a hot path, resolves from a paged cache without FFI fallback, mutates UI without server echo, leaves a banned comment, or adds genuinely out-of-scope code. A small, correct, scope-locked PR (even a 2-line fix) is an APPROVE, not a request-changes. Do not reject for "could add a test" on a trivial/UI change, for style, or for hypotheticals you cannot tie to a specific line.
+
+**request-changes ONLY when you can cite a concrete defect** (file:line + why it breaks for a real user). When you do, list every such finding so the builder can fix them in one pass. **close** only if the PR is a literal no-op / duplicate of already-merged work / re-implements something already present.
+
+If CI has already FAILED (not pending), return \`request-changes\` naming the failing job.${ciLine}
+
+${mergeLine}
+
+Return the structured REVIEW object.`
+}
+
+function disputePrompt(pr, w) {
+	return `OPUS DISPUTE PASS for PR #${pr} (wave ${w}). The Sonnet pass returned \`dispute-needs-opus\`. Follow the "Opus dispute pass" section of .claude/agents/adversarial-reviewer.md. You MAY read the PR description/issue now. Re-run the 8-category checklist; check Sonnet's findings were grounded AND any fixer pushback wasn't a deflection. You have final say. ${cfg.autoMerge ? 'If you approve: `gh pr review --approve` then `gh pr merge ' + pr + ' --squash --auto --delete-branch`, release any hotspot lock.' : 'If you approve: `gh pr review --approve` only.'} Return the structured REVIEW object.`
+}
+
+function refixPrompt(item, build, reviewNotes, w) {
+	return `The adversarial reviewer requested changes on PR #${build.prOpened} (wave ${w}, issue #${item.issue}). Address EVERY finding below on the SAME branch (${build.branch || 'the existing branch'}), scope locked to the issue. ${BUILD_GATE_DIRECTIVE} Push to the same branch (the PR updates). Do NOT open a new PR. No AI attribution.
+
+Reviewer findings:
+${reviewNotes || '(see the PR review comment)'}
+
+Return the structured BUILD object (prOpened = same PR number).`
+}
+
+function resolvePRBuilderPrompt(pr, head, reviewNotes, w) {
+	const isFeat = (head || '').startsWith('feat/')
+	return `Address the adversarial reviewer's change-requests on the EXISTING open PR #${pr} (head: ${head || '?'}, wave ${w}). ${isFeat ? 'This is a FEATURE PR.' : 'This is a bug-fix PR.'}
+
+1. \`git fetch origin && git checkout ${head}\` (or the PR's head). Read the PR diff and the reviewer's comments.
+2. Address EVERY reviewer finding with scope locked to the linked issue. Follow CLAUDE.md runtime-gap patterns. ${isFeat ? 'Hold the Apple Music / Spotify / Doppler quality bar.' : 'Make the minimal correct change.'}
+3. ${BUILD_GATE_DIRECTIVE}
+4. Push to the SAME branch (the PR updates). No new PR. No AI attribution.
+
+Reviewer findings:
+${reviewNotes || '(read the latest CHANGES_REQUESTED / COMMENTED review on the PR)'}
+
+Return the structured BUILD object (issue = the issue this PR closes, prOpened = ${pr}).`
+}
+
+function releaseGatePrompt(w) {
+	return `M4 release-readiness gate, wave ${w}. Read-only — do NOT sign/notarize/upload (needs the user's Apple credentials). Verify {name, pass, detail} each: (1) macos/Scripts/{sign,notarize,make-dmg,make-bundle,generate-appcast}.sh exist and are real implementations; (2) a release CI workflow under .github/workflows wires build→sign→notarize→staple→DMG→appcast; (3) hardened-runtime entitlements + Developer ID config present; (4) POLISH_TARGETS.md runnable checks; (5) Sparkle EdDSA appcast tooling present. Set \`releaseReady\` only if the user could produce a signed/notarized/stapled DMG just by supplying credentials. List \`blockers\`. Return the structured RELEASE_GATE object.`
+}
+
+function finalGatePrompt() {
+	return `Final gate for the lyrebird-desktop DRIVE run. Read POLISH_TARGETS.md and run every runnable \`check:\` line. Report: open priority:p0 count, open kind:bug count, open kind:feat count in milestone "${cfg.featMilestone}", open agent PR count (head fix/* or feat/*). \`polished\` = all runnable checks pass. Return the structured PREFLIGHT object.`
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW HELPERS
+// ---------------------------------------------------------------------------
+const giveUpPRs = new Set() // PRs that exhausted refix rounds — left for the human
+
+async function reviewPR(pr, w) {
+	if (!pr) return { pr: null, outcome: 'no-pr', notes: 'no PR' }
+	let rev = await agent(reviewPrompt(pr, w), {
+		agentType: 'adversarial-reviewer',
+		model: cfg.reviewModel,
+		isolation: 'worktree',
+		phase: 'Review',
+		schema: REVIEW_SCHEMA,
+		label: `review:#${pr}`,
+	})
+	if (rev && rev.outcome === 'dispute-needs-opus') {
+		rev = await agent(disputePrompt(pr, w), {
+			agentType: 'adversarial-reviewer',
+			model: 'opus',
+			isolation: 'worktree',
+			phase: 'Review',
+			schema: REVIEW_SCHEMA,
+			label: `dispute:#${pr}`,
+		})
+	}
+	return rev || { pr, outcome: 'error', notes: 'reviewer returned null' }
+}
+
+// Newly-built item: review, then up to refixRounds in-wave retries on request-changes.
+async function reviewAndRefix(build, item, w) {
+	if (!build) return { item, build: null, review: { outcome: 'error', notes: 'builder threw' } }
+	if (!build.prOpened) return { item, build, review: { outcome: 'no-pr', notes: build.notes || 'no PR opened' } }
+	let review = await reviewPR(build.prOpened, w)
+	let cur = build
+	let rounds = 0
+	while (review && review.outcome === 'request-changes' && rounds < cfg.refixRounds) {
+		rounds++
+		const refixed = await agent(refixPrompt(item, cur, review.notes, w), {
+			agentType: builderAgentType(item),
+			model: cfg.builderModel,
+			isolation: 'worktree',
+			phase: 'Build',
+			schema: BUILD_SCHEMA,
+			label: `refix${rounds}:#${item.issue}`,
+		})
+		if (!refixed || !refixed.prOpened) break
+		cur = refixed
+		review = await reviewPR(cur.prOpened, w)
+	}
+	if (review && review.outcome === 'request-changes') giveUpPRs.add(cur.prOpened)
+	return { item, build: cur, review }
+}
+
+// Pre-existing open PR: review, refix in place up to refixRounds, merge/close/flag.
+async function resolveOpenPR(pr, w) {
+	if (giveUpPRs.has(pr.number)) return { pr: pr.number, outcome: 'skipped-giveup', notes: 'exhausted prior rounds' }
+	let review = await reviewPR(pr.number, w)
+	let rounds = 0
+	while (review && review.outcome === 'request-changes' && rounds < cfg.refixRounds) {
+		rounds++
+		const refixed = await agent(resolvePRBuilderPrompt(pr.number, pr.head, review.notes, w), {
+			agentType: (pr.head || '').startsWith('feat/') ? 'claude' : 'area-fixer',
+			model: cfg.builderModel,
+			isolation: 'worktree',
+			phase: 'Build',
+			schema: BUILD_SCHEMA,
+			label: `pr-refix${rounds}:#${pr.number}`,
+		})
+		if (!refixed) break
+		review = await reviewPR(pr.number, w)
+	}
+	if (review && review.outcome === 'close') {
+		await agent(`Close PR #${pr.number} as not-mergeable (no-op/duplicate/superseded). Run \`gh pr close ${pr.number} --comment "Closing: superseded or no-op per adversarial review — ${(review.notes || '').replace(/"/g, "'")}"\`. Do not delete the linked issue.`, {
+			phase: 'Review',
+			label: `close:#${pr.number}`,
+		})
+	} else if (review && review.outcome === 'request-changes') {
+		giveUpPRs.add(pr.number)
+	}
+	return { pr: pr.number, outcome: review ? review.outcome : 'error', notes: review ? review.notes : '' }
+}
+
+// ---------------------------------------------------------------------------
+// MAIN
+// ---------------------------------------------------------------------------
+log(
+	`drive-lyrebird-desktop${cfg.ciGated ? ' [HYPER/CI-gated]' : ''} | builders: ${cfg.builderModel} | autoMerge: ${cfg.autoMerge} | wave cap: ${MAX_WAVES}${
+		budget.total ? ` (budget ${Math.round(budget.total / 1000)}k tok)` : ' (no budget directive — capped; pass args.maxWaves or +Ntok to extend)'
+	} | buildCeiling ${cfg.buildCeiling} | drainCeiling ${DRAIN_CEILING} | audit every ${cfg.auditEvery} waves | ${cfg.refixRounds} refix rounds`,
+)
+
+const run = {
+	waves: [],
+	issuesFiled: [],
+	prsOpened: [],
+	merged: [],
+	closed: [],
+	unresolvedPRs: [],
+	stoppedBecause: 'wave-cap',
+}
+let dryWaves = 0
+
+for (let w = 1; w <= MAX_WAVES; w++) {
+	if (budget.total && budget.remaining() < WAVE_TOKEN_COST / 2) {
+		run.stoppedBecause = 'budget-exhausted'
+		log(`stopping before wave ${w}: ~${Math.round(budget.remaining() / 1000)}k tokens left.`)
+		break
+	}
+
+	phase('Preflight')
+	log(`── wave ${w}/${MAX_WAVES} ──`)
+	const pre = await agent(preflightPrompt(w), { phase: 'Preflight', schema: PREFLIGHT_SCHEMA, label: `preflight:w${w}` })
+
+	let workedThisWave = 0
+
+	// ---- 1. Resolve open agent PRs (clear stalled work first) ----
+	const openPRs = (pre.openAgentPRs || []).filter((p) => p && p.number && !p.isDraft && !giveUpPRs.has(p.number))
+	if (openPRs.length) {
+		phase('Resolve PRs')
+		log(`wave ${w}: resolving ${openPRs.length} open agent PR(s): ${openPRs.map((p) => '#' + p.number).join(', ')}`)
+		const resolved = await parallel(openPRs.map((p) => () => resolveOpenPR(p, w)))
+		resolved.filter(Boolean).forEach((r) => {
+			workedThisWave++
+			if (r.outcome === 'approve') run.merged.push(r.pr)
+			else if (r.outcome === 'close') run.closed.push(r.pr)
+			else run.unresolvedPRs.push(r.pr)
+		})
+	}
+
+	// ---- 2. Audit (wave 1 + every Nth) ----
+	let freshBugs = []
+	const doAudit = cfg.auditEvery > 0 && (w === 1 || w % cfg.auditEvery === 0)
+	if (doAudit) {
+		phase('Audit')
+		const audits = (
+			await parallel(SLICES.map((s) => () => agent(auditPrompt(s, w), { agentType: 'area-auditor', phase: 'Audit', schema: AUDIT_SCHEMA, label: `audit:${s.replace('slice:', '')}:w${w}` })))
+		).filter(Boolean)
+		const filed = audits.flatMap((a) => a.issueNumbers || [])
+		const totalFiled = audits.reduce((n, a) => n + (a.issuesFiled || 0), 0)
+		run.issuesFiled.push(...filed)
+		log(`wave ${w} audit: ${totalFiled} new issue(s) filed.`)
+		if (totalFiled > 0 && totalFiled <= 10 && filed.length) {
+			phase('Triage')
+			const triage = await agent(triagePrompt(w, filed), { agentType: 'problem-triager', phase: 'Triage', schema: TRIAGE_SCHEMA, label: `triage:w${w}` })
+			freshBugs = (triage.manifest || []).map((m) => ({ issue: m.issue, slice: m.slice, hotspot: m.hotspot, kind: 'bug', builder: 'area-fixer', title: '' }))
+		} else if (totalFiled > 10) {
+			log(`wave ${w}: audit produced ${totalFiled} findings (>10) — leaving them filed for human review, not auto-fixing this wave.`)
+		}
+	}
+
+	// ---- 3. Backlog selection (real open issues without a PR) ----
+	phase('Backlog')
+	const throttle = (pre.openFixPRs || 0) >= DRAIN_CEILING
+	const backlogSel = await agent(backlogPrompt(w, cfg.backlogBatch, cfg.featMilestone, throttle ? 'NOTE: open fix/* PR count is high — bias this batch toward kind:feat (feat/* branches) over new kind:bug fixes.' : ''), {
+		phase: 'Backlog',
+		schema: SELECT_SCHEMA,
+		label: `backlog:w${w}`,
+	})
+	const backlogItems = (backlogSel.items || []).map((it) => ({ ...it, builder: it.builder === 'area-fixer' ? 'area-fixer' : 'claude' }))
+
+	// Combine fresh-audit bugs (highest signal) + backlog; enforce ≤1/hotspot + ceiling.
+	const combined = [...freshBugs, ...backlogItems]
+	const { selected: workItems, deferred } = pickWork(combined, cfg.buildCeiling)
+	log(`wave ${w} build set: ${workItems.length} [${workItems.map((i) => '#' + i.issue + '/' + (i.builder === 'area-fixer' ? 'bug' : 'feat')).join(', ') || 'none'}]${deferred.length ? `; deferred ${deferred.length}` : ''}.`)
+
+	// ---- 4. Build → review(≤refixRounds) → merge ----
+	if (workItems.length) {
+		phase('Build')
+		const results = await pipeline(
+			workItems,
+			(item) =>
+				agent(item.builder === 'area-fixer' ? fixerPrompt(item, w) : featureBuilderPrompt(item, w), {
+					agentType: builderAgentType(item),
+					model: cfg.builderModel,
+					isolation: 'worktree',
+					phase: 'Build',
+					schema: BUILD_SCHEMA,
+					label: `build:#${item.issue}/${item.builder === 'area-fixer' ? 'bug' : 'feat'}`,
+				}),
+			(build, item) => reviewAndRefix(build, item, w),
+		)
+		results.filter(Boolean).forEach((r) => {
+			if (r.build && r.build.prOpened) {
+				workedThisWave++
+				run.prsOpened.push(r.build.prOpened)
+				const o = r.review && r.review.outcome
+				if (o === 'approve') run.merged.push(r.build.prOpened)
+				else run.unresolvedPRs.push(r.build.prOpened)
+			}
+		})
+	}
+
+	// ---- 5. Release gate ----
+	let releaseGate = null
+	if (cfg.includeDist && (w === 1 || w === MAX_WAVES || w % cfg.auditEvery === 0)) {
+		phase('Release gate')
+		releaseGate = await agent(releaseGatePrompt(w), { phase: 'Release gate', schema: RELEASE_GATE_SCHEMA, label: `release-gate:w${w}` })
+		log(`wave ${w} release gate: releaseReady=${releaseGate.releaseReady}.`)
+	}
+
+	run.waves.push({ wave: w, openPRsResolved: openPRs.map((p) => p.number), built: workItems.map((i) => i.issue), releaseGate })
+
+	// ---- Loop control ----
+	const nothingActionable = pre.polished && (pre.openBugs || 0) === 0 && (pre.openFeatM3 || 0) === 0 && openPRs.length === 0
+	if (nothingActionable) {
+		run.stoppedBecause = 'polished'
+		log(`wave ${w}: polished + no open bugs/feats/PRs. Done.`)
+		break
+	}
+	if (workedThisWave === 0) {
+		dryWaves++
+		if (dryWaves >= 2) {
+			run.stoppedBecause = 'idle'
+			log(`wave ${w}: two consecutive waves with no work landed. Remaining backlog needs human input. Stopping.`)
+			break
+		}
+	} else dryWaves = 0
+}
+
+// ---------------------------------------------------------------------------
+// FINAL REPORT
+// ---------------------------------------------------------------------------
+phase('Report')
+const finalGate = await agent(finalGatePrompt(), { phase: 'Report', schema: PREFLIGHT_SCHEMA, label: 'final-gate' })
+
+const dedupe = (a) => Array.from(new Set(a))
+const mergedSet = new Set(run.merged)
+const summary = {
+	stoppedBecause: run.stoppedBecause,
+	wavesRun: run.waves.length,
+	issuesFiled: dedupe(run.issuesFiled),
+	prsOpened: dedupe(run.prsOpened),
+	mergedOrQueued: dedupe(run.merged),
+	closed: dedupe(run.closed),
+	unresolvedPRs: dedupe(run.unresolvedPRs).filter((p) => !mergedSet.has(p)),
+	gaveUpPRs: Array.from(giveUpPRs),
+	finalPolished: finalGate.polished,
+	finalPolishChecks: finalGate.polishChecks || [],
+	openP0: finalGate.openP0,
+	openBugs: finalGate.openBugs,
+	openFeatM3: finalGate.openFeatM3,
+}
+log(
+	`DONE — stopped: ${summary.stoppedBecause} | waves: ${summary.wavesRun} | merged/queued: ${summary.mergedOrQueued.length} | closed: ${summary.closed.length} | unresolved: ${summary.unresolvedPRs.length} | filed: ${summary.issuesFiled.length} | polished: ${summary.finalPolished}`,
+)
+return summary

--- a/.claude/workflows/finalize-lyrebird-desktop.js
+++ b/.claude/workflows/finalize-lyrebird-desktop.js
@@ -1,0 +1,671 @@
+export const meta = {
+	name: 'finalize-lyrebird-desktop',
+	description:
+		'Drive lyrebird-desktop to "polished": multi-wave audit → triage → fix (bugs/polish) + feature track (M3) + M4 distribution prep → adversarial review → auto-merge, looping until POLISH_TARGETS.md passes or the token budget / wave cap / drain ceiling stops it.',
+	whenToUse:
+		'Full development + finalization of lyrebird-desktop. Spawns the area-auditor/problem-triager/area-fixer/adversarial-reviewer agents plus a feature-builder track. Honors hotspot locks and the drain ceiling. Pass args to scope it (see CONFIG).',
+	phases: [
+		{ title: 'Preflight', detail: 'branch + POLISH_TARGETS gate + issue census + drain check' },
+		{ title: 'Audit', detail: '8 parallel area-auditors, one per slice' },
+		{ title: 'Triage', detail: 'problem-triager → ordered bug/polish fix manifest' },
+		{ title: 'Select', detail: 'pick M3 feature batch + M4 distribution batch from the backlog' },
+		{ title: 'Build', detail: 'area-fixer (bugs) + feature-builder (feat/dist), worktree-isolated, ≤1 per hotspot' },
+		{ title: 'Review', detail: 'adversarial-reviewer per PR; Opus on dispute; auto-merge on approve' },
+		{ title: 'Release gate', detail: 'M4 release-readiness verification (no live signing)' },
+		{ title: 'Report', detail: 'final polish-gate + wave summary' },
+	],
+}
+
+// ---------------------------------------------------------------------------
+// CONFIG — defaults match the "full arc, run until polished, auto-merge" choice.
+// Override any of these by passing them in Workflow `args`.
+// ---------------------------------------------------------------------------
+const cfg = {
+	includeFeatures: args && args.includeFeatures != null ? args.includeFeatures : true,
+	includeDist: args && args.includeDist != null ? args.includeDist : true,
+	autoMerge: args && args.autoMerge != null ? args.autoMerge : true,
+	maxWaves: args && args.maxWaves != null ? args.maxWaves : null, // null → derive from budget
+	featBatchPerWave: args && args.featBatchPerWave != null ? args.featBatchPerWave : 3,
+	distBatchPerWave: args && args.distBatchPerWave != null ? args.distBatchPerWave : 2,
+	// Per-wave PR ceiling. Kept below the pipeline's 5-open-PR drain ceiling.
+	buildCeiling: args && args.buildCeiling != null ? args.buildCeiling : 4,
+	featMilestone: args && args.featMilestone ? args.featMilestone : 'M3 — macOS polish',
+}
+
+const WAVE_BUDGET_SECONDS = 14400 // 4h — what preflight hands the agents' Scripts/wave-budget.sh
+const WAVE_TOKEN_COST = 400000 // rough per-wave output-token estimate, for budget-derived wave cap
+const DRAIN_CEILING = 5 // open fix/* PRs that abort new audit/fix work
+
+// No silent caps: derive the wave cap and announce it.
+const MAX_WAVES =
+	cfg.maxWaves != null
+		? cfg.maxWaves
+		: budget.total
+			? Math.max(1, Math.min(8, Math.floor(budget.total / WAVE_TOKEN_COST)))
+			: 3
+
+// ---------------------------------------------------------------------------
+// SCHEMAS
+// ---------------------------------------------------------------------------
+const PREFLIGHT_SCHEMA = {
+	type: 'object',
+	properties: {
+		branch: { type: 'string' },
+		polished: { type: 'boolean' },
+		polishChecks: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { name: { type: 'string' }, pass: { type: 'boolean' }, detail: { type: 'string' } },
+				required: ['name', 'pass'],
+			},
+		},
+		openP0: { type: 'integer' },
+		openBugs: { type: 'integer' },
+		openFeatM3: { type: 'integer' },
+		openDist: { type: 'integer' },
+		openFixPRs: { type: 'integer' },
+		openFixPRNumbers: { type: 'array', items: { type: 'integer' } },
+		notes: { type: 'string' },
+	},
+	required: ['polished', 'openP0', 'openFixPRs', 'notes'],
+	additionalProperties: true,
+}
+
+const AUDIT_SCHEMA = {
+	type: 'object',
+	properties: {
+		slice: { type: 'string' },
+		candidatesFound: { type: 'integer' },
+		issuesFiled: { type: 'integer' },
+		issueNumbers: { type: 'array', items: { type: 'integer' } },
+		autoDowngrade: { type: 'boolean' },
+		notes: { type: 'string' },
+	},
+	required: ['slice', 'issuesFiled', 'notes'],
+	additionalProperties: true,
+}
+
+const TRIAGE_SCHEMA = {
+	type: 'object',
+	properties: {
+		manifest: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					issue: { type: 'integer' },
+					slice: { type: 'string' },
+					hotspot: { type: 'string' },
+					priority: { type: 'string' },
+					effort: { type: 'string' },
+				},
+				required: ['issue', 'hotspot'],
+			},
+		},
+		rejected: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { issue: { type: 'integer' }, reason: { type: 'string' } },
+			},
+		},
+		notes: { type: 'string' },
+	},
+	required: ['manifest'],
+	additionalProperties: true,
+}
+
+const SELECT_SCHEMA = {
+	type: 'object',
+	properties: {
+		items: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					issue: { type: 'integer' },
+					slice: { type: 'string' },
+					hotspot: { type: 'string' },
+					title: { type: 'string' },
+					kind: { type: 'string' },
+				},
+				required: ['issue', 'hotspot'],
+			},
+		},
+		notes: { type: 'string' },
+	},
+	required: ['items'],
+	additionalProperties: true,
+}
+
+const BUILD_SCHEMA = {
+	type: 'object',
+	properties: {
+		issue: { type: 'integer' },
+		prOpened: { type: ['integer', 'null'] },
+		branch: { type: 'string' },
+		hotspotsClaimed: { type: 'array', items: { type: 'string' } },
+		buildGate: { type: 'string', enum: ['pass', 'fail', 'skipped'] },
+		resolved: { type: 'boolean' },
+		notes: { type: 'string' },
+	},
+	required: ['issue', 'prOpened', 'buildGate', 'resolved', 'notes'],
+	additionalProperties: true,
+}
+
+const REVIEW_SCHEMA = {
+	type: 'object',
+	properties: {
+		pr: { type: ['integer', 'null'] },
+		outcome: {
+			type: 'string',
+			enum: ['approve', 'request-changes', 'dispute-needs-opus', 'no-pr', 'error'],
+		},
+		checklistViolations: { type: 'integer' },
+		merged: { type: 'boolean' },
+		hotspotReleased: { type: ['string', 'null'] },
+		notes: { type: 'string' },
+	},
+	required: ['outcome', 'notes'],
+	additionalProperties: true,
+}
+
+const RELEASE_GATE_SCHEMA = {
+	type: 'object',
+	properties: {
+		checks: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { name: { type: 'string' }, pass: { type: 'boolean' }, detail: { type: 'string' } },
+				required: ['name', 'pass'],
+			},
+		},
+		releaseReady: { type: 'boolean' },
+		blockers: { type: 'array', items: { type: 'string' } },
+		notes: { type: 'string' },
+	},
+	required: ['releaseReady', 'notes'],
+	additionalProperties: true,
+}
+
+// ---------------------------------------------------------------------------
+// SLICES + hotspot helpers
+// ---------------------------------------------------------------------------
+const SLICES = [
+	'slice:client',
+	'slice:models',
+	'slice:state',
+	'slice:tests',
+	'slice:screens',
+	'slice:components',
+	'slice:audio',
+	'slice:scaffold',
+]
+
+// Normalize a slice/hotspot tag to one of the three real hotspot keys, or 'none'.
+function hotspotOf(item) {
+	const h = (item && item.hotspot ? String(item.hotspot) : '').toLowerCase()
+	if (h.includes('client')) return 'client'
+	if (h.includes('test')) return 'tests'
+	if (h.includes('appmodel') || h.includes('scaffold') || h.includes('lyrebirdapp')) return 'appmodel'
+	if (h && h !== 'none') return 'none'
+	const s = (item && item.slice ? String(item.slice) : '').toLowerCase()
+	if (s.includes('client')) return 'client'
+	if (s.includes('tests')) return 'tests'
+	if (s.includes('scaffold')) return 'appmodel'
+	return 'none'
+}
+
+// Enforce ≤1 in-flight item per hotspot and a per-wave ceiling. Returns selected + deferred.
+function pickWork(allItems, ceiling) {
+	const seen = new Set()
+	const selected = []
+	const deferred = []
+	for (const it of allItems) {
+		const h = hotspotOf(it)
+		if (selected.length >= ceiling) {
+			deferred.push(it)
+			continue
+		}
+		if (h !== 'none' && seen.has(h)) {
+			deferred.push(it)
+			continue
+		}
+		if (h !== 'none') seen.add(h)
+		selected.push({ ...it, _hotspot: h })
+	}
+	return { selected, deferred }
+}
+
+function builderAgentType(item) {
+	return item.builder === 'area-fixer' ? 'area-fixer' : 'claude'
+}
+
+// ---------------------------------------------------------------------------
+// PROMPTS
+// ---------------------------------------------------------------------------
+function preflightPrompt(w) {
+	return `Preflight for wave ${w} of the lyrebird-desktop finalization pipeline. You are read-mostly; you only WRITE the .wave-start marker. Run these and report results.
+
+1. \`git branch --show-current\` — record it. If it is \`main\` or a \`claude/*\` branch, just record it (do not switch).
+2. \`Scripts/wave-budget.sh start ${WAVE_BUDGET_SECONDS}\` — starts the wave budget so downstream agents' \`Scripts/wave-budget.sh remaining\` works.
+3. POLISH_TARGETS.md gate: read it, and for every target whose \`check:\` line is a real shell command (not a comment / placeholder), RUN it. A target passes iff its command exits 0. Report one {name, pass, detail} per target. \`polished\` = every runnable check passed.
+4. Issue census via \`gh\`:
+   - openP0 = \`gh issue list --state open --label 'priority:p0' --json number -q 'length'\`
+   - openBugs = open \`kind:bug\`
+   - openFeatM3 = open \`kind:feat\` in milestone "${cfg.featMilestone}"
+   - openDist = open \`area:dist\` (or milestone M4) issues
+5. Drain check: \`gh pr list --state open --search 'head:fix/' --json number\` → openFixPRs (count) + openFixPRNumbers (the numbers).
+
+Return the structured PREFLIGHT object. Do not file issues, open PRs, or change code.`
+}
+
+function auditPrompt(slice, w) {
+	return `You are auditing ${slice}. Wave ${w} of the lyrebird-desktop adversarial pipeline.
+
+Read CLAUDE.md fully (especially "Deferred / known-open work" and "Runtime gaps — common patterns") and follow your agent definition (.claude/agents/area-auditor.md) EXACTLY. Default verdict: findings: []. Empty output on a quiet slice is success.
+
+Pre-flight: \`git branch --show-current\`; de-dup against open issues with \`gh issue list --state open --search "<keyword>"\` before filing anything. Honor the five-part falsifiability gate and the auto-downgrade rule (5+ candidates ⇒ file none, surface them).
+
+File confirmed findings with \`gh issue create\` using the required labels incl. \`source:auto-audit\`. Then return the structured AUDIT summary for this slice.`
+}
+
+function triagePrompt(w, filedNumbers) {
+	return `You are the problem-triager for wave ${w}. Follow .claude/agents/problem-triager.md EXACTLY. Do NOT write code or open PRs.
+
+The wave start is in \`.wave-start\`. The issues filed by auditors this wave are: ${filedNumbers.length ? filedNumbers.map((n) => '#' + n).join(', ') : '(none — query source:auto-audit since wave start yourself)'}.
+
+For each: reject \`kind:feat\` (close with the standard comment), re-check the five falsifiability fields, reconcile priority/effort labels, and tag hotspot requirements (client.rs / tests.rs / AppModel.swift+LyrebirdApp.swift). Build the ordered fix manifest (priority desc, effort asc, non-hotspot first, ≤1 entry per hotspot, cap 6). IGNORE \`Scripts/wave-budget.sh\` — the orchestrator governs the budget; do NOT emit an empty manifest because wave-budget remaining is low/zero (treat it as ample). Return the structured TRIAGE object (manifest + rejected).`
+}
+
+function featSelectPrompt(w, count, milestone) {
+	return `You are selecting the FEATURE batch for wave ${w}. Read-only + \`gh\`. Do NOT write code.
+
+Pick up to ${count} \`kind:feat\` issues from milestone "${milestone}" that are the best next implementation targets. Prefer priority p0 > p1 > p2, then effort S > M (avoid L/XL unless p0). Requirements:
+- Skip any issue that already has an open \`fix/*\` or \`feat/*\` PR (check \`gh pr list --state open --search "<issue keyword>"\` or by \`Closes #n\`).
+- Skip issues blocked on unlanded core FFI (read CLAUDE.md "Deferred / known-open work").
+- For each chosen issue, determine its \`slice:\` and its hotspot: one of client | tests | appmodel | none (appmodel = touches AppModel.swift or LyrebirdApp.swift, i.e. slice:scaffold).
+Return the structured SELECT object: items:[{issue, slice, hotspot, title, kind:"feat"}].`
+}
+
+function distSelectPrompt(w, count) {
+	return `You are selecting the M4 DISTRIBUTION batch for wave ${w}. Read-only + \`gh\`. Do NOT write code.
+
+Pick up to ${count} M4 / \`area:dist\` issues that an agent can complete WITHOUT live Apple credentials — e.g. CI workflow YAML, hardened-runtime entitlements plists, packaging scripts (make-dmg/make-bundle), appcast generator, Sparkle SPM wiring, .desktop/flatpak manifests. EXCLUDE anything that requires actually signing, notarizing, or uploading with a real Developer ID (those need the user). For each, determine slice + hotspot (client|tests|appmodel|none) and kind. Return the structured SELECT object: items:[{issue, slice, hotspot, title, kind}].`
+}
+
+function fixerPrompt(item, w) {
+	const hs = item._hotspot === 'none' ? '[]' : `[${item._hotspot}]`
+	return `slice: ${item.slice || '(infer from issue labels)'}
+issues: [#${item.issue}]
+hotspots-required: ${hs}
+wave: ${w}
+
+Follow .claude/agents/area-fixer.md EXACTLY — EXCEPT do NOT abort on the wave-budget gate. The orchestrator governs the overall budget; if \`Scripts/wave-budget.sh remaining\` is unavailable OR reports 0/low, treat remaining as ample (~${WAVE_BUDGET_SECONDS}s) and proceed.
+
+Pre-flight: \`git branch --show-current\`; if on main/claude/*, create \`fix/${item.issue}-<slug>\` off \`origin/main\`. Make the MINIMAL change that closes #${item.issue} — nothing else. Run the build gates (cargo fmt/clippy/test for Rust; \`swift build\` for Swift; regenerate xcframework + bindings in the SAME commit for FFI-adjacent changes). No AI attribution, no Co-Authored-By, no banned comments. Open a PR with \`Closes #${item.issue}\` and the \`pipeline:\` block. Return the structured BUILD object (set prOpened to the PR number, or null if you aborted).`
+}
+
+function featureBuilderPrompt(item, w) {
+	const hs = item._hotspot === 'none' ? 'none' : item._hotspot
+	return `You implement ONE feature for lyrebird-desktop — a NATIVE desktop Jellyfin client (Rust \`core/\` exposed via UniFFI; \`macos/\` SwiftUI app consuming LyrebirdCore). Wave ${w}.
+
+Issue: #${item.issue} — "${item.title || ''}" (${item.slice || 'unknown slice'}, kind:${item.kind || 'feat'}). Hotspot: ${hs}.
+
+MANDATORY discipline (this is a finalization pipeline, not a hack):
+1. \`git branch --show-current\`. If on \`main\` or a \`claude/*\` branch, create \`feat/${item.issue}-<slug>\` off \`origin/main\` first.
+2. Read the issue body in full (\`gh issue view ${item.issue}\`). Read CLAUDE.md fully — especially "Runtime gaps — common patterns" (sync FFI on MainActor, paged-cache-only resolution, optimistic-UI-without-echo, tuple-destructure awaits) and the build gates. Read ROADMAP.md for the M3 design bar (Apple Music / Spotify / Doppler polish).
+3. If the hotspot is not 'none', claim it: \`Scripts/area-lock.sh claim ${hs} pending feature-builder-${item.issue}\`. If LOCKED, abort cleanly (return prOpened:null, resolved:false, notes explaining the lock) — do NOT wait.
+4. Implement the SMALLEST correct version of the feature that satisfies the issue's acceptance criteria. Follow existing patterns (resolveArtist/resolveAlbum cache-miss fallback, Log.app.notice over print, errorMessage + rollback for mutations). Do NOT invent scope beyond the issue. If the feature needs a core FFI that does not exist yet, and adding it is in scope, add it in \`core/\` AND regenerate the xcframework + \`lyrebird_core.swift\` bindings in the SAME commit (\`./macos/Scripts/build-core.sh --arm64-only\` then \`cd macos && rm -rf .build && swift build\`).
+5. Build gates MUST pass before you push:
+   - Rust touched: \`cargo fmt --all -- --check\`, \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`, \`cargo test --workspace --exclude lyrebird-desktop --all-features --no-fail-fast\`.
+   - Swift touched: \`cd macos && swift build\` (for FFI-adjacent, \`rm -rf macos/.build && swift build --package-path macos\`).
+   Fix the underlying cause; never \`--no-verify\` / \`--no-gpg-sign\` (the user did not authorize bypassing signing).
+6. Add a focused test only if it directly verifies the new behavior. No speculative tests/refactors/comments.
+7. NO AI attribution anywhere — no \`Co-Authored-By\`, no mention of Claude/AI in commits, the PR, or comments. Author as the user. (Sub-agent commits get squash-merged under the user's signature.)
+8. Open a PR: one sentence on the WHY, \`Closes #${item.issue}\`, and a \`pipeline:\` block (fixer-session, slice, hotspots-claimed, build-gate: pass, diff-stat). If you claimed a hotspot, name it so the reviewer releases it on merge.
+
+Return the structured BUILD object. prOpened = the PR number, or null if you aborted (locked-out / out-of-scope / gate-unfixable).`
+}
+
+function reviewPrompt(pr, w) {
+	const mergeLine = cfg.autoMerge
+		? 'On `approve`: run `gh pr review --approve` THEN `gh pr merge ' + pr + ' --squash --auto --delete-branch` (auto-merge is ON for this run). If the PR claimed a hotspot, run `Scripts/area-lock.sh release <hotspot>` after queuing the merge.'
+		: 'On `approve`: run `gh pr review --approve` only. Do NOT merge — the user merges manually. Still note the hotspot so it can be released on merge.'
+	return `Review PR #${pr} adversarially. Wave ${w}. Follow .claude/agents/adversarial-reviewer.md EXACTLY.
+
+Anti-anchoring: read the DIFF and its callers BEFORE the PR description / linked issue. Run the full 8-category rejection checklist (error-swallowing, MainActor-blocking FFI, paged-cache-only resolution, optimistic-UI-without-echo, hotspot growth, new-branch test coverage, speculative scope, banned-comments) — one finding each, "N/A because…" is valid, silence is not. Do the mandatory falsification step. Default outcome is request-changes; approve only if every category is N/A or addressed and scope is locked.
+
+${mergeLine}
+
+If you cannot form an independent verdict or the fixer-session equals your own, return outcome \`dispute-needs-opus\`. Return the structured REVIEW object.`
+}
+
+function disputePrompt(pr, w) {
+	return `OPUS DISPUTE PASS for PR #${pr} (wave ${w}). The Sonnet first pass returned \`dispute-needs-opus\`. Follow the "Opus dispute pass" section of .claude/agents/adversarial-reviewer.md.
+
+You MAY read the PR description and linked issue now (anchoring is no longer the failure mode; collusion is). Re-run the 8-category checklist. CHECK that Sonnet's findings were grounded (no false rejections) AND that any fixer pushback was not a deflection — either side can lose. You have final say.
+
+${cfg.autoMerge ? 'If you approve: `gh pr review --approve` then `gh pr merge ' + pr + ' --squash --auto --delete-branch`, and release any claimed hotspot lock.' : 'If you approve: `gh pr review --approve` only (no merge; user merges manually).'} Return the structured REVIEW object.`
+}
+
+function refixPrompt(item, build, reviewNotes, w) {
+	return `The adversarial reviewer requested changes on PR #${build.prOpened} (wave ${w}, issue #${item.issue}). Address EVERY finding below on the SAME branch (${build.branch || 'the existing fix/feat branch'}), keeping scope locked to the issue. Re-run the build gates. Push to the same branch (the existing PR updates). Do NOT open a new PR. No AI attribution. Ignore \`Scripts/wave-budget.sh\` (the orchestrator governs the budget — do not abort on it).
+
+Reviewer findings:
+${reviewNotes || '(see the PR review comment)'}
+
+Return the structured BUILD object (prOpened = the same PR number).`
+}
+
+function releaseGatePrompt(w) {
+	return `You are the M4 release-readiness gate for wave ${w}. Read-only verification — do NOT sign, notarize, or upload anything (that needs the user's Apple Developer credentials).
+
+Verify and report one {name, pass, detail} per check:
+1. macos/Scripts/{sign.sh, notarize.sh, make-dmg.sh, make-bundle.sh, generate-appcast.sh} exist and are non-trivial implementations (not stubs).
+2. A release CI workflow exists under .github/workflows that wires build → sign → notarize → staple → DMG → appcast.
+3. Hardened-runtime entitlements + Developer ID configuration are present in the macOS project.
+4. POLISH_TARGETS.md: run each runnable \`check:\` line; report pass/fail.
+5. \`gh release list\` / tags — is there release tooling/version wiring (Sparkle EdDSA appcast) in place?
+
+Set \`releaseReady\` true only if a signed/notarized/stapled DMG could be produced by the user just by supplying credentials + running the scripts. List concrete \`blockers\` otherwise. Return the structured RELEASE_GATE object.`
+}
+
+function finalGatePrompt() {
+	return `Final polish gate for the lyrebird-desktop finalization run. Read POLISH_TARGETS.md and run every runnable \`check:\` line. Also report: open priority:p0 count, open kind:bug count, open kind:feat count in milestone "${cfg.featMilestone}", and open fix/* PR count. \`polished\` = all runnable POLISH_TARGETS checks pass. Return the structured PREFLIGHT object.`
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW HELPERS
+// ---------------------------------------------------------------------------
+const refixAttempted = new Set()
+
+async function reviewPR(pr, w) {
+	if (!pr) return { pr: null, outcome: 'no-pr', notes: 'no PR to review' }
+	let rev = await agent(reviewPrompt(pr, w), {
+		agentType: 'adversarial-reviewer',
+		isolation: 'worktree',
+		phase: 'Review',
+		schema: REVIEW_SCHEMA,
+		label: `review:#${pr}`,
+	})
+	if (rev && rev.outcome === 'dispute-needs-opus') {
+		rev = await agent(disputePrompt(pr, w), {
+			agentType: 'adversarial-reviewer',
+			model: 'opus',
+			isolation: 'worktree',
+			phase: 'Review',
+			schema: REVIEW_SCHEMA,
+			label: `dispute:#${pr}`,
+		})
+	}
+	return rev || { pr, outcome: 'error', notes: 'reviewer returned null' }
+}
+
+// Build-stage callback's review side: review, and on request-changes do ONE in-wave refix.
+async function reviewAndMaybeRefix(build, item, w) {
+	if (!build) return { item, build: null, review: { outcome: 'error', notes: 'builder threw / returned null' } }
+	if (!build.prOpened) return { item, build, review: { outcome: 'no-pr', notes: build.notes || 'no PR opened' } }
+
+	let review = await reviewPR(build.prOpened, w)
+
+	if (review && review.outcome === 'request-changes' && !refixAttempted.has(build.prOpened)) {
+		refixAttempted.add(build.prOpened)
+		const refixType = builderAgentType(item)
+		const refixed = await agent(refixPrompt(item, build, review.notes, w), {
+			agentType: refixType,
+			isolation: 'worktree',
+			phase: 'Build',
+			schema: BUILD_SCHEMA,
+			label: `refix:#${item.issue}`,
+		})
+		if (refixed && refixed.prOpened) {
+			review = await reviewPR(refixed.prOpened, w)
+			return { item, build: refixed, review }
+		}
+	}
+	return { item, build, review }
+}
+
+// ---------------------------------------------------------------------------
+// MAIN — the wave loop
+// ---------------------------------------------------------------------------
+log(
+	`finalize-lyrebird-desktop | scope: bugs/polish${cfg.includeFeatures ? ' + features(M3)' : ''}${
+		cfg.includeDist ? ' + M4 dist' : ''
+	} | autoMerge: ${cfg.autoMerge} | wave cap: ${MAX_WAVES}${
+		budget.total ? ` (budget ${Math.round(budget.total / 1000)}k tok)` : ' (no budget directive set — capped; pass args.maxWaves or a +Ntok directive to extend)'
+	}`,
+)
+
+const run = {
+	waves: [],
+	issuesFiled: [],
+	prsOpened: [],
+	merged: [],
+	unresolvedPRs: [],
+	stoppedBecause: 'wave-cap',
+}
+
+let dryAuditRounds = 0
+
+for (let w = 1; w <= MAX_WAVES; w++) {
+	if (budget.total && budget.remaining() < WAVE_TOKEN_COST / 2) {
+		run.stoppedBecause = 'budget-exhausted'
+		log(`stopping before wave ${w}: ~${Math.round(budget.remaining() / 1000)}k tokens left, below half a wave.`)
+		break
+	}
+
+	phase('Preflight')
+	log(`── wave ${w}/${MAX_WAVES} ──`)
+	const pre = await agent(preflightPrompt(w), {
+		phase: 'Preflight',
+		schema: PREFLIGHT_SCHEMA,
+		label: `preflight:w${w}`,
+	})
+
+	// Polished + nothing actionable ⇒ done.
+	const nothingActionable =
+		(pre.openFeatM3 || 0) === 0 && (pre.openDist || 0) === 0 && (pre.openBugs || 0) === 0
+	if (pre.polished && nothingActionable) {
+		run.stoppedBecause = 'polished'
+		run.waves.push({ wave: w, preflight: pre, note: 'polished + no actionable issues' })
+		log(`wave ${w}: POLISH_TARGETS pass and no actionable issues. Pipeline idle — done.`)
+		break
+	}
+
+	// Drain ceiling ⇒ review the open fix/* PRs once, then stop new work.
+	if ((pre.openFixPRs || 0) >= DRAIN_CEILING) {
+		log(`wave ${w}: drain ceiling hit (${pre.openFixPRs} open fix/* PRs). Reviewing them, then stopping new audit/fix.`)
+		phase('Review')
+		const drainPRs = pre.openFixPRNumbers || []
+		const drained = await parallel(drainPRs.map((pr) => () => reviewPR(pr, w)))
+		drained.filter(Boolean).forEach((r) => {
+			if (r.outcome === 'approve') run.merged.push(r.pr)
+			else if (r.pr) run.unresolvedPRs.push(r.pr)
+		})
+		run.waves.push({ wave: w, preflight: pre, drainReviewed: drainPRs })
+		run.stoppedBecause = 'drain-ceiling'
+		break
+	}
+
+	// ---- Audit (8 parallel auditors) ----
+	phase('Audit')
+	const audits = (
+		await parallel(SLICES.map((s) => () => agent(auditPrompt(s, w), {
+			agentType: 'area-auditor',
+			phase: 'Audit',
+			schema: AUDIT_SCHEMA,
+			label: `audit:${s.replace('slice:', '')}:w${w}`,
+		})))
+	).filter(Boolean)
+
+	const filed = audits.flatMap((a) => a.issueNumbers || [])
+	const totalFiled = audits.reduce((n, a) => n + (a.issuesFiled || 0), 0)
+	run.issuesFiled.push(...filed)
+	const downgraded = audits.filter((a) => a.autoDowngrade).map((a) => a.slice)
+	log(`wave ${w} audit: ${totalFiled} issue(s) filed across ${audits.length} slices${downgraded.length ? `; auto-downgraded: ${downgraded.join(', ')}` : ''}.`)
+
+	if (downgraded.length) {
+		log(`wave ${w}: auto-downgrade on ${downgraded.join(', ')} — surfaced, not filed. Continuing with feature/dist track only for these.`)
+	}
+	if (totalFiled > 10) {
+		run.stoppedBecause = 'audit-overflow'
+		run.waves.push({ wave: w, preflight: pre, audits, note: 'audit exceeded 10-finding ceiling' })
+		log(`wave ${w}: audit produced ${totalFiled} findings (>10 ceiling). Halting for human review — likely a real regression cluster or noisy auditors.`)
+		break
+	}
+	if (totalFiled === 0) dryAuditRounds++
+	else dryAuditRounds = 0
+
+	// ---- Triage (bug/polish manifest) ----
+	phase('Triage')
+	let manifest = []
+	if (filed.length) {
+		const triage = await agent(triagePrompt(w, filed), {
+			agentType: 'problem-triager',
+			phase: 'Triage',
+			schema: TRIAGE_SCHEMA,
+			label: `triage:w${w}`,
+		})
+		manifest = (triage.manifest || []).map((m) => ({
+			issue: m.issue,
+			slice: m.slice,
+			hotspot: m.hotspot,
+			priority: m.priority,
+			kind: 'bug',
+			builder: 'area-fixer',
+			title: '',
+		}))
+		log(`wave ${w} triage: ${manifest.length} fix(es) in manifest, ${(triage.rejected || []).length} rejected.`)
+	}
+
+	// ---- Select feature + dist batches (independent of audit) ----
+	phase('Select')
+	let featItems = []
+	let distItems = []
+	if (cfg.includeFeatures && (pre.openFeatM3 || 0) > 0) {
+		const sel = await agent(featSelectPrompt(w, cfg.featBatchPerWave, cfg.featMilestone), {
+			phase: 'Select',
+			schema: SELECT_SCHEMA,
+			label: `select-feat:w${w}`,
+		})
+		featItems = (sel.items || []).map((it) => ({ ...it, kind: 'feat', builder: 'claude' }))
+	}
+	if (cfg.includeDist && (pre.openDist || 0) > 0) {
+		const sel = await agent(distSelectPrompt(w, cfg.distBatchPerWave), {
+			phase: 'Select',
+			schema: SELECT_SCHEMA,
+			label: `select-dist:w${w}`,
+		})
+		distItems = (sel.items || []).map((it) => ({ ...it, kind: it.kind || 'dist', builder: 'claude' }))
+	}
+
+	// Combine: bugs first (highest signal), then features, then dist. Enforce ≤1/hotspot + ceiling.
+	const combined = [...manifest, ...featItems, ...distItems]
+	const { selected: workItems, deferred } = pickWork(combined, cfg.buildCeiling)
+	log(
+		`wave ${w} work: ${workItems.length} item(s) [${workItems.map((i) => '#' + i.issue + '/' + i.kind).join(', ') || 'none'}]${
+			deferred.length ? `; deferred ${deferred.length} (hotspot/ceiling)` : ''
+		}.`,
+	)
+
+	if (workItems.length === 0) {
+		run.waves.push({ wave: w, preflight: pre, audits, note: 'no actionable work this wave' })
+		if (filed.length === 0 && dryAuditRounds >= 2) {
+			run.stoppedBecause = 'idle'
+			log(`wave ${w}: nothing to build and ${dryAuditRounds} dry audit rounds — pipeline idle. Done.`)
+			break
+		}
+		continue
+	}
+
+	// ---- Build → Review pipeline (per item, no barrier) ----
+	phase('Build')
+	const results = await pipeline(
+		workItems,
+		(item) =>
+			agent(item.builder === 'area-fixer' ? fixerPrompt(item, w) : featureBuilderPrompt(item, w), {
+				agentType: builderAgentType(item),
+				isolation: 'worktree',
+				phase: 'Build',
+				schema: BUILD_SCHEMA,
+				label: `build:#${item.issue}/${item.kind}`,
+			}),
+		(build, item) => reviewAndMaybeRefix(build, item, w),
+	)
+
+	// Tally this wave.
+	const waveOpened = []
+	const waveMerged = []
+	const waveUnresolved = []
+	results.filter(Boolean).forEach((r) => {
+		if (r.build && r.build.prOpened) waveOpened.push(r.build.prOpened)
+		const o = r.review && r.review.outcome
+		if (o === 'approve') waveMerged.push(r.build.prOpened)
+		else if (r.build && r.build.prOpened) waveUnresolved.push(r.build.prOpened)
+	})
+	run.prsOpened.push(...waveOpened)
+	run.merged.push(...waveMerged)
+	run.unresolvedPRs.push(...waveUnresolved)
+	log(`wave ${w} review: ${waveOpened.length} PR(s) opened, ${waveMerged.length} approved/auto-merge-queued, ${waveUnresolved.length} unresolved.`)
+
+	// ---- M4 release-readiness gate ----
+	let releaseGate = null
+	if (cfg.includeDist) {
+		phase('Release gate')
+		releaseGate = await agent(releaseGatePrompt(w), {
+			phase: 'Release gate',
+			schema: RELEASE_GATE_SCHEMA,
+			label: `release-gate:w${w}`,
+		})
+		log(`wave ${w} release gate: releaseReady=${releaseGate.releaseReady}${releaseGate.blockers && releaseGate.blockers.length ? `; blockers: ${releaseGate.blockers.length}` : ''}.`)
+	}
+
+	run.waves.push({
+		wave: w,
+		preflight: pre,
+		filed,
+		manifest: manifest.map((m) => m.issue),
+		featSelected: featItems.map((i) => i.issue),
+		distSelected: distItems.map((i) => i.issue),
+		opened: waveOpened,
+		merged: waveMerged,
+		unresolved: waveUnresolved,
+		releaseGate,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FINAL REPORT
+// ---------------------------------------------------------------------------
+phase('Report')
+const finalGate = await agent(finalGatePrompt(), {
+	phase: 'Report',
+	schema: PREFLIGHT_SCHEMA,
+	label: 'final-polish-gate',
+})
+
+const dedupe = (a) => Array.from(new Set(a))
+const summary = {
+	stoppedBecause: run.stoppedBecause,
+	wavesRun: run.waves.length,
+	issuesFiled: dedupe(run.issuesFiled),
+	prsOpened: dedupe(run.prsOpened),
+	mergedOrQueued: dedupe(run.merged),
+	unresolvedPRs: dedupe(run.unresolvedPRs).filter((p) => !run.merged.includes(p)),
+	finalPolished: finalGate.polished,
+	finalPolishChecks: finalGate.polishChecks || [],
+	openP0: finalGate.openP0,
+	openBugs: finalGate.openBugs,
+	openFeatM3: finalGate.openFeatM3,
+	openFixPRs: finalGate.openFixPRs,
+}
+
+log(
+	`DONE — stopped: ${summary.stoppedBecause} | waves: ${summary.wavesRun} | filed: ${summary.issuesFiled.length} | PRs opened: ${summary.prsOpened.length} | merged/queued: ${summary.mergedOrQueued.length} | unresolved: ${summary.unresolvedPRs.length} | polished: ${summary.finalPolished}`,
+)
+
+return summary

--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,11 @@ linux/flatpak/.cache/
 *.swo
 
 # Claude Code workspace artifacts (batch plans, worktree metadata, etc.)
-# We DO track .claude/agents/ and .claude/commands/ — they are how the
-# agentic-audit pipeline ships to the team. Everything else under .claude/
-# is local scratch. Pattern note: we use `.claude/*` (not `.claude/`) so
-# git can re-include subdirectories via `!` exceptions below.
+# We DO track .claude/agents/, .claude/commands/, and .claude/workflows/ —
+# they are how the agentic pipeline ships to the team. Everything else under
+# .claude/ is local scratch. Pattern note: we use `.claude/*` (not `.claude/`)
+# so git can re-include subdirectories via `!` exceptions below.
 .claude/*
 !.claude/agents/
 !.claude/commands/
+!.claude/workflows/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,220 @@ Per workspace-level CLAUDE.md and the user's global rules: never add
 messages, PR descriptions, issue comments, or any public context.
 Everything is authored by the user (skalthoff).
 
+## Feature-burn campaign — the reviewer-calibration bug (Jun 2026)
+
+Big M3 feature push (`drive` with `auditEvery:0, ciGated:false, buildCeiling:7,
+builderModel:opus`). Builders worked great — every wave produced mergeable, green-CI PRs
+(`gate=pass`). But **throughput cratered to ~0 merges/wave** and runs kept self-stopping
+`idle` with the backlog barely moving. Root cause (found by reading a run's journal:
+`BUILD→REVIEW(request-changes)→refix→REVIEW(request-changes)` on every PR, 7/7):
+
+- **The adversarial-reviewer rejected essentially everything — including a literal 2-line
+  dict fix.** The cause is the reviewer prompt/agent-def framing: *"Approving is the
+  exception, not the default"* + *"emit one finding per category; silence is not valid."*
+  That turns the 8-category checklist into a **quota** — the reviewer manufactures a
+  finding to avoid "rubber-stamping," so correct PRs get `request-changes` forever. The
+  drive workflow's review prompt now **OVERRIDES** that default with an explicit
+  CALIBRATION block: approve when (1) diff does what the issue asks, (2) scope-locked,
+  (3) CI green/pending, (4) you cannot cite a CONCRETE file:line defect; the 8 categories
+  are a LENS, not a quota; do NOT reject for "could add a test" on trivial/UI changes,
+  style, or hypotheticals. After this change the SAME reviewer agent approved 7/7 of the
+  same PRs (all genuinely correct) — and still legitimately caught real defects when
+  present (e.g. it earlier rejected #913 for a falsified "tests added" claim + a wrong
+  uninstall path). Calibration ≠ rubber-stamp.
+  NOTE: the shared `.claude/agents/adversarial-reviewer.md` keeps the strict default on
+  purpose (it's right for the single-issue bug pipeline / `/desktop-review`); the override
+  lives in the drive workflow prompt only.
+
+- **"Commits not landing" was a MERGE-gap, not a build-gap.** The builders committed +
+  opened mergeable green PRs every time; they just never reached `approve`→auto-merge
+  because the reviewer never approved and runs died mid-review-round (e.g. 36 started /
+  29 results = 7 agents cut off). Diagnose merge stalls by checking review *outcomes* in
+  the journal, not whether PRs exist.
+
+- **`gh pr review --approve` self-approval is blocked when PR author == the merging user
+  (skalthoff).** A reviewer agent's approve call fails; the merge still works via
+  `gh pr merge <n> --squash [--auto] --delete-branch`. Have reviewers merge directly
+  rather than relying on a separate --approve gate for self-authored PRs.
+
+- **Tar-pit PRs stall every relaunch.** Conflicting/DIRTY or repeatedly-rejected PRs make
+  the resolve-open-PRs phase burn whole waves re-trying the unfixable, then stop `idle`
+  with features untouched. Before each relaunch, CLOSE such PRs (their issue stays open →
+  rebuilt clean next wave); keep only mergeable+green+unreviewed ones. Now enforced in the
+  babysitter prompt.
+
+## HYPER / CI-gated campaign — findings (Jun 2026)
+
+Third campaign: `drive` with `ciGated:true` + `builderModel:opus`, args `{maxWaves:30,
+buildCeiling:14, backlogBatch:20, auditEvery:5}`, run across a 9h unlimited-token
+window via the ~45-min babysitter (relaunched once after a mid-run death). The idea:
+move the CPU-bound build gate OFF the local 10-core box onto GitHub Actions so local
+agents reason→edit→push fast and cloud CI verifies in parallel. **MEASURED (git/gh
+truth): ~10 PRs merged overnight (#879 #881 #877 #885 #887 #893 #894 #898 #900 #903 —
+incl. the release-prerelease fix and a Library filter popover), 0 junk closed.** But at
+wind-down **14 PRs sat open and NONE were mergeable: 10 failing CI, 2 conflicting, 2
+pending, 0 reviewed.** Findings:
+
+- **CI-gated mode trades local-compile time for a red-PR pileup.** Because builders skip
+  the local `swift build`/`cargo` gate, a large fraction of pushed PRs fail CI (the
+  `macOS app` job most often). Throughput per *merged* PR did NOT clearly beat the local-
+  build mode — the work just moved from "agent waits on compile" to "PR sits red waiting
+  for a builder to come back and fix CI." Builders rarely came back (the run died / moved
+  on), so red PRs accumulated. **Verdict: only worth it if the refix loop aggressively
+  re-drives red-CI PRs; otherwise local-build mode lands a higher fraction of what it opens.**
+
+- **Builders outrun the single serial reviewer, badly, at buildCeiling:14.** 14 PRs open,
+  0 reviewed at stop. The reviewer is the bottleneck; opening more PRs just grows an
+  unreviewed+unmergeable queue. Keep buildCeiling near the review throughput (≈ the agent
+  cap, 8), not above it.
+
+- **`gh issue list --label X` / `--search 'label:"X"'` intermittently returns `[]` (no
+  error) on this box mid-session**, making the backlog look drained (0/0/0) when it is NOT.
+  ALWAYS cross-check by pulling the full open list and aggregating labels client-side
+  (`gh issue list --state open --limit 200 --json labels --jq ...`). The full-list read is
+  trustworthy; the filtered read is not. (Bit my own wind-down report — reported 0 bugs
+  when there were 4 + 83 open M3.)
+
+- **FFI-adjacent PRs can't skip the local build** — they must regen the xcframework +
+  bindings and commit them, or CI goes red on stale bindings. Confirm those builders
+  actually ran `build-core.sh` before trusting their green.
+
+- **Stale `wf_*-N` worktrees hit 99.** `git worktree prune` + remove abandoned ones is now
+  overdue; keep only those backing a still-open PR.
+
+- **Poisoned SwiftPM cache breaks `main` CI reproducibly (not a flake).** Symptom: the
+  `macOS app` CI job fails with `error: XCFramework Info.plist not found at
+  .build/artifacts/sparkle/Sparkle/Sparkle.xcframework` while `test (macos-15)` passes.
+  Cause: ci.yml caches `macos/.build` keyed on `hashFiles(Package.swift, Package.resolved)`;
+  when those files don't change, every run restores a `.build` that references Sparkle's
+  artifact path without the extracted xcframework present → dangling ref. Reruns fail
+  identically (it is NOT transient). Fix: bust the cache —
+  `gh cache list --json key --jq '.[]|select(.key|test("spm";"i")).key'` then
+  `gh cache delete <key>` for each, and re-run; the cache-less rebuild resolves Sparkle
+  clean. Permanent fix (TODO): add Sparkle's resolved revision (or a manual bump input) to
+  the cache key, or `rm -rf .build` unconditionally when the restored cache lacks
+  `.build/artifacts/sparkle/.../Sparkle.xcframework/Info.plist`.
+
+## Overnight opus campaign — findings (May 2026)
+
+Second campaign: `drive` with `builderModel: opus` (all bug-fixers + feature-
+builders + in-place PR refixers on Opus; reviewer stayed Sonnet-first + Opus-
+on-dispute — wired via the new `cfg.builderModel`/`cfg.reviewModel`). Args
+`{maxWaves:14, buildCeiling:8, backlogBatch:16, builderModel:'opus'}`. Ran
+unattended via a ~45-min ScheduleWakeup babysitter (check-alive →
+relaunch-if-dead → stop-on-drain). **MEASURED result (git/gh truth, not the
+workflow's self-report): 4 PRs merged to main (#865, #867, #875, #876 — two of
+which, #865/#867, were stalled in-flight PRs the run finished), 1 junk closed
+(#871), 6 left open unreviewed (#877, #878, #879, #880, #881, #885); backlog p0 2→1
+(audio p0 #848 cleared via #867; only #431 DB-cache XL feat remains), bugs 8→9
+(audit filed new ones), M3 feats 30→30. main green throughout.** The honest read:
+the overnight run mostly *finished what was already in flight* and barely moved
+the feature backlog. Findings explaining why:
+
+- **`budget-exhausted` is the binding constraint, NOT the wave cap.** At ~1.3M
+  tok/wave, Opus drains the turn's shared token pool in a handful of waves
+  regardless of `maxWaves:14`. The run self-stopped on budget; net new
+  throughput per launch is only ~2-4 merges. To actually grind a big backlog
+  overnight you need the babysitter to RELAUNCH repeatedly (each launch = fresh
+  budget) AND you must accept the spend — a single launch does little.
+
+- **Opus didn't obviously out-yield Sonnet here.** Merges/launch were similar to
+  the Sonnet runs; the bottleneck was budget + review throughput, not builder
+  model quality. Don't assume "Opus = more shipped" — for drain campaigns the
+  limiter is token budget and the single-reviewer serialization, not codegen IQ.
+  Reserve Opus builders for genuinely hard core/FFI changes; Sonnet is fine for
+  the UI bulk and far cheaper per wave.
+
+- **Review is the throughput bottleneck.** 6 PRs sat open unreviewed at stop —
+  builders outran the (serial, worktree-isolated) reviewer. Raising
+  `buildCeiling` without parallelizing review just grows the open-PR queue.
+
+- **Babysitter pattern works but needs explicit spend consent.** It would have
+  relaunched on the next tick (backlog remained) and kept spending. Confirm you
+  want continuous overnight spend before arming; it does not self-limit on cost,
+  only on drain/human-gated/red-main.
+
+- **Dedup risk on relaunch.** After a budget-stop, the resolve-open-PRs phase
+  must close PRs whose `Closes #n` issue already merged via another squash, or
+  two PRs race the same issue. TODO: backlog selector should cross-check open
+  PRs' linked issues against recently-merged squashes, not just open-PR topics.
+
+- **Title/junk guard still leaks under load.** Despite the conventional-commit
+  title rule, junk PRs still reached open state (the reviewer closed 3). Title +
+  no-op detection needs to be a REVIEWER checklist item, not just a builder
+  instruction — builders under load treat prompt niceties as optional.
+
+- **Stale `wf_*-N` worktrees pile up fast** — 58 now accumulated across
+  campaigns. After a run, `git worktree prune` and remove abandoned ones (keep
+  any backing an open PR). They're disk + diagnostic noise: SourceKit indexes
+  them, producing the "No such module 'LyrebirdCore'" / "Cannot find Theme/
+  AppModel" cascades that look alarming but are just unbuilt worktrees — always
+  confirm against `main` CI before treating a diagnostic as breakage.
+
+- **Trust git/gh, not the workflow's self-tally.** The run's structured summary
+  over-counted merges (counted `--auto`-queued PRs that never landed, and
+  re-counted in-flight ones). Always reconcile the final report against
+  `git log origin/main` + `gh pr list --state merged` before believing numbers.
+
+## Workflow-driven campaigns — lessons (May 2026)
+
+Two deterministic orchestration scripts now live in `.claude/workflows/`:
+`drive-lyrebird-desktop.js` (resolve open PRs → drain the real open backlog:
+bugs p0→p2 then M3 feats → periodic audit → build → adversarial review →
+auto-merge) and `finalize-lyrebird-desktop.js` (audit-driven; same back half).
+Prefer **drive** to actually move the backlog; finalize only fixes
+freshly-audited bugs. Run via `Workflow({scriptPath, args:{maxWaves,
+buildCeiling, backlogBatch}})`. Lessons from the first campaign (8 PRs merged:
+#849 #62 #108 #856 #64 #342 #860 #850 — incl. the Mini Player p0):
+
+- **Concurrency cap = `min(16, cores−2)`** (8 on this 10-core box). Set
+  `buildCeiling` = the cap; more builders than cores just thrash — `cargo`/
+  `swift` compiles are CPU-bound. Do **not** run two workflows on this repo at
+  once (oversubscribes CPU + collides on hotspots/PRs). "More agents" past the
+  core count is a loss, not a win.
+
+- **CI gates auto-merge, so `main` stays green.** `--squash --auto` only lands
+  on green CI; nothing red merged across the whole campaign. This is the load-
+  bearing safety property — rely on it rather than reasoning about each merge.
+
+- **`.wave-start` / `wave-budget.sh` is broken for these runs.** The preflight
+  agent writes `.wave-start` as `key=value` lines; `wave-budget.sh remaining`
+  parses two space-separated ints (`awk '{print $2}'`) → returns 0 → reads as
+  "expired" → `area-fixer` (≤1800s) and `problem-triager` (≤600s) abort. Both
+  workflows now tell downstream agents to **ignore the wave-budget gate** (the
+  JS wave-cap + token budget govern). If you invoke those agents outside these
+  workflows, run `Scripts/wave-budget.sh start 14400` first or tell them to
+  ignore it.
+
+- **Background runs die mid-flight** (turn end, user interrupt, multi-hour
+  runtime). Recovery is cheap: relaunch `drive` — its wave-1 *resolve-open-PRs*
+  phase re-reviews/refixes/merges whatever was left in flight, and it re-reads
+  the live backlog, so nothing is lost. `finalize` also supports
+  `resumeFromRunId` (cached prefix replays instantly, no duplicate issue filing).
+
+- **Builder quality failures to guard:** agents have leaked internal monologue
+  into PR titles (e.g. #872 "wait. these aren't matching…") and opened
+  near-duplicate follow-up PRs on a topic already covered. The adversarial
+  reviewer + resolve-open-PRs phase self-heal (merge good, **close** junk), but
+  builder prompts now require a conventional-commit one-line title.
+
+- **Core hotspots drain slowly.** `client.rs` / `models.rs` / `state` /
+  `tests.rs` allow ≤1 in-flight item per hotspot — enforced in JS (`pickWork`),
+  not `area-lock.sh` (which doesn't coordinate across isolated worktrees).
+  Expect ~1 core fix per wave; UI/screens/components parallelize freely.
+
+- **Red diagnostics are usually environmental.** "No such module 'LyrebirdCore'"
+  + cascading "cannot find AppModel/Theme/…" in a worktree just means it was
+  never built (`./macos/Scripts/build-core.sh && (cd macos && swift build)` to
+  clear). An in-progress builder worktree can momentarily show real syntax
+  errors mid-edit — ignore unless they reach a PR (CI catches those). Always
+  confirm against `main` CI before treating a diagnostic as breakage.
+
+- **Stale worktrees accumulate** under `.claude/worktrees/wf_*-N/` — one per
+  builder. Unchanged ones auto-clean; changed ones persist. `git worktree
+  prune` + remove abandoned ones periodically, but never those backing an open
+  PR (e.g. the `fix/848-*`, `fix/861-*` branches still in flight).
+
 ## Runtime gaps — common patterns
 
 Catalogued during the April 2026 audit sweep. Recurring shapes to check

--- a/docs/agentic-pipeline.md
+++ b/docs/agentic-pipeline.md
@@ -1,0 +1,123 @@
+# Agentic pipeline — operations playbook
+
+How the multi-agent dev pipeline for lyrebird-desktop is run, what the knobs
+mean, and the failure modes learned the hard way. The narrative campaign logs
+live in `CLAUDE.md` ("… campaign — findings" sections); this file is the
+durable **how-to-run** reference. The orchestration scripts themselves are
+tracked under `.claude/workflows/`.
+
+## The two workflows
+
+- **`.claude/workflows/drive-lyrebird-desktop.js`** — the workhorse. Each wave:
+  resolve open agent PRs → (optionally) audit for regressions → triage → select
+  real open backlog (bugs p0→p2, then M3 features) → build → adversarial review
+  (≤2 refix rounds) → auto-merge. Use this to actually move the backlog.
+- **`.claude/workflows/finalize-lyrebird-desktop.js`** — audit-driven; only fixes
+  freshly-audited bugs + a feature track. Narrower; prefer `drive`.
+
+Run with `Workflow({scriptPath: ".../.claude/workflows/drive-lyrebird-desktop.js", args: {...}})`.
+
+## Config knobs (drive)
+
+| arg | meaning | good default |
+| --- | --- | --- |
+| `maxWaves` | hard wave cap | 40 (token budget stops it first) |
+| `buildCeiling` | max PRs opened per wave | **≈ review throughput (6–8)**, NOT higher |
+| `backlogBatch` | candidate issues pulled per wave | 16–18 |
+| `builderModel` | model for builders + refixers | `opus` for features/core; `sonnet` fine for UI bulk |
+| `reviewModel` | first-pass reviewer | `sonnet` (+ opus on dispute) |
+| `auditEvery` | audit every Nth wave; `0` = never | `0` for a pure feature push; `4–5` otherwise |
+| `ciGated` | builders skip local compile, rely on GH Actions | **`false`** (see CI-gated finding) |
+| `includeDist` | pull M4 dist work | `false` unless intentionally on dist |
+
+### Recommended recipes
+
+- **Feature push:** `{auditEvery:0, ciGated:false, buildCeiling:7, backlogBatch:18, builderModel:'opus', includeDist:false}`
+- **Bug/regression drain:** `{auditEvery:4, buildCeiling:8, builderModel:'sonnet'}`
+
+## The hard-won rules
+
+1. **Concurrency cap = `min(16, cores−2)`** (8 on the 10-core box). `cargo`/`swift`
+   compiles are CPU-bound; more builders than cores thrash. Never run two
+   workflows against this repo at once. Set `buildCeiling` ≤ the cap.
+
+2. **Review is the bottleneck, and reviewer calibration is load-bearing.** The
+   single serial reviewer caps throughput — raising `buildCeiling` above it just
+   grows an unreviewed queue. Worse: the stock `adversarial-reviewer.md` framing
+   ("approving is the exception", "one finding per category") makes the reviewer
+   **manufacture rejections on correct PRs** (it once rejected a 2-line dict fix,
+   7/7 PRs `request-changes`, ~0 merges/wave). The `drive` review prompt now
+   **overrides** that with a calibration block: approve when the diff does what
+   the issue asks + scope-locked + CI green + no concrete file:line defect; the
+   8 categories are a *lens, not a quota*. After calibration the same agent
+   approved 7/7 correct PRs **and** still caught real defects (falsified test
+   claims, wrong paths). The shared agent-def keeps the strict default for the
+   single-issue bug pipeline / `/desktop-review`.
+
+3. **CI gates auto-merge, so `main` stays green.** `--squash --auto` only lands on
+   green CI. Lean on this rather than reasoning about each merge.
+
+4. **"Commits not landing" is usually a MERGE-gap, not a build-gap.** Builders
+   commit + open mergeable green PRs reliably; stalls happen at review→merge.
+   Diagnose by reading review *outcomes* in the run journal
+   (`subagents/workflows/wf_*/journal.jsonl`), not by whether PRs exist.
+
+5. **`ciGated:true` underperforms.** Skipping the local build just moves the cost
+   to a red-PR pileup (most PRs fail the `macOS app` CI job and sit there unless a
+   builder re-drives them). Local-build mode lands a higher fraction of what it
+   opens. FFI-adjacent PRs *cannot* skip local build anyway — they must regen +
+   commit the xcframework/bindings or CI goes red on stale bindings.
+
+6. **Tar-pit PRs stall every relaunch.** Conflicting/`DIRTY` or repeatedly-rejected
+   PRs make the resolve-open-PRs phase burn whole waves, then stop `idle` with the
+   backlog untouched. Before relaunch, **close** them (the issue stays open → rebuilt
+   clean); keep only mergeable+green+unreviewed. Enforced in the babysitter prompt.
+
+7. **Self-approval is blocked** when the PR author == the merging user. A reviewer
+   agent's `gh pr review --approve` fails on self-authored PRs; merge directly with
+   `gh pr merge <n> --squash [--auto] --delete-branch`.
+
+8. **Trust git/gh, not the workflow self-tally.** Runs over-count merges (count
+   `--auto`-queued PRs that never landed). Reconcile against `git log origin/main`
+   + `gh pr list --state merged`.
+
+9. **`gh issue list --label X` intermittently returns `[]` with no error** on this
+   box. Count the backlog by pulling the full open list and aggregating client-side:
+   `gh issue list --state open --limit 250 --json labels,milestone --jq '[.[]|{f:([.labels[].name]|any(.=="kind:feat")),m3:(.milestone.title=="M3 — macOS polish")}]|"M3feat=\([.[]|select(.f and .m3)]|length)"'`
+
+10. **Red SourceKit diagnostics are usually environmental.** "No such module
+    'LyrebirdCore'/'Nuke'", "Cannot find Theme/AppModel" come from unbuilt builder
+    worktrees, not `main`. Confirm against `main` CI before treating as breakage.
+
+## Overnight (babysitter) pattern
+
+A `ScheduleWakeup` every ~45 min: check the run is alive + `main` green, relaunch
+if dead (each relaunch = fresh token budget; wave-1 resolve-open-PRs recovers
+in-flight work losslessly), close tar-pit PRs first, and **stop** on backlog drain
+/ human-gated-only / red-`main`-for-a-non-cache-reason. It does **not** self-limit
+on cost — confirm you want continuous overnight spend before arming.
+
+## Known infra gotchas
+
+- **Poisoned SwiftPM cache breaks `main` CI reproducibly** (not a flake). Symptom:
+  `macOS app` job fails `error: XCFramework Info.plist not found at
+  .build/artifacts/sparkle/Sparkle/Sparkle.xcframework` while `test (macos-15)`
+  passes. Cause: ci.yml caches `macos/.build` keyed on `hashFiles(Package.swift,
+  Package.resolved)`; unchanged files restore a `.build` with a dangling Sparkle
+  ref. Fix: `gh cache list --json key --jq '.[]|select(.key|test("spm";"i")).key'`
+  → `gh cache delete <key>` each → re-run. Permanent fix (TODO): add Sparkle's
+  resolved revision to the cache key.
+
+- **Stale `wf_*-N` worktrees pile up** (one per builder; hit 99). `git worktree
+  prune` + remove abandoned ones periodically — never those backing an open PR.
+
+- **`@`-in-prose makes GitHub @mentions.** Swift property wrappers (`@State`,
+  `@MainActor`) in PR/issue/commit text get linkified. Backtick them in bodies;
+  drop the `@` in titles. Now in the builder + auditor prompts.
+
+## Release builds
+
+Push a `v*` tag → `.github/workflows/macos-release.yml` signs + notarizes + publishes
+a DMG (all Apple secrets are configured in the repo). Pre-release tags
+(`-rc`/`-beta`) are marked pre-release by the workflow (fixed; previously grabbed
+"Latest"). See `docs/GITHUB-SECRETS.md`.


### PR DESCRIPTION
Captures the operational learnings from the overnight multi-agent campaigns in a durable, tracked form, and ships the orchestration scripts with the repo.

## What
- **`docs/agentic-pipeline.md`** — how to run the `drive`/`finalize` workflows, what each config knob means (with recommended recipes), and the failure modes learned the hard way:
  - reviewer **calibration** (the stock "approving is the exception" framing made the reviewer reject correct PRs on a quota → ~0 merges/wave; the drive prompt now overrides it)
  - the **merge-gap vs build-gap** distinction (commits land as PRs but stall at review→merge)
  - **`ciGated` tradeoff** (skipping local build just moves cost to a red-PR pileup)
  - **tar-pit PRs** (conflicting/rejected PRs stall every relaunch — close before relaunch)
  - **poisoned SwiftPM cache** breaking `main` CI reproducibly + the bust-the-cache fix
  - **`gh --label` flakiness** (returns `[]` silently — aggregate the full list instead)
  - self-approval block, trust git/gh over the self-tally, environmental SourceKit diagnostics
- **Track `.claude/workflows/`** (un-ignore in `.gitignore`) so `drive-lyrebird-desktop.js` and `finalize-lyrebird-desktop.js` ship with the repo like `agents/` and `commands/` already do. These were previously local-scratch and would vanish on a `.claude` clean.
- Record the **`@`-in-prose escape rule** in the auditor/fixer agent defs (bare `@State` in PR/issue text becomes a GitHub @mention).
- Consolidate the campaign findings in `CLAUDE.md`.

## Why
The detailed playbook only existed as uncommitted notes on a worktree branch plus gitignored `.js` files — not durable. This makes it part of the canonical history so future sessions (and the team) inherit the hard-won operating knowledge instead of re-learning it.

Docs + tooling only; no app code changes.