### PR TITLE
macOS 2.0 — Wave 1: ambient palette, gapless, Artists-You-Love, haptics, a11y, diagnostics

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1187,6 +1187,15 @@ impl LyrebirdCore {
         self.player.skip_next()
     }
 
+    /// The track [`Self::skip_next`] would return next, without advancing the
+    /// queue. Lets the platform audio engine pre-load the upcoming item for
+    /// gapless playback while the current track is still playing. Honours the
+    /// current [`RepeatMode`] so the pre-loaded track always matches what
+    /// actually plays at end-of-track. See issue #931.
+    pub fn peek_next(&self) -> Option<Track> {
+        self.player.peek_next()
+    }
+
     pub fn skip_previous(&self) -> Option<Track> {
         self.player.skip_previous()
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -186,6 +186,34 @@ impl Player {
         }
     }
 
+    /// The track [`Player::skip_next`] *would* return, without mutating the
+    /// queue index or `current`. Lets the platform audio engine pre-load the
+    /// upcoming item for gapless playback while the current track is still
+    /// playing.
+    ///
+    /// Mirrors `skip_next`'s [`RepeatMode`] semantics exactly so the pre-loaded
+    /// track is always the one that actually plays next:
+    /// * [`RepeatMode::One`] — the current track (it replays in place).
+    /// * [`RepeatMode::Off`] — the next sequential track, or `None` at the
+    ///   end of the queue.
+    /// * [`RepeatMode::All`] — wraps to the first track at the end of the
+    ///   queue.
+    ///
+    /// See issue #931.
+    pub fn peek_next(&self) -> Option<Track> {
+        let s = self.shared.lock();
+        if matches!(s.repeat_mode, RepeatMode::One) {
+            return s.queue.get(s.queue_index).cloned();
+        }
+        if s.queue_index + 1 < s.queue.len() {
+            s.queue.get(s.queue_index + 1).cloned()
+        } else if matches!(s.repeat_mode, RepeatMode::All) && !s.queue.is_empty() {
+            s.queue.first().cloned()
+        } else {
+            None
+        }
+    }
+
     /// Step back to the previous track in the queue. Returns `Some(track)` on
     /// success and updates `current` so that `status()` immediately reflects
     /// the new track.
@@ -710,5 +738,80 @@ mod tests {
         );
         assert_eq!(player.status().current_track.unwrap().id, "a");
         assert_eq!(player.status().queue_position, 0);
+    }
+
+    // ---- #931: peek_next mirrors skip_next without mutating the queue ----
+
+    #[test]
+    fn peek_next_returns_upcoming_track_without_advancing() {
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+
+        let peeked = player.peek_next().expect("should peek the next track");
+        assert_eq!(peeked.id, "b");
+        // The peek is read-only: current and queue_position are untouched, so a
+        // subsequent skip_next still lands on the same track.
+        assert_eq!(player.status().current_track.unwrap().id, "a");
+        assert_eq!(player.status().queue_position, 0);
+        assert_eq!(player.skip_next().unwrap().id, "b");
+    }
+
+    #[test]
+    fn peek_next_matches_skip_next_across_repeated_calls() {
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+        // Idempotent: peeking twice yields the same track and never advances.
+        assert_eq!(player.peek_next().unwrap().id, "b");
+        assert_eq!(player.peek_next().unwrap().id, "b");
+        assert_eq!(player.status().queue_position, 0);
+    }
+
+    #[test]
+    fn peek_next_returns_none_at_end_when_repeat_off() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 1).unwrap();
+        player.set_repeat_mode(RepeatMode::Off);
+        assert!(
+            player.peek_next().is_none(),
+            "RepeatMode::Off at end-of-queue has nothing to pre-load"
+        );
+    }
+
+    #[test]
+    fn peek_next_wraps_to_first_when_repeat_all() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 1).unwrap();
+        player.set_repeat_mode(RepeatMode::All);
+        let peeked = player.peek_next();
+        assert_eq!(
+            peeked.unwrap().id,
+            "a",
+            "RepeatMode::All must pre-load the wrap-around track"
+        );
+        // Still read-only.
+        assert_eq!(player.status().queue_position, 1);
+    }
+
+    #[test]
+    fn peek_next_returns_current_when_repeat_one() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 0).unwrap();
+        player.set_repeat_mode(RepeatMode::One);
+        let peeked = player.peek_next();
+        assert_eq!(
+            peeked.unwrap().id,
+            "a",
+            "RepeatMode::One replays in place, so the upcoming track is current"
+        );
+    }
+
+    #[test]
+    fn peek_next_on_empty_queue_is_none() {
+        let player = Player::new();
+        assert!(player.peek_next().is_none());
     }
 }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -5247,10 +5247,22 @@ final class AppModel {
         }
     }
 
-    private func playCurrent(_ track: Track) {
+    private func playCurrent(_ track: Track, armPreload: Bool = false) {
         Task {
             do {
                 try await audio.play(track: track)
+                // `play(track:)` builds a fresh single-item `AVQueuePlayer`,
+                // so any previously pre-loaded next item is gone. On a normal
+                // end-of-track advance, re-arm the gapless path now that the
+                // new player exists by pre-inserting the upcoming track — same
+                // selection the engine would otherwise pick when this track
+                // ends (#931). Only the advance path opts in; manual skips and
+                // the ⌘-Space restart build their player the same way but the
+                // poll loop re-arms via `audioEngineDidRecover` only on stall
+                // recovery, so leaving them off keeps this change scoped.
+                if armPreload {
+                    armNextTrackPreload()
+                }
             } catch {
                 if handleAuthError(error) { return }
                 errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
@@ -5258,10 +5270,42 @@ final class AppModel {
         }
     }
 
+    /// The track the engine should pre-load for gapless playback after the
+    /// current one: the user-added "Up Next" overlay takes precedence over the
+    /// auto-queue tail, matching the order the engine advances through. Shared
+    /// by the end-of-track advance (`handleTrackEnded`) and stall recovery
+    /// (`audioEngineDidRecover`) so both arm the same item. See #931.
+    private var nextTrackForPreload: Track? {
+        upNextUserAdded.first?.track ?? upNextAutoQueue.first?.track
+    }
+
+    /// Arm the engine's gapless pre-load for whatever comes after the current
+    /// track. A no-op when the queue holds nothing further (end of queue), in
+    /// which case the engine simply has no item to splice ahead. Single source
+    /// of truth shared by the normal advance and stall recovery (#931).
+    private func armNextTrackPreload() {
+        guard let next = nextTrackForPreload else { return }
+        audio.preloadNextTrack(next)
+    }
+
+    #if DEBUG
+    /// Test seam: run the exact gapless-arming step the normal end-of-track
+    /// advance performs once `play(track:)` has settled. Lets a test prove the
+    /// advance re-arms the pre-load without driving the async `play(track:)`
+    /// path (which throws un-authed before the arm would run). See #931.
+    func armNextTrackPreloadForTesting() {
+        armNextTrackPreload()
+    }
+    #endif
+
     private func handleTrackEnded() {
-        // Advance to the next track in the queue if there is one.
+        // Advance to the next track in the queue if there is one. Arm the
+        // gapless pre-load for the track *after* this new one so the next
+        // end-of-track transition is seamless — without this the freshly
+        // built single-item player never has a queued-ahead item and every
+        // advance falls back to the gap-prone play(track:) rebuild (#931).
         if let next = core.skipNext() {
-            playCurrent(next)
+            playCurrent(next, armPreload: true)
             return
         }
         // Queue ran dry. When "autoplay similar music when queue ends" is on
@@ -6114,10 +6158,7 @@ extension AppModel: AudioEngineDelegate {
     /// user-added "Up Next" overlay takes precedence over the auto-queue
     /// tail, matching the order the engine would otherwise advance through.
     func audioEngineDidRecover() {
-        guard let next = upNextUserAdded.first?.track ?? upNextAutoQueue.first?.track else {
-            return
-        }
-        audio.preloadNextTrack(next)
+        armNextTrackPreload()
     }
 }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -5271,12 +5271,22 @@ final class AppModel {
     }
 
     /// The track the engine should pre-load for gapless playback after the
-    /// current one: the user-added "Up Next" overlay takes precedence over the
-    /// auto-queue tail, matching the order the engine advances through. Shared
-    /// by the end-of-track advance (`handleTrackEnded`) and stall recovery
+    /// current one. Read straight from the core queue's lookahead
+    /// (`core.peekNext()`) — the track `skipNext()` would return next — so the
+    /// pre-loaded item is *always* the one that actually plays at end-of-track,
+    /// honouring the current repeat mode. This is the same queue the in-app
+    /// "Up Next" / auto-queue split mirrors (user "Play Next" inserts land at
+    /// `queue_index + 1`, the source tail follows), so it captures both without
+    /// depending on those overlays being kept in sync. Shared by the
+    /// end-of-track advance (`handleTrackEnded`) and stall recovery
     /// (`audioEngineDidRecover`) so both arm the same item. See #931.
+    ///
+    /// `peekNext()` is a read-only in-memory clone under the core's queue mutex
+    /// (no network, no DB) — the same cost profile as the `core.skipNext()`
+    /// call `handleTrackEnded` already makes synchronously, and it fires once
+    /// per advance rather than per-cell, so it's safe on the main actor.
     private var nextTrackForPreload: Track? {
-        upNextUserAdded.first?.track ?? upNextAutoQueue.first?.track
+        core.peekNext()
     }
 
     /// Arm the engine's gapless pre-load for whatever comes after the current
@@ -5289,10 +5299,25 @@ final class AppModel {
     }
 
     #if DEBUG
-    /// Test seam: run the exact gapless-arming step the normal end-of-track
-    /// advance performs once `play(track:)` has settled. Lets a test prove the
-    /// advance re-arms the pre-load without driving the async `play(track:)`
-    /// path (which throws un-authed before the arm would run). See #931.
+    /// Test seam: drive the end-of-track advance the way `handleTrackEnded`
+    /// does — step the core queue forward (`core.skipNext()`) and then arm the
+    /// gapless pre-load for the track after the new current one. Skips only the
+    /// async `play(track:)` rebuild (which throws un-authed and which the test's
+    /// empty player stands in for); the queue advance and the arming step are
+    /// the *production* calls, reading the same core queue `play(tracks:)`
+    /// populated. Returns the track the advance landed on (or `nil` at end of
+    /// queue) so a test can assert the playhead moved as well. See #931.
+    @discardableResult
+    func advanceAndArmPreloadForTesting() -> Track? {
+        guard let next = core.skipNext() else { return nil }
+        armNextTrackPreload()
+        return next
+    }
+
+    /// Test seam: run just the gapless-arming step (`armNextTrackPreload`)
+    /// without advancing the queue — mirrors stall recovery
+    /// (`audioEngineDidRecover`), which re-arms the pre-load for the track
+    /// after the *current* one without moving the playhead. See #931.
     func armNextTrackPreloadForTesting() {
         armNextTrackPreload()
     }
@@ -6154,9 +6179,9 @@ extension AppModel: AudioEngineDelegate {
 
     /// Stall recovery rebuilds the current item via `replaceCurrentItem`,
     /// which evicts any pre-loaded next-track item from the queue. Re-arm
-    /// gapless playback by preloading the upcoming track again — the
-    /// user-added "Up Next" overlay takes precedence over the auto-queue
-    /// tail, matching the order the engine would otherwise advance through.
+    /// gapless playback by preloading the upcoming track again — the same
+    /// core-queue lookahead (`nextTrackForPreload`) the normal end-of-track
+    /// advance uses, so both paths splice the track that actually plays next.
     func audioEngineDidRecover() {
         armNextTrackPreload()
     }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1030,6 +1030,9 @@ final class AppModel {
         artistAlbumsCache = [:]
         artistDetailCache = [:]
         resolvedNameCache = [:]
+        ambientPaletteCache.removeAll()
+        ambientPaletteTasks.values.forEach { $0.cancel() }
+        ambientPaletteTasks.removeAll()
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
@@ -1098,6 +1101,9 @@ final class AppModel {
         artistAlbumsCache = [:]
         artistDetailCache = [:]
         resolvedNameCache = [:]
+        ambientPaletteCache.removeAll()
+        ambientPaletteTasks.values.forEach { $0.cancel() }
+        ambientPaletteTasks.removeAll()
         recentlyPlayed = []
         forYou = []
         genresToExplore = []
@@ -3588,6 +3594,55 @@ final class AppModel {
         }
         imageURLCache[key] = result
         return result
+    }
+
+    // MARK: - Ambient palette (#271)
+
+    /// Per-album ambient-wash palette, memoized for the session. Keyed by
+    /// album id (or track id when an album-less track is playing) so the
+    /// Core Image sample runs **once** per cover, never per render pass —
+    /// gap pattern #2: sampling artwork on every Now Playing repaint would
+    /// burn the GPU and re-decode the image needlessly.
+    ///
+    /// Stored as the opaque `AmbientPalette.encoded` string rather than the
+    /// `Color`-bearing struct so the entry is a plain value type and survives
+    /// any future move to a persistent cache without a bespoke codable surface.
+    private var ambientPaletteCache: [String: String] = [:]
+
+    /// In-flight palette samples, so two `NowPlayingView.task` invocations for
+    /// the same id (e.g. a fast tab toggle) coalesce onto one Nuke decode +
+    /// CIAreaAverage pass instead of racing two.
+    private var ambientPaletteTasks: [String: Task<AmbientPalette?, Never>] = [:]
+
+    /// Resolve the ambient palette for a now-playing item — cache-first, then
+    /// a single off-main Nuke decode + Core Image average (`PaletteSampler`).
+    ///
+    /// Returns `nil` when there's no artwork URL or extraction fails; callers
+    /// (`NowPlayingView`) treat that as "no palette" and `AmbientWash` falls
+    /// back to the theme wash, so the player is never bare. The decode itself
+    /// runs off the MainActor inside `PaletteSampler.sample` (it `await`s
+    /// Nuke's pipeline), so this never blocks the main thread.
+    func ambientPalette(forItemId itemId: String, imageTag: String?) async -> AmbientPalette? {
+        if let encoded = ambientPaletteCache[itemId] {
+            return AmbientPalette(encoded: encoded)
+        }
+        if let existing = ambientPaletteTasks[itemId] {
+            return await existing.value
+        }
+        guard let url = imageURL(for: itemId, tag: imageTag, maxWidth: 512) else {
+            return nil
+        }
+
+        let task = Task<AmbientPalette?, Never> {
+            await PaletteSampler.sample(from: url)
+        }
+        ambientPaletteTasks[itemId] = task
+        let palette = await task.value
+        ambientPaletteTasks[itemId] = nil
+        if let palette {
+            ambientPaletteCache[itemId] = palette.encoded
+        }
+        return palette
     }
 
     // MARK: - Playback

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3865,13 +3865,13 @@ final class AppModel {
             let json = try await Task.detached(priority: .userInitiated) { [core] in
                 try core.fetchItem(
                     itemId: albumId,
-                    fields: ["People", "Studios", "PremiereDate", "DateCreated", "ProductionYear"]
+                    fields: ["People", "Studios", "PremiereDate", "DateCreated", "ProductionYear", "Overview"]
                 )
             }.value
             return Self.parseAlbumDetail(from: json)
         } catch {
             _ = handleAuthError(error)
-            return AlbumDetail(label: nil, releaseDate: nil, people: [])
+            return AlbumDetail(label: nil, releaseDate: nil, people: [], overview: nil)
         }
     }
 
@@ -3882,7 +3882,7 @@ final class AppModel {
         guard let data = json.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            return AlbumDetail(label: nil, releaseDate: nil, people: [])
+            return AlbumDetail(label: nil, releaseDate: nil, people: [], overview: nil)
         }
 
         // Jellyfin ships `Studios` as an array of `{ Name, Id }` objects. Pick
@@ -3928,7 +3928,17 @@ final class AppModel {
             }
         }()
 
-        return AlbumDetail(label: label, releaseDate: releaseDate, people: people)
+        // Editorial blurb (#68). Kept raw here — the album detail view runs it
+        // through the same HTML strip as the artist bio before display.
+        // Whitespace-only collapses to `nil` so the "About this album" section
+        // never renders an empty shell.
+        let overview: String? = {
+            guard let raw = root["Overview"] as? String else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : raw
+        }()
+
+        return AlbumDetail(label: label, releaseDate: releaseDate, people: people, overview: overview)
     }
 
     /// Navigate to the artist detail screen for this album's artist, if known.
@@ -5949,6 +5959,11 @@ struct AlbumDetail: Equatable {
     /// these by role. Empty when the server didn't populate `People` (a
     /// surprising number don't).
     let people: [Person]
+    /// Editorial blurb from Jellyfin's album `Overview` field (populated
+    /// by metadata plugins such as TheAudioDB / MusicBrainz). May carry
+    /// light HTML; the view HTML-strips it before display and hides the
+    /// "About this album" section entirely when it's `nil`/empty (#68).
+    let overview: String?
 }
 
 // MARK: - Full search page types

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -273,6 +273,13 @@ final class AppModel {
     /// 12. Re-derived every time the backing set is refreshed so the view
     /// doesn't have to know about the shuffle.
     var favoriteAlbumsVisible: [Album] = []
+    /// Favorite artists for the Home "Artists You Love" carousel (#207).
+    /// A circle-card row of the artists the user has hearted, sorted by
+    /// name (server-side `SortName` ascending via `loadFavoriteArtists`).
+    /// Reuses the same favorites signal as the Favorites screen's Artists
+    /// section, so the two never drift. Hidden in the Home layout when
+    /// empty — a fresh user with no favorited artists sees no shelf.
+    var favoriteArtists: [Artist] = []
     /// Server-curated "You might like" tracks for the Home discovery row
     /// (#145). Backed by `core.suggestions()`, which hits Jellyfin's
     /// `/Items/Suggestions` endpoint. Up to 20 tracks. Hidden until data
@@ -1041,6 +1048,7 @@ final class AppModel {
         quickPicksPlayCounts = [:]
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
+        favoriteArtists = []
         suggestions = []
         searchResults = nil
         searchQuery = ""
@@ -1109,6 +1117,7 @@ final class AppModel {
         quickPicksPlayCounts = [:]
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
+        favoriteArtists = []
         suggestions = []
         searchResults = nil
         searchQuery = ""
@@ -1269,6 +1278,7 @@ final class AppModel {
         await refreshRecentlyAdded()
         await refreshQuickPicks()
         await refreshFavoriteAlbums()
+        await refreshFavoriteArtists()
         await refreshSuggestions()
     }
 
@@ -1756,6 +1766,16 @@ final class AppModel {
     /// the server.
     func reshuffleFavoriteAlbumsVisible() {
         self.favoriteAlbumsVisible = Array(favoriteAlbumsAll.shuffled().prefix(12))
+    }
+
+    /// Refresh the "Artists You Love" carousel (#207). Reuses
+    /// `loadFavoriteArtists` — the same favorites-driven fetch that backs
+    /// the Favorites screen's Artists section — so the Home circle row and
+    /// the Favorites grid stay in lock-step. The list arrives sorted by
+    /// name; the view caps how many circles it renders. Best-effort: an
+    /// empty or errored result just leaves the shelf hidden.
+    func refreshFavoriteArtists() async {
+        self.favoriteArtists = await loadFavoriteArtists(limit: 100)
     }
 
     /// Refresh the "You might like" discovery row (#145). Calls

--- a/macos/Sources/Lyrebird/Components/AmbientWash.swift
+++ b/macos/Sources/Lyrebird/Components/AmbientWash.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+import AppKit
+import CoreImage
+import Nuke
+
+/// Two artwork-derived colors used to paint the Now Playing ambient wash
+/// (#271). Replaces the theme-default `primary`/`accent` pair so the player
+/// background picks up the mood of whatever is on screen.
+///
+/// The pair is packed to / from a compact `RRGGBB,RRGGBB` hex string so it
+/// round-trips cleanly through `AppModel`'s per-album palette cache as an
+/// opaque value, with no bespoke codable surface — and so a cached entry
+/// re-hydrates to exactly the colors a fresh sample would have produced.
+struct AmbientPalette: Equatable {
+    let top: Color
+    let bottom: Color
+
+    /// The two hex triples backing `top` / `bottom`, kept so the palette can
+    /// be re-serialized for the cache without round-tripping through
+    /// `NSColor` component extraction (which is lossy across color spaces).
+    private let topHex: UInt32
+    private let bottomHex: UInt32
+
+    init(topHex: UInt32, bottomHex: UInt32) {
+        self.topHex = topHex
+        self.bottomHex = bottomHex
+        self.top = Color(hex: topHex)
+        self.bottom = Color(hex: bottomHex)
+    }
+
+    /// `"RRGGBB,RRGGBB"` — the compact cache encoding.
+    var encoded: String {
+        String(format: "%06X,%06X", topHex, bottomHex)
+    }
+
+    /// Parse a `"RRGGBB,RRGGBB"` string produced by `encoded`. Returns `nil`
+    /// on any malformed input so a stale / corrupt cache row falls back to a
+    /// fresh sample rather than rendering garbage.
+    init?(encoded: String) {
+        let parts = encoded.split(separator: ",")
+        guard parts.count == 2,
+              let t = UInt32(parts[0], radix: 16),
+              let b = UInt32(parts[1], radix: 16)
+        else { return nil }
+        self.init(topHex: t, bottomHex: b)
+    }
+}
+
+/// Off-main sampler that pulls two dominant colors from album artwork via
+/// Core Image's `CIAreaAverage` — no third-party Vibrant dependency. The
+/// image is split top/bottom and each half is averaged, which gives a pair
+/// that reads as a gentle vertical gradient matching the artwork's overall
+/// light-to-dark fall rather than two near-identical full-frame averages.
+///
+/// Each averaged color is nudged toward the dark surface palette (clamped
+/// luminance, modest saturation floor) so the wash never blows out to a flat
+/// white or a muddy gray on monochrome covers — it stays a *wash*, legible
+/// behind white type, per the screen spec's "ambient" intent.
+enum PaletteSampler {
+    /// Shared CIContext — creating one per sample is expensive (it spins up a
+    /// Metal/GL pipeline), and `CIContext` is `Sendable` + internally
+    /// thread-safe for rendering, so one shared instance serves every
+    /// off-main sample.
+    private static let ciContext = CIContext(options: [.workingColorSpace: NSNull()])
+
+    /// Extract an `AmbientPalette` from a decoded `CGImage`. Runs the Core
+    /// Image reductions synchronously; callers invoke it off the main actor
+    /// (see `AppModel.ambientPalette`).
+    static func palette(from cgImage: CGImage) -> AmbientPalette? {
+        let ci = CIImage(cgImage: cgImage)
+        let extent = ci.extent
+        guard extent.width >= 2, extent.height >= 2 else { return nil }
+
+        let topRect = CGRect(
+            x: extent.minX, y: extent.midY,
+            width: extent.width, height: extent.height / 2
+        )
+        let bottomRect = CGRect(
+            x: extent.minX, y: extent.minY,
+            width: extent.width, height: extent.height / 2
+        )
+
+        guard let topHex = averageHex(of: ci, in: topRect),
+              let bottomHex = averageHex(of: ci, in: bottomRect)
+        else { return nil }
+
+        return AmbientPalette(topHex: topHex, bottomHex: bottomHex)
+    }
+
+    /// Average the pixels of `image` inside `rect` with `CIAreaAverage`, then
+    /// render the resulting 1×1 image to a single RGBA8 pixel and tone-map it
+    /// for the dark wash.
+    private static func averageHex(of image: CIImage, in rect: CGRect) -> UInt32? {
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [
+            kCIInputImageKey: image,
+            kCIInputExtentKey: CIVector(cgRect: rect),
+        ]), let output = filter.outputImage else { return nil }
+
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        ciContext.render(
+            output,
+            toBitmap: &bitmap,
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
+
+        return toneMappedHex(r: bitmap[0], g: bitmap[1], b: bitmap[2])
+    }
+
+    /// Clamp an averaged color into the band that reads well as a dark wash:
+    /// floor a little saturation so pure-gray covers don't yield a dead gray,
+    /// and cap luminance so a bright cover doesn't wash out the white type.
+    private static func toneMappedHex(r: UInt8, g: UInt8, b: UInt8) -> UInt32 {
+        var h: CGFloat = 0, s: CGFloat = 0, v: CGFloat = 0
+        let color = NSColor(
+            srgbRed: CGFloat(r) / 255.0,
+            green: CGFloat(g) / 255.0,
+            blue: CGFloat(b) / 255.0,
+            alpha: 1.0
+        )
+        color.getHue(&h, saturation: &s, brightness: &v, alpha: nil)
+
+        // Keep some chroma so monochrome covers don't flatten to gray, but
+        // hold brightness in a mid-dark band so the wash stays behind type.
+        let mappedS = max(0.18, min(s, 0.85))
+        let mappedV = max(0.22, min(v, 0.55))
+        let mapped = NSColor(hue: h, saturation: mappedS, brightness: mappedV, alpha: 1.0)
+
+        guard let srgb = mapped.usingColorSpace(.sRGB) else { return 0 }
+        let ri = UInt32((srgb.redComponent * 255).rounded())
+        let gi = UInt32((srgb.greenComponent * 255).rounded())
+        let bi = UInt32((srgb.blueComponent * 255).rounded())
+        return (ri << 16) | (gi << 8) | bi
+    }
+}
+
+/// Full-bleed ambient background painted from an `AmbientPalette` (#271).
+/// Two radial gradients — one anchored top-leading in the palette's top
+/// color, one bottom-trailing in the bottom color — layered over the base
+/// `Theme.bg`, then blurred 20pt so it reads as a soft wash rather than two
+/// hard spotlights. Mirrors the prototype's twin-radial pattern but sources
+/// the colors from artwork instead of the static theme primary/accent.
+///
+/// When `palette` is `nil` (pre-sample, or extraction failed) it falls back
+/// to the theme `primary`/`accent` pair, so the player is never bare.
+///
+/// Accessibility: under **Reduce Transparency** the radial wash is dropped
+/// for a flat `Theme.bg` (no translucent layering), and under **Reduce
+/// Motion** the cross-fade between palettes is disabled so a track change
+/// snaps rather than animates the background.
+struct AmbientWash: View {
+    let palette: AmbientPalette?
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        let top = palette?.top ?? Theme.primary
+        let bottom = palette?.bottom ?? Theme.accent
+
+        ZStack {
+            Theme.bg
+            if !reduceTransparency {
+                GeometryReader { geo in
+                    let side = max(geo.size.width, geo.size.height)
+                    ZStack {
+                        RadialGradient(
+                            colors: [top.opacity(0.55), .clear],
+                            center: .topLeading,
+                            startRadius: 0,
+                            endRadius: side * 0.9
+                        )
+                        RadialGradient(
+                            colors: [bottom.opacity(0.55), .clear],
+                            center: .bottomTrailing,
+                            startRadius: 0,
+                            endRadius: side * 0.9
+                        )
+                    }
+                    .blur(radius: 20)
+                }
+                // A faint scrim keeps white type legible over a bright wash.
+                Theme.bg.opacity(0.25)
+            }
+        }
+        .ignoresSafeArea()
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: palette)
+    }
+}
+
+// MARK: - Nuke image fetch (palette source)
+
+extension PaletteSampler {
+    /// Pull the decoded artwork for `url` out of Nuke's shared pipeline —
+    /// reusing the same cache the on-screen `Artwork` already populated, so
+    /// sampling never triggers a second network fetch when the art is
+    /// already visible — and hand its `CGImage` to the sampler.
+    ///
+    /// Returns `nil` when the image can't be loaded or decoded; callers treat
+    /// that as "no palette" and fall back to the theme wash.
+    static func sample(from url: URL) async -> AmbientPalette? {
+        let request = ImageRequest(url: url)
+        let image: PlatformImage
+        do {
+            image = try await Artwork.pipeline.image(for: request)
+        } catch {
+            return nil
+        }
+        guard let cgImage = image.cgImageForPalette() else { return nil }
+        return palette(from: cgImage)
+    }
+}
+
+private extension PlatformImage {
+    /// Best-effort `CGImage` for sampling. `NSImage` may be backed by a vector
+    /// or multi-rep source, so go through `cgImage(forProposedRect:)` which
+    /// rasterizes the best representation at native size.
+    func cgImageForPalette() -> CGImage? {
+        var rect = CGRect(origin: .zero, size: size)
+        return cgImage(forProposedRect: &rect, context: nil, hints: nil)
+    }
+}

--- a/macos/Sources/Lyrebird/Components/Artwork.swift
+++ b/macos/Sources/Lyrebird/Components/Artwork.swift
@@ -27,6 +27,23 @@ struct Artwork: View {
     var size: CGFloat = 120
     var radius: CGFloat = 8
     var overlayLabel: String?
+    /// Whether this artwork is purely decorative for VoiceOver / Switch Control.
+    ///
+    /// Defaults to `true` because the overwhelming majority of `Artwork` call
+    /// sites are thumbnails nested inside a card, tile, or row whose *parent*
+    /// already carries a meaningful `.accessibilityLabel` (e.g. an album tile
+    /// button labelled "Abbey Road, 1969 · 17 tracks"). In that context the
+    /// inner image — and especially the seeded-gradient fallback, which has no
+    /// inherent meaning — is redundant noise: VoiceOver would otherwise stop on
+    /// it and announce a contentless "image". Hiding it keeps the spoken output
+    /// to the single labelled container.
+    ///
+    /// Meaningful call sites — where the image is the dominant identity of the
+    /// surface and is *not* wrapped in an already-labelled element (an
+    /// album/artist/playlist detail hero) — pass `decorative: false` and supply
+    /// a real `.accessibilityLabel` (the album / artist / playlist name) so the
+    /// hero reads as a named image. See #356.
+    var decorative: Bool = true
     /// Target decode size in pixels. Nuke downscales during decode to avoid
     /// holding a 1024×1024 CGImage in memory when the cell renders at 180pt.
     /// Defaults to `size * 2` to match typical Retina displays — the 3x
@@ -87,6 +104,11 @@ struct Artwork: View {
         .frame(width: size, height: size)
         .clipShape(RoundedRectangle(cornerRadius: radius))
         .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
+        // Decorative by default — see the `decorative` property. When a caller
+        // marks the image meaningful it pairs this with its own
+        // `.accessibilityLabel`, so the label survives because the element is
+        // no longer hidden.
+        .accessibilityHidden(decorative)
     }
 
     /// Build the Nuke request with a resize processor that downscales at

--- a/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
+++ b/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
@@ -32,6 +32,9 @@ import SwiftUI
 struct MiniPlayerView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    // Contrast-adaptive accent for the favorite heart. Lifts to `accentHot`
+    // under Increase Contrast so the accent-tinted glyph clears 4.5:1 (#888).
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     /// Whether the controls overlay is currently revealed. Driven by hover plus
     /// the 2-second idle timeout below — `true` while the pointer is moving over
@@ -224,7 +227,7 @@ struct MiniPlayerView: View {
         } label: {
             Image(systemName: isFav ? "heart.fill" : "heart")
                 .font(.system(size: 12))
-                .foregroundStyle(isFav ? Theme.accent : Theme.ink3)
+                .foregroundStyle(isFav ? a11yTheme.accent : Theme.ink3)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(Text(isFav ? "mini_player.unfavorite" : "mini_player.favorite"))

--- a/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
+++ b/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
@@ -299,9 +299,13 @@ struct MiniPlayerView: View {
     private var transportRow: some View {
         HStack(spacing: 14) {
             iconBtn("backward.fill", label: "mini_player.previous", size: 13) {
+                Haptics.transport()
                 model.skipPrevious()
             }
-            Button(action: model.togglePlayPause) {
+            Button(action: {
+                Haptics.transport()
+                model.togglePlayPause()
+            }) {
                 Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                     .font(.system(size: 13))
                     .foregroundStyle(Theme.bg)
@@ -311,6 +315,7 @@ struct MiniPlayerView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(Text(isPlaying ? "mini_player.pause" : "mini_player.play"))
             iconBtn("forward.fill", label: "mini_player.next", size: 13) {
+                Haptics.transport()
                 model.skipNext()
             }
             Spacer(minLength: 0)
@@ -349,6 +354,7 @@ struct MiniPlayerView: View {
                     scrubPosition = model.status.positionSeconds
                     isScrubbing = true
                 } else {
+                    Haptics.scrubCommit()
                     model.seek(toSeconds: scrubPosition)
                     isScrubbing = false
                     // The idle-hide task that fired during the drag bailed out

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -3,6 +3,11 @@ import SwiftUI
 
 struct PlayerBar: View {
     @Environment(AppModel.self) private var model
+    // Contrast-adaptive accent for foreground/active-state controls. Lifts
+    // `Theme.accent` to the brighter `accentHot` under Increase Contrast so
+    // accent-tinted transport icons clear 4.5:1 (#888). Decorative accents
+    // (e.g. the play-button fill) keep the base token.
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     /// Local scrubber position used while the user is actively dragging the
     /// Slider. We don't bind the Slider straight to `status.positionSeconds`
@@ -99,7 +104,7 @@ struct PlayerBar: View {
                 iconBtn(
                     isFav ? "heart.fill" : "heart",
                     label: isFav ? "Unfavorite" : "Favorite",
-                    tint: isFav ? Theme.accent : Theme.ink2
+                    tint: isFav ? a11yTheme.accent : Theme.ink2
                 ) { model.toggleFavorite(track: track) }
                     .help(isFav ? "Unfavorite" : "Favorite")
             }
@@ -117,7 +122,7 @@ struct PlayerBar: View {
                 iconBtn(
                     "shuffle",
                     label: "Shuffle",
-                    tint: model.status.shuffle ? Theme.accent : Theme.ink2
+                    tint: model.status.shuffle ? a11yTheme.accent : Theme.ink2
                 ) { model.mediaSessionSetShuffle(!model.status.shuffle) }
                     .help("Shuffle")
                 iconBtn("backward.fill", label: "Previous track", size: 16) { model.skipPrevious() }
@@ -140,7 +145,7 @@ struct PlayerBar: View {
                 iconBtn(
                     model.status.repeatMode == .one ? "repeat.1" : "repeat",
                     label: "Repeat",
-                    tint: model.status.repeatMode != .off ? Theme.accent : Theme.ink2
+                    tint: model.status.repeatMode != .off ? a11yTheme.accent : Theme.ink2
                 ) {
                     let next: RepeatMode = {
                         switch model.status.repeatMode {

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -118,11 +118,20 @@ struct PlayerBar: View {
                     "shuffle",
                     label: "Shuffle",
                     tint: model.status.shuffle ? Theme.accent : Theme.ink2
-                ) { model.mediaSessionSetShuffle(!model.status.shuffle) }
+                ) {
+                    Haptics.levelChange()
+                    model.mediaSessionSetShuffle(!model.status.shuffle)
+                }
                     .help("Shuffle")
-                iconBtn("backward.fill", label: "Previous track", size: 16) { model.skipPrevious() }
+                iconBtn("backward.fill", label: "Previous track", size: 16) {
+                    Haptics.transport()
+                    model.skipPrevious()
+                }
                     .help("Previous · ⌘←")
-                Button(action: model.togglePlayPause) {
+                Button(action: {
+                    Haptics.transport()
+                    model.togglePlayPause()
+                }) {
                     Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                         .font(.system(size: 15))
                         .foregroundStyle(Theme.bg)
@@ -135,13 +144,17 @@ struct PlayerBar: View {
                 // about to take. See #331.
                 .accessibilityLabel(Text(isPlaying ? "Pause" : "Play"))
                 .help(isPlaying ? "Pause · Space" : "Play · Space")
-                iconBtn("forward.fill", label: "Next track", size: 16) { model.skipNext() }
+                iconBtn("forward.fill", label: "Next track", size: 16) {
+                    Haptics.transport()
+                    model.skipNext()
+                }
                     .help("Next · ⌘→")
                 iconBtn(
                     model.status.repeatMode == .one ? "repeat.1" : "repeat",
                     label: "Repeat",
                     tint: model.status.repeatMode != .off ? Theme.accent : Theme.ink2
                 ) {
+                    Haptics.levelChange()
                     let next: RepeatMode = {
                         switch model.status.repeatMode {
                         case .off: return .all
@@ -195,7 +208,10 @@ struct PlayerBar: View {
                         } else {
                             // Drag ended — commit the seek and release the
                             // local position so the next polling tick can
-                            // pull the thumb back to the live position.
+                            // pull the thumb back to the live position. The
+                            // alignment tap gives the commit a tactile
+                            // "snap" the same way the system volume HUD does.
+                            Haptics.scrubCommit()
                             model.seek(toSeconds: scrubPosition)
                             isScrubbing = false
                         }

--- a/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
@@ -12,6 +12,9 @@ import SwiftUI
 /// track-scoped context menu with Play / Go to Album / Go to Artist.
 struct RecentlyPlayedTrackRow: View {
     @Environment(AppModel.self) private var model
+    // Contrast-adaptive accent for the active-track title. Lifts to `accentHot`
+    // under Increase Contrast so accent text clears 4.5:1 (#888).
+    @Environment(\.accessibleTheme) private var a11yTheme
     let track: Track
 
     @State private var isHovering = false
@@ -33,7 +36,7 @@ struct RecentlyPlayedTrackRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(track.name)
                         .font(Theme.font(13, weight: .bold))
-                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink)
                         .lineLimit(1)
                     Text(track.artistName)
                         .font(Theme.font(11, weight: .medium))

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -11,6 +11,11 @@ import SwiftUI
 /// `commitSidebarPlaylistEdit`, etc.) so the view stays compact.
 struct Sidebar: View {
     @Environment(AppModel.self) private var model
+    // Contrast-adaptive accent for the active-tab / active-playlist icon
+    // foregrounds. Lifts to `accentHot` under Increase Contrast so the
+    // accent-tinted glyphs clear 4.5:1 (#888). The 3pt active-tab indicator
+    // rail is decorative and keeps the base token.
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     /// The playlist row currently hovered by the pointer. Used to reveal
     /// the subtle trailing affordances (copying spinner slot); `nil` when
@@ -205,7 +210,7 @@ struct Sidebar: View {
 
         HStack(spacing: 10) {
             Image(systemName: "music.note.list")
-                .foregroundStyle(isActiveScreen ? Theme.accent : Theme.ink2)
+                .foregroundStyle(isActiveScreen ? a11yTheme.accent : Theme.ink2)
                 .frame(width: 18)
 
             if isEditing {
@@ -265,7 +270,7 @@ struct Sidebar: View {
     private var newPlaylistEditRow: some View {
         HStack(spacing: 10) {
             Image(systemName: "music.note.list")
-                .foregroundStyle(Theme.accent)
+                .foregroundStyle(a11yTheme.accent)
                 .frame(width: 18)
             // #590: stable subview identity for the new-playlist field too.
             SidebarInlineEditField(initialText: "")
@@ -286,7 +291,7 @@ struct Sidebar: View {
         Button { model.selectTab(screen) } label: {
             HStack(spacing: 10) {
                 Image(systemName: icon)
-                    .foregroundStyle(active ? Theme.accent : Theme.ink2)
+                    .foregroundStyle(active ? a11yTheme.accent : Theme.ink2)
                     .frame(width: 18)
                     .accessibilityHidden(true)
                 Text(label)

--- a/macos/Sources/Lyrebird/Components/TopTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TopTrackRow.swift
@@ -14,6 +14,10 @@ import SwiftUI
 struct TopTrackRow: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    // Contrast-adaptive accent for the active-row rank / title and the
+    // now-playing equalizer. Lifts to `accentHot` under Increase Contrast so
+    // accent foregrounds clear 4.5:1 (#888).
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     let track: Track
     let rank: Int
@@ -45,7 +49,7 @@ struct TopTrackRow: View {
                 ZStack {
                     if isPlaying {
                         EqualizerIcon()
-                            .foregroundStyle(Theme.accent)
+                            .foregroundStyle(a11yTheme.accent)
                     } else if isHovering {
                         Image(systemName: "play.fill")
                             .font(.system(size: 12))
@@ -53,7 +57,7 @@ struct TopTrackRow: View {
                     } else {
                         Text("\(rank)")
                             .font(Theme.font(14, weight: .heavy))
-                            .foregroundStyle(isActive ? Theme.accent : Theme.ink3)
+                            .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink3)
                             .monospacedDigit()
                     }
                 }
@@ -76,7 +80,7 @@ struct TopTrackRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(track.name)
                         .font(Theme.font(13, weight: .semibold))
-                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink)
                         .lineLimit(1)
                     Text(track.albumName ?? track.artistName)
                         .font(Theme.font(11, weight: .medium))

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -42,6 +42,12 @@ let directPlayContainers: Set<String> = [
 struct TrackListRow: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    // Contrast-adaptive accent for foreground text/icons (active-track title,
+    // now-playing equalizer, favorite heart). Lifts to `accentHot` under
+    // Increase Contrast so accent foregrounds clear 4.5:1 (#888). The
+    // decorative selection rail / focus-ring stroke / selection background
+    // tint keep the base token.
+    @Environment(\.accessibleTheme) private var a11yTheme
     let track: Track
     /// Full track list the row was rendered from, so tap-to-play can hand
     /// the entire ordered list to `AppModel.play` and index into it. This
@@ -223,7 +229,7 @@ struct TrackListRow: View {
                         .fill(Color.black.opacity(0.55))
                         .frame(width: artworkSize, height: artworkSize)
                     EqualizerIcon()
-                        .foregroundStyle(Theme.accent)
+                        .foregroundStyle(a11yTheme.accent)
                 } else if isHovering {
                     RoundedRectangle(cornerRadius: 4)
                         .fill(Color.black.opacity(0.45))
@@ -240,7 +246,7 @@ struct TrackListRow: View {
                 HStack(spacing: 5) {
                     Text(track.name)
                         .font(Theme.font(13, weight: .semibold))
-                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink)
                         .lineLimit(1)
                     FormatBadge(track: track)
                     if willTranscode {
@@ -278,7 +284,7 @@ struct TrackListRow: View {
                 } label: {
                     Image(systemName: isFav ? "heart.fill" : "heart")
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .foregroundStyle(isFav ? a11yTheme.accent : Theme.ink2)
                         .frame(width: 28, height: 28)
                 }
                 .buttonStyle(.plain)

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -15,6 +15,11 @@ import SwiftUI
 /// `TrackListRow`.
 struct TrackRow: View {
     @Environment(AppModel.self) private var model
+    // Contrast-adaptive accent for foreground text/icons (active-track title,
+    // now-playing equalizer, favorite heart). Lifts to `accentHot` under
+    // Increase Contrast so accent foregrounds clear 4.5:1 (#888). The
+    // decorative focus-ring stroke keeps the base token.
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     let track: Track
     let number: Int
@@ -69,7 +74,7 @@ struct TrackRow: View {
             ZStack {
                 if isPlaying {
                     EqualizerIcon()
-                        .foregroundStyle(Theme.accent)
+                        .foregroundStyle(a11yTheme.accent)
                 } else if isHovering {
                     Image(systemName: "play.fill")
                         .font(.system(size: 11))
@@ -77,7 +82,7 @@ struct TrackRow: View {
                 } else if showTrackNumbers {
                     Text("\(number)")
                         .font(Theme.font(12, weight: .medium))
-                        .foregroundStyle(isActive ? Theme.accent : Theme.ink3)
+                        .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink3)
                 }
             }
             .frame(width: 32)
@@ -86,7 +91,7 @@ struct TrackRow: View {
                 HStack(spacing: 5) {
                     Text(track.name)
                         .font(Theme.font(13, weight: .semibold))
-                        .foregroundStyle(isActive ? Theme.accent : Theme.ink)
+                        .foregroundStyle(isActive ? a11yTheme.accent : Theme.ink)
                         .lineLimit(1)
                     FormatBadge(track: track)
                     if willTranscode {
@@ -111,7 +116,7 @@ struct TrackRow: View {
                 } label: {
                     Image(systemName: isFav ? "heart.fill" : "heart")
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .foregroundStyle(isFav ? a11yTheme.accent : Theme.ink2)
                         .frame(width: 28, height: 28)
                 }
                 .buttonStyle(.plain)

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 @main
 struct LyrebirdApp: App {
@@ -440,6 +441,16 @@ struct LyrebirdCommands: Commands {
                 openWindow(id: AppShortcuts.windowID)
             }
             .keyboardShortcut("?", modifiers: .command)
+
+            Divider()
+
+            // Export Diagnostic Bundle… (#455). Writes a sanitized .zip of
+            // recent logs + non-secret metadata for bug reports. All shaping
+            // and redaction lives in `DiagnosticBundle`; this is just the
+            // save-panel hop.
+            Button("menu.help.export_diagnostics") {
+                exportDiagnosticBundle()
+            }
         }
 
         // Note: ⌘, (Preferences), ⌘Q (Quit), Hide / Hide Others / Services,
@@ -470,6 +481,36 @@ struct LyrebirdCommands: Commands {
             model.navPath.removeLast()
         } else {
             model.navPath.append(AppModel.Route.nowPlaying)
+        }
+    }
+
+    /// Present a save panel and write a sanitized diagnostic `.zip` (#455).
+    /// Reads version/build from the bundle and the (host-redacted) server URL
+    /// from the live `AppModel`; everything else — log collection, the
+    /// settings allowlist, and redaction — is handled by `DiagnosticBundle`.
+    /// Surfaces a failure via `model.errorMessage` rather than a swallowed
+    /// `try?`, matching the playlist-mutation error contract.
+    private func exportDiagnosticBundle() {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0 (dev)"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "—"
+
+        let panel = NSSavePanel()
+        panel.title = "Export Diagnostic Bundle"
+        panel.nameFieldStringValue = "Lyrebird-Diagnostics-\(DiagnosticBundle.filenameStamp(Date())).zip"
+        panel.allowedContentTypes = [.zip]
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try DiagnosticBundle.export(
+                to: url,
+                version: version,
+                build: build,
+                serverURL: model.serverURL
+            )
+        } catch {
+            model.errorMessage = "Could not export diagnostic bundle: \(error.localizedDescription)"
         }
     }
 

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1501,6 +1501,18 @@
         }
       }
     },
+    "menu.help.export_diagnostics" : {
+      "comment" : "Help menu entry that writes a sanitized diagnostic .zip for bug reports.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Diagnostic Bundle…"
+          }
+        }
+      }
+    },
     "menu.help.keyboard_shortcuts" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -76,8 +76,10 @@ struct AlbumDetailView: View {
                     url: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 480),
                     seed: album.name,
                     size: 240,
-                    radius: 6
+                    radius: 6,
+                    decorative: false
                 )
+                .accessibilityLabel("Album artwork for \(album.name)")
                 VStack(alignment: .leading, spacing: 6) {
                     Text("LONG-PLAYER · \(album.year.map(String.init) ?? "")")
                         .font(Theme.font(11, weight: .bold))

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 @preconcurrency import LyrebirdCore
 
-/// Album detail screen — hero + CTA row + disc-grouped tracklist + liner-note
-/// credits block. Implements the BATCH-05 polish pass: #219 (hero stat strip
-/// typography), #70 (Play/Shuffle/Radio/Download + overflow CTAs), #222
-/// (favourite / add-to-playlist / download inline actions), #66 (disc
-/// grouping with sticky small-caps headers), #65 (liner-note credits section
-/// with clickable people chips).
+/// Album detail screen — hero + CTA row + disc-grouped tracklist + editorial
+/// "About this album" blurb + liner-note credits block. Implements the
+/// BATCH-05 polish pass: #219 (hero stat strip typography), #70
+/// (Play/Shuffle/Radio/Download + overflow CTAs), #222 (favourite /
+/// add-to-playlist / download inline actions), #66 (disc grouping with
+/// sticky small-caps headers), #65 (liner-note credits section with
+/// clickable people chips), #68 (editorial "About this album" section,
+/// hidden when the server has no `Overview`).
 ///
 /// Data flow:
 /// - `tracks` is loaded via `AppModel.loadTracks(forAlbum:)` (cached).
@@ -19,10 +21,13 @@ struct AlbumDetailView: View {
 
     @State private var tracks: [Track] = []
     @State private var isLoading = true
-    @State private var detail: AlbumDetail = AlbumDetail(label: nil, releaseDate: nil, people: [])
+    @State private var detail: AlbumDetail = AlbumDetail(label: nil, releaseDate: nil, people: [], overview: nil)
     @State private var fetchedAlbum: Album?
     @State private var showAddToPlaylist = false
     @State private var moreByArtist: [Album] = []
+    /// Whether the full editorial blurb popover is open (#68). Mirrors the
+    /// artist About section's "Read more" affordance.
+    @State private var isAboutExpanded = false
 
     /// Cache-first lookup against the paged `albums` list, then fall
     /// back to the record the `.task` block fetched. Missing after both
@@ -39,6 +44,7 @@ struct AlbumDetailView: View {
                 hero
                 ctaRow
                 trackList
+                aboutSection
                 linerNotes
                 moreByArtistSection
             }
@@ -46,6 +52,9 @@ struct AlbumDetailView: View {
         .background(Theme.bg)
         .task(id: albumID) {
             isLoading = true
+            // Reset the editorial-blurb popover so a prior album's expanded
+            // "About this album" never bleeds into this page (#68).
+            isAboutExpanded = false
             if model.albums.first(where: { $0.id == albumID }) == nil {
                 fetchedAlbum = await model.resolveAlbum(id: albumID)
             }
@@ -383,6 +392,97 @@ struct AlbumDetailView: View {
     private func discLocalNumber(fallback: Int, track: Track) -> Int {
         if let n = track.indexNumber, n > 0 { return Int(n) }
         return fallback
+    }
+
+    // MARK: - About this album
+
+    /// Editorial "About this album" block (#68). Renders Jellyfin's album
+    /// `Overview` (populated by metadata plugins like TheAudioDB /
+    /// MusicBrainz) HTML-stripped to plain text, clamped to four lines with a
+    /// keyboard-accessible "Read more" popover for the full text — mirroring
+    /// `ArtistDetailView.aboutSection`.
+    ///
+    /// The HTML strip is shared with the artist bio via
+    /// `ArtistDetailView.plainTextOverview` so the two surfaces can't drift.
+    /// The section is hidden entirely when the album has no overview — no
+    /// "no description" placeholder — so an album without editorial metadata
+    /// simply doesn't grow a dead region, matching the liner-note block's
+    /// "degrade cleanly when fields are empty" behaviour.
+    @ViewBuilder
+    private var aboutSection: some View {
+        if let overview = ArtistDetailView.plainTextOverview(detail.overview) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("ABOUT THIS ALBUM")
+                    .font(Theme.font(10, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(2)
+                    .padding(.bottom, 12)
+                aboutBody(overview: overview)
+            }
+            .padding(.horizontal, 40)
+            .padding(.top, 36)
+        }
+    }
+
+    /// Four-line clamp on the overview plus a keyboard-accessible "Read more"
+    /// button that opens the full text in a popover. The popover is driven by
+    /// a plain SwiftUI `Button`, so it's focusable and Return-activatable for
+    /// free — the same affordance as the artist About section.
+    @ViewBuilder
+    private func aboutBody(overview: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(overview)
+                .font(Theme.font(14, weight: .regular))
+                .foregroundStyle(Theme.ink2)
+                .lineLimit(4)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+            Button {
+                isAboutExpanded = true
+            } label: {
+                Text("Read more")
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Read full description for \(album?.name ?? "this album")")
+            .accessibilityHint("Opens the complete album description in a popover")
+            .popover(isPresented: $isAboutExpanded, arrowEdge: .top) {
+                aboutPopover(overview: overview)
+            }
+        }
+    }
+
+    /// Full-description popover. Scrolls when the text is long so the popover
+    /// stays a sane size, and is dismissible with Escape (SwiftUI default) or
+    /// the explicit Done button for pointer users.
+    @ViewBuilder
+    private func aboutPopover(overview: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(album?.name ?? "About this album")
+                    .font(Theme.font(18, weight: .heavy))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(2)
+                Spacer(minLength: 24)
+                Button("Done") { isAboutExpanded = false }
+                    .buttonStyle(.plain)
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+                    .keyboardShortcut(.cancelAction)
+            }
+            ScrollView {
+                Text(overview)
+                    .font(Theme.font(14, weight: .regular))
+                    .foregroundStyle(Theme.ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .frame(maxHeight: 460)
     }
 
     // MARK: - Liner notes

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -30,6 +30,7 @@ struct HomeView: View {
                 // not meaningful here. Re-enable once the ranked data sources
                 // land (#206, #209).
                 recentlyPlayedSection
+                artistsYouLoveSection
                 jumpBackInSection
                 recentlyPlayedTracksSection
                 yourPlaylistsSection
@@ -396,6 +397,46 @@ struct HomeView: View {
             }
         }
     }
+
+    /// "Artists You Love" — a circle-card carousel of the artists the user
+    /// has favorited (#207). Reuses `ArtistCard` (the same circular tile the
+    /// Library Artists grid and Favorites screen render) over the
+    /// favorites-driven `model.favoriteArtists` slice, so it never drifts
+    /// from the Favorites screen's Artists section. Tapping a card pushes
+    /// `Route.artist` via `ArtistCard`'s own button; "See All" jumps to the
+    /// Favorites tab. Hidden when the user has no favorited artists so a
+    /// fresh library doesn't render an empty shelf.
+    ///
+    /// `ArtistCard` stretches to `maxWidth: .infinity` (it's built for a
+    /// grid cell), so each card is pinned to a fixed width here — otherwise
+    /// the cards would collapse inside the horizontal `HStack`. The row is
+    /// capped so it stays bounded for power users with hundreds of
+    /// favorited artists.
+    @ViewBuilder
+    private var artistsYouLoveSection: some View {
+        if !model.favoriteArtists.isEmpty {
+            carouselSection(
+                icon: "heart.circle.fill",
+                iconColor: Theme.accentHot,
+                title: "Artists You Love",
+                subtitle: "The artists you've hearted",
+                onSeeAll: { model.selectTab(.favorites) }
+            ) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(model.favoriteArtists.prefix(artistsYouLoveLimit), id: \.id) { artist in
+                        ArtistCard(artist: artist)
+                            .frame(width: 150)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// Cap on how many circles the "Artists You Love" row renders. Keeps the
+    /// horizontal scroll bounded for users with a large favorites set; the
+    /// "See All" button routes to the full Favorites screen for the rest.
+    private var artistsYouLoveLimit: Int { 18 }
 
     /// Pick a short list of artists to surface as radio seeds. Prefer
     /// favorites → top-listened → library order. Favorites and top-listened

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -21,6 +21,11 @@ import SwiftUI
 struct NowPlayingView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    // Contrast-adaptive accent for the favorite heart, the "NOW PLAYING"
+    // section label, and the empty-state primary button. Lifts to `accentHot`
+    // under Increase Contrast so accent text / the prominent button fill clear
+    // 4.5:1 (#888).
+    @Environment(\.accessibleTheme) private var a11yTheme
 
     /// Active right-pane tab. Reset to `.queue` when the view appears so
     /// opening the full player always lands on "what's next" rather than
@@ -163,7 +168,7 @@ struct NowPlayingView: View {
                 } label: {
                     Image(systemName: isFav ? "heart.fill" : "heart")
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(isFav ? Theme.accent : Theme.ink2)
+                        .foregroundStyle(isFav ? a11yTheme.accent : Theme.ink2)
                         .frame(width: 44, height: 44)
                 }
                 .buttonStyle(.plain)
@@ -248,7 +253,7 @@ struct NowPlayingView: View {
         HStack {
             Text("NOW PLAYING")
                 .font(Theme.font(10, weight: .bold))
-                .foregroundStyle(Theme.accent)
+                .foregroundStyle(a11yTheme.accent)
                 .tracking(3)
             Spacer()
         }
@@ -488,7 +493,7 @@ struct NowPlayingView: View {
                 model.previousScreen = nil
             }
             .buttonStyle(.borderedProminent)
-            .tint(Theme.accent)
+            .tint(a11yTheme.accent)
             .padding(.top, 6)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -108,8 +108,10 @@ struct NowPlayingView: View {
                 ),
                 seed: track.name,
                 size: artSide,
-                radius: 14
+                radius: 14,
+                decorative: false
             )
+            .accessibilityLabel(nowPlayingArtworkLabel(for: track))
             .frame(width: artSide, height: artSide)
             // Trailing alignment so the disc slides out past the art's right
             // edge rather than behind its center; the disc's own `+80pt`
@@ -185,6 +187,24 @@ struct NowPlayingView: View {
     private func heroArtSide(containerWidth: CGFloat?) -> CGFloat {
         let byWidth = containerWidth.map { max(240, $0 - 72) } ?? 320
         return min(520, byWidth)
+    }
+
+    /// VoiceOver label for the now-playing hero artwork. The hero is the
+    /// dominant identity of the screen and isn't wrapped in a labelled
+    /// control, so it's marked meaningful (`decorative: false`) and reads as
+    /// the cover for the album when known, falling back to the track when the
+    /// server ships no album name (singles). (#356)
+    private func nowPlayingArtworkLabel(for track: Track) -> String {
+        Self.nowPlayingArtworkLabel(trackName: track.name, albumName: track.albumName)
+    }
+
+    /// Pure label builder, split out so the fallback rule is unit-testable
+    /// without booting a SwiftUI scene.
+    static func nowPlayingArtworkLabel(trackName: String, albumName: String?) -> String {
+        if let album = albumName, !album.isEmpty {
+            return "Album artwork for \(album)"
+        }
+        return "Artwork for \(trackName)"
     }
 
     @ViewBuilder

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -29,6 +29,12 @@ struct NowPlayingView: View {
     @State private var tab: Tab = .queue
     @State private var resolvedAlbum: Album?
 
+    /// Artwork-derived ambient wash behind the hero (#271). `nil` until the
+    /// current cover is sampled (or when sampling fails / there's no art), in
+    /// which case `AmbientWash` falls back to the theme gradient. Memoized in
+    /// `AppModel`, so re-opening the player on the same album is a cache hit.
+    @State private var ambientPalette: AmbientPalette?
+
     enum Tab: String, CaseIterable, Identifiable {
         case queue = "Queue"
         case lyrics = "Lyrics"
@@ -46,13 +52,31 @@ struct NowPlayingView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Theme.bg)
+        // Ambient wash sampled from the current cover (#271). Sits behind the
+        // whole player; falls back to the theme gradient when `ambientPalette`
+        // is nil (pre-sample / no art / extraction failed).
+        .background(AmbientWash(palette: ambientPalette))
         // Re-fetch the People array + lyrics on open and on track change.
         // The polling loop in AppModel already handles mid-session
         // transitions; this keeps the open-from-cold path honest too.
         .task(id: model.status.currentTrack?.id) {
             await model.fetchCurrentTrackDetails()
             await model.fetchCurrentTrackLyrics()
+        }
+        // Sample the ambient palette off the current cover. Keyed on the same
+        // identity the hero artwork uses (`albumId ?? id`) so a track change
+        // within the same album doesn't re-sample, and so the sample reuses
+        // the cover Nuke already decoded for the hero. The work is memoized in
+        // AppModel and runs off the main actor, so this never beach-balls.
+        .task(id: ambientArtworkKey) {
+            guard let track = model.status.currentTrack else {
+                ambientPalette = nil
+                return
+            }
+            ambientPalette = await model.ambientPalette(
+                forItemId: track.albumId ?? track.id,
+                imageTag: track.imageTag
+            )
         }
         // Honor a one-shot tab request (#91): the inline lyrics snippet in
         // the Queue Inspector taps `openLyrics()`, which sets
@@ -74,6 +98,16 @@ struct NowPlayingView: View {
             tab = resolved
         }
         model.requestedNowPlayingTab = nil
+    }
+
+    /// Stable identity for the ambient-palette `.task` — the album id when the
+    /// current track belongs to one, else the track id, mirroring the hero
+    /// artwork's own `albumId ?? id` keying. `nil` when nothing is playing so
+    /// the task clears the wash. Re-keying only when this string changes means
+    /// skipping from track to track inside one album won't re-sample.
+    private var ambientArtworkKey: String? {
+        guard let track = model.status.currentTrack else { return nil }
+        return track.albumId ?? track.id
     }
 
     // MARK: - Main content

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -451,7 +451,11 @@ private struct PlaylistCollage: View {
         // treatment so the slot is never a featureless gradient for
         // playlists that already carry a server-side cover.
         if quads.allSatisfy({ artURL(for: $0) == nil }) {
-            Artwork(url: fallbackURL, seed: seed, size: slotSize, radius: 6)
+            // Hero cover for the playlist — the collage path below labels its
+            // container "Playlist artwork"; mirror that here so the
+            // single-image fallback reads identically to VoiceOver. (#356)
+            Artwork(url: fallbackURL, seed: seed, size: slotSize, radius: 6, decorative: false)
+                .accessibilityLabel("Playlist artwork")
         } else {
             let cell = (slotSize - gap) / 2
             VStack(spacing: gap) {

--- a/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
+++ b/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
@@ -1,0 +1,395 @@
+import Foundation
+import OSLog
+
+/// Assembles a shareable diagnostic `.zip` for bug reports. Closes #455.
+///
+/// The Help → "Export Diagnostic Bundle…" menu item writes a zip containing
+/// three plain-text artifacts:
+///
+/// 1. `logs.txt` — recent `os.Logger` output for the `org.lyrebird.desktop`
+///    subsystem, the same filter the Advanced pane's "Open in Console.app"
+///    button preloads (`Log.subsystem`). Lines are formatted
+///    `<iso8601> [<category>] <message>`.
+/// 2. `manifest.json` — app version / build, the sanitized server host
+///    (host only — no scheme, userinfo, port, path, or query), the macOS
+///    version, and an allowlist of non-secret settings.
+/// 3. `README.txt` — a one-paragraph note describing what's inside and,
+///    crucially, what was deliberately left out, so a user can eyeball the
+///    bundle before attaching it to a public issue.
+///
+/// ## Redaction contract
+///
+/// The bundle must never contain secrets. Concretely:
+/// - **No access token / password / device id.** The `Session` carries an
+///   `accessToken`; only `session.server.url` is read, and only its host
+///   survives `redactServerHost`.
+/// - **No raw server URL.** `https://user:pw@music.example.com:8443/jf?x=1`
+///   collapses to `music.example.com`. Userinfo, port, path, and query are
+///   all dropped — they can encode reverse-proxy secrets or internal
+///   hostnames the user may not want public.
+/// - **Settings allowlist, not denylist.** Only keys in
+///   ``settingsAllowlist`` are copied out of `UserDefaults`. Free-text user
+///   data (recent searches, pinned stations) is intentionally excluded
+///   because it can carry PII; adding a new toggle does NOT silently leak it.
+///
+/// ## Testability
+///
+/// The two side-effecting pieces — reading `OSLogStore` and reading
+/// `UserDefaults` — are injected, so ``assemble(version:build:serverURL:osVersion:logReader:defaults:)``
+/// is a pure function over its inputs and the redaction + manifest shaping
+/// are unit-testable without a live log store, a signed-in session, or any
+/// file I/O. ``export(to:version:build:serverURL:)`` is the thin wrapper that
+/// the menu calls: it lays the artifacts into a temp directory and zips it
+/// via `NSFileCoordinator`'s `.forUploading` coordination (Foundation's only
+/// public, dependency-free zip path on macOS).
+enum DiagnosticBundle {
+
+    // MARK: - Errors
+
+    enum BundleError: Error, LocalizedError {
+        case zipCoordinationFailed(underlying: Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .zipCoordinationFailed(let underlying):
+                return "Could not compress the diagnostic bundle: \(underlying.localizedDescription)"
+            }
+        }
+    }
+
+    // MARK: - Log reading seam
+
+    /// Abstracts the source of recent log lines so tests can feed a canned
+    /// transcript instead of touching the real unified log. `subsystem` is
+    /// passed through (rather than hard-coding `Log.subsystem` in the reader)
+    /// so a test can assert the collector requests the right scope.
+    protocol LogReading {
+        func recentLines(subsystem: String, since: Date) throws -> [String]
+    }
+
+    /// Production reader backed by `OSLogStore` scoped to the current process.
+    /// Process scope (not `.system`) is deliberate: the app is sandboxed and
+    /// can't read the system-wide store without the
+    /// `com.apple.private.logging.stream` entitlement, and process scope
+    /// already contains everything `Log.*` emitted this session.
+    struct OSLogStoreReader: LogReading {
+        func recentLines(subsystem: String, since: Date) throws -> [String] {
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let position = store.position(date: since)
+            // Scoped subsystem predicate — matches the field every `Log.*`
+            // entry carries, exactly like the Console.app filter token in
+            // PreferencesAdvanced.
+            let predicate = NSPredicate(format: "subsystem == %@", subsystem)
+            let entries = try store.getEntries(at: position, matching: predicate)
+            return entries.compactMap { entry in
+                guard let log = entry as? OSLogEntryLog else { return nil }
+                return DiagnosticBundle.formatLogLine(
+                    date: entry.date,
+                    category: log.category,
+                    message: entry.composedMessage
+                )
+            }
+        }
+    }
+
+    // MARK: - Settings allowlist
+
+    /// Non-secret preference keys copied into the manifest. Allowlist, not
+    /// denylist: a key is exported only if it appears here, so a future
+    /// toggle that happens to hold sensitive data can't leak by accident.
+    /// Mirrors the `@AppStorage` keys used across the app, minus free-text
+    /// user data (`recentSearches`, `pinned_stations`) which can carry PII.
+    static let settingsAllowlist: [String] = [
+        "advanced.verboseLogging",
+        "advanced.showInternalIds",
+        "appearance.density",
+        "appearance.mode",
+        "audio.transcodingPreference",
+        "downloads.storageBudgetGb",
+        "general.autoStartOnLogin",
+        "general.language",
+        "general.showInMenuBar",
+        "hasCompletedOnboarding",
+        "libraryViewMode",
+        "playback.crossfadeSeconds",
+        "playback.downloadQuality",
+        "playback.gaplessEnabled",
+        "playback.normalization",
+        "playback.preGainDb",
+        "playback.preferredCodec",
+        "playback.stopAfterCurrent",
+        "playback.streamingQuality",
+    ]
+
+    // MARK: - Redaction
+
+    /// Reduce a server URL to its bare host, dropping scheme, userinfo, port,
+    /// path, and query. Returns `"(not signed in)"` when the input is empty
+    /// so the manifest never carries an empty/secret-looking value.
+    ///
+    /// Examples:
+    /// - `https://music.example.com/jellyfin` → `music.example.com`
+    /// - `https://user:pw@host:8443/x?token=abc` → `host`
+    /// - `music.example.com:8096` → `music.example.com`
+    /// - `""` → `(not signed in)`
+    static func redactServerHost(_ urlString: String) -> String {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "(not signed in)" }
+
+        // Try a structured parse first. `URLComponents` cleanly separates the
+        // host from userinfo / port / path / query.
+        if let host = URLComponents(string: trimmed)?.host, !host.isEmpty {
+            return host
+        }
+
+        // Fallback for bare `host[:port][/path]` strings with no scheme, which
+        // `URLComponents` parses as a path rather than a host. Strip any
+        // `scheme://`, then any `user:pw@` userinfo, then cut at the first
+        // `/`, `:`, or `?`.
+        var rest = trimmed
+        if let schemeRange = rest.range(of: "://") {
+            rest = String(rest[schemeRange.upperBound...])
+        }
+        if let atIndex = rest.firstIndex(of: "@") {
+            rest = String(rest[rest.index(after: atIndex)...])
+        }
+        let host = rest.prefix { $0 != "/" && $0 != ":" && $0 != "?" }
+        let result = String(host)
+        return result.isEmpty ? "(not signed in)" : result
+    }
+
+    // MARK: - Manifest
+
+    /// Snapshot of the non-secret metadata serialized to `manifest.json`.
+    /// Kept `Codable` + `Equatable` so tests assert on the shaped value
+    /// rather than parsing JSON text.
+    struct Manifest: Codable, Equatable {
+        var appVersion: String
+        var appBuild: String
+        var serverHost: String
+        var osVersion: String
+        var generatedAt: String
+        /// Non-secret settings, keyed by preference name. String-valued so the
+        /// JSON is stable and human-eyeballable regardless of the underlying
+        /// `UserDefaults` storage type.
+        var settings: [String: String]
+    }
+
+    /// Read the allowlisted settings out of a `UserDefaults`, stringifying
+    /// each present value. Missing keys are simply omitted.
+    static func collectSettings(from defaults: UserDefaults) -> [String: String] {
+        var out: [String: String] = [:]
+        for key in settingsAllowlist where out[key] == nil {
+            guard let value = defaults.object(forKey: key) else { continue }
+            out[key] = stringify(value)
+        }
+        return out
+    }
+
+    /// Stable string form for an arbitrary `UserDefaults` value. Bool-backed
+    /// `NSNumber`s render as `true`/`false` (not `1`/`0`) so toggle states read
+    /// cleanly in the manifest.
+    static func stringify(_ value: Any) -> String {
+        if let number = value as? NSNumber {
+            // `UserDefaults` stores Bool as a CFBoolean-backed NSNumber;
+            // distinguish it from a numeric NSNumber so a toggle doesn't show
+            // up as `1`.
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue ? "true" : "false"
+            }
+            return number.stringValue
+        }
+        if let s = value as? String {
+            return s
+        }
+        return String(describing: value)
+    }
+
+    // MARK: - Assembly (pure)
+
+    /// Assemble the in-memory artifact set for the bundle. Pure over its
+    /// inputs: no `Bundle.main`, no live `OSLogStore`, no `UserDefaults.standard`
+    /// reach in here — the menu wrapper supplies them. Returns a map of
+    /// filename → file contents.
+    ///
+    /// `logWindow` bounds how far back log lines are read; the default of one
+    /// hour covers a typical reproduce-then-export session without dragging in
+    /// the whole boot transcript.
+    static func assemble(
+        version: String,
+        build: String,
+        serverURL: String,
+        osVersion: String,
+        now: Date = Date(),
+        logWindow: TimeInterval = 3600,
+        logReader: LogReading,
+        defaults: UserDefaults
+    ) -> [String: Data] {
+        let host = redactServerHost(serverURL)
+
+        let manifest = Manifest(
+            appVersion: version,
+            appBuild: build,
+            serverHost: host,
+            osVersion: osVersion,
+            generatedAt: Self.iso8601(now),
+            settings: collectSettings(from: defaults)
+        )
+
+        var files: [String: Data] = [:]
+
+        // manifest.json — sorted keys for deterministic, diff-friendly output.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let manifestData = try? encoder.encode(manifest) {
+            files["manifest.json"] = manifestData
+        }
+
+        // logs.txt — best-effort. A failure to read the store must not sink
+        // the whole export, so a read error becomes an in-file note instead.
+        let logBody: String
+        do {
+            let lines = try logReader.recentLines(subsystem: Log.subsystem, since: now.addingTimeInterval(-logWindow))
+            logBody = lines.isEmpty
+                ? "(no log entries in the last \(Int(logWindow / 60)) minutes for subsystem \(Log.subsystem))"
+                : lines.joined(separator: "\n")
+        } catch {
+            logBody = "(could not read the unified log: \(error.localizedDescription))"
+        }
+        files["logs.txt"] = Data((logBody + "\n").utf8)
+
+        // README.txt — states what's in and what's deliberately out.
+        files["README.txt"] = Data(readmeText.utf8)
+
+        return files
+    }
+
+    /// Human-readable explainer that ships inside every bundle so a user can
+    /// confirm no secrets are present before attaching it to a public issue.
+    static let readmeText = """
+        Lyrebird Diagnostic Bundle
+        ==========================
+
+        This archive was generated by Help → Export Diagnostic Bundle… to help
+        diagnose a problem. Attach it to a GitHub issue or send it to a
+        maintainer.
+
+        Contents:
+          • manifest.json — app version/build, macOS version, the server HOST
+            ONLY (no scheme, port, path, or query), and your non-secret
+            settings.
+          • logs.txt      — recent log output for subsystem
+            org.lyrebird.desktop, the same data shown by Console.app.
+
+        Deliberately NOT included:
+          • Your access token, password, or device id.
+          • The full server URL — only the bare host is recorded.
+          • Recent searches, pinned stations, or any free-text you entered.
+
+        You can open both files in any text editor to review them before
+        sharing.
+
+        """
+
+    // MARK: - Export (I/O)
+
+    /// Write the assembled artifacts into a temporary directory and compress
+    /// that directory to the destination `.zip` at `destination`.
+    ///
+    /// Uses `NSFileCoordinator`'s `.forUploading` coordination, which hands
+    /// back a system-produced zip of the coordinated directory — Foundation's
+    /// only public, dependency-free zip primitive on macOS. The temp staging
+    /// directory is cleaned up in a `defer` regardless of outcome.
+    ///
+    /// This is intentionally thin: all shaping/redaction lives in
+    /// ``assemble(version:build:serverURL:osVersion:now:logWindow:logReader:defaults:)``,
+    /// which the tests cover directly.
+    static func export(
+        to destination: URL,
+        version: String,
+        build: String,
+        serverURL: String,
+        osVersion: String = ProcessInfo.processInfo.operatingSystemVersionString,
+        logReader: LogReading = OSLogStoreReader(),
+        defaults: UserDefaults = .standard
+    ) throws {
+        let files = assemble(
+            version: version,
+            build: build,
+            serverURL: serverURL,
+            osVersion: osVersion,
+            logReader: logReader,
+            defaults: defaults
+        )
+
+        let fm = FileManager.default
+        let staging = fm.temporaryDirectory
+            .appendingPathComponent("LyrebirdDiagnostics-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: staging) }
+
+        for (name, data) in files {
+            try data.write(to: staging.appendingPathComponent(name), options: .atomic)
+        }
+
+        // Coordinate a read with `.forUploading` to get a zip of `staging`,
+        // then copy it to the user's chosen location. The coordinator's temp
+        // zip is only valid inside the accessor block, so we copy out within
+        // it. If a stale file sits at the destination, remove it first so the
+        // copy doesn't fail.
+        let coordinator = NSFileCoordinator()
+        var coordinationError: NSError?
+        var copyError: Error?
+        coordinator.coordinate(
+            readingItemAt: staging,
+            options: [.forUploading],
+            error: &coordinationError
+        ) { zippedURL in
+            do {
+                if fm.fileExists(atPath: destination.path) {
+                    try fm.removeItem(at: destination)
+                }
+                try fm.copyItem(at: zippedURL, to: destination)
+            } catch {
+                copyError = error
+            }
+        }
+
+        if let coordinationError {
+            throw BundleError.zipCoordinationFailed(underlying: coordinationError)
+        }
+        if let copyError {
+            throw copyError
+        }
+    }
+
+    // MARK: - Formatting helpers
+
+    /// `<iso8601> [<category>] <message>` — the per-line shape in `logs.txt`.
+    static func formatLogLine(date: Date, category: String, message: String) -> String {
+        "\(iso8601(date)) [\(category)] \(message)"
+    }
+
+    /// Shared ISO-8601 formatter. Stable, locale-independent timestamps so the
+    /// manifest and log lines sort and diff predictably across machines.
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    static func iso8601(_ date: Date) -> String {
+        isoFormatter.string(from: date)
+    }
+
+    /// Filename-safe timestamp (`yyyy-MM-dd-HHmmss`) for the default save-panel
+    /// name. Colons from ISO-8601 aren't valid in HFS+/APFS display names, so
+    /// this uses a flat, sortable form instead.
+    static func filenameStamp(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        f.dateFormat = "yyyy-MM-dd-HHmmss"
+        return f.string(from: date)
+    }
+}

--- a/macos/Sources/Lyrebird/System/Haptics.swift
+++ b/macos/Sources/Lyrebird/System/Haptics.swift
@@ -1,0 +1,115 @@
+import AppKit
+
+/// Trackpad haptic feedback for transport + scrub interactions (#18, #325).
+///
+/// Force Touch trackpads expose a haptic actuator through
+/// `NSHapticFeedbackManager.defaultPerformer`. Firing a short pattern when the
+/// user taps play/pause/skip, or when the scrub thumb settles, gives the
+/// transport the same tactile "click" Music.app and the system volume HUD
+/// have — the control feels physical rather than purely visual.
+///
+/// ## Pattern mapping
+///
+/// AppKit ships three feedback patterns; we map each to the interaction whose
+/// semantics it was designed for:
+///   - `.generic`     → discrete transport taps (play / pause / skip). The
+///                      catch-all "a thing happened" tap.
+///   - `.levelChange` → a value moved through detents (shuffle / repeat mode
+///                      cycling), matching the system volume / brightness HUD.
+///   - `.alignment`   → the scrub thumb committing to a position, mirroring the
+///                      snap-to-guide feel AppKit designed this pattern for.
+///
+/// ## Reduce-Motion gate
+///
+/// All feedback is suppressed when **Reduce Motion** is enabled. Apple groups
+/// non-essential haptics under the motion-sensitivity umbrella (the same
+/// accessibility preference that quiets parallax / autoplay), so a user who
+/// has opted out of incidental motion shouldn't feel incidental buzzes either.
+/// We read `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`
+/// directly, mirroring how `Theme` reads the increase-contrast /
+/// differentiate-without-color accessibility flags inline at the call site
+/// rather than threading them through state.
+///
+/// ## Testability
+///
+/// The gate and the dispatch are split from the system singletons: the pure
+/// `perform(_:reduceMotion:using:)` overload takes the reduce-motion flag and
+/// a `HapticPerformer` so the gating contract can be asserted headlessly,
+/// without a Force Touch device or a live `NSWorkspace`. The zero-argument
+/// convenience methods wire in the real performer + the live accessibility
+/// flag for production call sites.
+enum Haptics {
+    /// The subset of `NSHapticFeedbackPerformer` behaviour we depend on,
+    /// abstracted so tests can inject a recording double. `NSHapticFeedbackManager`'s
+    /// `defaultPerformer` conforms to `NSHapticFeedbackPerformer` and is
+    /// adapted to this protocol below.
+    protocol HapticPerformer {
+        func perform(
+            _ pattern: NSHapticFeedbackManager.FeedbackPattern,
+            performanceTime: NSHapticFeedbackManager.PerformanceTime
+        )
+    }
+
+    /// Discrete transport tap — play / pause / previous / next. Maps to
+    /// `.generic`.
+    @MainActor
+    static func transport() {
+        perform(.generic)
+    }
+
+    /// A value cycled through detents — shuffle toggle, repeat-mode rotation.
+    /// Maps to `.levelChange`, matching the system volume/brightness HUD feel.
+    @MainActor
+    static func levelChange() {
+        perform(.levelChange)
+    }
+
+    /// The scrub thumb settling onto a committed position. Maps to
+    /// `.alignment`, the snap-to-guide pattern.
+    @MainActor
+    static func scrubCommit() {
+        perform(.alignment)
+    }
+
+    /// Production entry point: fire `pattern` on the system performer unless
+    /// Reduce Motion is on. Reads the live accessibility flag inline.
+    @MainActor
+    static func perform(_ pattern: NSHapticFeedbackManager.FeedbackPattern) {
+        perform(
+            pattern,
+            reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+            using: SystemHapticPerformer.shared
+        )
+    }
+
+    /// Pure, injectable core used by both production and tests. No-ops when
+    /// `reduceMotion` is true; otherwise performs `pattern` on `performer` at
+    /// `.now` so the tap lands on the same runloop turn as the interaction
+    /// that triggered it. Returns whether the feedback was actually dispatched
+    /// so the gating contract is observable in tests.
+    @discardableResult
+    static func perform(
+        _ pattern: NSHapticFeedbackManager.FeedbackPattern,
+        reduceMotion: Bool,
+        using performer: HapticPerformer
+    ) -> Bool {
+        guard !reduceMotion else { return false }
+        performer.perform(pattern, performanceTime: .now)
+        return true
+    }
+}
+
+/// Adapts the real `NSHapticFeedbackManager.defaultPerformer` to
+/// `Haptics.HapticPerformer`. `defaultPerformer` is re-fetched on every call
+/// rather than cached because AppKit documents it as a dynamic accessor whose
+/// returned performer can change with the active device configuration.
+private struct SystemHapticPerformer: Haptics.HapticPerformer {
+    static let shared = SystemHapticPerformer()
+
+    func perform(
+        _ pattern: NSHapticFeedbackManager.FeedbackPattern,
+        performanceTime: NSHapticFeedbackManager.PerformanceTime
+    ) {
+        NSHapticFeedbackManager.defaultPerformer.perform(pattern, performanceTime: performanceTime)
+    }
+}

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -137,6 +137,16 @@ public final class AudioEngine: NSObject {
     /// can't clobber the queue with the wrong next item.
     private var preloadGeneration: Int = 0
 
+    #if DEBUG
+    /// Test seam: the id of the most recent track passed to
+    /// `preloadNextTrack(_:)` that passed the `player != nil` guard, i.e. the
+    /// track the engine actually armed for gapless playback. `nil` until the
+    /// first successful arm. Lets a test assert that a normal queue advance
+    /// re-arms the pre-load without waiting on the off-main stream resolve
+    /// (which fails fast un-authed and never enqueues). See #931.
+    private(set) var lastPreloadedTrackIdForTesting: String?
+    #endif
+
     /// Called when AVPlayer reaches the end of the current item, so the
     /// owner (AppModel) can advance the queue.
     public var onTrackEnded: (() -> Void)?
@@ -501,6 +511,12 @@ public final class AudioEngine: NSObject {
     /// so rapid skip-next doesn't accumulate stale entries.
     public func preloadNextTrack(_ track: Track) {
         guard player != nil else { return }
+
+        #if DEBUG
+        // Record the armed track *before* the off-main resolve so tests can
+        // observe the intent without the network round-trip (#931).
+        lastPreloadedTrackIdForTesting = track.id
+        #endif
 
         // The PlaybackInfo + stream-URL + auth-header resolution all cross
         // the FFI into Rust, each blocking the calling thread on the core's

--- a/macos/Tests/LyrebirdTests/AccessibleThemeTests.swift
+++ b/macos/Tests/LyrebirdTests/AccessibleThemeTests.swift
@@ -104,4 +104,74 @@ final class AccessibleThemeTests: XCTestCase {
         XCTAssertLessThan(standard.a, 0.5)
         XCTAssertEqual(increased.a, 1.0, accuracy: 0.02)
     }
+
+    // MARK: - Accent adoption at view call sites (#888)
+    //
+    // The legibility-critical accent foregrounds (active-track titles, the
+    // now-playing equalizer, favorite hearts, the "NOW PLAYING" label, the
+    // sidebar active-tab glyphs, prominent buttons) now read
+    // `@Environment(\.accessibleTheme).accent` instead of the static
+    // `Theme.accent`. These tests pin the two invariants that swap relies on:
+    // (1) the accessor routes to the right hex per contrast mode, and
+    // (2) the lift is load-bearing — the standard accent fails AA body
+    // contrast while the high-contrast accent clears it. Surfaces (`bg`/`bgAlt`)
+    // mirror `Theme.bg` / `Theme.bgAlt`.
+
+    private let bg: UInt32 = 0x0C0622
+    private let bgAlt: UInt32 = 0x140B30
+    /// Standard body accent (`Theme.accent`) and its Increase-Contrast lift
+    /// (`Theme.accentHighContrast` == `Theme.accentHot`).
+    private let accentHex: UInt32 = 0xCC2F71
+    private let accentHotHex: UInt32 = 0xFF066F
+    /// WCAG 2.2 §1.4.3 minimum for body text.
+    private let bodyTextMin = 4.5
+
+    /// The `colorSchemeContrast`-driven accessor a view binds via
+    /// `@Environment(\.accessibleTheme)` must resolve to the static `accent`
+    /// under `.standard` and to the brighter `accentHot` lift under
+    /// `.increased`. This is the exact value every converted call site now
+    /// renders, so the mapping is pinned against silent drift.
+    func testAccessibleAccentResolvesPerContrastForCallSites() {
+        XCTAssertEqual(AccessibleTheme(.standard).accent, Theme.accent)
+        XCTAssertEqual(AccessibleTheme(.increased).accent, Theme.accentHighContrast)
+        // The high-contrast variant is intentionally `accentHot`.
+        XCTAssertEqual(Theme.accentHighContrast, Theme.accentHot)
+        // Standard and increased must differ, or the adoption would be a
+        // no-op under Increase Contrast.
+        XCTAssertNotEqual(AccessibleTheme(.standard).accent, AccessibleTheme(.increased).accent)
+    }
+
+    /// Why the call-site swap matters: the static `Theme.accent` fails the
+    /// 4.5:1 body-text threshold on both dark surfaces, while the
+    /// high-contrast accent the wrapper substitutes clears it. If a future
+    /// palette edit made the base accent already-compliant (or broke the
+    /// lift), this test flags that the adoption is no longer load-bearing /
+    /// correct.
+    func testStandardAccentFailsBodyContrastButHighContrastAccentPasses() {
+        for surface in [bg, bgAlt] {
+            let standard = Color.contrastRatio(accentHex, surface)
+            let lifted = Color.contrastRatio(accentHotHex, surface)
+            XCTAssertLessThan(
+                standard, bodyTextMin,
+                "Standard accent contrast \(standard) unexpectedly clears 4.5:1 on \(String(format: "#%06X", surface)) — accent adoption may no longer be needed"
+            )
+            XCTAssertGreaterThanOrEqual(
+                lifted, bodyTextMin,
+                "High-contrast accent contrast \(lifted) below 4.5:1 on \(String(format: "#%06X", surface)) — the lift no longer clears AA body text"
+            )
+        }
+    }
+
+    /// The high-contrast accent must resolve to the documented `accentHot`
+    /// RGBA (#FF066F) when the wrapper reports increased contrast, so the
+    /// converted foregrounds actually paint the brighter pink rather than
+    /// silently falling back to the standard token.
+    func testIncreasedAccentResolvesToAccentHotComponents() {
+        let rgb = NSColor(AccessibleTheme(.increased).accent)
+            .usingColorSpace(.sRGB) ?? NSColor(AccessibleTheme(.increased).accent)
+        XCTAssertEqual(rgb.redComponent, Double(0xFF) / 255.0, accuracy: 0.01)
+        XCTAssertEqual(rgb.greenComponent, Double(0x06) / 255.0, accuracy: 0.01)
+        XCTAssertEqual(rgb.blueComponent, Double(0x6F) / 255.0, accuracy: 0.01)
+        XCTAssertEqual(rgb.alphaComponent, 1.0, accuracy: 0.01)
+    }
 }

--- a/macos/Tests/LyrebirdTests/AlbumOverviewTests.swift
+++ b/macos/Tests/LyrebirdTests/AlbumOverviewTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Lyrebird
+
+/// Coverage for the album editorial "About this album" data path (#68):
+/// `AppModel.parseAlbumDetail(from:)` lifting Jellyfin's album `Overview`
+/// field out of the `fetch_item` JSON, plus the hide-when-empty contract the
+/// `AlbumDetailView.aboutSection` guard relies on.
+///
+/// `parseAlbumDetail` is a pure static function over a JSON string, so it can
+/// be exercised without a live core. The shape used here mirrors what the
+/// real server returns for a `MusicAlbum` with `Fields=...,Overview` (verified
+/// against music.skalthoff.com): a root-level `"Overview"` string with `\n`
+/// paragraph breaks.
+///
+/// `parseAlbumDetail` is `@MainActor`-isolated (it lives on the `@MainActor`
+/// `AppModel`), so the suite is annotated `@MainActor` to call it
+/// synchronously — matching the other AppModel-static test suites.
+@MainActor
+final class AlbumOverviewTests: XCTestCase {
+	/// A populated `Overview` is carried through onto `AlbumDetail.overview`
+	/// verbatim (the HTML strip happens later, in the view).
+	func testParsesOverviewFromJSON() {
+		let json = """
+		{"Name":"÷","Overview":"Third studio album by Ed Sheeran.","Studios":[],"People":[]}
+		"""
+		let detail = AppModel.parseAlbumDetail(from: json)
+		XCTAssertEqual(detail.overview, "Third studio album by Ed Sheeran.")
+	}
+
+	/// Multi-paragraph overviews (Jellyfin uses literal `\n` between
+	/// paragraphs) survive the parse intact so the view can clamp / expand
+	/// them.
+	func testPreservesMultiParagraphOverview() {
+		let json = """
+		{"Name":"Batman Forever","Overview":"Soundtrack to the 1995 film.\\n\\nOnly five songs feature in the movie."}
+		"""
+		let detail = AppModel.parseAlbumDetail(from: json)
+		XCTAssertEqual(
+			detail.overview,
+			"Soundtrack to the 1995 film.\n\nOnly five songs feature in the movie.")
+	}
+
+	/// A missing `Overview` key yields `nil` — the signal the About section
+	/// uses to hide itself. The rest of the detail still parses.
+	func testMissingOverviewIsNil() {
+		let json = """
+		{"Name":"Some Album","Studios":[{"Name":"Asylum"}],"PremiereDate":"2017-03-03T00:00:00.0000000Z"}
+		"""
+		let detail = AppModel.parseAlbumDetail(from: json)
+		XCTAssertNil(detail.overview)
+		// Sibling fields are unaffected by the new parse branch.
+		XCTAssertEqual(detail.label, "Asylum")
+	}
+
+	/// An empty-string `Overview` collapses to `nil` so the section never
+	/// renders an empty shell.
+	func testEmptyOverviewIsNil() {
+		let json = #"{"Name":"X","Overview":""}"#
+		XCTAssertNil(AppModel.parseAlbumDetail(from: json).overview)
+	}
+
+	/// A whitespace-only `Overview` (spaces / tabs / newlines) likewise
+	/// collapses to `nil`.
+	func testWhitespaceOnlyOverviewIsNil() {
+		let json = #"{"Name":"X","Overview":"  \n\t  "}"#
+		XCTAssertNil(AppModel.parseAlbumDetail(from: json).overview)
+	}
+
+	/// A non-string `Overview` (defensive: a server quirk emitting a number /
+	/// null) is treated as absent rather than crashing the parse.
+	func testNonStringOverviewIsNil() {
+		let json = #"{"Name":"X","Overview":42}"#
+		XCTAssertNil(AppModel.parseAlbumDetail(from: json).overview)
+	}
+
+	/// Malformed JSON degrades to an all-`nil` detail, including `overview` —
+	/// the parser never throws.
+	func testGarbageJSONYieldsNilOverview() {
+		let detail = AppModel.parseAlbumDetail(from: "not json at all")
+		XCTAssertNil(detail.overview)
+		XCTAssertNil(detail.label)
+		XCTAssertTrue(detail.people.isEmpty)
+	}
+
+	// MARK: - Hide-when-empty contract
+
+	/// The `aboutSection` renders iff `plainTextOverview(detail.overview)` is
+	/// non-nil. These cases pin that end-to-end decision: a real overview
+	/// shows, every empty variant hides. The HTML strip is shared with the
+	/// artist bio, so HTML-only overviews ("<p></p>") collapse to nil and the
+	/// album section hides exactly like the artist one.
+	func testAboutSectionVisibilityFollowsPlainTextOverview() {
+		// Present → visible.
+		let present = AppModel.parseAlbumDetail(
+			from: #"{"Overview":"<p>A landmark record.</p>"}"#)
+		XCTAssertEqual(
+			ArtistDetailView.plainTextOverview(present.overview),
+			"A landmark record.")
+
+		// Absent → hidden.
+		let absent = AppModel.parseAlbumDetail(from: #"{"Name":"X"}"#)
+		XCTAssertNil(ArtistDetailView.plainTextOverview(absent.overview))
+
+		// HTML that strips to nothing → hidden.
+		let htmlOnly = AppModel.parseAlbumDetail(
+			from: #"{"Overview":"<p></p><br>"}"#)
+		XCTAssertNil(ArtistDetailView.plainTextOverview(htmlOnly.overview))
+	}
+}

--- a/macos/Tests/LyrebirdTests/AmbientPaletteTests.swift
+++ b/macos/Tests/LyrebirdTests/AmbientPaletteTests.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// #271 — coverage for `AmbientPalette`'s string codec, the Swift half of the
+/// per-album ambient-wash cache. `AppModel` keys an in-memory cache by album
+/// id and stores the opaque `"RRGGBB,RRGGBB"` value verbatim; what these tests
+/// pin is the *decoder contract* — that a cached string bridges back to the
+/// correct `Color` values, and that a malformed / stale entry is rejected so
+/// the wash falls back to a fresh sample instead of rendering garbage.
+///
+/// They cover `init?(encoded:)` parsing, the hex→`Color` mapping (resolved
+/// through sRGB components, the same technique `AccessibleThemeTests` uses),
+/// `encoded` symmetry, and the full set of rejection cases.
+final class AmbientPaletteTests: XCTestCase {
+
+    /// An sRGB byte triple, made `Equatable` so `XCTAssertEqual` can compare a
+    /// whole color in one assertion (raw tuples aren't `Equatable`).
+    private struct RGB: Equatable {
+        let r: Int
+        let g: Int
+        let b: Int
+    }
+
+    /// Resolve a SwiftUI `Color` to its sRGB byte triple so we can assert the
+    /// decoded palette landed on the exact channels the hex string encoded.
+    private func rgb(_ color: Color) -> RGB {
+        let ns = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return RGB(
+            r: Int((ns.redComponent * 255).rounded()),
+            g: Int((ns.greenComponent * 255).rounded()),
+            b: Int((ns.blueComponent * 255).rounded())
+        )
+    }
+
+    // MARK: - Decode contract
+
+    /// A well-formed cache string decodes, and each half bridges to the exact
+    /// `Color` the hex triple names — this is the contract a byte-level
+    /// round-trip can't observe (it only proves the bytes survive storage).
+    func testDecodesWellFormedStringToCorrectColors() {
+        guard let palette = AmbientPalette(encoded: "0C0622,887BFF") else {
+            return XCTFail("well-formed palette string must decode")
+        }
+
+        let top = rgb(palette.top)
+        XCTAssertEqual(top.r, 0x0C)
+        XCTAssertEqual(top.g, 0x06)
+        XCTAssertEqual(top.b, 0x22)
+
+        let bottom = rgb(palette.bottom)
+        XCTAssertEqual(bottom.r, 0x88)
+        XCTAssertEqual(bottom.g, 0x7B)
+        XCTAssertEqual(bottom.b, 0xFF)
+    }
+
+    /// The decoded palette's `top`/`bottom` must match the canonical
+    /// `Color(hex:)` constructor for the same triples — i.e. the codec path and
+    /// the direct constructor agree, so a cached value renders identically to a
+    /// freshly sampled one.
+    func testDecodedColorsMatchCanonicalHexInitializer() {
+        guard let palette = AmbientPalette(encoded: "140B30,FF066F") else {
+            return XCTFail("well-formed palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), rgb(Color(hex: 0x140B30)))
+        XCTAssertEqual(rgb(palette.bottom), rgb(Color(hex: 0xFF066F)))
+    }
+
+    /// Pure black / white extremes must survive the decode without channel
+    /// truncation or overflow.
+    func testDecodesBlackAndWhiteExtremes() {
+        guard let palette = AmbientPalette(encoded: "000000,FFFFFF") else {
+            return XCTFail("extreme palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0, g: 0, b: 0))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 255, g: 255, b: 255))
+    }
+
+    /// `UInt32(_:radix:)` accepts lowercase hex, so a cache entry that was
+    /// written (or hand-edited) in lowercase must still decode to the same
+    /// colors.
+    func testDecodesLowercaseHex() {
+        guard let palette = AmbientPalette(encoded: "0c0622,887bff") else {
+            return XCTFail("lowercase palette string must decode")
+        }
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0x0C, g: 0x06, b: 0x22))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 0x88, g: 0x7B, b: 0xFF))
+    }
+
+    // MARK: - encode/decode symmetry
+
+    /// `encoded` re-serializes to the canonical uppercase form, and that form
+    /// decodes back to an equal palette — closing the loop the cache relies on.
+    func testEncodeDecodeRoundTrip() {
+        let original = AmbientPalette(topHex: 0x0C0622, bottomHex: 0x887BFF)
+        XCTAssertEqual(original.encoded, "0C0622,887BFF")
+
+        guard let restored = AmbientPalette(encoded: original.encoded) else {
+            return XCTFail("re-encoded palette must decode")
+        }
+        XCTAssertEqual(restored, original)
+    }
+
+    /// Decoding a lowercase string then re-encoding yields the canonical
+    /// uppercase form, so the cache self-heals casing on re-write.
+    func testReEncodeNormalizesCasing() {
+        let palette = AmbientPalette(encoded: "0c0622,887bff")
+        XCTAssertEqual(palette?.encoded, "0C0622,887BFF")
+    }
+
+    // MARK: - Rejection of malformed / stale cache entries
+
+    func testRejectsMalformedStrings() {
+        let bad = [
+            "",                  // empty
+            "0C0622",            // single color, no comma
+            "0C0622,887BFF,FF0", // three colors
+            "0C0622887BFF",      // missing separator
+            "ZZZZZZ,887BFF",     // non-hex in first half
+            "0C0622,ZZZZZZ",     // non-hex in second half
+            "0C0622,",           // trailing empty half
+            ",887BFF",           // leading empty half
+            "  0C0622,887BFF",   // stray whitespace breaks hex parse
+        ]
+        for input in bad {
+            XCTAssertNil(
+                AmbientPalette(encoded: input),
+                "malformed cache entry \"\(input)\" must decode to nil so the wash re-samples"
+            )
+        }
+    }
+
+    /// A value with more than six hex digits per half still *parses* as a
+    /// `UInt32` but names a color outside the 0xRRGGBB space; the high bits are
+    /// simply ignored by `Color(hex:)`, so we assert the documented masking
+    /// behavior rather than a crash. This pins that an over-wide stale entry
+    /// degrades gracefully (low 24 bits win) instead of trapping.
+    func testOverWideHexMasksToLow24Bits() {
+        guard let palette = AmbientPalette(encoded: "FF887BFF,00000000") else {
+            return XCTFail("parseable-but-wide hex should still decode")
+        }
+        // 0xFF887BFF & 0xFFFFFF == 0x887BFF
+        XCTAssertEqual(rgb(palette.top), RGB(r: 0x88, g: 0x7B, b: 0xFF))
+        XCTAssertEqual(rgb(palette.bottom), RGB(r: 0, g: 0, b: 0))
+    }
+}

--- a/macos/Tests/LyrebirdTests/ArtistsYouLoveTests.swift
+++ b/macos/Tests/LyrebirdTests/ArtistsYouLoveTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the Home "Artists You Love" row (#207).
+///
+/// The shelf is a "dumb" Home section: it reads the favorites-driven
+/// `AppModel.favoriteArtists` slice and hides itself when that slice is
+/// empty (the `@ViewBuilder` guards `if !model.favoriteArtists.isEmpty`).
+/// These tests pin the three contracts the view depends on:
+///
+/// 1. A fresh model starts with no loved artists, so the row hides on first
+///    paint instead of punching an empty hole in the layout.
+/// 2. The slice is the single source the row renders, in order, and the
+///    view's display cap is large enough that a typical favorites set isn't
+///    silently truncated below what the row promises.
+/// 3. Signing out (`logout`) and forgetting the token (`forgetToken`) both
+///    clear the slice, so one account's loved artists never bleed into the
+///    next session's Home row.
+///
+/// Same isolation contract as the other Home/Favorites suites: `AppModel`
+/// is `@MainActor` and boots a live `LyrebirdCore` pointed at a throwaway
+/// data dir via `XDG_DATA_HOME`, so the test never touches the real app
+/// database and never hits the network (we drive the published slice
+/// directly rather than calling the live `refreshFavoriteArtists` fetch).
+@MainActor
+final class ArtistsYouLoveTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-artists-you-love-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeArtist(id: String, name: String) -> Artist {
+        Artist(
+            id: id, name: name, albumCount: 0, songCount: 0, genres: [],
+            imageTag: nil, userData: nil
+        )
+    }
+
+    func testFavoriteArtistsStartEmptySoRowHides() throws {
+        let model = try AppModel()
+        XCTAssertTrue(
+            model.favoriteArtists.isEmpty,
+            "a fresh model has no loved artists, so the Home row hides on first paint"
+        )
+    }
+
+    func testFavoriteArtistsSliceIsRenderedInOrder() throws {
+        let model = try AppModel()
+        let loved = [
+            makeArtist(id: "a1", name: "Aretha Franklin"),
+            makeArtist(id: "a2", name: "Bill Withers"),
+            makeArtist(id: "a3", name: "Curtis Mayfield"),
+        ]
+        model.favoriteArtists = loved
+
+        XCTAssertEqual(
+            model.favoriteArtists.map(\.id),
+            ["a1", "a2", "a3"],
+            "the row renders exactly the favoriteArtists slice, preserving server name order"
+        )
+        XCTAssertFalse(
+            model.favoriteArtists.isEmpty,
+            "a non-empty slice reveals the Home shelf"
+        )
+    }
+
+    func testFavoriteArtistsDisplayCapKeepsTypicalSetIntact() throws {
+        let model = try AppModel()
+        // The Home row caps how many circles it renders (HomeView's
+        // `artistsYouLoveLimit`). A modest favorites set must survive that
+        // cap untouched — only large sets get trimmed, with "See All"
+        // routing to the full Favorites screen for the remainder.
+        let loved = (1...12).map { makeArtist(id: "a\($0)", name: "Artist \($0)") }
+        model.favoriteArtists = loved
+
+        XCTAssertGreaterThanOrEqual(
+            model.favoriteArtists.prefix(18).count,
+            12,
+            "a 12-artist favorites set renders in full under the row's display cap"
+        )
+    }
+
+    func testLogoutClearsLovedArtists() throws {
+        let model = try AppModel()
+        model.favoriteArtists = [makeArtist(id: "a1", name: "Nina Simone")]
+
+        model.logout()
+
+        XCTAssertTrue(
+            model.favoriteArtists.isEmpty,
+            "logout must drop the loved-artists slice so the next account's Home row starts clean"
+        )
+    }
+
+    func testForgetTokenClearsLovedArtists() throws {
+        let model = try AppModel()
+        model.favoriteArtists = [makeArtist(id: "a1", name: "Otis Redding")]
+
+        model.forgetToken()
+
+        XCTAssertTrue(
+            model.favoriteArtists.isEmpty,
+            "forgetting the token (auth expiry) must clear loved artists alongside the rest of session state"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/ArtworkAccessibilityTests.swift
+++ b/macos/Tests/LyrebirdTests/ArtworkAccessibilityTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+import LyrebirdCore
+
+@testable import Lyrebird
+
+/// Guards the decorative-vs-meaningful VoiceOver split on the `Artwork`
+/// component (#356).
+///
+/// `Artwork` is rendered by ~30 surfaces. The overwhelming majority are
+/// thumbnails nested inside a card / tile / row whose *parent* already carries
+/// a meaningful `.accessibilityLabel`, so the inner image — and especially the
+/// seeded-gradient fallback, which has no inherent meaning — must be hidden
+/// from VoiceOver to avoid a contentless "image" stop. A handful of hero
+/// surfaces (album detail, now-playing, playlist cover) are the dominant
+/// identity of their screen and are *not* wrapped in a labelled control, so
+/// they opt in as meaningful and supply their own label.
+///
+/// SwiftUI exposes no public API to introspect `.accessibilityHidden` /
+/// `.accessibilityLabel` off a `some View` without booting a scene or pulling
+/// in ViewInspector, so this suite asserts two complementary things, mirroring
+/// `SwitchControlGroupingTests`:
+///   1. behavioural facts off the type (the `decorative` default; the pure
+///      now-playing label builder), and
+///   2. structural invariants read directly from source (the modifier on the
+///      root view; which call sites flip `decorative` and pair it with a
+///      label).
+/// Each assertion is falsifiable: it fails if the flag default flips, the
+/// modifier is dropped, a hero loses its label, or a decorative thumbnail is
+/// wrongly marked meaningful.
+final class ArtworkAccessibilityTests: XCTestCase {
+
+    // MARK: - Behavioural: default + label builder
+
+    /// The default must stay `decorative: true` so the ~30 thumbnail call
+    /// sites that pass no flag inherit hidden-from-VoiceOver behaviour. A flip
+    /// to `false` would make every gradient placeholder a spoken "image".
+    func testArtworkDefaultsToDecorative() {
+        let art = Artwork(url: nil, seed: "Abbey Road")
+        XCTAssertTrue(art.decorative,
+                      "Artwork must default to decorative:true so nested thumbnails stay hidden from VoiceOver")
+    }
+
+    /// A caller can opt a hero in as meaningful.
+    func testArtworkCanBeMarkedMeaningful() {
+        let art = Artwork(url: nil, seed: "Abbey Road", decorative: false)
+        XCTAssertFalse(art.decorative)
+    }
+
+    /// The now-playing hero prefers the album name when the server ships one.
+    func testNowPlayingLabelUsesAlbumWhenPresent() {
+        XCTAssertEqual(
+            NowPlayingView.nowPlayingArtworkLabel(trackName: "Come Together", albumName: "Abbey Road"),
+            "Album artwork for Abbey Road"
+        )
+    }
+
+    /// Singles / loose tracks with no album name fall back to the track name
+    /// rather than reading an empty "Album artwork for ".
+    func testNowPlayingLabelFallsBackToTrackWhenNoAlbum() {
+        XCTAssertEqual(
+            NowPlayingView.nowPlayingArtworkLabel(trackName: "Strobe", albumName: nil),
+            "Artwork for Strobe"
+        )
+        XCTAssertEqual(
+            NowPlayingView.nowPlayingArtworkLabel(trackName: "Strobe", albumName: ""),
+            "Artwork for Strobe"
+        )
+    }
+
+    // MARK: - Source invariant: Artwork.swift
+
+    /// `Artwork` must expose a `decorative` flag defaulting to `true` and apply
+    /// `.accessibilityHidden(decorative)` on its composed root so the whole
+    /// image (art *and* gradient fallback) is hidden by default.
+    func testArtworkDeclaresDecorativeFlagAndAppliesHidden() throws {
+        let code = strippingLineComments(try source("Sources/Lyrebird/Components/Artwork.swift"))
+        XCTAssertTrue(code.contains("var decorative: Bool = true"),
+                      "Artwork must declare `var decorative: Bool = true`")
+        XCTAssertTrue(code.contains(".accessibilityHidden(decorative)"),
+                      "Artwork must apply `.accessibilityHidden(decorative)` on its root view")
+    }
+
+    // MARK: - Source invariant: meaningful call sites are labelled
+
+    /// The album-detail hero is meaningful and must carry its own label.
+    func testAlbumDetailHeroIsLabelledMeaningful() throws {
+        let code = strippingLineComments(try source("Sources/Lyrebird/Screens/AlbumDetailView.swift"))
+        XCTAssertTrue(code.contains("decorative: false"),
+                      "AlbumDetailView hero must opt out of decorative")
+        XCTAssertTrue(code.contains(".accessibilityLabel(\"Album artwork for \\(album.name)\")"),
+                      "AlbumDetailView hero must label the artwork with the album name")
+    }
+
+    /// The now-playing hero is meaningful and must carry its computed label.
+    func testNowPlayingHeroIsLabelledMeaningful() throws {
+        let code = strippingLineComments(try source("Sources/Lyrebird/Screens/NowPlayingView.swift"))
+        XCTAssertTrue(code.contains("decorative: false"),
+                      "NowPlayingView hero must opt out of decorative")
+        XCTAssertTrue(code.contains(".accessibilityLabel(nowPlayingArtworkLabel(for: track))"),
+                      "NowPlayingView hero must label the artwork via nowPlayingArtworkLabel(for:)")
+    }
+
+    /// The single-image playlist cover fallback must mirror the labelled
+    /// collage path so a playlist hero is announced regardless of which branch
+    /// renders.
+    func testPlaylistCoverFallbackIsLabelledMeaningful() throws {
+        let code = strippingLineComments(try source("Sources/Lyrebird/Screens/PlaylistView.swift"))
+        XCTAssertTrue(code.contains("decorative: false"),
+                      "PlaylistView single-image cover fallback must opt out of decorative")
+        // Both the collage container and the single-image fallback read
+        // "Playlist artwork".
+        let labels = ranges(of: ".accessibilityLabel(\"Playlist artwork\")", in: code).count
+        XCTAssertGreaterThanOrEqual(labels, 2,
+                      "Both the playlist collage and its single-image fallback must label as 'Playlist artwork'")
+    }
+
+    /// Regression guard: decorative thumbnail surfaces must NOT opt out of
+    /// decorative. A discography tile / library row / track row already lives
+    /// inside a labelled parent, so flipping `decorative: false` there would
+    /// re-introduce the redundant "image" announcement #356 removes.
+    func testThumbnailSurfacesStayDecorative() throws {
+        for path in [
+            "Sources/Lyrebird/Components/TrackListRow.swift",
+            "Sources/Lyrebird/Components/LibraryListRow.swift",
+            "Sources/Lyrebird/Components/ArtistCard.swift",
+            "Sources/Lyrebird/Components/HomeAlbumTile.swift",
+        ] {
+            let code = strippingLineComments(try source(path))
+            XCTAssertFalse(code.contains("decorative: false"),
+                           "\(path) renders a thumbnail inside a labelled parent and must keep Artwork decorative")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Loads a repo-relative source file. Uses `#filePath` so the lookup is
+    /// stable regardless of the runner's working directory.
+    private func source(_ relativePath: String, file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let target = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent(relativePath)
+        guard let data = try? Data(contentsOf: target),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read \(relativePath) at \(target.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+
+    /// Drops `//`-style line comments so source-invariant assertions match
+    /// live code rather than explanatory prose (this component's comments
+    /// quote the very modifiers under test).
+    private func strippingLineComments(_ src: String) -> String {
+        src
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                if let r = line.range(of: "//") {
+                    return line[line.startIndex..<r.lowerBound]
+                }
+                return line
+            }
+            .joined(separator: "\n")
+    }
+
+    private func ranges(of needle: String, in haystack: String) -> [Range<String.Index>] {
+        var result: [Range<String.Index>] = []
+        var searchStart = haystack.startIndex
+        while let r = haystack.range(of: needle, range: searchStart..<haystack.endIndex) {
+            result.append(r)
+            searchStart = r.upperBound
+        }
+        return result
+    }
+}

--- a/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import Lyrebird
 @testable import LyrebirdAudio
 import LyrebirdCore
 
@@ -88,4 +89,105 @@ private final class RecoverySpy: AudioEngineDelegate {
     func audioEngineDidStall() {}
     func audioEngineDidFail(_ message: String) {}
     func audioEngineDidRecover() { didRecoverCount += 1 }
+}
+
+/// #931 — gapless must engage on a *normal* queue advance, not just stall
+/// recovery. `AppModel.handleTrackEnded` advances the queue and rebuilds the
+/// player via `play(track:)` (a fresh single-item `AVQueuePlayer`), which drops
+/// any pre-inserted next item. The advance must therefore re-arm the engine's
+/// pre-load for the track *after* the new current one — selecting it with the
+/// same precedence stall recovery uses (user-added "Up Next" over the
+/// auto-queue tail).
+///
+/// These exercise the production arming step directly (`armNextTrackPreload`,
+/// surfaced for tests as `armNextTrackPreloadForTesting`) rather than the async
+/// `play(track:)` path, which throws against the un-authed test core before the
+/// arm would run. The engine records the armed track id before its off-main
+/// stream resolve, so we can assert the *intent* without a network round-trip.
+///
+/// `AppModel` is `@MainActor`; constructing it boots a live `LyrebirdCore`. We
+/// redirect the core's data dir to a throwaway temp dir via `XDG_DATA_HOME`
+/// (honoured by `storage::default_data_dir()`) so tests never touch the real
+/// app database — same pattern as `AutoplayWhenQueueEndsTests`.
+@MainActor
+final class AppModelAdvancePreloadTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-advance-preload-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    /// A normal advance arms the engine pre-load for the head of the auto-queue
+    /// tail when there is no user-added "Up Next". Without the #931 wiring the
+    /// freshly built player would carry no queued-ahead item and the engine's
+    /// `lastPreloadedTrackIdForTesting` would stay nil.
+    func testAdvanceArmsPreloadFromAutoQueueTail() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+        model.upNextAutoQueue = [Queue(track: makeTrack("auto-next"))]
+
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertEqual(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "auto-next",
+            "advance must pre-load the next auto-queue track for gapless playback"
+        )
+    }
+
+    /// User-added "Up Next" wins over the auto-queue tail — the engine advances
+    /// through explicit queue entries first, so the pre-loaded item must match.
+    func testAdvancePrefersUserAddedOverAutoQueue() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+        model.upNextUserAdded = [Queue(track: makeTrack("user-next"))]
+        model.upNextAutoQueue = [Queue(track: makeTrack("auto-next"))]
+
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertEqual(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "user-next",
+            "user-added Up Next must take precedence over the auto-queue tail"
+        )
+    }
+
+    /// At the end of the queue (nothing user-added, empty tail) there is no
+    /// next track to arm, so the advance must leave the engine pre-load
+    /// untouched rather than re-arming a stale item.
+    func testAdvanceAtEndOfQueueArmsNothing() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+        model.upNextUserAdded = []
+        model.upNextAutoQueue = []
+
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertNil(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "no upcoming track means nothing to pre-load at end of queue"
+        )
+    }
 }

--- a/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEnginePreloadTests.swift
@@ -92,18 +92,27 @@ private final class RecoverySpy: AudioEngineDelegate {
 }
 
 /// #931 — gapless must engage on a *normal* queue advance, not just stall
-/// recovery. `AppModel.handleTrackEnded` advances the queue and rebuilds the
-/// player via `play(track:)` (a fresh single-item `AVQueuePlayer`), which drops
-/// any pre-inserted next item. The advance must therefore re-arm the engine's
-/// pre-load for the track *after* the new current one — selecting it with the
-/// same precedence stall recovery uses (user-added "Up Next" over the
-/// auto-queue tail).
+/// recovery. `AppModel.handleTrackEnded` steps the core queue forward
+/// (`core.skipNext()`) and rebuilds the player via `play(track:)` (a fresh
+/// single-item `AVQueuePlayer`), which drops any pre-inserted next item. The
+/// advance must therefore re-arm the engine's pre-load for the track *after*
+/// the new current one, read from the core queue lookahead (`core.peekNext()`)
+/// so it always matches what `skipNext()` plays next.
 ///
-/// These exercise the production arming step directly (`armNextTrackPreload`,
-/// surfaced for tests as `armNextTrackPreloadForTesting`) rather than the async
-/// `play(track:)` path, which throws against the un-authed test core before the
-/// arm would run. The engine records the armed track id before its off-main
-/// stream resolve, so we can assert the *intent* without a network round-trip.
+/// These drive the **production queue-population path** the app actually uses:
+/// `model.play(tracks:)` calls `core.setQueue(...)` synchronously (an in-memory
+/// queue mutation that succeeds un-authed; only the async `play(track:)` it
+/// kicks off needs the network, and that's irrelevant to the queue state), so
+/// the core queue is populated exactly as it is in the running app. The advance
+/// itself runs through `advanceAndArmPreloadForTesting()`, which performs the
+/// same `core.skipNext()` + `armNextTrackPreload()` calls `handleTrackEnded`
+/// makes — skipping only the async player rebuild the empty test player stands
+/// in for. Nothing here hand-sets `upNextAutoQueue` / `upNextUserAdded`; a
+/// regression that left the preload unwired would surface as a nil armed id.
+///
+/// The engine records the armed track id (`lastPreloadedTrackIdForTesting`)
+/// before its off-main stream resolve, so we assert the *intent* without a
+/// network round-trip.
 ///
 /// `AppModel` is `@MainActor`; constructing it boots a live `LyrebirdCore`. We
 /// redirect the core's data dir to a throwaway temp dir via `XDG_DATA_HOME`
@@ -139,55 +148,112 @@ final class AppModelAdvancePreloadTests: XCTestCase {
         )
     }
 
-    /// A normal advance arms the engine pre-load for the head of the auto-queue
-    /// tail when there is no user-added "Up Next". Without the #931 wiring the
-    /// freshly built player would carry no queued-ahead item and the engine's
-    /// `lastPreloadedTrackIdForTesting` would stay nil.
-    func testAdvanceArmsPreloadFromAutoQueueTail() throws {
+    /// A normal advance through a queue built by `play(tracks:)` arms the
+    /// engine pre-load for the track *after* the one the advance landed on.
+    /// This is the end-to-end #931 guarantee: start at the head of a three-track
+    /// queue, advance once (now playing track 1), and the engine must have
+    /// pre-loaded track 2 for the next gapless transition. Before the wiring the
+    /// freshly built player carried no queued-ahead item and the armed id stayed
+    /// nil.
+    func testNormalAdvanceArmsPreloadForFollowingTrack() throws {
         let model = try AppModel()
         model.audio.installEmptyPlayerForTesting()
-        model.upNextAutoQueue = [Queue(track: makeTrack("auto-next"))]
 
-        model.armNextTrackPreloadForTesting()
+        // Production path: populate the core queue exactly as the app does.
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1"), makeTrack("t2")], startIndex: 0)
 
+        // End-of-track advance: now playing t1, pre-load should be t2.
+        let landed = model.advanceAndArmPreloadForTesting()
+
+        XCTAssertEqual(landed?.id, "t1", "advance must move the playhead to the next track")
         XCTAssertEqual(
             model.audio.lastPreloadedTrackIdForTesting,
-            "auto-next",
-            "advance must pre-load the next auto-queue track for gapless playback"
+            "t2",
+            "a normal advance must pre-load the track after the new current one"
         )
     }
 
-    /// User-added "Up Next" wins over the auto-queue tail — the engine advances
-    /// through explicit queue entries first, so the pre-loaded item must match.
-    func testAdvancePrefersUserAddedOverAutoQueue() throws {
+    /// "Play Next" inserts the user's track at `queue_index + 1` in the core
+    /// queue, so after an advance it is exactly what the lookahead pre-loads —
+    /// the same precedence the old in-app "Up Next" overlay was meant to model,
+    /// now sourced straight from the core. Build the base queue via the
+    /// production path, insert a track via `core.playNext`, then advance.
+    func testAdvanceAfterPlayNextArmsTheInsertedTrack() throws {
         let model = try AppModel()
         model.audio.installEmptyPlayerForTesting()
-        model.upNextUserAdded = [Queue(track: makeTrack("user-next"))]
-        model.upNextAutoQueue = [Queue(track: makeTrack("auto-next"))]
 
-        model.armNextTrackPreloadForTesting()
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+        // User "Play Next" — lands right after the current track (t0).
+        _ = model.core.playNext(tracks: [makeTrack("inserted")])
 
+        // Advance off t0: lands on the inserted track, and the *next* one
+        // (the original t1) is what gets pre-loaded.
+        let landed = model.advanceAndArmPreloadForTesting()
+
+        XCTAssertEqual(landed?.id, "inserted", "advance must land on the Play-Next track first")
         XCTAssertEqual(
             model.audio.lastPreloadedTrackIdForTesting,
-            "user-next",
-            "user-added Up Next must take precedence over the auto-queue tail"
+            "t1",
+            "the queue lookahead after the inserted track must be pre-loaded"
         )
     }
 
-    /// At the end of the queue (nothing user-added, empty tail) there is no
-    /// next track to arm, so the advance must leave the engine pre-load
-    /// untouched rather than re-arming a stale item.
-    func testAdvanceAtEndOfQueueArmsNothing() throws {
+    /// Advancing onto the last track of the queue leaves nothing further to
+    /// pre-load (repeat off), so the engine's armed id must stay nil rather than
+    /// re-arming a stale item.
+    func testAdvanceOntoLastTrackArmsNothing() throws {
         let model = try AppModel()
         model.audio.installEmptyPlayerForTesting()
-        model.upNextUserAdded = []
-        model.upNextAutoQueue = []
 
-        model.armNextTrackPreloadForTesting()
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
 
+        // Advance onto t1 (the last track) — peekNext is nil, nothing to arm.
+        let landed = model.advanceAndArmPreloadForTesting()
+
+        XCTAssertEqual(landed?.id, "t1")
         XCTAssertNil(
             model.audio.lastPreloadedTrackIdForTesting,
-            "no upcoming track means nothing to pre-load at end of queue"
+            "no track after the last one means nothing to pre-load"
+        )
+    }
+
+    /// With repeat-all engaged, advancing onto the last track must pre-load the
+    /// wrap-around (first) track — the lookahead honours repeat mode so the
+    /// pre-loaded item still matches what `skipNext()` would play next.
+    func testAdvanceOntoLastTrackWithRepeatAllArmsWrapAround() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+        model.core.setRepeatMode(mode: .all)
+
+        let landed = model.advanceAndArmPreloadForTesting()
+
+        XCTAssertEqual(landed?.id, "t1")
+        XCTAssertEqual(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "t0",
+            "repeat-all must pre-load the wrap-around track at the end of the queue"
+        )
+    }
+
+    /// Stall recovery re-arms the pre-load *without* advancing the playhead —
+    /// it re-loads the track after the current one. Mirrors
+    /// `audioEngineDidRecover`. Build the queue via the production path, then
+    /// arm without an advance: the head's successor is what gets pre-loaded.
+    func testStallRecoveryArmsFollowingTrackWithoutAdvancing() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+
+        // No advance — recovery re-arms for the track after the current (t0).
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertEqual(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "t1",
+            "stall recovery must re-arm the pre-load for the track after current"
         )
     }
 }

--- a/macos/Tests/LyrebirdTests/DiagnosticBundleTests.swift
+++ b/macos/Tests/LyrebirdTests/DiagnosticBundleTests.swift
@@ -1,0 +1,319 @@
+import Foundation
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the Help → Export Diagnostic Bundle collector (#455).
+///
+/// The two side-effecting inputs — the unified log and `UserDefaults` — are
+/// injected, so every assertion runs against `DiagnosticBundle.assemble`
+/// (pure) or the redaction / stringify helpers, with no live `OSLogStore`,
+/// signed-in session, or file I/O. The contract being defended:
+///
+/// 1. The bundle redacts the server URL down to its bare host.
+/// 2. No access token / password / device id ever lands in the bundle.
+/// 3. Only allowlisted settings are copied; free-text user data is excluded.
+/// 4. A log-read failure degrades to an in-file note instead of throwing.
+final class DiagnosticBundleTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// Canned log source. Records the requested subsystem so the collector's
+    /// scope can be asserted, and can be flipped to throw.
+    private final class FakeLogReader: DiagnosticBundle.LogReading {
+        var lines: [String]
+        var error: Error?
+        private(set) var requestedSubsystem: String?
+
+        init(lines: [String] = [], error: Error? = nil) {
+            self.lines = lines
+            self.error = error
+        }
+
+        func recentLines(subsystem: String, since: Date) throws -> [String] {
+            requestedSubsystem = subsystem
+            if let error { throw error }
+            return lines
+        }
+    }
+
+    private struct DummyError: Error {}
+
+    /// Fresh, isolated defaults so the test never reads or mutates the real
+    /// user domain. Caller seeds whatever keys it needs.
+    private func makeDefaults(_ seed: [String: Any]) -> UserDefaults {
+        let suiteName = "DiagnosticBundleTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        for (k, v) in seed { defaults.set(v, forKey: k) }
+        return defaults
+    }
+
+    private func decodeManifest(_ files: [String: Data]) throws -> DiagnosticBundle.Manifest {
+        let data = try XCTUnwrap(files["manifest.json"], "bundle must contain manifest.json")
+        return try JSONDecoder().decode(DiagnosticBundle.Manifest.self, from: data)
+    }
+
+    private func logsText(_ files: [String: Data]) throws -> String {
+        let data = try XCTUnwrap(files["logs.txt"], "bundle must contain logs.txt")
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    // MARK: - Redaction
+
+    func testRedactStripsSchemePathAndQuery() {
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("https://music.example.com/jellyfin?x=1"),
+            "music.example.com",
+            "scheme, path, and query must be dropped"
+        )
+    }
+
+    func testRedactStripsUserinfoAndPort() {
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("https://admin:hunter2@host.internal:8443/jf"),
+            "host.internal",
+            "userinfo and port must be dropped — they can carry secrets"
+        )
+    }
+
+    func testRedactHandlesBareHostWithoutScheme() {
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("music.example.com:8096/jf"),
+            "music.example.com",
+            "a scheme-less host:port/path string must still reduce to the host"
+        )
+    }
+
+    func testRedactEmptyURLIsNotSignedIn() {
+        XCTAssertEqual(DiagnosticBundle.redactServerHost(""), "(not signed in)")
+        XCTAssertEqual(DiagnosticBundle.redactServerHost("   "), "(not signed in)")
+    }
+
+    // MARK: - Secret exclusion (the core safety property)
+
+    func testBundleNeverContainsTokenOrPassword() throws {
+        let reader = FakeLogReader(lines: ["2026-06-04T00:00:00Z [auth] signed in"])
+        let defaults = makeDefaults(["playback.gaplessEnabled": true])
+
+        let files = DiagnosticBundle.assemble(
+            version: "1.2.3",
+            build: "456",
+            // A maximally hostile URL: token in the query, password in
+            // userinfo. None of it may survive into any artifact.
+            serverURL: "https://user:SuperSecretPassword@music.example.com:8443/jf?api_key=TOPSECRETTOKEN",
+            osVersion: "macOS 26.4",
+            logReader: reader,
+            defaults: defaults
+        )
+
+        // Scan every emitted byte across every file for the secrets.
+        let haystack = files.values
+            .map { String(decoding: $0, as: UTF8.self) }
+            .joined(separator: "\n")
+
+        XCTAssertFalse(haystack.contains("SuperSecretPassword"), "password must never appear in the bundle")
+        XCTAssertFalse(haystack.contains("TOPSECRETTOKEN"), "access token must never appear in the bundle")
+        XCTAssertFalse(haystack.contains("api_key"), "query string must be stripped entirely")
+        XCTAssertFalse(haystack.contains("8443"), "port must not survive redaction")
+
+        // And the host that SHOULD survive does.
+        let manifest = try decodeManifest(files)
+        XCTAssertEqual(manifest.serverHost, "music.example.com")
+    }
+
+    // MARK: - Settings allowlist
+
+    func testOnlyAllowlistedSettingsAreCopied() throws {
+        let defaults = makeDefaults([
+            "playback.gaplessEnabled": true,            // allowlisted
+            "appearance.density": "comfortable",        // allowlisted
+            "recentSearches": ["my private query"],     // NOT allowlisted (PII)
+            "pinned_stations": ["secret station"],      // NOT allowlisted (PII)
+            "some.unknown.key": "whatever",             // NOT allowlisted
+        ])
+
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logReader: FakeLogReader(),
+            defaults: defaults
+        )
+        let manifest = try decodeManifest(files)
+
+        XCTAssertEqual(manifest.settings["playback.gaplessEnabled"], "true", "Bool toggles render as true/false")
+        XCTAssertEqual(manifest.settings["appearance.density"], "comfortable")
+        XCTAssertNil(manifest.settings["recentSearches"], "free-text searches must not be exported")
+        XCTAssertNil(manifest.settings["pinned_stations"], "pinned stations must not be exported")
+        XCTAssertNil(manifest.settings["some.unknown.key"], "non-allowlisted keys must not be exported")
+
+        // The PII values must not leak anywhere in the bundle either.
+        let haystack = files.values.map { String(decoding: $0, as: UTF8.self) }.joined()
+        XCTAssertFalse(haystack.contains("my private query"))
+        XCTAssertFalse(haystack.contains("secret station"))
+    }
+
+    func testMissingSettingsAreOmittedNotDefaulted() throws {
+        // Empty defaults — no allowlisted key present.
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logReader: FakeLogReader(),
+            defaults: makeDefaults([:])
+        )
+        let manifest = try decodeManifest(files)
+        XCTAssertTrue(manifest.settings.isEmpty, "absent keys must be omitted, not invented")
+    }
+
+    func testStringifyRendersBoolAndNumberDistinctly() {
+        XCTAssertEqual(DiagnosticBundle.stringify(true), "true", "Bool must not render as 1")
+        XCTAssertEqual(DiagnosticBundle.stringify(false), "false")
+        XCTAssertEqual(DiagnosticBundle.stringify(3), "3")
+        XCTAssertEqual(DiagnosticBundle.stringify(2.5), "2.5")
+        XCTAssertEqual(DiagnosticBundle.stringify("hello"), "hello")
+    }
+
+    // MARK: - Manifest metadata
+
+    func testManifestCarriesVersionBuildAndOS() throws {
+        let files = DiagnosticBundle.assemble(
+            version: "9.9.9",
+            build: "777",
+            serverURL: "https://music.example.com",
+            osVersion: "macOS 26.4 (Build 99X)",
+            logReader: FakeLogReader(),
+            defaults: makeDefaults([:])
+        )
+        let manifest = try decodeManifest(files)
+        XCTAssertEqual(manifest.appVersion, "9.9.9")
+        XCTAssertEqual(manifest.appBuild, "777")
+        XCTAssertEqual(manifest.osVersion, "macOS 26.4 (Build 99X)")
+        XCTAssertFalse(manifest.generatedAt.isEmpty, "a generation timestamp must be recorded")
+    }
+
+    // MARK: - Logs artifact
+
+    func testLogsArtifactRequestsCorrectSubsystemAndJoinsLines() throws {
+        let reader = FakeLogReader(lines: [
+            "2026-06-04T00:00:01Z [app] launched",
+            "2026-06-04T00:00:02Z [net] GET /Items 200",
+        ])
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logReader: reader,
+            defaults: makeDefaults([:])
+        )
+
+        XCTAssertEqual(reader.requestedSubsystem, Log.subsystem, "must scope the read to the app's subsystem")
+        let text = try logsText(files)
+        XCTAssertTrue(text.contains("launched"))
+        XCTAssertTrue(text.contains("GET /Items 200"))
+    }
+
+    func testLogReadFailureDegradesGracefully() throws {
+        let reader = FakeLogReader(error: DummyError())
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logReader: reader,
+            defaults: makeDefaults([:])
+        )
+
+        // A failed log read must not drop the artifact or sink the bundle —
+        // the manifest must still be present and the logs file must explain.
+        XCTAssertNotNil(files["manifest.json"], "manifest must survive a log-read failure")
+        let text = try logsText(files)
+        XCTAssertTrue(text.contains("could not read the unified log"), "the failure must be noted in-file")
+    }
+
+    func testEmptyLogsProducesExplanatoryNote() throws {
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logWindow: 1800,
+            logReader: FakeLogReader(lines: []),
+            defaults: makeDefaults([:])
+        )
+        let text = try logsText(files)
+        XCTAssertTrue(text.contains("no log entries"), "an empty read must say so")
+        XCTAssertTrue(text.contains("30 minutes"), "the window should be reported in minutes")
+    }
+
+    // MARK: - README + file set
+
+    func testBundleAlwaysContainsThreeArtifacts() {
+        let files = DiagnosticBundle.assemble(
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://host",
+            osVersion: "macOS 26.4",
+            logReader: FakeLogReader(),
+            defaults: makeDefaults([:])
+        )
+        XCTAssertEqual(Set(files.keys), ["manifest.json", "logs.txt", "README.txt"])
+    }
+
+    func testReadmeStatesWhatIsExcluded() {
+        // The README is the user's pre-share safety check; it must explicitly
+        // promise no token/password and host-only URL.
+        let readme = DiagnosticBundle.readmeText
+        XCTAssertTrue(readme.contains("access token"))
+        XCTAssertTrue(readme.contains("password"))
+        XCTAssertTrue(readme.lowercased().contains("host"))
+    }
+
+    // MARK: - Filename stamp
+
+    func testFilenameStampIsPathSafe() {
+        let stamp = DiagnosticBundle.filenameStamp(Date(timeIntervalSince1970: 0))
+        XCTAssertFalse(stamp.contains(":"), "colons are not valid in macOS display filenames")
+        XCTAssertFalse(stamp.contains("/"), "slashes would create unintended path components")
+    }
+
+    // MARK: - End-to-end zip write
+
+    func testExportWritesAZipFileToDisk() throws {
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent("diag-export-\(UUID().uuidString).zip")
+        defer { try? FileManager.default.removeItem(at: dest) }
+
+        try DiagnosticBundle.export(
+            to: dest,
+            version: "1.0.0",
+            build: "1",
+            serverURL: "https://music.example.com/jf",
+            osVersion: "macOS 26.4",
+            logReader: FakeLogReader(lines: ["2026-06-04T00:00:00Z [app] hi"]),
+            defaults: makeDefaults(["playback.gaplessEnabled": true])
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dest.path), "a .zip must be written at the destination")
+        let size = (try FileManager.default.attributesOfItem(atPath: dest.path)[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(size, 0, "the written zip must be non-empty")
+
+        // A second export to the same path must overwrite cleanly, not throw.
+        XCTAssertNoThrow(
+            try DiagnosticBundle.export(
+                to: dest,
+                version: "1.0.1",
+                build: "2",
+                serverURL: "https://music.example.com/jf",
+                osVersion: "macOS 26.4",
+                logReader: FakeLogReader(),
+                defaults: makeDefaults([:])
+            ),
+            "re-exporting over an existing file must overwrite it"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/HapticsTests.swift
+++ b/macos/Tests/LyrebirdTests/HapticsTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `Haptics`' Reduce-Motion gate and pattern dispatch.
+///
+/// The transport / scrub call sites in `PlayerBar` and `MiniPlayerView` fire
+/// haptic feedback through `Haptics`, which must stay silent when the user has
+/// Reduce Motion enabled (Apple groups incidental haptics under that
+/// accessibility preference). Exercising the pure
+/// `perform(_:reduceMotion:using:)` overload with a recording double lets us
+/// assert the gating + pattern mapping deterministically — no Force Touch
+/// actuator and no live `NSWorkspace` required.
+final class HapticsTests: XCTestCase {
+
+    /// Records every dispatch so tests can assert what (if anything) fired.
+    private final class RecordingPerformer: Haptics.HapticPerformer {
+        private(set) var calls: [(pattern: NSHapticFeedbackManager.FeedbackPattern,
+                                  time: NSHapticFeedbackManager.PerformanceTime)] = []
+
+        func perform(
+            _ pattern: NSHapticFeedbackManager.FeedbackPattern,
+            performanceTime: NSHapticFeedbackManager.PerformanceTime
+        ) {
+            calls.append((pattern, performanceTime))
+        }
+    }
+
+    func testSuppressedWhenReduceMotionOn() {
+        let performer = RecordingPerformer()
+        let fired = Haptics.perform(.generic, reduceMotion: true, using: performer)
+
+        XCTAssertFalse(fired, "feedback must report not-fired when Reduce Motion is on")
+        XCTAssertTrue(performer.calls.isEmpty, "no haptic may reach the performer under Reduce Motion")
+    }
+
+    func testFiresWhenReduceMotionOff() {
+        let performer = RecordingPerformer()
+        let fired = Haptics.perform(.generic, reduceMotion: false, using: performer)
+
+        XCTAssertTrue(fired, "feedback must report fired when Reduce Motion is off")
+        XCTAssertEqual(performer.calls.count, 1, "exactly one dispatch reaches the performer")
+    }
+
+    func testPatternIsForwardedUnchanged() {
+        // Each call site maps its interaction to a specific AppKit pattern;
+        // the gate must forward whichever pattern it was handed, not coerce
+        // them all to one value.
+        let patterns: [NSHapticFeedbackManager.FeedbackPattern] = [.generic, .alignment, .levelChange]
+        for pattern in patterns {
+            let performer = RecordingPerformer()
+            Haptics.perform(pattern, reduceMotion: false, using: performer)
+            XCTAssertEqual(performer.calls.first?.pattern, pattern, "the requested pattern must propagate verbatim")
+        }
+    }
+
+    func testDispatchUsesNowTiming() {
+        // The tap should land on the same runloop turn as the interaction
+        // (transport tap / scrub commit), so it's perceived as part of the
+        // gesture rather than a delayed afterthought.
+        let performer = RecordingPerformer()
+        Haptics.perform(.alignment, reduceMotion: false, using: performer)
+        XCTAssertEqual(performer.calls.first?.time, .now, "transport/scrub feedback fires at .now")
+    }
+
+    func testRepeatedDispatchesAccumulate() {
+        // Rapid transport taps (e.g. holding next) should each produce their
+        // own feedback rather than coalescing — the gate is stateless.
+        let performer = RecordingPerformer()
+        for _ in 0..<5 {
+            Haptics.perform(.generic, reduceMotion: false, using: performer)
+        }
+        XCTAssertEqual(performer.calls.count, 5, "each interaction fires its own feedback")
+    }
+}


### PR DESCRIPTION
First wave of the 2.0 feature push. Eight additive features, each built in isolation, adversarially reviewed, and integrated on a green base (clean build + 229 Swift tests + cargo test + clippy `-D warnings`, all passing).

- **Ambient palette wash** behind Now Playing, sampled from artwork (CIAreaAverage, memoized per album, honors Reduce Motion/Transparency). Closes #271
- **Artists You Love** circle-card row on Home (favorites-driven). Closes #207
- **Gapless actually engages on normal advance** — added a `peek_next` core FFI and wired `preloadNextTrack` off the live queue (previously only fired on stall recovery). Closes #931
- **"About this album"** editorial notes section on the album page. Closes #68
- **Help → Export Diagnostic Bundle** — sanitized zip (logs + version + redacted config), never secrets. Closes #455
- **Trackpad haptics** for transport + scrub (Reduce-Motion gated). Closes #18, closes #325
- **Decorative artwork hidden to VoiceOver**; meaningful artwork labeled. Closes #356
- **Contrast-adaptive accent** at view call sites (legibility under Increase Contrast). Closes #888