### PR TITLE
macOS 2.0 — Wave 2: scrobbling, Full Player backdrop, Instant Mix, sidebar UX, window restore

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error;
 pub mod models;
 pub mod player;
 pub mod query;
+pub mod scrobble;
 pub mod storage;
 
 pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
@@ -32,6 +33,12 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 uniffi::setup_scaffolding!();
+
+/// Settings-table key under which the ListenBrainz user token is persisted.
+/// Deliberately *not* on the diagnostic-bundle allowlist and *not* cleared by
+/// [`storage::Database::clear_user_data`], so the secret never leaks into a
+/// support bundle and survives logout like other account-independent prefs.
+const SCROBBLE_TOKEN_KEY: &str = "scrobble_listenbrainz_token";
 
 /// Handle for a running heartbeat task.  Dropping or calling [`stop`] cancels
 /// the background interval so there are no leaked timers after skip / logout.
@@ -1099,6 +1106,80 @@ impl LyrebirdCore {
         self.with_client(|c| self.runtime.block_on(c.report_playback_progress(info)))
     }
 
+    // ---------- Scrobbling (ListenBrainz) ----------
+
+    /// Persist the user's ListenBrainz token. Pass `None` (or an empty/blank
+    /// string) to disconnect scrobbling and clear the stored token.
+    ///
+    /// The token is a secret: it lives in the local settings table only, is
+    /// never written to logs, and is intentionally excluded from the
+    /// diagnostic bundle (which reads an allowlist of non-secret keys). It is
+    /// also *not* cleared on logout — like shuffle/repeat it is an
+    /// account-independent preference, so signing out of a Jellyfin server
+    /// leaves the scrobble connection intact for the next sign-in.
+    pub fn set_scrobble_token(
+        &self,
+        token: Option<String>,
+    ) -> std::result::Result<(), LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        match token.map(|t| t.trim().to_string()).filter(|t| !t.is_empty()) {
+            Some(t) => db.set_setting(SCROBBLE_TOKEN_KEY, &t)?,
+            None => db.delete_setting(SCROBBLE_TOKEN_KEY)?,
+        }
+        Ok(())
+    }
+
+    /// Whether a ListenBrainz token is currently stored. Returns a boolean
+    /// rather than the token itself so the UI can render connected / not-
+    /// connected state without the secret ever crossing the FFI boundary.
+    pub fn is_scrobble_configured(&self) -> bool {
+        self.inner
+            .lock()
+            .db
+            .get_setting(SCROBBLE_TOKEN_KEY)
+            .ok()
+            .flatten()
+            .map(|t| !t.trim().is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Submit a ListenBrainz `playing_now` for the track that just started.
+    /// No-op error (`InvalidInput`) when no token is configured, which the
+    /// platform layer treats as "scrobbling disabled" and swallows. Other
+    /// errors (network, 401) propagate so the UI can surface a token problem.
+    pub fn scrobble_now_playing(
+        &self,
+        track: Track,
+    ) -> std::result::Result<(), LyrebirdError> {
+        let token = self.scrobble_token()?;
+        let scrobbler = scrobble::Scrobbler::new(token)?;
+        self.runtime
+            .block_on(scrobbler.submit_playing_now(&track))
+    }
+
+    /// Submit a durable ListenBrainz `single` listen for a track that has
+    /// passed the scrobble threshold. `listened_at` is the Unix timestamp
+    /// (seconds) at which the track *started* — ListenBrainz keys the listen
+    /// on it. No-op error (`InvalidInput`) when no token is configured.
+    pub fn scrobble_submit_listen(
+        &self,
+        track: Track,
+        listened_at: i64,
+    ) -> std::result::Result<(), LyrebirdError> {
+        let token = self.scrobble_token()?;
+        let scrobbler = scrobble::Scrobbler::new(token)?;
+        self.runtime
+            .block_on(scrobbler.submit_listen(&track, listened_at))
+    }
+
+    /// Pure threshold predicate exposed for the platform trigger gate: returns
+    /// `true` once a track at `position_secs` of its `runtime_secs` has played
+    /// long enough to count as a listen (half the track, or four minutes).
+    /// Side-effect free — safe to call on the main thread.
+    pub fn scrobble_threshold_reached(&self, position_secs: f64, runtime_secs: f64) -> bool {
+        scrobble::scrobble_threshold_reached(position_secs, runtime_secs)
+    }
+
     /// Start (or restart) the background heartbeat scheduler.
     ///
     /// Every `interval_secs` seconds (capped at 10 s — Jellyfin's server-side
@@ -1247,6 +1328,23 @@ impl LyrebirdCore {
 }
 
 impl LyrebirdCore {
+    /// Read the stored ListenBrainz token, mapping "absent or blank" to a
+    /// clean [`LyrebirdError::InvalidInput`] so submit paths share one guard.
+    ///
+    /// Deliberately **not** part of the `#[uniffi::export]` block: the raw
+    /// token must never cross the FFI boundary. Platform code learns *whether*
+    /// a token is set via [`Self::is_scrobble_configured`], never its value.
+    fn scrobble_token(&self) -> std::result::Result<String, LyrebirdError> {
+        self.inner
+            .lock()
+            .db
+            .get_setting(SCROBBLE_TOKEN_KEY)
+            .ok()
+            .flatten()
+            .filter(|t| !t.trim().is_empty())
+            .ok_or_else(|| LyrebirdError::InvalidInput("scrobble token not configured".into()))
+    }
+
     /// Run `f` with a reference to the live HTTP client, releasing the
     /// `Inner` mutex before the closure executes.
     ///

--- a/core/src/scrobble.rs
+++ b/core/src/scrobble.rs
@@ -1,0 +1,232 @@
+//! Scrobbling — submit "listens" to a ListenBrainz-compatible server.
+//!
+//! ListenBrainz is the MVP target because it is the simplest of the common
+//! scrobbling backends: a single user token authenticates every request and
+//! the submit endpoint takes plain JSON, so there is no session handshake (as
+//! Last.fm requires) to maintain. The user pastes their token from
+//! <https://listenbrainz.org/profile/> into the Scrobbling preferences pane;
+//! the platform UI feeds track-start and threshold-crossing events here.
+//!
+//! Two kinds of submission, mirroring the ListenBrainz API:
+//!
+//! - **`playing_now`** — sent once when a track starts. Drives the "now
+//!   playing" indicator on the user's ListenBrainz profile. Carries no
+//!   timestamp and is never counted as a listen.
+//! - **`single`** — sent once a track has been played long enough to count
+//!   (the [`scrobble_threshold_reached`] rule: at least half the track, or
+//!   four minutes, whichever comes first). This is the durable listen that
+//!   shows up in the user's history.
+//!
+//! The token is a secret. It is never logged: error paths log the HTTP status
+//! and a generic message, never the `Authorization` header or its value.
+
+use crate::error::{LyrebirdError, Result};
+use crate::models::Track;
+use reqwest::Client as HttpClient;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+/// The canonical public ListenBrainz ingest endpoint. Stored as a field on
+/// [`Scrobbler`] (rather than hard-coded at the call site) so tests can point
+/// the client at a wiremock server.
+pub const LISTENBRAINZ_API_ROOT: &str = "https://api.listenbrainz.org";
+
+/// Submit-listens path appended to the API root.
+const SUBMIT_LISTENS_PATH: &str = "/1/submit-listens";
+
+/// Client identity stamped into every listen's `additional_info`. Mirrors the
+/// `CLIENT_NAME` / `CLIENT_VERSION` the Jellyfin client uses, but kept local
+/// here so this module has no dependency on `client.rs`'s private constants.
+const SCROBBLE_CLIENT_NAME: &str = "Lyrebird Desktop";
+const SCROBBLE_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// A track counts as "listened" — and so earns a `single` submission — once it
+/// has been played for at least half its length **or** four minutes,
+/// whichever comes first. This matches the long-standing Last.fm / ListenBrainz
+/// community scrobble rule (see the ListenBrainz docs and the original AudioScrobbler
+/// spec).
+///
+/// `position_secs` is the current playhead; `runtime_secs` is the track's full
+/// duration. A `runtime_secs` of `0` (unknown duration) falls back to the
+/// four-minute wall-clock rule alone, so a track with no reported length still
+/// scrobbles after four minutes of play rather than never.
+///
+/// Returns `false` for a zero/negative position so a freshly-started track
+/// (or a seek back to the very beginning) never trips the threshold.
+pub fn scrobble_threshold_reached(position_secs: f64, runtime_secs: f64) -> bool {
+    /// Four minutes, the absolute cap from the scrobble spec.
+    const FOUR_MINUTES: f64 = 240.0;
+    /// Tracks shorter than this are too short to scrobble under the spec
+    /// (ListenBrainz/Last.fm both ignore sub-30-second items). Guards against
+    /// counting a stinger / interstitial as a real listen.
+    const MIN_TRACK_SECS: f64 = 30.0;
+
+    if position_secs <= 0.0 {
+        return false;
+    }
+    // Tracks under the minimum length are never eligible — but only when we
+    // actually know the runtime. Unknown runtime (0) defers entirely to the
+    // four-minute rule below.
+    if runtime_secs > 0.0 && runtime_secs < MIN_TRACK_SECS {
+        return false;
+    }
+
+    if position_secs >= FOUR_MINUTES {
+        return true;
+    }
+    if runtime_secs > 0.0 && position_secs >= runtime_secs / 2.0 {
+        return true;
+    }
+    false
+}
+
+/// Build the inner `track_metadata` object shared by both `playing_now` and
+/// `single` submissions. Split out so the payload shape is unit-testable
+/// without standing up an HTTP server.
+///
+/// Maps [`Track`] fields onto the ListenBrainz schema:
+/// - `artist_name`  ← `track.artist_name`
+/// - `track_name`   ← `track.name`
+/// - `release_name` ← `track.album_name` (omitted when absent)
+///
+/// `additional_info` always carries the submitting client name + version so
+/// the listen is attributable in the user's ListenBrainz history, and echoes
+/// the Jellyfin item id under a namespaced key for debugging / dedupe.
+fn track_metadata(track: &Track) -> Value {
+    let mut metadata = json!({
+        "artist_name": track.artist_name,
+        "track_name": track.name,
+        "additional_info": {
+            "media_player": SCROBBLE_CLIENT_NAME,
+            "submission_client": SCROBBLE_CLIENT_NAME,
+            "submission_client_version": SCROBBLE_CLIENT_VERSION,
+            "music_service_name": "Jellyfin",
+            "jellyfin_item_id": track.id,
+        }
+    });
+    if let Some(album) = track.album_name.as_ref().filter(|a| !a.is_empty()) {
+        metadata["release_name"] = json!(album);
+    }
+    metadata
+}
+
+/// Build a full `playing_now` request body for a track. No timestamp — the
+/// ListenBrainz API rejects `playing_now` payloads that carry `listened_at`.
+pub fn playing_now_payload(track: &Track) -> Value {
+    json!({
+        "listen_type": "playing_now",
+        "payload": [
+            { "track_metadata": track_metadata(track) }
+        ]
+    })
+}
+
+/// Build a full `single` (durable listen) request body. `listened_at` is the
+/// Unix timestamp (seconds) at which the track began playing — ListenBrainz
+/// keys the listen on this value, so callers should pass the *start* time, not
+/// the moment the threshold was crossed.
+pub fn single_listen_payload(track: &Track, listened_at: i64) -> Value {
+    json!({
+        "listen_type": "single",
+        "payload": [
+            {
+                "listened_at": listened_at,
+                "track_metadata": track_metadata(track)
+            }
+        ]
+    })
+}
+
+/// A configured ListenBrainz client. Cheap to construct; holds a `reqwest`
+/// client (connection-pooled) and the user token. Created per-submission by
+/// [`crate::LyrebirdCore`] from the persisted token, so a token change takes
+/// effect on the very next scrobble without any cached-client invalidation.
+pub struct Scrobbler {
+    http: HttpClient,
+    api_root: String,
+    token: String,
+}
+
+impl Scrobbler {
+    /// Construct a scrobbler against the public ListenBrainz endpoint.
+    /// Returns `InvalidInput` for an empty token so the caller surfaces a
+    /// clear "token not configured" error rather than firing a request that
+    /// would 401.
+    pub fn new(token: impl Into<String>) -> Result<Self> {
+        Self::with_root(LISTENBRAINZ_API_ROOT, token)
+    }
+
+    /// Construct a scrobbler against an arbitrary API root. Used by tests to
+    /// target a wiremock server; production always goes through
+    /// [`Self::new`].
+    pub fn with_root(api_root: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+        let token = token.into();
+        if token.trim().is_empty() {
+            return Err(LyrebirdError::InvalidInput(
+                "scrobble token is empty".into(),
+            ));
+        }
+        let http = HttpClient::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .map_err(|e| LyrebirdError::Network(e.to_string()))?;
+        Ok(Self {
+            http,
+            api_root: api_root.into(),
+            token,
+        })
+    }
+
+    /// `Authorization` header value. ListenBrainz uses `Token <user-token>`
+    /// (not `Bearer`). Kept private so the secret never escapes this module.
+    fn auth_header(&self) -> String {
+        format!("Token {}", self.token)
+    }
+
+    /// POST a pre-built submission body to `/1/submit-listens`.
+    ///
+    /// On a non-2xx response the body is read for diagnostics but the token is
+    /// never logged. A 401 maps to [`LyrebirdError::Auth`] so the UI can tell
+    /// the user their token is wrong; everything else surfaces as
+    /// [`LyrebirdError::Server`].
+    async fn submit(&self, body: Value) -> Result<()> {
+        let url = format!("{}{}", self.api_root.trim_end_matches('/'), SUBMIT_LISTENS_PATH);
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LyrebirdError::Network(e.to_string()))?;
+
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        // Read the body for the error message but keep it short; never echo
+        // the request (which carries the token).
+        let snippet = resp.text().await.unwrap_or_default();
+        let snippet: String = snippet.chars().take(500).collect();
+        if status.as_u16() == 401 {
+            return Err(LyrebirdError::Auth(
+                "ListenBrainz rejected the token".into(),
+            ));
+        }
+        Err(LyrebirdError::Server {
+            status: status.as_u16(),
+            body: snippet,
+        })
+    }
+
+    /// Submit a `playing_now` for the given track.
+    pub async fn submit_playing_now(&self, track: &Track) -> Result<()> {
+        self.submit(playing_now_payload(track)).await
+    }
+
+    /// Submit a durable `single` listen for the given track, keyed to the Unix
+    /// `listened_at` start time.
+    pub async fn submit_listen(&self, track: &Track, listened_at: i64) -> Result<()> {
+        self.submit(single_listen_payload(track, listened_at)).await
+    }
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7998,3 +7998,290 @@ async fn playlists_containing_artist_zero_limit_is_empty() {
         .unwrap();
     assert!(result.is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Scrobbling — ListenBrainz (#46)
+// ---------------------------------------------------------------------------
+
+/// Minimal `Track` builder for the scrobble tests. Mirrors the helper used by
+/// the player tests above but lives here so the scrobble block is
+/// self-contained when it lands on a fresh rebase.
+fn scrobble_track(id: &str, name: &str, artist: &str, album: Option<&str>) -> crate::models::Track {
+    crate::models::Track {
+        id: id.into(),
+        name: name.into(),
+        album_id: None,
+        album_name: album.map(|a| a.into()),
+        artist_name: artist.into(),
+        artist_id: None,
+        index_number: None,
+        disc_number: None,
+        year: None,
+        runtime_ticks: 1_800_000_000,
+        is_favorite: false,
+        play_count: 0,
+        container: None,
+        bitrate: None,
+        image_tag: None,
+        playlist_item_id: None,
+        user_data: None,
+    }
+}
+
+#[test]
+fn scrobble_threshold_not_reached_before_half_or_four_min() {
+    // 3-minute track (180s). Half is 90s. At 89s neither rule is satisfied.
+    assert!(!crate::scrobble::scrobble_threshold_reached(89.0, 180.0));
+    // Just started.
+    assert!(!crate::scrobble::scrobble_threshold_reached(1.0, 180.0));
+    // Position zero never trips, even with a long runtime.
+    assert!(!crate::scrobble::scrobble_threshold_reached(0.0, 6000.0));
+    // Negative position (defensive) never trips.
+    assert!(!crate::scrobble::scrobble_threshold_reached(-5.0, 180.0));
+}
+
+#[test]
+fn scrobble_threshold_reached_at_half_track() {
+    // 3-minute track: crosses at exactly half (90s).
+    assert!(crate::scrobble::scrobble_threshold_reached(90.0, 180.0));
+    assert!(crate::scrobble::scrobble_threshold_reached(120.0, 180.0));
+}
+
+#[test]
+fn scrobble_threshold_reached_at_four_minutes_for_long_track() {
+    // 20-minute track (1200s). Half (600s) is way past four minutes, so the
+    // four-minute cap is what fires first — at 240s, not 600s.
+    assert!(!crate::scrobble::scrobble_threshold_reached(239.0, 1200.0));
+    assert!(crate::scrobble::scrobble_threshold_reached(240.0, 1200.0));
+    assert!(crate::scrobble::scrobble_threshold_reached(241.0, 1200.0));
+    // 300s is past the four-minute cap, so it DOES trip even though it's
+    // well below the 600s half-track mark.
+    assert!(crate::scrobble::scrobble_threshold_reached(300.0, 1200.0));
+}
+
+#[test]
+fn scrobble_threshold_unknown_runtime_uses_four_minute_rule() {
+    // runtime 0 == unknown duration. Defers entirely to the four-minute rule.
+    assert!(!crate::scrobble::scrobble_threshold_reached(120.0, 0.0));
+    assert!(crate::scrobble::scrobble_threshold_reached(240.0, 0.0));
+}
+
+#[test]
+fn scrobble_threshold_short_track_never_scrobbles() {
+    // A 20-second sting: under the 30s minimum, never eligible even at its end.
+    assert!(!crate::scrobble::scrobble_threshold_reached(20.0, 20.0));
+    assert!(!crate::scrobble::scrobble_threshold_reached(19.0, 20.0));
+}
+
+#[test]
+fn scrobble_playing_now_payload_shape() {
+    let track = scrobble_track("item-1", "Yona", "Saloli", Some("The Deep End"));
+    let payload = crate::scrobble::playing_now_payload(&track);
+
+    assert_eq!(payload["listen_type"], "playing_now");
+    let listen = &payload["payload"][0];
+    // playing_now must NOT carry a timestamp — ListenBrainz rejects it.
+    assert!(listen.get("listened_at").is_none());
+    let md = &listen["track_metadata"];
+    assert_eq!(md["artist_name"], "Saloli");
+    assert_eq!(md["track_name"], "Yona");
+    assert_eq!(md["release_name"], "The Deep End");
+    assert_eq!(md["additional_info"]["jellyfin_item_id"], "item-1");
+    assert_eq!(md["additional_info"]["music_service_name"], "Jellyfin");
+    // Client identity is stamped so the listen is attributable.
+    assert!(md["additional_info"]["submission_client"]
+        .as_str()
+        .unwrap()
+        .contains("Lyrebird"));
+}
+
+#[test]
+fn scrobble_single_listen_payload_shape() {
+    let track = scrobble_track("item-2", "Tides", "Saloli", None);
+    let payload = crate::scrobble::single_listen_payload(&track, 1_700_000_000);
+
+    assert_eq!(payload["listen_type"], "single");
+    let listen = &payload["payload"][0];
+    assert_eq!(listen["listened_at"], 1_700_000_000i64);
+    let md = &listen["track_metadata"];
+    assert_eq!(md["artist_name"], "Saloli");
+    assert_eq!(md["track_name"], "Tides");
+    // No album -> release_name omitted entirely (not null).
+    assert!(md.get("release_name").is_none());
+}
+
+#[test]
+fn scrobble_empty_token_is_rejected() {
+    assert!(crate::scrobble::Scrobbler::new("").is_err());
+    assert!(crate::scrobble::Scrobbler::new("   ").is_err());
+    assert!(crate::scrobble::Scrobbler::new("lb-token").is_ok());
+}
+
+#[tokio::test]
+async fn scrobble_submit_single_posts_to_listenbrainz() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/1/submit-listens"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "Token lb-secret-token",
+        ))
+        .and(wiremock::matchers::body_json(json!({
+            "listen_type": "single",
+            "payload": [{
+                "listened_at": 1_700_000_000i64,
+                "track_metadata": {
+                    "artist_name": "Saloli",
+                    "track_name": "Yona",
+                    "release_name": "The Deep End",
+                    "additional_info": {
+                        "media_player": "Lyrebird Desktop",
+                        "submission_client": "Lyrebird Desktop",
+                        "submission_client_version": env!("CARGO_PKG_VERSION"),
+                        "music_service_name": "Jellyfin",
+                        "jellyfin_item_id": "item-1",
+                    }
+                }
+            }]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "ok" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let track = scrobble_track("item-1", "Yona", "Saloli", Some("The Deep End"));
+    let scrobbler =
+        crate::scrobble::Scrobbler::with_root(server.uri(), "lb-secret-token").unwrap();
+    scrobbler
+        .submit_listen(&track, 1_700_000_000)
+        .await
+        .unwrap();
+    // `.expect(1)` on the mock asserts exactly one POST landed on drop.
+}
+
+#[tokio::test]
+async fn scrobble_submit_playing_now_posts_without_timestamp() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/1/submit-listens"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "ok" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Capture the request body to assert the listen_type and absence of a
+    // timestamp directly.
+    let track = scrobble_track("item-7", "Drift", "Saloli", None);
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "tok").unwrap();
+    scrobbler.submit_playing_now(&track).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body["listen_type"], "playing_now");
+    assert!(body["payload"][0].get("listened_at").is_none());
+}
+
+#[tokio::test]
+async fn scrobble_submit_maps_401_to_auth_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/1/submit-listens"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({ "error": "Invalid token" })))
+        .mount(&server)
+        .await;
+
+    let track = scrobble_track("item-1", "Yona", "Saloli", None);
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "bad-token").unwrap();
+    let err = scrobbler.submit_listen(&track, 1).await.unwrap_err();
+    assert!(matches!(err, LyrebirdError::Auth(_)));
+}
+
+#[tokio::test]
+async fn scrobble_submit_maps_500_to_server_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/1/submit-listens"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("upstream boom"))
+        .mount(&server)
+        .await;
+
+    let track = scrobble_track("item-1", "Yona", "Saloli", None);
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "tok").unwrap();
+    let err = scrobbler.submit_listen(&track, 1).await.unwrap_err();
+    match err {
+        LyrebirdError::Server { status, .. } => assert_eq!(status, 500),
+        other => panic!("expected Server error, got {other:?}"),
+    }
+}
+
+#[test]
+fn scrobble_token_persistence_and_configured_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CoreConfig {
+        data_dir: dir.path().to_string_lossy().into_owned(),
+        device_name: "Test".into(),
+    };
+    let core = LyrebirdCore::new(config).unwrap();
+
+    // Fresh install: not configured.
+    assert!(!core.is_scrobble_configured());
+
+    // Set a token -> configured.
+    core.set_scrobble_token(Some("lb-user-token".into())).unwrap();
+    assert!(core.is_scrobble_configured());
+
+    // Blank/whitespace token clears it (treated as disconnect).
+    core.set_scrobble_token(Some("   ".into())).unwrap();
+    assert!(!core.is_scrobble_configured());
+
+    // Set again, then explicit None clears.
+    core.set_scrobble_token(Some("lb-user-token".into())).unwrap();
+    assert!(core.is_scrobble_configured());
+    core.set_scrobble_token(None).unwrap();
+    assert!(!core.is_scrobble_configured());
+}
+
+#[test]
+fn scrobble_submit_without_token_errors_invalid_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CoreConfig {
+        data_dir: dir.path().to_string_lossy().into_owned(),
+        device_name: "Test".into(),
+    };
+    let core = LyrebirdCore::new(config).unwrap();
+    let track = scrobble_track("x", "X", "Y", None);
+
+    // No token configured -> InvalidInput, never a panic / network call.
+    let err = core.scrobble_now_playing(track.clone()).unwrap_err();
+    assert!(matches!(err, LyrebirdError::InvalidInput(_)));
+    let err = core.scrobble_submit_listen(track, 1).unwrap_err();
+    assert!(matches!(err, LyrebirdError::InvalidInput(_)));
+}
+
+#[test]
+fn scrobble_token_survives_clear_user_data() {
+    // Logout must NOT wipe the scrobble token (account-independent pref).
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open(dir.path().join("lb.db")).unwrap();
+    db.set_setting("scrobble_listenbrainz_token", "keep-me").unwrap();
+    db.clear_user_data().unwrap();
+    assert_eq!(
+        db.get_setting("scrobble_listenbrainz_token").unwrap().as_deref(),
+        Some("keep-me")
+    );
+}
+
+#[test]
+fn scrobble_core_threshold_predicate_matches_module() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CoreConfig {
+        data_dir: dir.path().to_string_lossy().into_owned(),
+        device_name: "Test".into(),
+    };
+    let core = LyrebirdCore::new(config).unwrap();
+    // The FFI wrapper must agree with the pure function it delegates to.
+    assert!(!core.scrobble_threshold_reached(89.0, 180.0));
+    assert!(core.scrobble_threshold_reached(90.0, 180.0));
+    assert!(core.scrobble_threshold_reached(240.0, 0.0));
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -280,6 +280,13 @@ final class AppModel {
     /// section, so the two never drift. Hidden in the Home layout when
     /// empty — a fresh user with no favorited artists sees no shelf.
     var favoriteArtists: [Artist] = []
+    /// "Rediscover" — albums the user has never played, for the Home shelf
+    /// of the same name (#57). Backed by an `/Items` query filtered to
+    /// `IsUnplayed` and sorted `Random` so the row surfaces a fresh,
+    /// varied handful each session (the same shuffle-for-freshness shape
+    /// as the Favorites carousel). Up to 12 albums. Hidden when empty so a
+    /// fully-played library renders no shelf rather than a blank band.
+    var rediscover: [Album] = []
     /// Server-curated "You might like" tracks for the Home discovery row
     /// (#145). Backed by `core.suggestions()`, which hits Jellyfin's
     /// `/Items/Suggestions` endpoint. Up to 20 tracks. Hidden until data
@@ -1052,6 +1059,7 @@ final class AppModel {
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
         favoriteArtists = []
+        rediscover = []
         suggestions = []
         searchResults = nil
         searchQuery = ""
@@ -1124,6 +1132,7 @@ final class AppModel {
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
         favoriteArtists = []
+        rediscover = []
         suggestions = []
         searchResults = nil
         searchQuery = ""
@@ -1285,6 +1294,7 @@ final class AppModel {
         await refreshQuickPicks()
         await refreshFavoriteAlbums()
         await refreshFavoriteArtists()
+        await refreshRediscover()
         await refreshSuggestions()
     }
 
@@ -1772,6 +1782,24 @@ final class AppModel {
     /// the server.
     func reshuffleFavoriteAlbumsVisible() {
         self.favoriteAlbumsVisible = Array(favoriteAlbumsAll.shuffled().prefix(12))
+    }
+
+    /// Refresh the "Rediscover" carousel (#57). Fetches up to 12 albums the
+    /// user has never played, filtered to `IsUnplayed` and sorted `Random`
+    /// server-side so the row surfaces a different corner of the library on
+    /// each cold launch / refresh rather than the same alphabetically-first
+    /// dozen. Reuses `fetchAlbumsViaItemsQuery` — the `Descending` sort order
+    /// it hardcodes is a no-op for `Random`. Best-effort: an empty result
+    /// (a fully-played library) just leaves the shelf hidden.
+    func refreshRediscover() async {
+        let albums = await fetchAlbumsViaItemsQuery(
+            sortBy: "Random",
+            filters: "IsUnplayed",
+            limit: 12,
+            extraFields: [],
+            minDateLastSaved: nil
+        )
+        self.rediscover = albums
     }
 
     /// Refresh the "Artists You Love" carousel (#207). Reuses

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -885,11 +885,139 @@ final class AppModel {
     /// Look up a palette action by id and run it. Called by `CommandPalette`
     /// on ↩ commit. Also closes the palette on success, mirroring the
     /// "execute and dismiss" behavior users expect from Spotlight-style
-    /// launchers. See #307.
+    /// launchers. Records the run in the recents list so the next empty-query
+    /// open surfaces it under "Recent". See #307 / #308.
     func executePaletteAction(id: String) {
         guard let action = paletteActions.first(where: { $0.id == id }) else { return }
+        recordPaletteActionUsage(id: id)
         action.run()
         isCommandPaletteOpen = false
+    }
+
+    // MARK: - Command Palette recents + pinned (#308)
+    //
+    // The empty-query palette shows Pinned actions first, then the most
+    // recently run actions, then the remaining static roster. Both lists are
+    // persisted as JSON `[String]` (action ids) in `UserDefaults` — the same
+    // `@Observable` → UserDefaults bridge the mini-player flag (above) and the
+    // recent-searches list use, since `@Observable` can't reach `@AppStorage`
+    // directly. Storing ids (not the `PaletteAction` structs) keeps the store
+    // decoupled from the live roster: an id that no longer resolves (e.g. a
+    // capability-gated action whose flag is now off) is simply skipped when
+    // the palette rebuilds its rows, and the persisted entry is harmless.
+
+    /// UserDefaults key for the JSON-encoded recent-action-id list.
+    private static let paletteRecentActionIdsKey = "palette.recentActionIds"
+
+    /// UserDefaults key for the JSON-encoded pinned-action-id list.
+    private static let palettePinnedActionIdsKey = "palette.pinnedActionIds"
+
+    /// How many recently-run actions to retain. Five keeps the empty-query
+    /// "Recent" group short enough to scan at a glance without pushing the
+    /// full roster below the fold of the 360pt results scroll.
+    static let paletteRecentActionsCap = 5
+
+    /// Most-recently-run palette action ids, newest first. Mirrored into
+    /// `UserDefaults` through `recordPaletteActionUsage(id:)`; initialised
+    /// from the persisted JSON so recents survive relaunch.
+    private(set) var paletteRecentActionIds: [String] =
+        AppModel.decodePaletteActionIds(
+            UserDefaults.standard.string(forKey: AppModel.paletteRecentActionIdsKey) ?? "[]"
+        )
+
+    /// Pinned palette action ids, in user-pin order (newest pin first).
+    /// Mirrored into `UserDefaults` through `pinPaletteAction` /
+    /// `unpinPaletteAction`; initialised from the persisted JSON.
+    private(set) var palettePinnedActionIds: [String] =
+        AppModel.decodePaletteActionIds(
+            UserDefaults.standard.string(forKey: AppModel.palettePinnedActionIdsKey) ?? "[]"
+        )
+
+    /// Record that `id` was just run: dedupe, insert at the front, cap to
+    /// `paletteRecentActionsCap`, and persist. Mirrors `addRecentSearch`'s
+    /// dedupe/cap/insert-at-0 contract so the most-recent action is always
+    /// first and a re-run promotes (rather than duplicates) an entry.
+    func recordPaletteActionUsage(id: String) {
+        paletteRecentActionIds = AppModel.appendPaletteRecent(
+            id,
+            into: paletteRecentActionIds,
+            cap: AppModel.paletteRecentActionsCap
+        )
+        persist(paletteRecentActionIds, forKey: AppModel.paletteRecentActionIdsKey)
+    }
+
+    /// Whether `id` is currently pinned. Cheap membership test for the row
+    /// context menu's "Pin"/"Unpin" label and the empty-query grouping.
+    func isPaletteActionPinned(id: String) -> Bool {
+        palettePinnedActionIds.contains(id)
+    }
+
+    /// Pin `id` (no-op if already pinned). New pins go to the front so the
+    /// most-recently-pinned action leads the "Pinned" group, matching the
+    /// recents ordering.
+    func pinPaletteAction(id: String) {
+        guard !palettePinnedActionIds.contains(id) else { return }
+        palettePinnedActionIds.insert(id, at: 0)
+        persist(palettePinnedActionIds, forKey: AppModel.palettePinnedActionIdsKey)
+    }
+
+    /// Unpin `id` (no-op if not pinned).
+    func unpinPaletteAction(id: String) {
+        guard palettePinnedActionIds.contains(id) else { return }
+        palettePinnedActionIds.removeAll { $0 == id }
+        persist(palettePinnedActionIds, forKey: AppModel.palettePinnedActionIdsKey)
+    }
+
+    /// Toggle the pin state of `id`. Wired to the palette row's right-click
+    /// "Pin"/"Unpin" affordance.
+    func togglePaletteActionPin(id: String) {
+        if isPaletteActionPinned(id: id) {
+            unpinPaletteAction(id: id)
+        } else {
+            pinPaletteAction(id: id)
+        }
+    }
+
+    /// Append a run to the recent-action-id list: drop any existing copy,
+    /// insert at the front, cap to `cap`. Pure + static so the cap / dedupe /
+    /// ordering contract is unit-testable without booting an `AppModel`,
+    /// mirroring `addRecentSearch`. Action ids are exact-match (not
+    /// case-insensitive) since they're internal identifiers, not user text.
+    static func appendPaletteRecent(_ id: String, into list: [String], cap: Int) -> [String] {
+        guard !id.isEmpty else { return list }
+        var next = list
+        next.removeAll { $0 == id }
+        next.insert(id, at: 0)
+        if next.count > cap {
+            next = Array(next.prefix(cap))
+        }
+        return next
+    }
+
+    /// Decode a persisted JSON `[String]` of action ids. Returns `[]` on
+    /// malformed data so a stale shape from a prior build can't wedge the
+    /// palette — same defensive decode as `decodeRecentSearches`.
+    static func decodePaletteActionIds(_ json: String) -> [String] {
+        guard let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    /// Encode an action-id list back to the JSON string persisted in
+    /// `UserDefaults`. Returns `"[]"` on failure so a write never stores a
+    /// half-baked value.
+    static func encodePaletteActionIds(_ list: [String]) -> String {
+        guard let data = try? JSONEncoder().encode(list),
+              let s = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return s
+    }
+
+    /// Persist an action-id list under `key` via the JSON-in-UserDefaults
+    /// bridge.
+    private func persist(_ list: [String], forKey key: String) {
+        UserDefaults.standard.set(AppModel.encodePaletteActionIds(list), forKey: key)
     }
 
     init() throws {

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4367,10 +4367,10 @@ final class AppModel {
         Task { await duplicatePlaylist(id: playlist.id) }
     }
 
-    /// Present a save panel and write the playlist to disk as an `.m3u8` file.
-    /// Fetches the playlist's tracks via `playlist_tracks` FFI, then builds an
-    /// extended M3U file with `#EXTINF` metadata per track. Stream URLs are
-    /// written without auth tokens so the file is safe to share (#76).
+    /// Present a save panel and write the playlist to disk as an extended-M3U
+    /// (`.m3u8`) file. Fetches the playlist's tracks via `playlist_tracks` FFI,
+    /// then delegates the string-building to `PlaylistExport.m3u8`. Stream URLs
+    /// are written without auth tokens so the file is safe to share (#76 / #237).
     func exportPlaylist(playlist: Playlist) {
         Task {
             // Fetch tracks before opening the panel so we know the export
@@ -4380,39 +4380,74 @@ final class AppModel {
                 errorMessage = "No tracks to export for \"\(playlist.name)\"."
                 return
             }
+            let content = PlaylistExport.m3u8(
+                playlistName: playlist.name,
+                tracks: tracks,
+                serverURL: serverURL
+            )
+            writeExport(
+                content,
+                suggestedName: "\(playlist.name).m3u8",
+                fileExtension: "m3u8",
+                panelTitle: "Export Playlist as .m3u8"
+            )
+        }
+    }
 
-            // Build the extended M3U content. runtimeTicks is in 100-nanosecond
-            // units; divide by 10_000_000 to get whole seconds for #EXTINF.
-            var lines: [String] = ["#EXTM3U"]
-            let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
-            for track in tracks {
-                let durationSec = Int(track.runtimeTicks / 10_000_000)
-                let inf = "#EXTINF:\(durationSec),\(track.artistName) - \(track.name)"
-                // Use the auth-free universal-stream path: no query parameters,
-                // no api_key. Works with servers that allow unauthenticated
-                // download (many local setups), and is safe to share even when
-                // that's not the case.
-                let streamPath = "\(base)/Audio/\(track.id)/universal"
-                lines.append(inf)
-                lines.append(streamPath)
+    /// Present a save panel and write the playlist to disk as a JSON manifest
+    /// (`.json`). Fetches the playlist's tracks via `playlist_tracks` FFI, then
+    /// delegates serialization to `PlaylistExport.json`. The manifest is a
+    /// stable, self-contained projection (id + ordered tracks) suitable for
+    /// backup / re-import / scripting (#237).
+    func exportPlaylistJSON(playlist: Playlist) {
+        Task {
+            let tracks = await loadPlaylistTracks(playlist: playlist)
+            guard !tracks.isEmpty else {
+                errorMessage = "No tracks to export for \"\(playlist.name)\"."
+                return
             }
-            let m3u8Content = lines.joined(separator: "\n") + "\n"
-
-            // Present the save panel on the main actor.
-            let panel = NSSavePanel()
-            panel.title = "Export Playlist as .m3u8"
-            panel.nameFieldStringValue = "\(playlist.name).m3u8"
-            panel.allowedContentTypes = [.init(filenameExtension: "m3u8") ?? .plainText]
-            panel.canCreateDirectories = true
-
-            let response = panel.runModal()
-            guard response == .OK, let url = panel.url else { return }
-
+            let content: String
             do {
-                try m3u8Content.write(to: url, atomically: true, encoding: .utf8)
+                content = try PlaylistExport.json(
+                    playlistId: playlist.id,
+                    playlistName: playlist.name,
+                    tracks: tracks
+                )
             } catch {
                 errorMessage = "Export failed: \(error.localizedDescription)"
+                return
             }
+            writeExport(
+                content,
+                suggestedName: "\(playlist.name).json",
+                fileExtension: "json",
+                panelTitle: "Export Playlist as JSON"
+            )
+        }
+    }
+
+    /// Shared `NSSavePanel` IO for the playlist export formats. Presents the
+    /// panel on the main actor and writes `content` to the chosen URL, routing
+    /// any failure to `errorMessage`. A user cancel is a silent no-op.
+    private func writeExport(
+        _ content: String,
+        suggestedName: String,
+        fileExtension: String,
+        panelTitle: String
+    ) {
+        let panel = NSSavePanel()
+        panel.title = panelTitle
+        panel.nameFieldStringValue = suggestedName
+        panel.allowedContentTypes = [.init(filenameExtension: fileExtension) ?? .plainText]
+        panel.canCreateDirectories = true
+
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
+
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            errorMessage = "Export failed: \(error.localizedDescription)"
         }
     }
 
@@ -4704,10 +4739,12 @@ final class AppModel {
     /// Jellyfin web URL for a playlist, e.g.
     /// `https://server.example.com/web/#/details?id=<playlistId>`. The Jellyfin
     /// web UI uses the same `details` route for albums, artists, and playlists.
+    ///
+    /// Routes through `PlaylistExport.webURL`, which strips any embedded
+    /// credentials / query / fragment from the stored server URL so a copied
+    /// "Copy Link" never leaks a password or token (#237).
     func webURL(for playlist: Playlist) -> URL? {
-        guard !serverURL.isEmpty else { return nil }
-        let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
-        return URL(string: "\(base)/web/#/details?id=\(playlist.id)")
+        PlaylistExport.webURL(serverURL: serverURL, itemId: playlist.id)
     }
 
     /// Copy the playlist's web URL to the system pasteboard.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -694,6 +694,21 @@ final class AppModel {
     /// #307 / #309.
     var isCommandPaletteOpen: Bool = false
 
+    /// Whether the Instant Mix seed-picker sheet is presented. Flipped by
+    /// the "New Instant Mix…" menu command (`presentInstantMixPicker`) and
+    /// cleared when the sheet dismisses or a mix is generated. Mounted on
+    /// `MainShell` so the picker floats over whichever screen is active.
+    /// The engine behind it (`playInstantMix` / `startGenreRadio`) was
+    /// already wired; this flag only drives the seed-picker UI. See #327.
+    var isShowingInstantMixPicker: Bool = false
+
+    /// Display name of the most recently generated Instant Mix seed (e.g.
+    /// "Radiohead", "OK Computer", "Jazz"). Surfaced as the sheet's
+    /// "Last mix" hint so a re-open offers a one-tap regenerate without
+    /// re-searching. `nil` until the first mix is generated this session.
+    /// See #327.
+    var instantMixSeedLabel: String?
+
     /// A single verb entry in the command palette's action list. See
     /// `paletteActions` for the live roster and `executePaletteAction(id:)`
     /// for the dispatcher. Actions are intentionally held by id + closure
@@ -3174,6 +3189,67 @@ final class AppModel {
         } else {
             startInstantMix()
         }
+    }
+
+    /// Present the Instant Mix seed-picker sheet (#327). The sheet lets the
+    /// user search for and pick any track / album / artist / genre to seed a
+    /// fresh radio station, rather than relying on the implicit "currently
+    /// playing" seed that `startInstantMix` uses. Mounted on `MainShell`
+    /// driven by `isShowingInstantMixPicker`; wired to the View ▸ "New
+    /// Instant Mix…" menu command.
+    func presentInstantMixPicker() {
+        isShowingInstantMixPicker = true
+    }
+
+    /// Generate an Instant Mix from an explicitly chosen seed (#327). The
+    /// seed-picker sheet hands back a heterogeneous `SearchItem`; we dispatch
+    /// on its case because the seed id semantics differ:
+    ///
+    /// - Tracks / albums / artists carry a real Jellyfin UUID, so they feed
+    ///   `playInstantMix` directly.
+    /// - Genres surfaced by search only carry the display name as their id
+    ///   (`Genre.init(name:)`), so they route through `startGenreRadio`,
+    ///   which resolves the name → real UUID before seeding. Playlists aren't
+    ///   offered as a seed by the picker today, but fall through to the
+    ///   direct path should the picker ever surface one.
+    ///
+    /// Records the seed's display name in `instantMixSeedLabel` so a re-open
+    /// of the picker can offer a one-tap regenerate, then dismisses the sheet.
+    func generateInstantMix(seed: SearchItem) {
+        switch seed {
+        case .track(let t):
+            instantMixSeedLabel = t.name
+            playInstantMix(seedId: t.id)
+        case .album(let a):
+            instantMixSeedLabel = a.name
+            playInstantMix(seedId: a.id)
+        case .artist(let a):
+            instantMixSeedLabel = a.name
+            playInstantMix(seedId: a.id)
+        case .playlist(let p):
+            instantMixSeedLabel = p.name
+            playInstantMix(seedId: p.id)
+        case .genre(let g):
+            instantMixSeedLabel = g.name
+            startGenreRadio(genre: g)
+        }
+        isShowingInstantMixPicker = false
+    }
+
+    /// Read-only search used by the Instant Mix seed picker (#327). Returns a
+    /// raw `SearchResults` without touching any of the page-level search
+    /// state (`searchResults`, `searchPageResults`, …) so opening the picker
+    /// never disturbs the standalone Search screen the user may have set up.
+    /// The FFI hop runs off the MainActor per CLAUDE.md gap pattern #2;
+    /// errors collapse to `nil` because the picker treats "no matches" and
+    /// "search failed" identically (an empty candidate list), and a flaky
+    /// keystroke shouldn't raise an error banner mid-typing.
+    func searchSeeds(query: String, limit: UInt32 = 20) async -> SearchResults? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return await Task.detached(priority: .userInitiated) { [core] in
+            try? core.search(query: trimmed, offset: 0, limit: limit)
+        }.value
     }
 
     /// Common driver for every "Start Radio" entry point. `core.instantMix`

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -434,6 +434,15 @@ final class AppModel {
     /// playing launch instead of waiting for a pause/resume transition. See #266.
     private var didApplyMenuBarPlayingState = false
 
+    // MARK: - Scrobbling (#46)
+    /// Decides when to fire a `playing_now` vs a durable `single` listen. Driven
+    /// from the 1 Hz status poll; the actual POSTs go to the Rust core off the
+    /// main actor. Pure value type — see `ScrobbleGate`.
+    private var scrobbleGate = ScrobbleGate()
+    /// Mirrors `core.isScrobbleConfigured()` for the Preferences pane to read
+    /// without a per-render FFI. Refreshed when the token changes and at launch.
+    var scrobbleConnected: Bool = false
+
     // MARK: - Queue inspector (BATCH-07a, #79 / #80 / #282)
     //
     // Issue #282 — separate "Up Next" (user-added) from "Auto Queue" (what
@@ -917,6 +926,9 @@ final class AppModel {
         // pane to mount. An empty/absent value means "follow system default".
         let savedDeviceUID = UserDefaults.standard.string(forKey: AudioOutputDevices.preferenceKey) ?? ""
         self.audio.outputDeviceUID = savedDeviceUID.isEmpty ? nil : savedDeviceUID
+        // Seed the scrobble-connected flag from the core's persisted token so
+        // the Preferences pane shows the right state on first open.
+        self.scrobbleConnected = core.isScrobbleConfigured()
     }
 
     // MARK: - Network
@@ -5408,6 +5420,66 @@ final class AppModel {
     }
     #endif
 
+    // MARK: - Scrobbling (#46)
+
+    /// Persist a ListenBrainz token through the core and refresh the connected
+    /// flag. Passing `nil` / blank disconnects. The token never lives in
+    /// `UserDefaults` — only the core's settings table — so it stays out of the
+    /// diagnostic bundle. Surfaces failures via `errorMessage`.
+    func connectScrobbler(token: String?) {
+        do {
+            try core.setScrobbleToken(token: token)
+            scrobbleConnected = core.isScrobbleConfigured()
+        } catch {
+            errorMessage = LyrebirdErrorPresenter.message(for: error, context: .generic)
+        }
+    }
+
+    /// Clear the stored token and reset the in-flight gate so a re-connect
+    /// starts clean.
+    func disconnectScrobbler() {
+        scrobbleGate.reset()
+        connectScrobbler(token: nil)
+    }
+
+    /// Drive the scrobble gate from one status-poll observation and perform
+    /// whichever action it returns. Called once per poll tick.
+    ///
+    /// Both submit paths hop off the main actor via `Task.detached` — they take
+    /// the core's `parking_lot` mutex and make a network call, neither of which
+    /// belongs on the main thread (gap pattern #2). The threshold *decision*
+    /// stays on the main actor: `core.scrobbleThresholdReached` is side-effect
+    /// free (no mutex, no I/O), so calling it per tick is cheap.
+    ///
+    /// Submit errors are swallowed by design — a failed scrobble must never
+    /// interrupt playback or surface a toast. A genuinely bad token shows up
+    /// in the pane (the connect call validates it); transient network blips
+    /// are simply skipped.
+    private func driveScrobble() {
+        let track = status.currentTrack
+        let enabled = ScrobblePreference.enabled && scrobbleConnected
+        let action = scrobbleGate.noteTrack(
+            track,
+            position: status.positionSeconds,
+            duration: (track?.runtimeTicks).map { Double($0) / 10_000_000.0 } ?? 0,
+            enabled: enabled,
+            thresholdReached: { [core] pos, dur in
+                core.scrobbleThresholdReached(positionSecs: pos, runtimeSecs: dur)
+            }
+        )
+
+        switch action {
+        case .none:
+            break
+        case .nowPlaying(let t):
+            let core = self.core
+            Task.detached { try? core.scrobbleNowPlaying(track: t) }
+        case .submitListen(let t, let listenedAt):
+            let core = self.core
+            Task.detached { try? core.scrobbleSubmitListen(track: t, listenedAt: listenedAt) }
+        }
+    }
+
     private func handleTrackEnded() {
         // Advance to the next track in the queue if there is one. Arm the
         // gapless pre-load for the track *after* this new one so the next
@@ -5605,6 +5677,10 @@ final class AppModel {
                 // time. The controller throttles its own redraws to ≤1 Hz, so
                 // calling it on every 1 s poll tick is the right cadence.
                 AppDelegate.shared?.refreshDockTile()
+                // Feed the scrobble gate the fresh status. Fires a ListenBrainz
+                // `playing_now` on track change and a durable listen once the
+                // current track passes the threshold — both off the main actor.
+                self.driveScrobble()
                 // Trigger a details refetch when the track changes. Scoped
                 // to the polling loop so skipping via the PlayerBar,
                 // media keys, or end-of-track auto-advance all get it

--- a/macos/Sources/Lyrebird/Components/CommandPalette.swift
+++ b/macos/Sources/Lyrebird/Components/CommandPalette.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// dim scrim behind the centered 640pt column keeps the rest of the UI legible
 /// and hints at the modal nature of the palette.
 ///
-/// Issues: #305 (shell + ⌘K), #306 (library results), #307 (actions), #309
-/// (keyboard-only UX). #308 (recent + pinned) is a follow-up.
+/// Issues: #305 (shell + ⌘K), #306 (library results), #307 (actions), #308
+/// (recent + pinned actions), #309 (keyboard-only UX).
 struct CommandPalette: View {
     @Environment(AppModel.self) private var model
 
@@ -239,6 +239,7 @@ struct CommandPalette: View {
                             PaletteRow(
                                 row: row,
                                 isSelected: idx == selectedIndex,
+                                isPinned: isPinned(row),
                                 onActivate: { activate(at: idx) }
                             )
                             .id(idx)
@@ -246,6 +247,7 @@ struct CommandPalette: View {
                             .onHover { hovering in
                                 if hovering { selectedIndex = idx }
                             }
+                            .contextMenu { pinContextMenu(for: row) }
                         }
                     }
                     .padding(.vertical, 6)
@@ -343,16 +345,73 @@ struct CommandPalette: View {
 
         if actionsVisible {
             let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            for action in model.paletteActions {
-                // Action matching is intentionally prefix-only so typing
-                // "play" shows "Play" / "Play Next" but not unrelated
-                // verbs. Empty query always shows the full list.
-                if trimmed.isEmpty || actionTitleString(action).lowercased().hasPrefix(trimmed) {
-                    rows.append(.action(action.id))
+            if trimmed.isEmpty {
+                // #308: empty query surfaces Pinned first, then Recent, then
+                // the remaining roster — each action exactly once. Both the
+                // pinned and recents lists are persisted id lists that may
+                // reference actions not in the current roster (a
+                // capability-gated verb whose flag is off); intersecting with
+                // the live ids drops those stale entries silently.
+                rows.append(contentsOf: orderedActionRows())
+            } else {
+                for action in model.paletteActions {
+                    // Action matching is intentionally prefix-only so typing
+                    // "play" shows "Play" / "Play Next" but not unrelated
+                    // verbs.
+                    if actionTitleString(action).lowercased().hasPrefix(trimmed) {
+                        rows.append(.action(action.id))
+                    }
                 }
             }
         }
         return rows
+    }
+
+    /// Empty-query action ordering: Pinned → Recent → the rest, deduped, in
+    /// roster order within the trailing group. Computed off the live roster so
+    /// an action whose capability flag is off (and thus absent from
+    /// `paletteActions`) never appears even if its id lingers in a persisted
+    /// pinned/recent list. See #308.
+    private func orderedActionRows() -> [Row] {
+        let rosterIds = model.paletteActions.map(\.id)
+        let rosterSet = Set(rosterIds)
+
+        var ordered: [String] = []
+        var seen = Set<String>()
+        func push(_ ids: [String]) {
+            for id in ids where rosterSet.contains(id) && seen.insert(id).inserted {
+                ordered.append(id)
+            }
+        }
+        push(model.palettePinnedActionIds)
+        push(model.paletteRecentActionIds)
+        push(rosterIds) // the remainder, in the roster's own order
+        return ordered.map(Row.action)
+    }
+
+    /// Whether `row` is a currently-pinned action. Library rows can't be
+    /// pinned (pin/unpin is an action-only affordance for #308), so they
+    /// always report `false`.
+    private func isPinned(_ row: Row) -> Bool {
+        guard case .action(let id) = row else { return false }
+        return model.isPaletteActionPinned(id: id)
+    }
+
+    /// Right-click affordance for palette rows. Only action rows expose a
+    /// Pin/Unpin toggle; library rows return an empty menu (so the
+    /// right-click is a no-op rather than surfacing an irrelevant item).
+    /// See #308.
+    @ViewBuilder
+    private func pinContextMenu(for row: Row) -> some View {
+        if case .action(let id) = row {
+            let pinned = model.isPaletteActionPinned(id: id)
+            Button {
+                model.togglePaletteActionPin(id: id)
+            } label: {
+                Label(pinned ? "Unpin" : "Pin",
+                      systemImage: pinned ? "pin.slash" : "pin")
+            }
+        }
     }
 
     // MARK: - Actions
@@ -495,6 +554,11 @@ struct CommandPalette: View {
 struct PaletteRow: View {
     let row: CommandPalette.Row
     let isSelected: Bool
+    /// Whether this row is a pinned action. Drives the small pin glyph shown
+    /// before the ↩ hint so the user can tell at a glance which actions are
+    /// pinned (and that the right-click "Unpin" applies). Always `false` for
+    /// library rows. See #308.
+    var isPinned: Bool = false
     let onActivate: () -> Void
 
     var body: some View {
@@ -516,6 +580,14 @@ struct PaletteRow: View {
                 }
             }
             Spacer()
+            if isPinned {
+                // Persistent pin marker — drawn whether or not the row is
+                // selected, unlike the ↩ hint which only shows on selection.
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                    .accessibilityLabel("Pinned")
+            }
             HStack(spacing: 4) {
                 Text("\u{21A9}")
                     .font(Theme.font(10, weight: .bold))

--- a/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
+++ b/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
@@ -1,0 +1,563 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Seed-picker modal for Instant Mix (#327).
+///
+/// The Instant Mix *engine* was already wired end-to-end —
+/// `AppModel.playInstantMix(seedId:)` feeds `core.instantMix(itemId:limit:)`,
+/// and the Discover / Home CTAs (`startInstantMix`) seed it off whatever is
+/// currently playing. What was missing was a way to *choose* the seed. This
+/// sheet fills that gap: search the library, pick a track / album / artist /
+/// genre, hit Generate, and the chosen seed is handed to `generateInstantMix`.
+///
+/// Presentation mirrors `TrackInfoSheet` / `NowPlayingSheet`: a fixed-width
+/// `VStack` mounted via `.sheet` on `MainShell`, driven by the
+/// `AppModel.isShowingInstantMixPicker` flag and summoned from the View ▸
+/// "New Instant Mix…" menu command.
+///
+/// All the searchable / selectable logic lives in `InstantMixSeedPickerModel`
+/// (below) so it can be unit-tested headlessly without booting the scene
+/// graph — the view is a thin shell around it. See
+/// `Tests/LyrebirdTests/InstantMixSeedPickerTests.swift`.
+struct InstantMixSheet: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    /// The picker view-model. Built in `init` so the closures it needs
+    /// (`search` / `onGenerate`) can capture the live `AppModel`. Held as
+    /// `@State` so its `@Observable` mutations drive re-render.
+    @State private var picker: InstantMixSeedPickerModel
+
+    @FocusState private var searchFocused: Bool
+
+    init(model: AppModel) {
+        // `@State`'s wrappedValue initializer captures the model once; the
+        // sheet is re-created per presentation so this never goes stale.
+        _picker = State(wrappedValue: InstantMixSeedPickerModel(
+            search: { [weak model] query in await model?.searchSeeds(query: query) },
+            onGenerate: { [weak model] seed in model?.generateInstantMix(seed: seed) }
+        ))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            searchField
+            categoryBar
+            Divider().background(Theme.border)
+            resultsBody
+            footer
+        }
+        .frame(width: 460, height: 560)
+        .background(Theme.bg)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+        .onAppear { searchFocused = true }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("instant_mix.picker.title")
+                    .font(Theme.font(16, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                if let label = model.instantMixSeedLabel {
+                    // One-tap regenerate hint — echoes the last seed so a
+                    // re-open offers "again" without re-searching. Composed as
+                    // a localized prefix + verbatim seed name so the user-data
+                    // title isn't fed through the catalog. Mirrors the
+                    // playlist-delete dialog's prefix + verbatim split.
+                    (Text("instant_mix.picker.last_mix") + Text(verbatim: " \(label)"))
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 24, height: 24)
+                    .background(Circle().fill(Theme.surface))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityLabel("instant_mix.picker.close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Search field
+
+    private var searchField: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Theme.ink2)
+                .font(.system(size: 15, weight: .medium))
+            TextField("instant_mix.picker.search_placeholder", text: $picker.query)
+                .textFieldStyle(.plain)
+                .font(Theme.font(15, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .focused($searchFocused)
+                .onChange(of: picker.query) { _, _ in picker.queryChanged() }
+            if picker.isSearching {
+                ProgressView()
+                    .tint(Theme.ink2)
+                    .scaleEffect(0.55)
+                    .frame(width: 16, height: 16)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Theme.surface)
+        )
+        .padding(.horizontal, 20)
+        .padding(.bottom, 10)
+        .spaceKeyGuardForTextField()
+    }
+
+    // MARK: - Category chips
+
+    private var categoryBar: some View {
+        HStack(spacing: 6) {
+            ForEach(InstantMixSeedPickerModel.SeedCategory.allCases, id: \.self) { cat in
+                Button {
+                    picker.category = cat
+                } label: {
+                    Text(cat.label)
+                        .font(Theme.font(11, weight: .semibold))
+                        .foregroundStyle(picker.category == cat ? Theme.ink : Theme.ink2)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(picker.category == cat ? Theme.surface2 : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(picker.category == cat ? Theme.borderStrong : Color.clear, lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(picker.category == cat ? [.isButton, .isSelected] : .isButton)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 10)
+    }
+
+    // MARK: - Results
+
+    @ViewBuilder
+    private var resultsBody: some View {
+        if picker.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            emptyPrompt
+        } else if picker.candidates.isEmpty {
+            noMatches
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(picker.candidates, id: \.id) { item in
+                        SeedRow(
+                            item: item,
+                            isSelected: picker.selectedSeed?.id == item.id,
+                            onPick: { picker.select(item) }
+                        )
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            }
+        }
+    }
+
+    private var emptyPrompt: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "dial.medium")
+                .font(.system(size: 32, weight: .light))
+                .foregroundStyle(Theme.ink3)
+            Text("instant_mix.picker.empty_prompt")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 32)
+    }
+
+    private var noMatches: some View {
+        Text("instant_mix.picker.no_matches")
+            .font(Theme.font(13, weight: .medium))
+            .foregroundStyle(Theme.ink3)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            if let seed = picker.selectedSeed {
+                // Localized "Seed:" prefix + verbatim title (user data).
+                (Text("instant_mix.picker.selected") + Text(verbatim: " \(seed.title)"))
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button(action: { picker.generate() }) {
+                Text("instant_mix.picker.generate")
+                    .font(Theme.font(13, weight: .semibold))
+                    .frame(width: 120, height: 32)
+                    .foregroundStyle(picker.canGenerate ? Theme.bg : Theme.ink3)
+                    .background(picker.canGenerate ? Theme.ink : Theme.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .buttonStyle(.plain)
+            .disabled(!picker.canGenerate)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("instant_mix.picker.generate")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 18)
+        .overlay(alignment: .top) {
+            Rectangle().fill(Theme.border).frame(height: 1)
+        }
+    }
+}
+
+// MARK: - Seed row
+
+/// One selectable seed candidate. A compact artwork + title/subtitle row that
+/// mirrors `SearchInstantDropdown`'s track row, plus a trailing checkmark when
+/// it's the chosen seed. Genres render with an SF Symbol since they carry no
+/// artwork.
+private struct SeedRow: View {
+    @Environment(AppModel.self) private var model
+    let item: SearchItem
+    let isSelected: Bool
+    let onPick: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            icon
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(isSelected || isHovering ? Theme.accent : Theme.ink)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(item.typeLabel)
+                        .font(Theme.font(9, weight: .bold))
+                        .foregroundStyle(Theme.ink3)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+                    if let subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(Theme.font(10, weight: .medium))
+                            .foregroundStyle(Theme.ink2)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Theme.surface2 : (isHovering ? Theme.rowHover : Color.clear))
+        )
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture { onPick() }
+        .focusable(true)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(item.typeLabel) \(item.title)")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        switch item {
+        case .genre:
+            // Genres carry no artwork — render a tinted glyph chip instead of
+            // a seeded gradient so they read as a distinct seed kind.
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Theme.surface2)
+                .frame(width: 34, height: 34)
+                .overlay(
+                    Image(systemName: "guitars")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                )
+        case .artist(let a):
+            Artwork(
+                url: model.imageURL(for: a.id, tag: a.imageTag, maxWidth: 120),
+                seed: a.name,
+                size: 34,
+                radius: 17,
+                targetPixelSize: CGSize(width: 102, height: 102)
+            )
+            .frame(width: 34, height: 34)
+            .clipShape(Circle())
+        case .album(let a):
+            Artwork(
+                url: model.imageURL(for: a.id, tag: a.imageTag, maxWidth: 120),
+                seed: a.name,
+                size: 34,
+                radius: 4,
+                targetPixelSize: CGSize(width: 102, height: 102)
+            )
+            .frame(width: 34, height: 34)
+        case .track(let t):
+            Artwork(
+                url: model.imageURL(for: t.albumId ?? t.id, tag: t.imageTag, maxWidth: 120),
+                seed: t.name,
+                size: 34,
+                radius: 4,
+                targetPixelSize: CGSize(width: 102, height: 102)
+            )
+            .frame(width: 34, height: 34)
+        case .playlist(let p):
+            Artwork(
+                url: model.imageURL(for: p.id, tag: p.imageTag, maxWidth: 120),
+                seed: p.name,
+                size: 34,
+                radius: 4,
+                targetPixelSize: CGSize(width: 102, height: 102)
+            )
+            .frame(width: 34, height: 34)
+        }
+    }
+
+    /// Secondary line — artist for tracks/albums, counts for artists. Genres
+    /// get nothing (the type label alone is enough).
+    private var subtitle: String? {
+        switch item {
+        case .track(let t):
+            if let album = t.albumName, !album.isEmpty {
+                return "\(t.artistName) \u{00B7} \(album)"
+            }
+            return t.artistName
+        case .album(let a):
+            return a.artistName
+        case .artist(let a):
+            return a.albumCount == 1 ? "1 album" : "\(a.albumCount) albums"
+        case .playlist(let p):
+            return p.trackCount == 1 ? "1 track" : "\(p.trackCount) tracks"
+        case .genre:
+            return nil
+        }
+    }
+}
+
+// MARK: - View-model
+
+/// Headless, testable engine behind `InstantMixSheet` (#327).
+///
+/// Owns the search query, a debounced/cancellable fetch, the category filter,
+/// the flattened candidate list, and the chosen seed. Deliberately holds no
+/// reference to `AppModel`: the two side-effecting hooks it needs are injected
+/// as closures (`search` for the FFI-backed lookup, `onGenerate` for handing
+/// the chosen seed back), so the suite can drive it with deterministic data
+/// and assert on `candidates` / `canGenerate` / generate-dispatch without any
+/// network or scene graph.
+@MainActor
+@Observable
+final class InstantMixSeedPickerModel {
+    /// Seed-kind filter chip. `all` unions every kind; the rest scope the
+    /// candidate list to a single seed type.
+    enum SeedCategory: String, CaseIterable, Hashable, Sendable {
+        case all, tracks, albums, artists, genres
+
+        var label: LocalizedStringKey {
+            switch self {
+            case .all: return "instant_mix.picker.category.all"
+            case .tracks: return "instant_mix.picker.category.tracks"
+            case .albums: return "instant_mix.picker.category.albums"
+            case .artists: return "instant_mix.picker.category.artists"
+            case .genres: return "instant_mix.picker.category.genres"
+            }
+        }
+    }
+
+    /// Bound to the search field's text.
+    var query: String = ""
+
+    /// Active seed-kind filter. Re-filtering is pure (`candidates` recomputes
+    /// off `lastResults`), so flipping a chip never re-hits the network.
+    var category: SeedCategory = .all
+
+    /// Spinner state for the search field.
+    private(set) var isSearching: Bool = false
+
+    /// Raw results from the most recent successful search, retained so a
+    /// category change can re-bucket locally without a refetch. `nil` until
+    /// the first search resolves (or after the query is cleared).
+    private(set) var lastResults: SearchResults?
+
+    /// The seed the user has chosen. `nil` disables Generate.
+    private(set) var selectedSeed: SearchItem?
+
+    /// Debounce interval before a keystroke triggers a fetch. Matches the
+    /// instant-search dropdown's 250ms cadence.
+    private let debounceNanos: UInt64
+
+    private let search: (String) async -> SearchResults?
+    private let onGenerate: (SearchItem) -> Void
+    private var searchTask: Task<Void, Never>?
+
+    init(
+        debounceNanos: UInt64 = 250_000_000,
+        search: @escaping (String) async -> SearchResults?,
+        onGenerate: @escaping (SearchItem) -> Void
+    ) {
+        self.debounceNanos = debounceNanos
+        self.search = search
+        self.onGenerate = onGenerate
+    }
+
+    /// The flattened, filtered list of seed candidates the sheet renders.
+    /// Derived purely from `lastResults` + `category` so the view never has
+    /// to re-partition and tests can assert on it directly.
+    var candidates: [SearchItem] {
+        guard let results = lastResults else { return [] }
+        return Self.seedCandidates(from: results, category: category)
+    }
+
+    /// Generate is actionable only once a seed is chosen.
+    var canGenerate: Bool { selectedSeed != nil }
+
+    /// Choose (or, if tapped again, keep) a seed. Selecting a row that's
+    /// already selected is a no-op rather than a toggle-off — a picker should
+    /// always leave *something* selected once the user has committed to one,
+    /// so an accidental second tap doesn't silently disable Generate.
+    func select(_ item: SearchItem) {
+        selectedSeed = item
+    }
+
+    /// Hand the chosen seed back to the host (which performs the actual
+    /// `instantMix` FFI) and tear down any in-flight search. No-op when
+    /// nothing is selected, so a stray Return on an empty picker is harmless.
+    func generate() {
+        guard let seed = selectedSeed else { return }
+        searchTask?.cancel()
+        onGenerate(seed)
+    }
+
+    /// Debounced search driven by the field's `onChange`. Cancels any prior
+    /// in-flight pass, clears state immediately on an empty query, and drops
+    /// a selection that's no longer present in the fresh candidate set so the
+    /// footer never claims a seed the list no longer shows.
+    func queryChanged() {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            lastResults = nil
+            selectedSeed = nil
+            isSearching = false
+            searchTask = nil
+            return
+        }
+
+        isSearching = true
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(nanoseconds: self.debounceNanos)
+            } catch {
+                return // cancelled by the next keystroke
+            }
+            if Task.isCancelled { return }
+            let results = await self.search(trimmed)
+            if Task.isCancelled { return }
+            self.apply(results: results)
+        }
+    }
+
+    /// Fold a fresh search response into state. Split out from `queryChanged`
+    /// so tests can exercise the candidate/selection-pruning contract without
+    /// waiting on the debounce timer.
+    func apply(results: SearchResults?) {
+        isSearching = false
+        lastResults = results
+        // Drop a stale selection if the new candidate set no longer contains
+        // it (the user kept typing past the row they'd tapped).
+        if let selected = selectedSeed,
+           !Self.allCandidates(from: results).contains(where: { $0.id == selected.id }) {
+            selectedSeed = nil
+        }
+    }
+
+    // MARK: - Pure helpers (deterministic; unit-tested)
+
+    /// Every seed candidate a response yields, unfiltered: artists, albums,
+    /// tracks, then genres harvested from the album/artist `genres` arrays.
+    /// Genres are reconstructed client-side (case-insensitive de-dupe,
+    /// alpha-sorted) exactly like `AppModel.bucketSearchResults` because
+    /// Jellyfin's combined search endpoint doesn't return genre items
+    /// directly — the seed carries the display name, and
+    /// `AppModel.generateInstantMix` resolves it to a UUID via
+    /// `startGenreRadio`.
+    nonisolated static func allCandidates(from results: SearchResults?) -> [SearchItem] {
+        guard let results else { return [] }
+        var items: [SearchItem] = []
+        items.append(contentsOf: results.artists.map(SearchItem.artist))
+        items.append(contentsOf: results.albums.map(SearchItem.album))
+        items.append(contentsOf: results.tracks.map(SearchItem.track))
+        items.append(contentsOf: genres(from: results).map(SearchItem.genre))
+        return items
+    }
+
+    /// `allCandidates` narrowed to a single seed kind (or unchanged for `.all`).
+    nonisolated static func seedCandidates(
+        from results: SearchResults,
+        category: SeedCategory
+    ) -> [SearchItem] {
+        let all = allCandidates(from: results)
+        switch category {
+        case .all:
+            return all
+        case .tracks:
+            return all.filter { if case .track = $0 { return true }; return false }
+        case .albums:
+            return all.filter { if case .album = $0 { return true }; return false }
+        case .artists:
+            return all.filter { if case .artist = $0 { return true }; return false }
+        case .genres:
+            return all.filter { if case .genre = $0 { return true }; return false }
+        }
+    }
+
+    /// Distinct genres harvested from a response's album + artist genre
+    /// arrays, case-insensitively de-duped and alpha-sorted.
+    nonisolated static func genres(from results: SearchResults) -> [Genre] {
+        var seen = Set<String>()
+        var out: [Genre] = []
+        let raw = results.albums.flatMap(\.genres) + results.artists.flatMap(\.genres)
+        for name in raw {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            guard seen.insert(trimmed.lowercased()).inserted else { continue }
+            out.append(Genre(name: trimmed))
+        }
+        out.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return out
+    }
+}

--- a/macos/Sources/Lyrebird/Components/NowPlayingBackdrop.swift
+++ b/macos/Sources/Lyrebird/Components/NowPlayingBackdrop.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import Nuke
+import NukeUI
+
+/// Heavily-blurred, dimmed artwork backdrop behind the Now Playing hero
+/// (#21). The current cover is decoded once by the hero `Artwork` and reused
+/// here straight out of Nuke's shared pipeline, then scaled to fill, blurred,
+/// and dropped to a low opacity so it reads as a soft, immersive wash rather
+/// than a second copy of the cover.
+///
+/// Layering contract (see `NowPlayingView.body`): this sits *in front of*
+/// `AmbientWash` but *behind* the player content. `AmbientWash` paints the
+/// opaque `Theme.bg` base plus the artwork-derived palette gradient, so when
+/// this backdrop renders nothing — under **Reduce Transparency**, or before
+/// the cover resolves / when there's no art — the wash shows through
+/// unchanged. That is the single source of the "fall back to Theme.bg /
+/// ambient palette" rule.
+///
+/// **No double-darken.** The dim here is the *only* scrim applied over the
+/// blurred cover: where the cover is opaque it fully occludes `AmbientWash`'s
+/// own `0.25` scrim, so the two layers never stack their darkening. The dim is
+/// a single top-to-bottom gradient (lighter at the top behind the artwork,
+/// heavier toward the metadata column) tuned to keep white type legible on
+/// bright covers without muddying dark ones.
+struct NowPlayingBackdrop: View {
+    /// Size-hinted URL for the current cover, or `nil` when the track has no
+    /// artwork — in which case the backdrop renders nothing and the ambient
+    /// wash beneath shows through.
+    let url: URL?
+    /// Track / album name, used only to mirror the hero's decode key; the
+    /// blurred backdrop has no fallback gradient of its own (that's the
+    /// ambient wash's job), so a seed-derived placeholder would double up.
+    let seed: String
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Blur radius applied to the cover. Large enough that the cover dissolves
+    /// into colour/shape rather than reading as a recognisable second thumbnail
+    /// of the album art.
+    static let blurRadius: CGFloat = 60
+
+    /// Opacity the blurred cover is drawn at before the dim gradient. Low so
+    /// the immersive wash never competes with the foreground type.
+    static let artworkOpacity: CGFloat = 0.5
+
+    /// Whether the blurred-artwork layer should be drawn at all. Pure so the
+    /// Reduce-Transparency fallback and the no-artwork fallback are unit-
+    /// testable without booting a SwiftUI scene (see `NowPlayingBackdropTests`).
+    ///
+    /// Returns `false` under Reduce Transparency (the system asks us to drop
+    /// translucent / layered material — the flat `Theme.bg` from `AmbientWash`
+    /// is the correct fallback) and `false` when there is no artwork URL to
+    /// sample (the ambient palette gradient is the fallback there).
+    static func showsArtworkLayer(reduceTransparency: Bool, hasArtwork: Bool) -> Bool {
+        !reduceTransparency && hasArtwork
+    }
+
+    var body: some View {
+        // When the layer is suppressed we render `Color.clear` rather than an
+        // empty view so the `.background` ZStack keeps a stable child identity
+        // (avoids a layout/transition hiccup when the rule flips on a track or
+        // accessibility-setting change), letting the opaque `AmbientWash`
+        // beneath provide the full background.
+        if NowPlayingBackdrop.showsArtworkLayer(
+            reduceTransparency: reduceTransparency,
+            hasArtwork: url != nil
+        ), let url {
+            GeometryReader { geo in
+                LazyImage(request: backdropRequest(for: url, in: geo.size)) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .clipped()
+                            .opacity(NowPlayingBackdrop.artworkOpacity)
+                            .blur(radius: NowPlayingBackdrop.blurRadius)
+                            .overlay(dimGradient)
+                    } else {
+                        // Pre-decode / decode failure: stay transparent so the
+                        // ambient wash beneath carries the background. No
+                        // seeded placeholder — that's the wash's responsibility.
+                        Color.clear
+                    }
+                }
+                .pipeline(Artwork.pipeline)
+            }
+            .ignoresSafeArea()
+            // Cross-fade between covers on a track change so the immersive
+            // wash doesn't hard-cut. Disabled under Reduce Motion.
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: url)
+            // Purely atmospheric — the hero `Artwork` already carries the
+            // meaningful cover label, so VoiceOver should skip this layer.
+            .accessibilityHidden(true)
+        } else {
+            Color.clear
+        }
+    }
+
+    /// A vertical dim that keeps white type legible over a bright cover. The
+    /// top stays lighter (behind the artwork itself) and it deepens toward the
+    /// bottom / metadata. This is the only scrim over the cover — see the
+    /// "no double-darken" note in the type doc.
+    private var dimGradient: some View {
+        LinearGradient(
+            colors: [
+                Theme.bg.opacity(0.35),
+                Theme.bg.opacity(0.55),
+                Theme.bg.opacity(0.7),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    /// Decode the cover at a modest pixel size — a 60pt blur destroys detail,
+    /// so there's no point holding a full-resolution `CGImage` for the
+    /// backdrop. Reuses `Artwork.pipeline`, so when the hero already decoded
+    /// this URL the backdrop is a cache hit with no second network fetch.
+    /// Mirrors `Artwork`'s `.pixels`-unit resize so Nuke doesn't double-multiply
+    /// by screen scale; the side is clamped to a sane floor for tiny windows.
+    private func backdropRequest(for url: URL, in size: CGSize) -> ImageRequest {
+        let side = max(640, max(size.width, size.height))
+        let processors: [any ImageProcessing] = [
+            ImageProcessors.Resize(
+                size: CGSize(width: side, height: side),
+                unit: .pixels,
+                contentMode: .aspectFill,
+                crop: false,
+                upscale: false
+            )
+        ]
+        return ImageRequest(url: url, processors: processors)
+    }
+}

--- a/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     ─
 ///     Rename (inline), Duplicate, Delete (with confirm)
 ///     ─
-///     Export as .m3u8…, Copy Link
+///     Export as M3U…, Export as JSON…, Copy Link  (#237)
 ///
 /// BATCH-06b (#71 / #75):
 ///   - **Rename** flips the sidebar row into an inline `TextField` (see
@@ -60,8 +60,11 @@ struct PlaylistContextMenu: View {
 
         Divider()
 
-        Button("Export as .m3u8…", systemImage: "square.and.arrow.up.on.square") {
+        Button("Export as M3U…", systemImage: "square.and.arrow.up.on.square") {
             model.exportPlaylist(playlist: playlist)
+        }
+        Button("Export as JSON…", systemImage: "curlybraces") {
+            model.exportPlaylistJSON(playlist: playlist)
         }
         Button("Copy Link", systemImage: "link") { model.copyShareLink(playlist: playlist) }
             .disabled(model.webURL(for: playlist) == nil)

--- a/macos/Sources/Lyrebird/Components/PlaylistExport.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistExport.swift
@@ -1,0 +1,196 @@
+import Foundation
+@preconcurrency import LyrebirdCore
+
+/// Pure, side-effect-free serializers behind the playlist Share / Export
+/// affordances (#237). Kept free of `AppModel`, `NSSavePanel`, and the Rust
+/// FFI so the string-building logic is unit-testable in isolation — the only
+/// inputs are an already-loaded `[Track]`, the playlist name, and the raw
+/// server URL string.
+///
+/// Two export formats plus a sharable deep link:
+///   - **M3U** (`#EXTM3U` + `#EXTINF`) — the de-facto playlist interchange
+///     format every desktop player understands.
+///   - **JSON** — a stable, machine-readable manifest of the playlist for
+///     re-import / backup / scripting.
+///   - **Deep link** — the Jellyfin web `details` route, with any embedded
+///     credentials and query/fragment secrets stripped so the URL is safe to
+///     paste into a chat.
+///
+/// `AppModel` owns the IO (track fetch, `NSSavePanel`, pasteboard); this type
+/// owns only the bytes.
+enum PlaylistExport {
+
+    // MARK: - Stream URL
+
+    /// The auth-free universal-stream path for a track, e.g.
+    /// `https://server.example.com/Audio/<id>/universal`. No query parameters
+    /// and no `api_key`, so the resulting M3U is safe to share even though it
+    /// references the origin server. Servers that allow unauthenticated
+    /// download (common on LAN setups) can play it directly; others will
+    /// prompt for auth, which is the correct behaviour for a shared file.
+    static func streamURL(forTrackId trackId: String, base: String) -> String {
+        "\(base)/Audio/\(trackId)/universal"
+    }
+
+    // MARK: - M3U
+
+    /// Build an extended-M3U (`.m3u8`) document for `playlist` from its
+    /// already-loaded `tracks`.
+    ///
+    /// `runtimeTicks` is in 100-nanosecond units; `#EXTINF` wants whole
+    /// seconds, so we integer-divide by 10,000,000. A track with unknown
+    /// runtime (0 ticks) emits `#EXTINF:-1`, the M3U convention for
+    /// "duration unknown", rather than a misleading `0`.
+    ///
+    /// The document always ends with a trailing newline so appending to it /
+    /// concatenating files behaves.
+    static func m3u8(playlistName: String, tracks: [Track], serverURL: String) -> String {
+        let base = normalizedBase(serverURL)
+        var lines: [String] = ["#EXTM3U"]
+        // A comment header naming the playlist — ignored by players, but makes
+        // the file self-describing when opened in a text editor.
+        lines.append("#PLAYLIST:\(sanitizedLine(playlistName))")
+        for track in tracks {
+            let seconds = track.runtimeTicks > 0 ? Int(track.runtimeTicks / 10_000_000) : -1
+            let title = displayTitle(for: track)
+            lines.append("#EXTINF:\(seconds),\(sanitizedLine(title))")
+            lines.append(streamURL(forTrackId: track.id, base: base))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - JSON
+
+    /// Build a stable JSON manifest for `playlist` from its already-loaded
+    /// `tracks`. Keys are sorted and the output is pretty-printed so the file
+    /// is diff-friendly and human-readable. Durations are emitted in whole
+    /// seconds (mirroring the M3U `#EXTINF` convention) rather than raw ticks.
+    ///
+    /// The schema is intentionally small and self-contained — id, name, and an
+    /// ordered `tracks` array — so a future "Import Playlist" path can round-
+    /// trip it without depending on the server's full item projection.
+    static func json(playlistId: String, playlistName: String, tracks: [Track]) throws -> String {
+        let manifest = PlaylistManifest(
+            schema: "lyrebird.playlist/v1",
+            id: playlistId,
+            name: playlistName,
+            trackCount: tracks.count,
+            tracks: tracks.map(TrackManifest.init(track:))
+        )
+        let encoder = JSONEncoder()
+        // Sorted keys + pretty-print → deterministic, reviewable output.
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(manifest)
+        return String(decoding: data, as: UTF8.self) + "\n"
+    }
+
+    // MARK: - Deep link
+
+    /// Jellyfin web URL for an item id, e.g.
+    /// `https://server.example.com/web/#/details?id=<id>`. The web UI uses the
+    /// same `details` route for albums, artists, and playlists.
+    ///
+    /// **Secret stripping (#237):** the stored server URL is whatever the user
+    /// typed at login, which can carry embedded credentials
+    /// (`https://user:pass@host`) or a stray query/fragment. We rebuild the URL
+    /// from `scheme://host[:port]/path` only, so the copied link never leaks a
+    /// password or token. Returns `nil` when `serverURL` is empty or can't be
+    /// parsed into a scheme + host.
+    static func webURL(serverURL: String, itemId: String) -> URL? {
+        guard let base = sanitizedOrigin(serverURL) else { return nil }
+        return URL(string: "\(base)/web/#/details?id=\(itemId)")
+    }
+
+    // MARK: - Helpers
+
+    /// A user-facing "Artist - Title" label for a track, falling back to the
+    /// bare title when the artist is blank so we never emit a dangling " - ".
+    static func displayTitle(for track: Track) -> String {
+        let artist = track.artistName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return artist.isEmpty ? track.name : "\(artist) - \(track.name)"
+    }
+
+    /// Trim a trailing slash from the raw server URL so path concatenation
+    /// doesn't produce a double slash. Does not strip credentials — used for
+    /// the stream-URL base where the host is the same origin the app is
+    /// already authenticated against.
+    private static func normalizedBase(_ serverURL: String) -> String {
+        serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+    }
+
+    /// Rebuild a credential-free origin (`scheme://host[:port][/path]`) from a
+    /// raw server URL, dropping any `user:password@` userinfo, query, and
+    /// fragment. The trailing slash is removed so callers can append `/web/...`
+    /// cleanly. Returns `nil` if the string lacks a scheme or host.
+    private static func sanitizedOrigin(_ serverURL: String) -> String? {
+        let trimmed = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              var components = URLComponents(string: trimmed),
+              let scheme = components.scheme,
+              let host = components.host,
+              !host.isEmpty
+        else { return nil }
+
+        // Drop everything that could carry a secret.
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+
+        var origin = "\(scheme)://\(host)"
+        if let port = components.port {
+            origin += ":\(port)"
+        }
+        // Preserve any sub-path the server is mounted under (reverse proxies),
+        // minus a trailing slash.
+        var path = components.path
+        if path.hasSuffix("/") { path = String(path.dropLast()) }
+        origin += path
+        return origin
+    }
+
+    /// Collapse newlines / carriage returns to spaces so a track title or
+    /// playlist name can't inject extra M3U directive lines.
+    private static func sanitizedLine(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+}
+
+// MARK: - JSON manifest shapes
+
+/// Top-level JSON export shape. `Codable` so the same type can back a future
+/// import path. `schema` is a version tag so importers can branch on format
+/// changes without sniffing the payload.
+struct PlaylistManifest: Codable, Equatable {
+    let schema: String
+    let id: String
+    let name: String
+    let trackCount: Int
+    let tracks: [TrackManifest]
+}
+
+/// Per-track JSON export shape. A deliberately small projection of `Track`:
+/// the stable identifiers plus the human-readable metadata needed to re-resolve
+/// or display the entry. Optional fields are omitted from the output when nil
+/// (default `JSONEncoder` behaviour) to keep the manifest compact.
+struct TrackManifest: Codable, Equatable {
+    let id: String
+    let name: String
+    let artist: String?
+    let album: String?
+    let albumId: String?
+    let durationSeconds: Int
+
+    init(track: Track) {
+        self.id = track.id
+        self.name = track.name
+        let artist = track.artistName.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.artist = artist.isEmpty ? nil : artist
+        self.album = track.albumName
+        self.albumId = track.albumId
+        self.durationSeconds = track.runtimeTicks > 0 ? Int(track.runtimeTicks / 10_000_000) : 0
+    }
+}

--- a/macos/Sources/Lyrebird/Components/SidebarAutoHide.swift
+++ b/macos/Sources/Lyrebird/Components/SidebarAutoHide.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Pure decision logic for the resizable, auto-hiding sidebar (#318).
+///
+/// `MainShell` drives `NavigationSplitView`'s `columnVisibility` from two
+/// independent sources:
+///   1. the user (the toolbar `Toggle Sidebar` button), and
+///   2. the window width — narrow windows auto-collapse the rail to give the
+///      detail column room, then auto-restore it when the window widens again.
+///
+/// The hard part is keeping those two from fighting: once a user has manually
+/// hidden or shown the sidebar we must respect that and stop auto-driving it,
+/// otherwise a manual reveal in a narrow window would immediately re-collapse
+/// (and vice-versa). This type captures that contract as a single pure
+/// reducer so the threshold behaviour is unit-testable without booting a
+/// SwiftUI scene or introspecting `some View`.
+///
+/// The reducer is intentionally allocation-free and side-effect-free; the view
+/// owns the `@State` and feeds the previous values back in on every width
+/// change.
+enum SidebarAutoHide {
+    /// Window widths at or below this point collapse the sidebar; widths above
+    /// it restore it. Chosen as ideal sidebar (252) + a comfortable minimum
+    /// detail column (~420) so the auto-hide only kicks in when the two columns
+    /// would genuinely crowd each other on a small window, not during normal
+    /// resizing on a laptop display.
+    static let collapseThreshold: CGFloat = 720
+
+    /// Records whether the sidebar's current collapsed state was driven by
+    /// auto-hide (vs. the user). Persisted-adjacent: the view keeps this in
+    /// `@State`, the user-override flag in `@AppStorage`.
+    struct State: Equatable {
+        /// True while the sidebar is collapsed *because* the window is narrow —
+        /// i.e. the collapse came from auto-hide, not a manual toggle. Only an
+        /// auto-collapse is eligible for auto-restore when the window widens.
+        var didAutoCollapse: Bool = false
+        /// True once the user has manually toggled the sidebar. While set, the
+        /// width-driven reducer leaves `columnVisibility` alone so auto-hide
+        /// never overrides an explicit choice. A subsequent width change does
+        /// not clear it — only an explicit `clearUserOverride()` (wired to a
+        /// fresh manual toggle) does.
+        var userDidOverride: Bool = false
+    }
+
+    /// The outcome of a width change: the visibility the view should adopt and
+    /// the updated auto-hide bookkeeping. `visibility == nil` means "leave
+    /// `columnVisibility` untouched" — used when the user override is active or
+    /// when no transition is warranted, so the view doesn't stomp an in-flight
+    /// animation with a redundant assignment.
+    struct Decision: Equatable {
+        var visibility: NavigationSplitViewVisibility?
+        var state: State
+    }
+
+    /// Pure reducer. Given the new window `width`, the current `visibility`,
+    /// and the prior `state`, returns whether to collapse / restore and the
+    /// updated bookkeeping.
+    ///
+    /// Contract:
+    ///   * If the user has manually overridden visibility, never auto-drive —
+    ///     return `visibility: nil` and preserve the override flag.
+    ///   * Otherwise, crossing below `collapseThreshold` collapses the rail
+    ///     (recording that the collapse was automatic), and crossing back above
+    ///     restores it — but *only* if the collapse was the one we made. A rail
+    ///     the user left open in a narrow window (no override, already `.all`)
+    ///     is left open; we don't retroactively collapse a window that was
+    ///     already narrow without a width transition.
+    static func decide(
+        width: CGFloat,
+        visibility: NavigationSplitViewVisibility,
+        state: State
+    ) -> Decision {
+        // A manual choice wins until it's explicitly cleared. Don't touch
+        // visibility, and don't disturb the auto-collapse bookkeeping.
+        guard !state.userDidOverride else {
+            return Decision(visibility: nil, state: state)
+        }
+
+        if width <= collapseThreshold {
+            // Narrow: collapse if currently shown. If it's already collapsed we
+            // leave it (and only claim the auto-collapse if we were the cause).
+            if visibility != .detailOnly {
+                var next = state
+                next.didAutoCollapse = true
+                return Decision(visibility: .detailOnly, state: next)
+            }
+            return Decision(visibility: nil, state: state)
+        } else {
+            // Wide: restore only the collapse we made. A user-collapsed rail is
+            // guarded by `userDidOverride` above, so reaching here with
+            // `didAutoCollapse == true` means it's safe to reopen.
+            if state.didAutoCollapse {
+                var next = state
+                next.didAutoCollapse = false
+                return Decision(visibility: .all, state: next)
+            }
+            return Decision(visibility: nil, state: state)
+        }
+    }
+
+    /// Folds a manual toggle into the bookkeeping: the user has now taken
+    /// explicit control, so future width changes must not auto-drive the rail.
+    /// Clears the auto-collapse marker because any collapse is now the user's.
+    static func registeringManualToggle(_ state: State) -> State {
+        State(didAutoCollapse: false, userDidOverride: true)
+    }
+}
+
+/// Stable `@AppStorage` key for the sidebar auto-hide override (#318).
+/// Centralised so the writer (`MainShell`) and any future reader never drift on
+/// a string literal. Must not be renamed without a migration — a drift silently
+/// resets every user's "I manually pinned the sidebar" preference.
+enum SidebarDefaults {
+    /// `Bool` — set once the user manually toggles the sidebar, after which
+    /// width-driven auto-hide stops overriding their choice for the session's
+    /// window. Persisted so the preference survives relaunch.
+    static let userDidOverrideAutoHideKey = "sidebar.userDidOverrideAutoHide"
+}

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -312,6 +312,17 @@ struct LyrebirdCommands: Commands {
             .keyboardShortcut("k", modifiers: .command)
             .disabled(model.session == nil)
 
+            // New Instant Mix… (#327). Opens the seed-picker sheet so the
+            // user can search for and pick any track / album / artist /
+            // genre to seed a radio station, rather than relying on the
+            // implicit "currently playing" seed the Discover/Home CTAs use.
+            // ⌘⌥M keeps it adjacent to ⌘K's palette in the home-row cluster.
+            Button("menu.nav.instant_mix") {
+                model.presentInstantMixPicker()
+            }
+            .keyboardShortcut("m", modifiers: [.command, .option])
+            .disabled(model.session == nil)
+
             Divider()
 
             // Mini Player. ⌘⌥P toggles the detached, borderless

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1633,6 +1633,174 @@
           }
         }
       }
+    },
+    "instant_mix.picker.category.albums" : {
+      "comment" : "Instant Mix picker filter chip: albums only.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albums"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.category.all" : {
+      "comment" : "Instant Mix picker filter chip: show every kind of seed candidate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.category.artists" : {
+      "comment" : "Instant Mix picker filter chip: artists only.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artists"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.category.genres" : {
+      "comment" : "Instant Mix picker filter chip: genres only.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genres"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.category.tracks" : {
+      "comment" : "Instant Mix picker filter chip: tracks only.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tracks"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.close" : {
+      "comment" : "Accessibility label for the close button on the Instant Mix seed-picker sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Instant Mix picker"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.empty_prompt" : {
+      "comment" : "Prompt shown in the Instant Mix picker before the user has typed a query.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search for something to build a mix around."
+          }
+        }
+      }
+    },
+    "instant_mix.picker.generate" : {
+      "comment" : "Primary action button that starts the Instant Mix from the chosen seed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.last_mix" : {
+      "comment" : "Prefix for the most recently used Instant Mix seed name, shown as a regenerate hint. Followed verbatim by the seed name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last mix:"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.no_matches" : {
+      "comment" : "Shown in the Instant Mix picker when a search returns no seed candidates.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No matches"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.search_placeholder" : {
+      "comment" : "Placeholder for the search field in the Instant Mix seed picker.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search for a track, album, artist, or genre"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.selected" : {
+      "comment" : "Prefix for the currently selected Instant Mix seed name in the picker footer. Followed verbatim by the seed name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed:"
+          }
+        }
+      }
+    },
+    "instant_mix.picker.title" : {
+      "comment" : "Title of the Instant Mix seed-picker sheet (#327).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Instant Mix"
+          }
+        }
+      }
+    },
+    "menu.nav.instant_mix" : {
+      "comment" : "View menu item that opens the Instant Mix seed-picker sheet (#327).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Instant Mix…"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -35,6 +35,7 @@ struct HomeView: View {
                 recentlyPlayedTracksSection
                 yourPlaylistsSection
                 recentlyAddedSection
+                rediscoverSection
                 quickPicksSection
                 suggestionsSection
                 favoritesSection
@@ -558,6 +559,33 @@ struct HomeView: View {
                                 NewBadge()
                             }
                         }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// "Rediscover" — albums the user has never played (#57). Backed by
+    /// `model.rediscover`, an `/Items` query filtered to `IsUnplayed` and
+    /// sorted `Random`, so the shelf surfaces a fresh handful from the
+    /// unplayed corners of the library on each refresh. Hidden when empty
+    /// (a fully-played library) so we don't punch a blank hole in the
+    /// layout. Reuses `HomeAlbumTile`, the same tile the other album
+    /// carousels render.
+    @ViewBuilder
+    private var rediscoverSection: some View {
+        if !model.rediscover.isEmpty {
+            carouselSection(
+                icon: "binoculars.fill",
+                iconColor: Theme.primary,
+                title: "Rediscover",
+                subtitle: "Albums in your library you haven't played yet",
+                onSeeAll: { model.selectTab(.library) }
+            ) {
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(model.rediscover, id: \.id) { album in
+                        HomeAlbumTile(album: album)
                     }
                 }
                 .padding(.vertical, 4)

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -16,8 +16,28 @@ struct MainShell: View {
 
     /// Drives `NavigationSplitView`'s sidebar visibility so the toolbar
     /// `Toggle Sidebar` item has somewhere to write. SwiftUI animates the
-    /// column collapse / reveal for us when this changes.
+    /// column collapse / reveal for us when this changes. Seeded from
+    /// `persistedSidebarRaw` / the Appearance preference on first appearance
+    /// and mirrored back into `@SceneStorage` so the layout survives a
+    /// relaunch — see `restoreWindowState()` and `WindowStateStore` (#10).
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+
+    /// Persisted main-window content state (#10). The OS already restores the
+    /// window's size/position via `WindowGroup` (#17); these three reach the
+    /// things it can't — the last-viewed tab, the sidebar column visibility,
+    /// and the queue inspector — via `@SceneStorage` so each is keyed to the
+    /// window scene rather than leaking globally across windows. All decode /
+    /// fallback logic lives in the testable `WindowStateStore`; these hold
+    /// only the stable raw strings.
+    @SceneStorage(WindowStateKeys.screen) private var persistedScreenRaw: String = ""
+    @SceneStorage(WindowStateKeys.sidebar) private var persistedSidebarRaw: String = ""
+    @SceneStorage(WindowStateKeys.inspector) private var persistedInspectorRaw: String = ""
+
+    /// The Appearance pane's `Sidebar` preference (`PreferencesAppearance`).
+    /// Read here so a window with no persisted per-scene visibility yet opens
+    /// honouring the user's chosen default — wiring the previously UI-only
+    /// `AppearanceSidebar` enum into real behaviour (#10).
+    @AppStorage(AppearanceKeys.sidebar) private var sidebarPreferenceRaw: String = AppearanceSidebar.visible.rawValue
 
     var body: some View {
         @Bindable var model = model
@@ -162,6 +182,27 @@ struct MainShell: View {
                 .accessibilitySortPriority(50)
         }
         .background(Theme.bg)
+        // Restore the persisted window content state once, on first
+        // appearance of the shell (#10). `WindowStateStore` owns the decode +
+        // fallback rules; here we just apply the resolved values. Runs after
+        // the scene mounts so `@SceneStorage` has rehydrated.
+        .onAppear { restoreWindowState() }
+        // Persist the last-viewed tab whenever it changes so the next launch
+        // lands where the user left off.
+        .onChange(of: model.screen) { _, newScreen in
+            persistedScreenRaw = newScreen.persistedRawValue
+        }
+        // Persist the sidebar column visibility on every change — the toolbar
+        // toggle, the native separator drag/collapse, and ⌘⌃S all write
+        // `columnVisibility`, so observing it here captures every path.
+        .onChange(of: columnVisibility) { _, newValue in
+            persistedSidebarRaw = newValue.persistedRawValue
+        }
+        // Persist the queue inspector visibility (#79 surface) so it reopens
+        // with the window if the user left it open.
+        .onChange(of: model.isQueueInspectorOpen) { _, isOpen in
+            persistedInspectorRaw = isOpen ? "true" : "false"
+        }
         // Announce track changes to VoiceOver (#342). Keyed on the track id
         // so it fires for user skips and autoplay alike but not for
         // non-identity status churn (position / volume polls). The stop
@@ -229,6 +270,34 @@ struct MainShell: View {
             // explainer on the next line.
             Text(verbatim: "\u{201C}\(playlist.name)\u{201D}\n")
                 + Text("playlist.delete.message")
+        }
+    }
+
+    /// Apply the persisted window content state on first appearance (#10).
+    /// Pulls the resolved values out of `WindowStateStore` (which encapsulates
+    /// every fallback rule, including the Appearance `Sidebar` preference) and
+    /// writes them into the live state. Idempotent and cheap: re-running it
+    /// would just re-apply the same values, but `.onAppear` only fires it once
+    /// per shell mount.
+    ///
+    /// Restoring the tab routes through `selectTab(_:)` rather than assigning
+    /// `model.screen` directly so any drill stack from a stale launch is
+    /// cleared — the user should land on the tab root, not a half-restored
+    /// detail page whose subject may no longer exist.
+    private func restoreWindowState() {
+        let restoredScreen = WindowStateStore.restoredScreen(persistedRaw: persistedScreenRaw)
+        if model.screen != restoredScreen {
+            model.selectTab(restoredScreen)
+        }
+
+        columnVisibility = WindowStateStore.initialSidebarVisibility(
+            persistedRaw: persistedSidebarRaw,
+            preferenceRaw: sidebarPreferenceRaw
+        )
+
+        let restoredInspector = WindowStateStore.restoredInspectorVisible(persistedRaw: persistedInspectorRaw)
+        if model.isQueueInspectorOpen != restoredInspector {
+            model.isQueueInspectorOpen = restoredInspector
         }
     }
 

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -207,6 +207,14 @@ struct MainShell: View {
                 model.trackInfoSubject = nil
             }
         }
+        // Instant Mix seed-picker — search/pick a track, album, artist, or
+        // genre to seed a radio station (#327). Driven by
+        // `AppModel.isShowingInstantMixPicker`; summoned from the View ▸
+        // "New Instant Mix…" menu command (⌘⌥M). Mounted here so it floats
+        // over whichever screen is active.
+        .sheet(isPresented: $model.isShowingInstantMixPicker) {
+            InstantMixSheet(model: model)
+        }
         // Playlist-delete confirmation — see #98 / #131. Triggered from
         // `PlaylistContextMenu` via `AppModel.confirmDelete(playlist:)`.
         .confirmationDialog(

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -19,6 +19,18 @@ struct MainShell: View {
     /// column collapse / reveal for us when this changes.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
+    /// Auto-hide bookkeeping (#318). Tracks whether the current collapse was
+    /// width-driven so it (and only it) is eligible for auto-restore when the
+    /// window widens again. `userDidOverride` mirrors the persisted flag below
+    /// so the reducer can read both in one value.
+    @State private var sidebarAutoHide = SidebarAutoHide.State()
+
+    /// Persisted manual-override flag (#318). Set once the user clicks the
+    /// `Toggle Sidebar` toolbar button, after which width-driven auto-hide
+    /// stops overriding their choice. Survives relaunch via `@AppStorage`.
+    @AppStorage(SidebarDefaults.userDidOverrideAutoHideKey)
+    private var userDidOverrideAutoHide: Bool = false
+
     var body: some View {
         @Bindable var model = model
         VStack(spacing: 0) {
@@ -47,10 +59,11 @@ struct MainShell: View {
                     // (sidebar first) is read off the inner element and the
                     // container falls back to default priority.
                     .accessibilitySortPriority(100)
-                    // Pin the sidebar to the existing 252pt design width so
-                    // NavigationSplitView's auto-sizing doesn't expand the
-                    // column past what the brand mark + nav rows assume.
-                    .navigationSplitViewColumnWidth(252)
+                    // Drag-resizable sidebar (#318). The 252pt design width is
+                    // the ideal; users can drag the separator between a 200pt
+                    // floor (brand mark + nav rows stay legible) and a 360pt
+                    // ceiling (so the rail can't swallow the detail column).
+                    .navigationSplitViewColumnWidth(min: 200, ideal: 252, max: 360)
             } detail: {
                 HStack(spacing: 0) {
                     NavigationStack(path: $model.navPath) {
@@ -72,9 +85,7 @@ struct MainShell: View {
                             .toolbar {
                                 ToolbarItem(placement: .navigation) {
                                     Button {
-                                        columnVisibility = (columnVisibility == .all)
-                                            ? .detailOnly
-                                            : .all
+                                        toggleSidebarManually()
                                     } label: {
                                         Image(systemName: "sidebar.left")
                                     }
@@ -162,6 +173,22 @@ struct MainShell: View {
                 .accessibilitySortPriority(50)
         }
         .background(Theme.bg)
+        // Width-driven sidebar auto-hide (#318). A zero-cost GeometryReader in
+        // the background reports the shell's width; `onChange` runs the pure
+        // `SidebarAutoHide` reducer to collapse the rail on narrow windows and
+        // restore it when they widen. The reducer no-ops once the user has
+        // manually toggled the sidebar, so auto-hide never fights an explicit
+        // choice. Driven off the *outer* VStack so the measured width spans the
+        // whole window (sidebar + detail), matching the threshold's intent.
+        .background(
+            GeometryReader { proxy in
+                Color.clear
+                    .onAppear { applySidebarAutoHide(width: proxy.size.width) }
+                    .onChange(of: proxy.size.width) { _, newWidth in
+                        applySidebarAutoHide(width: newWidth)
+                    }
+            }
+        )
         // Announce track changes to VoiceOver (#342). Keyed on the track id
         // so it fires for user skips and autoplay alike but not for
         // non-identity status churn (position / volume polls). The stop
@@ -229,6 +256,36 @@ struct MainShell: View {
             // explainer on the next line.
             Text(verbatim: "\u{201C}\(playlist.name)\u{201D}\n")
                 + Text("playlist.delete.message")
+        }
+    }
+
+    /// Toolbar `Toggle Sidebar` handler (#318). Flips `columnVisibility` and
+    /// records that the user has taken explicit control, so width-driven
+    /// auto-hide stops overriding their choice. The override is persisted via
+    /// `@AppStorage` so the rail stays where they put it across relaunches.
+    private func toggleSidebarManually() {
+        columnVisibility = (columnVisibility == .all) ? .detailOnly : .all
+        sidebarAutoHide = SidebarAutoHide.registeringManualToggle(sidebarAutoHide)
+        userDidOverrideAutoHide = true
+    }
+
+    /// Runs the pure `SidebarAutoHide` reducer for the latest window `width`
+    /// and applies its decision (#318). Seeds the reducer's `userDidOverride`
+    /// from the persisted `@AppStorage` flag so a manual choice from a prior
+    /// launch is honoured. Only assigns `columnVisibility` when the reducer
+    /// asks for a transition, so a redundant write never stomps an in-flight
+    /// collapse / reveal animation.
+    private func applySidebarAutoHide(width: CGFloat) {
+        var state = sidebarAutoHide
+        state.userDidOverride = userDidOverrideAutoHide
+        let decision = SidebarAutoHide.decide(
+            width: width,
+            visibility: columnVisibility,
+            state: state
+        )
+        sidebarAutoHide = decision.state
+        if let newVisibility = decision.visibility, newVisibility != columnVisibility {
+            columnVisibility = newVisibility
         }
     }
 

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -57,10 +57,27 @@ struct NowPlayingView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // Ambient wash sampled from the current cover (#271). Sits behind the
-        // whole player; falls back to the theme gradient when `ambientPalette`
-        // is nil (pre-sample / no art / extraction failed).
-        .background(AmbientWash(palette: ambientPalette))
+        // Immersive background behind the whole player.
+        //
+        // Two layers compose here (#271 + #21):
+        //   1. `AmbientWash` — opaque `Theme.bg` base + the artwork-derived
+        //      palette gradient. This is the fallback surface and is always
+        //      present.
+        //   2. `NowPlayingBackdrop` — the large, heavily-blurred, dimmed
+        //      current cover, layered *over* the wash but *under* the content.
+        //      It renders nothing under Reduce Transparency or when there's no
+        //      art, so the wash beneath shows through unchanged. Its single dim
+        //      scrim is the only darkening over the cover, so the two layers
+        //      never double-darken.
+        .background {
+            ZStack {
+                AmbientWash(palette: ambientPalette)
+                NowPlayingBackdrop(
+                    url: backdropArtworkURL,
+                    seed: model.status.currentTrack?.name ?? ""
+                )
+            }
+        }
         // Re-fetch the People array + lyrics on open and on track change.
         // The polling loop in AppModel already handles mid-session
         // transitions; this keeps the open-from-cold path honest too.
@@ -113,6 +130,24 @@ struct NowPlayingView: View {
     private var ambientArtworkKey: String? {
         guard let track = model.status.currentTrack else { return nil }
         return track.albumId ?? track.id
+    }
+
+    /// Size-hinted URL for the blurred-artwork backdrop (#21). Resolves the
+    /// same cover the hero shows (`albumId ?? id` identity, matching
+    /// `ambientArtworkKey`) so the backdrop reuses the cover Nuke already
+    /// decoded — a 1024px hint gives the heavy blur enough source detail
+    /// without re-fetching a higher resolution than the screen can use.
+    /// `imageURL` is memoized in `AppModel`, so reading this each body pass is
+    /// a dictionary hit, not a per-render FFI crossing (gap pattern #2).
+    /// `nil` when nothing is playing or the track has no art, in which case
+    /// `NowPlayingBackdrop` stays transparent and the ambient wash shows.
+    private var backdropArtworkURL: URL? {
+        guard let track = model.status.currentTrack else { return nil }
+        return model.imageURL(
+            for: track.albumId ?? track.id,
+            tag: track.imageTag,
+            maxWidth: 1024
+        )
     }
 
     // MARK: - Main content

--- a/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
@@ -238,8 +238,15 @@ struct PlaylistDetailView: View {
                     Button("Add to Queue") { model.addToQueue(playlist: playlist) }
                         .disabled(true)
                     Divider()
+                    Button("Export as M3U…") { model.exportPlaylist(playlist: playlist) }
+                        .disabled(tracks.isEmpty)
+                    Button("Export as JSON…") { model.exportPlaylistJSON(playlist: playlist) }
+                        .disabled(tracks.isEmpty)
+                    Divider()
                     Button("Copy Link") { model.copyShareLink(playlist: playlist) }
+                        .disabled(model.webURL(for: playlist) == nil)
                     Button("Open in Jellyfin") { model.openInJellyfin(playlist: playlist) }
+                        .disabled(model.webURL(for: playlist) == nil)
                 }
             } label: {
                 Image(systemName: "ellipsis")

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesScrobbling.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesScrobbling.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// Scrobbling preferences pane (#46).
+///
+/// MVP target is **ListenBrainz**, the simplest token-based scrobbler: the user
+/// pastes their token from <https://listenbrainz.org/profile/> and Lyrebird
+/// submits a `playing_now` when a track starts plus a durable listen once it
+/// passes the scrobble threshold (half the track, or four minutes).
+///
+/// Security: the token is a secret. It is written straight through to the Rust
+/// core's settings table via `AppModel.connectScrobbler(token:)` and is **never**
+/// stored in `UserDefaults`, never logged, and never included in the diagnostic
+/// bundle. The pane only ever learns *whether* a token is configured
+/// (`model.scrobbleConnected`), never its value — there is no FFI that returns
+/// the token. The text field is cleared the moment it is saved.
+///
+/// Last.fm is shown as a clearly-disabled "Coming soon" section: it needs an
+/// API key + shared-secret signing handshake and a web-auth session token,
+/// which is follow-up work. The disabled section documents the intent without
+/// pretending to function.
+struct PreferencesScrobbling: View {
+    @Environment(AppModel.self) private var model
+
+    @AppStorage(ScrobblePreference.enabledKey) private var enabled: Bool = false
+
+    /// Local editing buffer for the token. Never pre-filled from storage (the
+    /// token can't be read back), so it starts empty and the user pastes a
+    /// fresh token to (re)connect.
+    @State private var tokenDraft: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Scrobbling",
+                footnote: "When on, Lyrebird reports each track you play to your scrobbling service. A track counts once you've listened to at least half of it, or four minutes — whichever comes first."
+            ) {
+                PreferenceRow(
+                    label: "Enable scrobbling",
+                    help: enabled
+                        ? (model.scrobbleConnected
+                            ? "On — plays are submitted to ListenBrainz."
+                            : "On, but no ListenBrainz token is connected yet.")
+                        : "Off — Lyrebird won't submit any plays."
+                ) {
+                    Toggle("", isOn: $enabled)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Enable scrobbling")
+                }
+            }
+
+            listenBrainzSection
+
+            lastFmSection
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - ListenBrainz
+
+    @ViewBuilder
+    private var listenBrainzSection: some View {
+        PreferenceSection(
+            title: "ListenBrainz",
+            footnote: "Paste your user token from listenbrainz.org/profile. The token is stored securely on this Mac and is never shown again or included in diagnostics."
+        ) {
+            if model.scrobbleConnected {
+                connectedRow
+            } else {
+                connectRow
+            }
+        }
+    }
+
+    /// Shown when a token is already stored: confirmation + a Disconnect button.
+    private var connectedRow: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            PreferenceRow(
+                label: "Account",
+                help: "A ListenBrainz token is connected."
+            ) {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundStyle(Theme.accent)
+                    Text("Connected")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("ListenBrainz connected")
+            }
+
+            Divider()
+                .background(Theme.border)
+                .padding(.vertical, 10)
+
+            PreferenceRow(
+                label: "Disconnect",
+                help: "Removes the stored token. You can reconnect at any time."
+            ) {
+                Button("Disconnect") {
+                    model.disconnectScrobbler()
+                    tokenDraft = ""
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Disconnect ListenBrainz")
+            }
+        }
+    }
+
+    /// Shown when no token is stored: a secure field + Connect button.
+    private var connectRow: some View {
+        PreferenceRow(
+            label: "User token",
+            help: "Find it on your ListenBrainz profile page."
+        ) {
+            HStack(spacing: 8) {
+                SecureField("Paste token", text: $tokenDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 240)
+                    .accessibilityLabel("ListenBrainz user token")
+                Button("Connect") {
+                    model.connectScrobbler(token: tokenDraft)
+                    // Clear the buffer immediately — the secret is now in the
+                    // core and must not linger in view state.
+                    tokenDraft = ""
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(tokenDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+                .accessibilityLabel("Connect ListenBrainz")
+            }
+        }
+    }
+
+    // MARK: - Last.fm (not yet available)
+
+    /// Last.fm requires an API key + shared secret and a signed web-auth session
+    /// handshake (`auth.getSession`), none of which is implemented yet. Render a
+    /// clearly-disabled section rather than a working control so the roadmap is
+    /// visible without misleading the user.
+    @ViewBuilder
+    private var lastFmSection: some View {
+        PreferenceSection(
+            title: "Last.fm",
+            footnote: "Last.fm scrobbling is planned. It needs an API key and a sign-in handshake, which isn't available in this build yet."
+        ) {
+            PreferenceRow(
+                label: "Last.fm",
+                help: "Coming soon."
+            ) {
+                Button("Connect") {}
+                    .buttonStyle(.bordered)
+                    .disabled(true)
+                    .accessibilityLabel("Connect Last.fm (coming soon)")
+            }
+            .opacity(0.55)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Scrobbling")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Report the tracks you play to ListenBrainz.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+}
+
+#Preview {
+    // Real rendering requires an `AppModel` in the environment; the Settings
+    // scene in `LyrebirdApp` injects one. Kept as documentation for where the
+    // view lives — see `PreferencesNotifications` for the same note.
+    PreferencesScrobbling()
+        .frame(width: 560, height: 520)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case general, server, playback, audio, library, appearance, notifications, downloads, advanced, about
+        case general, server, playback, audio, library, appearance, notifications, scrobbling, downloads, advanced, about
 
         var id: String { rawValue }
 
@@ -31,6 +31,7 @@ struct PreferencesView: View {
             case .library: return "Library"
             case .appearance: return "Appearance"
             case .notifications: return "Notifications"
+            case .scrobbling: return "Scrobbling"
             case .downloads: return "Downloads"
             case .advanced: return "Advanced"
             case .about: return "About"
@@ -46,6 +47,7 @@ struct PreferencesView: View {
             case .library: return "music.note.list"
             case .appearance: return "paintpalette"
             case .notifications: return "bell"
+            case .scrobbling: return "dot.radiowaves.up.forward"
             case .downloads: return "arrow.down.circle"
             case .advanced: return "wrench.and.screwdriver"
             case .about: return "info.circle"
@@ -84,6 +86,7 @@ struct PreferencesView: View {
         case .library: PreferencesLibrary()
         case .appearance: AppearancePane()
         case .notifications: PreferencesNotifications()
+        case .scrobbling: PreferencesScrobbling()
         case .downloads: PreferencesDownloads()
         case .advanced: PreferencesAdvanced()
         case .about: PreferencesAbout()

--- a/macos/Sources/Lyrebird/System/ScrobbleGate.swift
+++ b/macos/Sources/Lyrebird/System/ScrobbleGate.swift
@@ -1,0 +1,111 @@
+import Foundation
+import LyrebirdCore
+
+/// Decides *when* to scrobble, independent of *how*.
+///
+/// The "how" — POSTing to ListenBrainz — lives in the Rust core
+/// (`scrobble_now_playing` / `scrobble_submit_listen`). This gate owns the
+/// per-track bookkeeping that decides which of those calls to make and exactly
+/// once each:
+///
+/// - A **`playing_now`** fires the moment a new track becomes current.
+/// - A **`single`** (durable listen) fires once that track crosses the
+///   scrobble threshold (half the track, or four minutes — see
+///   `core.scrobbleThresholdReached`). It is keyed to the track's *start*
+///   time, which the gate captures when the track first appears.
+///
+/// The gate is a plain value type with no networking and no `LyrebirdCore`
+/// dependency in its decision path (the threshold rule is injected), so the
+/// trigger logic is deterministic and unit-testable without a server. The
+/// owner (`AppModel`) drives it from the 1 Hz status poll: `noteTrack(...)` on
+/// every tick, then performs whichever `Action` comes back.
+///
+/// Implements #46.
+struct ScrobbleGate {
+    /// What the owner should do in response to a poll tick. `.none` is the
+    /// overwhelmingly common case (mid-track, nothing to send).
+    enum Action: Equatable {
+        case none
+        /// Send a `playing_now` for this track.
+        case nowPlaying(Track)
+        /// Send a durable `single` listen for this track, keyed to the given
+        /// Unix start timestamp (seconds).
+        case submitListen(Track, listenedAt: Int64)
+    }
+
+    /// The track currently being tracked, and the bookkeeping for it.
+    private var currentId: String?
+    private var startedAtUnix: Int64 = 0
+    private var submittedListen = false
+
+    /// Feed the gate one observation. Pass the current track (or `nil` when
+    /// playback stopped), its playhead `position` and `duration` in seconds,
+    /// whether scrobbling is enabled + configured, and a `thresholdReached`
+    /// predicate (production hands in `core.scrobbleThresholdReached`).
+    ///
+    /// `now` is injectable for tests; production passes the wall clock.
+    ///
+    /// Returns the single action to perform this tick. When scrobbling is off
+    /// the gate still tracks the current track id (so re-enabling mid-track
+    /// doesn't retro-fire a stale `playing_now`) but emits `.none`.
+    mutating func noteTrack(
+        _ track: Track?,
+        position: Double,
+        duration: Double,
+        enabled: Bool,
+        now: Int64 = Int64(Date().timeIntervalSince1970),
+        thresholdReached: (_ position: Double, _ duration: Double) -> Bool
+    ) -> Action {
+        // Playback stopped / no track: reset so the next track starts clean.
+        guard let track, !track.id.isEmpty else {
+            reset()
+            return .none
+        }
+
+        // New track became current — reset per-track state and capture the
+        // start time. Emit `playing_now` only when scrobbling is live.
+        if track.id != currentId {
+            currentId = track.id
+            startedAtUnix = now
+            submittedListen = false
+            return enabled ? .nowPlaying(track) : .none
+        }
+
+        // Same track, already counted, or scrobbling disabled: nothing to do.
+        guard enabled, !submittedListen else { return .none }
+
+        // Threshold crossed for the first time -> one durable listen, keyed to
+        // the captured start time (ListenBrainz dedupes on `listened_at`).
+        if thresholdReached(position, duration) {
+            submittedListen = true
+            return .submitListen(track, listenedAt: startedAtUnix)
+        }
+
+        return .none
+    }
+
+    /// Forget the current track. Called implicitly when playback stops; exposed
+    /// so the owner can also clear state on logout / explicit stop.
+    mutating func reset() {
+        currentId = nil
+        startedAtUnix = 0
+        submittedListen = false
+    }
+}
+
+/// `@AppStorage` keys + convenience readers for the scrobbling preference.
+///
+/// Only the **enabled** flag lives in `UserDefaults`; the ListenBrainz token
+/// itself is a secret and is stored exclusively in the Rust core's settings
+/// table (never `UserDefaults`, never the diagnostic bundle). The pane writes
+/// the token through `AppModel`, which forwards it to the core.
+enum ScrobblePreference {
+    /// Whether scrobbling is switched on. A token can be configured while the
+    /// master switch is off (e.g. temporarily paused), so the gate checks
+    /// *both* this flag and the core's `isScrobbleConfigured()`.
+    static let enabledKey = "scrobble.enabled"
+
+    static var enabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledKey)
+    }
+}

--- a/macos/Sources/Lyrebird/System/WindowStateStore.swift
+++ b/macos/Sources/Lyrebird/System/WindowStateStore.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+// MARK: - Persisted window-state keys
+//
+// Keys are namespaced under `window.*` so they sit alongside (and never
+// collide with) the `appearance.*` family in `PreferencesAppearance.swift`.
+// They back `@SceneStorage`-driven restoration of the main window's chrome:
+// the last-viewed root tab, the sidebar column visibility, and the queue
+// inspector visibility. OS-provided size/position restoration is left to
+// `WindowGroup` (see `LyrebirdApp` / #17); this layer only restores the
+// *content* state the OS can't reach.
+enum WindowStateKeys {
+    /// Last-viewed root tab (`AppModel.Screen`).
+    static let screen = "window.lastScreen"
+    /// Sidebar column visibility (`NavigationSplitViewVisibility`).
+    static let sidebar = "window.sidebarVisibility"
+    /// Queue inspector open/closed.
+    static let inspector = "window.inspectorVisible"
+}
+
+// MARK: - Stable codecs for @SceneStorage round-trips
+//
+// `@SceneStorage` and `@AppStorage` persist `RawRepresentable` values whose
+// `RawValue` is a property-list type (here `String`). Neither `AppModel.Screen`
+// nor `NavigationSplitViewVisibility` is `RawRepresentable`, so we give each a
+// stable String codec rather than widening the enums themselves (Screen lives
+// in the AppModel hotspot; NavigationSplitViewVisibility is an Apple type).
+//
+// The raw strings are an on-disk contract: renaming one silently resets every
+// user's saved window state, so `WindowStateStoreTests` pins them.
+
+extension AppModel.Screen {
+    /// Stable on-disk identifier for `@SceneStorage`. Distinct from the Swift
+    /// case name so a future case rename doesn't churn persisted state.
+    var persistedRawValue: String {
+        switch self {
+        case .home: return "home"
+        case .discover: return "discover"
+        case .library: return "library"
+        case .favorites: return "favorites"
+        case .search: return "search"
+        case .settings: return "settings"
+        }
+    }
+
+    /// Decode a persisted identifier. Returns `nil` for unknown values (e.g.
+    /// a key written by a newer build) so the caller's default kicks in.
+    init?(persistedRawValue raw: String) {
+        switch raw {
+        case "home": self = .home
+        case "discover": self = .discover
+        case "library": self = .library
+        case "favorites": self = .favorites
+        case "search": self = .search
+        case "settings": self = .settings
+        default: return nil
+        }
+    }
+}
+
+extension NavigationSplitViewVisibility {
+    /// Stable on-disk identifier for the sidebar column visibility. Only the
+    /// states `MainShell` actually drives (`all` / `detailOnly`) plus the
+    /// `automatic` default are encoded; anything else collapses to `automatic`
+    /// so the store never persists a state the two-column shell can't honour.
+    var persistedRawValue: String {
+        switch self {
+        case .all: return "all"
+        case .detailOnly: return "detailOnly"
+        default: return "automatic"
+        }
+    }
+
+    /// Decode a persisted sidebar identifier. Returns `nil` for unknown values
+    /// so the caller's default applies.
+    init?(persistedRawValue raw: String) {
+        switch raw {
+        case "all": self = .all
+        case "detailOnly": self = .detailOnly
+        case "automatic": self = .automatic
+        default: return nil
+        }
+    }
+}
+
+// MARK: - WindowStateStore
+
+/// Pure, value-type resolver for the main window's restorable content state.
+///
+/// All of the launch-time decision logic lives here — free of SwiftUI scene
+/// plumbing — so it can be exercised headlessly in `WindowStateStoreTests`.
+/// `MainShell` owns the `@SceneStorage`/`@AppStorage` properties and feeds
+/// their raw strings in; this type maps them to concrete values to apply.
+///
+/// Restore precedence for the sidebar (`initialSidebarVisibility`):
+///   1. A persisted per-window visibility (the user explicitly toggled the
+///      sidebar last session) wins — restoring *their* last layout is the
+///      whole point of #10.
+///   2. With no persisted state (first launch in this scene), fall back to the
+///      Appearance pane's `Sidebar` preference, wiring the previously UI-only
+///      `AppearanceSidebar` enum into real behaviour: `.hidden` opens collapsed,
+///      `.visible` / `.auto_hide` open expanded.
+struct WindowStateStore {
+    /// Map an `AppearanceSidebar` preference to the column visibility a window
+    /// should adopt when it has no persisted per-window state of its own.
+    /// `.autoHide` reveals on hover at the OS level but still *starts* expanded,
+    /// so it resolves to `.all` like `.visible`.
+    static func defaultVisibility(for preference: AppearanceSidebar) -> NavigationSplitViewVisibility {
+        switch preference {
+        case .visible, .autoHide: return .all
+        case .hidden: return .detailOnly
+        }
+    }
+
+    /// Resolve the column visibility `MainShell` should apply on launch.
+    ///
+    /// - Parameters:
+    ///   - persistedRaw: the `@SceneStorage` raw string for this scene, or an
+    ///     empty string when nothing has been persisted yet.
+    ///   - preferenceRaw: the `@AppStorage` `appearance.sidebar` raw string.
+    static func initialSidebarVisibility(
+        persistedRaw: String,
+        preferenceRaw: String
+    ) -> NavigationSplitViewVisibility {
+        if let restored = NavigationSplitViewVisibility(persistedRawValue: persistedRaw) {
+            return restored
+        }
+        let preference = AppearanceSidebar(rawValue: preferenceRaw) ?? .visible
+        return defaultVisibility(for: preference)
+    }
+
+    /// Decode the persisted last-viewed root tab, falling back to `.library`
+    /// (the app's cold-start default) for empty or unknown raw values.
+    static func restoredScreen(persistedRaw: String) -> AppModel.Screen {
+        AppModel.Screen(persistedRawValue: persistedRaw) ?? .library
+    }
+
+    /// Decode the persisted inspector visibility. Defaults to closed — the
+    /// inspector is an opt-in surface (see `MainShell.isQueueInspectorOpen`).
+    static func restoredInspectorVisible(persistedRaw: String?) -> Bool {
+        persistedRaw == "true"
+    }
+}

--- a/macos/Tests/LyrebirdTests/InstantMixSeedPickerTests.swift
+++ b/macos/Tests/LyrebirdTests/InstantMixSeedPickerTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Instant Mix seed-picker (#327).
+///
+/// The picker's logic lives in the headless `InstantMixSeedPickerModel` so it
+/// can be exercised without booting the SwiftUI scene graph or hitting the
+/// network — the model takes its two side-effecting hooks (`search`,
+/// `onGenerate`) as injected closures, and these tests feed it deterministic
+/// `SearchResults` fixtures and capture the generated seed.
+///
+/// What's pinned:
+/// 1. `seedCandidates` flattens artists/albums/tracks and reconstructs genres
+///    from the album/artist `genres` arrays (deduped, alpha-sorted), matching
+///    `AppModel.bucketSearchResults`'s genre derivation.
+/// 2. The category chip narrows the candidate list to a single seed kind.
+/// 3. Selection drives `canGenerate`; re-tapping a row keeps the selection.
+/// 4. A fresh search prunes a now-absent selection but keeps a still-present one.
+/// 5. `generate()` hands exactly the chosen seed to the host, and is inert
+///    when nothing is selected.
+/// 6. An emptied query resets results + selection.
+///
+/// The `AppModel`-side wiring (`presentInstantMixPicker` flips the sheet flag;
+/// `generateInstantMix` records the seed label and dismisses) is also pinned.
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore` against a
+/// throwaway data dir via `XDG_DATA_HOME`, so the suite never touches the real
+/// database — we drive the view-model directly rather than the live FFI search.
+@MainActor
+final class InstantMixSeedPickerTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-instant-mix-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTrack(id: String, name: String, artist: String = "Artist") -> Track {
+        Track(
+            id: id, name: name, albumId: nil, albumName: nil, artistName: artist,
+            artistId: nil, indexNumber: nil, discNumber: nil, year: nil,
+            runtimeTicks: 0, isFavorite: false, playCount: 0, container: nil,
+            bitrate: nil, imageTag: nil, playlistItemId: nil, userData: nil
+        )
+    }
+
+    private func makeAlbum(id: String, name: String, genres: [String] = []) -> Album {
+        Album(
+            id: id, name: name, artistName: "Artist", artistId: nil, year: nil,
+            trackCount: 0, runtimeTicks: 0, genres: genres, imageTag: nil, userData: nil
+        )
+    }
+
+    private func makeArtist(id: String, name: String, genres: [String] = []) -> Artist {
+        Artist(
+            id: id, name: name, albumCount: 0, songCount: 0, genres: genres,
+            imageTag: nil, userData: nil
+        )
+    }
+
+    private func results(
+        artists: [Artist] = [],
+        albums: [Album] = [],
+        tracks: [Track] = []
+    ) -> SearchResults {
+        SearchResults(
+            artists: artists,
+            albums: albums,
+            tracks: tracks,
+            totalRecordCount: UInt32(artists.count + albums.count + tracks.count)
+        )
+    }
+
+    /// A picker wired to a fixed result set, capturing whatever seed gets
+    /// generated. The `generated` box lets a test assert the dispatch.
+    private func makePicker(
+        returning fixture: SearchResults?,
+        generated: @escaping (SearchItem) -> Void = { _ in }
+    ) -> InstantMixSeedPickerModel {
+        InstantMixSeedPickerModel(
+            search: { _ in fixture },
+            onGenerate: generated
+        )
+    }
+
+    // MARK: - Candidate flattening + genre derivation
+
+    func testSeedCandidatesFlattensEveryKind() {
+        let r = results(
+            artists: [makeArtist(id: "ar1", name: "Radiohead")],
+            albums: [makeAlbum(id: "al1", name: "OK Computer")],
+            tracks: [makeTrack(id: "t1", name: "Karma Police")]
+        )
+        let all = InstantMixSeedPickerModel.seedCandidates(from: r, category: .all)
+
+        // Order is artists, then albums, then tracks, then genres.
+        XCTAssertEqual(all.count, 3)
+        if case .artist(let a) = all[0] { XCTAssertEqual(a.id, "ar1") } else { XCTFail("expected artist first") }
+        if case .album(let a) = all[1] { XCTAssertEqual(a.id, "al1") } else { XCTFail("expected album second") }
+        if case .track(let t) = all[2] { XCTAssertEqual(t.id, "t1") } else { XCTFail("expected track third") }
+    }
+
+    func testGenresDerivedDedupedAndSorted() {
+        // Genres come off album + artist metadata; "Rock" appears thrice
+        // across two casings and two records and must collapse to one.
+        let r = results(
+            artists: [makeArtist(id: "ar1", name: "A", genres: ["rock", "Jazz"])],
+            albums: [makeAlbum(id: "al1", name: "B", genres: ["Rock", "Ambient"])]
+        )
+        let genres = InstantMixSeedPickerModel.seedCandidates(from: r, category: .genres)
+        let names = genres.compactMap { item -> String? in
+            if case .genre(let g) = item { return g.name }
+            return nil
+        }
+        // Albums are harvested before artists, so the first-seen casing of the
+        // shared genre is the album's ("Rock"); the artist's lowercase "rock"
+        // is the de-duped duplicate. The whole list is then alpha-sorted
+        // (case-insensitively), so "Rock" sorts last of the three.
+        XCTAssertEqual(names, ["Ambient", "Jazz", "Rock"])
+    }
+
+    func testEmptyResultsYieldNoCandidates() {
+        XCTAssertTrue(InstantMixSeedPickerModel.allCandidates(from: nil).isEmpty)
+        XCTAssertTrue(InstantMixSeedPickerModel.allCandidates(from: results()).isEmpty)
+    }
+
+    // MARK: - Category filter
+
+    func testCategoryFilterNarrowsToSingleKind() {
+        let r = results(
+            artists: [makeArtist(id: "ar1", name: "A")],
+            albums: [makeAlbum(id: "al1", name: "B", genres: ["Jazz"])],
+            tracks: [makeTrack(id: "t1", name: "C"), makeTrack(id: "t2", name: "D")]
+        )
+
+        let tracksOnly = InstantMixSeedPickerModel.seedCandidates(from: r, category: .tracks)
+        XCTAssertEqual(tracksOnly.count, 2)
+        XCTAssertTrue(tracksOnly.allSatisfy { if case .track = $0 { return true }; return false })
+
+        let albumsOnly = InstantMixSeedPickerModel.seedCandidates(from: r, category: .albums)
+        XCTAssertEqual(albumsOnly.count, 1)
+
+        let genresOnly = InstantMixSeedPickerModel.seedCandidates(from: r, category: .genres)
+        XCTAssertEqual(genresOnly.count, 1)
+        if case .genre(let g) = genresOnly[0] { XCTAssertEqual(g.name, "Jazz") } else { XCTFail() }
+    }
+
+    func testCandidatesReflectActiveCategory() {
+        let r = results(
+            artists: [makeArtist(id: "ar1", name: "A")],
+            tracks: [makeTrack(id: "t1", name: "C")]
+        )
+        let picker = makePicker(returning: r)
+        picker.apply(results: r)
+
+        XCTAssertEqual(picker.candidates.count, 2, "All shows artist + track")
+        picker.category = .artists
+        XCTAssertEqual(picker.candidates.count, 1)
+        if case .artist = picker.candidates[0] {} else { XCTFail("artists chip should leave only the artist") }
+    }
+
+    // MARK: - Selection + canGenerate
+
+    func testCanGenerateRequiresSelection() {
+        let r = results(tracks: [makeTrack(id: "t1", name: "Seed")])
+        let picker = makePicker(returning: r)
+        picker.apply(results: r)
+
+        XCTAssertFalse(picker.canGenerate, "nothing selected yet")
+        picker.select(picker.candidates[0])
+        XCTAssertTrue(picker.canGenerate)
+    }
+
+    func testReSelectingSameSeedKeepsItSelected() {
+        let r = results(tracks: [makeTrack(id: "t1", name: "Seed")])
+        let picker = makePicker(returning: r)
+        picker.apply(results: r)
+        let seed = picker.candidates[0]
+
+        picker.select(seed)
+        picker.select(seed) // second tap must not toggle off
+        XCTAssertTrue(picker.canGenerate)
+        XCTAssertEqual(picker.selectedSeed?.id, seed.id)
+    }
+
+    // MARK: - Stale-selection pruning across searches
+
+    func testApplyDropsSelectionThatVanishesFromNewResults() {
+        let first = results(tracks: [makeTrack(id: "t1", name: "First")])
+        let picker = makePicker(returning: first)
+        picker.apply(results: first)
+        picker.select(picker.candidates[0])
+        XCTAssertTrue(picker.canGenerate)
+
+        // New search no longer contains t1 — selection must clear so the
+        // footer can't claim a seed the list no longer shows.
+        let second = results(tracks: [makeTrack(id: "t2", name: "Second")])
+        picker.apply(results: second)
+        XCTAssertNil(picker.selectedSeed)
+        XCTAssertFalse(picker.canGenerate)
+    }
+
+    func testApplyKeepsSelectionStillPresentInNewResults() {
+        let first = results(tracks: [makeTrack(id: "t1", name: "Keep"), makeTrack(id: "t2", name: "Other")])
+        let picker = makePicker(returning: first)
+        picker.apply(results: first)
+        // Select t1.
+        let keep = picker.candidates.first { $0.id == "track:t1" }!
+        picker.select(keep)
+
+        // A refined search still contains t1 — selection survives.
+        let second = results(tracks: [makeTrack(id: "t1", name: "Keep")])
+        picker.apply(results: second)
+        XCTAssertEqual(picker.selectedSeed?.id, "track:t1")
+        XCTAssertTrue(picker.canGenerate)
+    }
+
+    // MARK: - generate() dispatch
+
+    func testGenerateHandsSelectedSeedToHost() {
+        var captured: SearchItem?
+        let r = results(albums: [makeAlbum(id: "al1", name: "Seed Album")])
+        let picker = makePicker(returning: r, generated: { captured = $0 })
+        picker.apply(results: r)
+        picker.select(picker.candidates[0])
+
+        picker.generate()
+        XCTAssertEqual(captured?.id, "album:al1", "the chosen album must be the seed handed back")
+    }
+
+    func testGenerateIsInertWithoutSelection() {
+        var fired = false
+        let picker = makePicker(returning: results(), generated: { _ in fired = true })
+        picker.generate()
+        XCTAssertFalse(fired, "Generate with no seed selected must not dispatch")
+    }
+
+    // MARK: - Query reset
+
+    func testEmptyingQueryClearsResultsAndSelection() {
+        let r = results(tracks: [makeTrack(id: "t1", name: "Seed")])
+        let picker = makePicker(returning: r)
+        picker.apply(results: r)
+        picker.select(picker.candidates[0])
+
+        // Emptying the field synchronously tears everything down (no debounce
+        // wait needed because the empty-query branch short-circuits).
+        picker.query = "   "
+        picker.queryChanged()
+        XCTAssertTrue(picker.candidates.isEmpty)
+        XCTAssertNil(picker.selectedSeed)
+        XCTAssertFalse(picker.canGenerate)
+    }
+
+    // MARK: - AppModel wiring
+
+    func testPresentInstantMixPickerFlipsFlag() throws {
+        let model = try AppModel()
+        XCTAssertFalse(model.isShowingInstantMixPicker, "sheet starts hidden")
+        model.presentInstantMixPicker()
+        XCTAssertTrue(model.isShowingInstantMixPicker)
+    }
+
+    func testGenerateInstantMixRecordsSeedLabelAndDismisses() throws {
+        let model = try AppModel()
+        model.isShowingInstantMixPicker = true
+
+        let album = Album(
+            id: "al1", name: "Kind of Blue", artistName: "Miles Davis", artistId: nil,
+            year: nil, trackCount: 0, runtimeTicks: 0, genres: [], imageTag: nil, userData: nil
+        )
+        model.generateInstantMix(seed: .album(album))
+
+        XCTAssertEqual(model.instantMixSeedLabel, "Kind of Blue", "seed label echoes the chosen item for the regenerate hint")
+        XCTAssertFalse(model.isShowingInstantMixPicker, "generating dismisses the picker")
+    }
+}

--- a/macos/Tests/LyrebirdTests/NowPlayingBackdropTests.swift
+++ b/macos/Tests/LyrebirdTests/NowPlayingBackdropTests.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// #21 — coverage for the Now Playing blurred-artwork backdrop's visibility
+/// rule. The backdrop's whole accessibility + fallback contract collapses to
+/// one pure predicate — `NowPlayingBackdrop.showsArtworkLayer(reduceTransparency:hasArtwork:)`
+/// — so we pin that truth table directly rather than booting a SwiftUI scene
+/// (same idiom as `DockTileTests` / `NowPlayingView.nowPlayingArtworkLabel`).
+///
+/// What it guarantees:
+///   * the blurred cover *is* present in the normal case (art available,
+///     transparency allowed),
+///   * **Reduce Transparency** suppresses the translucent layer so the opaque
+///     `AmbientWash` (`Theme.bg` + palette gradient) is the fallback, and
+///   * a track with no artwork suppresses the layer too, deferring to the
+///     ambient palette wash.
+///
+/// Plus a guard on the tuned dim/blur constants so an accidental edit that
+/// would either stop blurring the cover or blow the dim past opaque (hiding
+/// the cover entirely) trips a test.
+final class NowPlayingBackdropTests: XCTestCase {
+
+    // MARK: - Visibility truth table
+
+    /// The normal path: there's a cover URL and the user hasn't asked for
+    /// reduced transparency, so the immersive blurred backdrop layer renders.
+    func testBackdropLayerPresentWhenArtworkAvailable() {
+        XCTAssertTrue(
+            NowPlayingBackdrop.showsArtworkLayer(
+                reduceTransparency: false,
+                hasArtwork: true
+            ),
+            "With artwork and transparency allowed, the blurred backdrop must render"
+        )
+    }
+
+    /// Reduce-Transparency fallback: the system asks us to drop translucent /
+    /// layered material, so the backdrop suppresses itself and the opaque
+    /// `AmbientWash` (`Theme.bg` + palette) carries the background — even when a
+    /// cover is available.
+    func testReduceTransparencySuppressesBackdropEvenWithArtwork() {
+        XCTAssertFalse(
+            NowPlayingBackdrop.showsArtworkLayer(
+                reduceTransparency: true,
+                hasArtwork: true
+            ),
+            "Reduce Transparency must drop the blurred cover so AmbientWash's flat Theme.bg shows"
+        )
+    }
+
+    /// No-artwork fallback: an album-less / art-less track has no cover to
+    /// blur, so the layer stays hidden and the ambient palette gradient is the
+    /// background.
+    func testNoArtworkSuppressesBackdrop() {
+        XCTAssertFalse(
+            NowPlayingBackdrop.showsArtworkLayer(
+                reduceTransparency: false,
+                hasArtwork: false
+            ),
+            "Without a cover URL the backdrop must defer to the ambient palette wash"
+        )
+    }
+
+    /// Both fallbacks at once still resolves to hidden — no accidental
+    /// re-enable when neither precondition holds.
+    func testReduceTransparencyAndNoArtworkSuppressesBackdrop() {
+        XCTAssertFalse(
+            NowPlayingBackdrop.showsArtworkLayer(
+                reduceTransparency: true,
+                hasArtwork: false
+            )
+        )
+    }
+
+    /// The predicate depends on *both* inputs: it is true only when transparency
+    /// is allowed AND artwork exists. This exhaustively pins the 2×2 table so a
+    /// future refactor can't silently weaken it to depend on a single input.
+    func testVisibilityIsConjunctionOfBothInputs() {
+        let cases: [(reduceTransparency: Bool, hasArtwork: Bool, expected: Bool)] = [
+            (false, false, false),
+            (false, true, true),
+            (true, false, false),
+            (true, true, false),
+        ]
+        for c in cases {
+            XCTAssertEqual(
+                NowPlayingBackdrop.showsArtworkLayer(
+                    reduceTransparency: c.reduceTransparency,
+                    hasArtwork: c.hasArtwork
+                ),
+                c.expected,
+                "reduceTransparency=\(c.reduceTransparency) hasArtwork=\(c.hasArtwork) should be \(c.expected)"
+            )
+        }
+    }
+
+    // MARK: - Tuned constants
+
+    /// The cover must actually be blurred — a backdrop that rendered the cover
+    /// sharp would read as a second thumbnail rather than an immersive wash.
+    func testBlurRadiusIsSubstantial() {
+        XCTAssertGreaterThanOrEqual(
+            NowPlayingBackdrop.blurRadius,
+            20,
+            "The backdrop blur must be heavy enough to dissolve the cover into a wash"
+        )
+    }
+
+    /// The blurred cover is drawn at reduced opacity so it never competes with
+    /// the foreground type — strictly between fully transparent (invisible) and
+    /// fully opaque (would dominate the screen).
+    func testArtworkOpacityIsDimmedButVisible() {
+        XCTAssertGreaterThan(NowPlayingBackdrop.artworkOpacity, 0)
+        XCTAssertLessThan(
+            NowPlayingBackdrop.artworkOpacity,
+            1,
+            "The cover is dimmed, not drawn at full strength, so type stays legible"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/PaletteRecentPinnedTests.swift
+++ b/macos/Tests/LyrebirdTests/PaletteRecentPinnedTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the command-palette recents + pinned store (#308).
+///
+/// Two layers are exercised:
+///   1. The pure, static `appendPaletteRecent(_:into:cap:)` helper — the
+///      cap / dedupe / insert-at-front contract that drives the "Recent"
+///      group. Pinned by a unit test so a future refactor can't silently
+///      drop dedupe or let the list grow past the cap.
+///   2. The `AppModel` instance API (`recordPaletteActionUsage`,
+///      `pin`/`unpin`/`togglePaletteActionPin`) and its JSON-in-UserDefaults
+///      persistence round-trip, mirroring `AutoplayWhenQueueEndsTests`.
+///
+/// `AppModel` is `@MainActor`, so the suite is main-actor isolated.
+/// Constructing it boots a live `LyrebirdCore`; we redirect the core's data
+/// directory to a throwaway temp dir via `XDG_DATA_HOME` so the test never
+/// touches the real app's database. Persistence runs against the standard
+/// `UserDefaults` domain, so each test scrubs both keys before and after to
+/// stay hermetic.
+@MainActor
+final class PaletteRecentPinnedTests: XCTestCase {
+
+    /// Persisted keys, kept in sync with `AppModel`'s private constants. If
+    /// those strings ever change, these assertions go stale, so this test
+    /// pins the contract.
+    private let recentKey = "palette.recentActionIds"
+    private let pinnedKey = "palette.pinnedActionIds"
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-palette-rp-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: recentKey)
+        UserDefaults.standard.removeObject(forKey: pinnedKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: recentKey)
+        UserDefaults.standard.removeObject(forKey: pinnedKey)
+        super.tearDown()
+    }
+
+    // MARK: - appendPaletteRecent (pure: cap / dedupe / ordering)
+
+    /// Newest run lands at the front of the list.
+    func testAppendInsertsAtFront() {
+        let list = AppModel.appendPaletteRecent("b", into: ["a"], cap: 5)
+        XCTAssertEqual(list, ["b", "a"])
+    }
+
+    /// Re-running an action promotes its existing entry rather than
+    /// duplicating it — dedupe is by exact id.
+    func testAppendDedupesAndPromotes() {
+        var list = ["a", "b", "c"]
+        list = AppModel.appendPaletteRecent("c", into: list, cap: 5)
+        XCTAssertEqual(list, ["c", "a", "b"], "re-run must move 'c' to front, not duplicate it")
+        XCTAssertEqual(list.count, 3, "dedupe must not grow the list")
+    }
+
+    /// The list is capped to the most-recent `cap` entries; the oldest tail
+    /// falls off when a new id pushes past the limit.
+    func testAppendCapsToMostRecent() {
+        var list: [String] = []
+        for id in ["a", "b", "c", "d", "e", "f"] {
+            list = AppModel.appendPaletteRecent(id, into: list, cap: 5)
+        }
+        XCTAssertEqual(list.count, 5, "cap must bound the list length")
+        XCTAssertEqual(list, ["f", "e", "d", "c", "b"], "oldest entry ('a') must fall off")
+        XCTAssertFalse(list.contains("a"))
+    }
+
+    /// An empty id is ignored — `executePaletteAction` only ever passes a
+    /// real id, but the guard keeps a stray empty string out of the store.
+    func testAppendIgnoresEmptyId() {
+        let list = AppModel.appendPaletteRecent("", into: ["a"], cap: 5)
+        XCTAssertEqual(list, ["a"])
+    }
+
+    /// The shipped cap is 5 (load-bearing for the empty-query layout).
+    func testRecentsCapConstantIsFive() {
+        XCTAssertEqual(AppModel.paletteRecentActionsCap, 5)
+    }
+
+    // MARK: - JSON codec round-trip
+
+    func testEncodeDecodeRoundTrip() {
+        let ids = ["nav.home", "playback.play", "queue.clear"]
+        let json = AppModel.encodePaletteActionIds(ids)
+        XCTAssertEqual(AppModel.decodePaletteActionIds(json), ids)
+    }
+
+    /// Malformed persisted data decodes to `[]` so a stale shape can't wedge
+    /// the palette.
+    func testDecodeMalformedReturnsEmpty() {
+        XCTAssertEqual(AppModel.decodePaletteActionIds("not json"), [])
+        XCTAssertEqual(AppModel.decodePaletteActionIds("{\"a\":1}"), [])
+    }
+
+    // MARK: - recordPaletteActionUsage (instance + persistence)
+
+    func testRecordUsageUpdatesPropertyAndPersists() throws {
+        let model = try AppModel()
+        XCTAssertTrue(model.paletteRecentActionIds.isEmpty, "starts empty with no persisted data")
+
+        model.recordPaletteActionUsage(id: "nav.home")
+        model.recordPaletteActionUsage(id: "nav.library")
+        XCTAssertEqual(model.paletteRecentActionIds, ["nav.library", "nav.home"], "newest first")
+
+        let persisted = UserDefaults.standard.string(forKey: recentKey) ?? "[]"
+        XCTAssertEqual(
+            AppModel.decodePaletteActionIds(persisted),
+            ["nav.library", "nav.home"],
+            "recents must persist so the next launch restores them"
+        )
+    }
+
+    func testExecutePaletteActionRecordsUsage() throws {
+        let model = try AppModel()
+        // `nav.home` is always present in the roster (no capability gate) and
+        // its side effect (selecting the Home tab) is local + safe in tests.
+        model.executePaletteAction(id: "nav.home")
+        XCTAssertEqual(
+            model.paletteRecentActionIds.first,
+            "nav.home",
+            "committing an action from the palette must record it as most-recent"
+        )
+    }
+
+    func testRecentsRestoreFromPersistedJSONOnLaunch() throws {
+        UserDefaults.standard.set(
+            AppModel.encodePaletteActionIds(["queue.clear", "nav.discover"]),
+            forKey: recentKey
+        )
+        let model = try AppModel()
+        XCTAssertEqual(
+            model.paletteRecentActionIds,
+            ["queue.clear", "nav.discover"],
+            "a freshly-constructed model must restore the persisted recents"
+        )
+    }
+
+    // MARK: - pin / unpin / toggle (instance + persistence)
+
+    func testPinInsertsAtFrontAndPersists() throws {
+        let model = try AppModel()
+
+        model.pinPaletteAction(id: "nav.home")
+        model.pinPaletteAction(id: "queue.clear")
+        XCTAssertEqual(model.palettePinnedActionIds, ["queue.clear", "nav.home"], "newest pin first")
+        XCTAssertTrue(model.isPaletteActionPinned(id: "nav.home"))
+        XCTAssertTrue(model.isPaletteActionPinned(id: "queue.clear"))
+
+        let persisted = UserDefaults.standard.string(forKey: pinnedKey) ?? "[]"
+        XCTAssertEqual(
+            AppModel.decodePaletteActionIds(persisted),
+            ["queue.clear", "nav.home"]
+        )
+    }
+
+    /// Pinning an already-pinned id is a no-op — no duplicate, no reorder.
+    func testPinIsIdempotent() throws {
+        let model = try AppModel()
+        model.pinPaletteAction(id: "nav.home")
+        model.pinPaletteAction(id: "queue.clear")
+        model.pinPaletteAction(id: "nav.home")
+        XCTAssertEqual(
+            model.palettePinnedActionIds,
+            ["queue.clear", "nav.home"],
+            "re-pinning must not duplicate or reorder"
+        )
+    }
+
+    func testUnpinRemovesAndPersists() throws {
+        let model = try AppModel()
+        model.pinPaletteAction(id: "nav.home")
+        model.pinPaletteAction(id: "queue.clear")
+
+        model.unpinPaletteAction(id: "nav.home")
+        XCTAssertEqual(model.palettePinnedActionIds, ["queue.clear"])
+        XCTAssertFalse(model.isPaletteActionPinned(id: "nav.home"))
+
+        let persisted = UserDefaults.standard.string(forKey: pinnedKey) ?? "[]"
+        XCTAssertEqual(AppModel.decodePaletteActionIds(persisted), ["queue.clear"])
+    }
+
+    /// Unpinning an id that isn't pinned is a safe no-op.
+    func testUnpinUnknownIsNoOp() throws {
+        let model = try AppModel()
+        model.pinPaletteAction(id: "nav.home")
+        model.unpinPaletteAction(id: "not.pinned")
+        XCTAssertEqual(model.palettePinnedActionIds, ["nav.home"])
+    }
+
+    func testToggleFlipsPinState() throws {
+        let model = try AppModel()
+
+        XCTAssertFalse(model.isPaletteActionPinned(id: "nav.discover"))
+        model.togglePaletteActionPin(id: "nav.discover")
+        XCTAssertTrue(model.isPaletteActionPinned(id: "nav.discover"))
+        model.togglePaletteActionPin(id: "nav.discover")
+        XCTAssertFalse(model.isPaletteActionPinned(id: "nav.discover"))
+    }
+
+    func testPinnedRestoreFromPersistedJSONOnLaunch() throws {
+        UserDefaults.standard.set(
+            AppModel.encodePaletteActionIds(["app.openPreferences"]),
+            forKey: pinnedKey
+        )
+        let model = try AppModel()
+        XCTAssertTrue(
+            model.isPaletteActionPinned(id: "app.openPreferences"),
+            "a freshly-constructed model must restore persisted pins"
+        )
+    }
+
+    /// Recents and pinned are independent stores: recording usage must not
+    /// touch the pinned list, and vice-versa.
+    func testRecentAndPinnedStoresAreIndependent() throws {
+        let model = try AppModel()
+        model.recordPaletteActionUsage(id: "nav.home")
+        model.pinPaletteAction(id: "queue.clear")
+
+        XCTAssertEqual(model.paletteRecentActionIds, ["nav.home"])
+        XCTAssertEqual(model.palettePinnedActionIds, ["queue.clear"])
+        XCTAssertFalse(model.isPaletteActionPinned(id: "nav.home"), "recents are not implicitly pinned")
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaylistExportTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistExportTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the pure playlist export serializers behind the Share / Export
+/// affordances (#237): the extended-M3U writer, the JSON manifest writer, and
+/// the secret-stripping deep-link builder. These are deliberately `AppModel`-,
+/// `NSSavePanel`-, and FFI-free — `PlaylistExport` takes only an already-loaded
+/// `[Track]` plus the playlist name / server URL, so the byte-level output can
+/// be locked down deterministically.
+final class PlaylistExportTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeTrack(
+        id: String,
+        name: String,
+        artistName: String = "Artist",
+        albumName: String? = "Album",
+        albumId: String? = "alb-1",
+        runtimeTicks: UInt64 = 2_000_000_000  // 200s
+    ) -> Track {
+        Track(
+            id: id,
+            name: name,
+            albumId: albumId,
+            albumName: albumName,
+            artistName: artistName,
+            artistId: "art-1",
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: runtimeTicks,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - M3U
+
+    func testM3UHeaderAndPlaylistName() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "My Mix",
+            tracks: [makeTrack(id: "1", name: "Song")],
+            serverURL: "https://music.example.com"
+        )
+        let lines = out.split(separator: "\n", omittingEmptySubsequences: false)
+        XCTAssertEqual(lines.first, "#EXTM3U")
+        XCTAssertEqual(lines[1], "#PLAYLIST:My Mix")
+    }
+
+    func testM3UEmitsExtinfAndAuthFreeStreamURLPerTrack() {
+        let tracks = [
+            makeTrack(id: "abc", name: "First", artistName: "A", runtimeTicks: 1_800_000_000),  // 180s
+            makeTrack(id: "def", name: "Second", artistName: "B", runtimeTicks: 2_400_000_000),  // 240s
+        ]
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: tracks,
+            serverURL: "https://music.example.com"
+        )
+        XCTAssertTrue(out.contains("#EXTINF:180,A - First"))
+        XCTAssertTrue(out.contains("https://music.example.com/Audio/abc/universal"))
+        XCTAssertTrue(out.contains("#EXTINF:240,B - Second"))
+        XCTAssertTrue(out.contains("https://music.example.com/Audio/def/universal"))
+        // No auth material in the stream URLs.
+        XCTAssertFalse(out.lowercased().contains("api_key"))
+        XCTAssertFalse(out.contains("?"))
+    }
+
+    func testM3UTrimsTrailingSlashOnServerURL() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "x", name: "T")],
+            serverURL: "https://music.example.com/"
+        )
+        XCTAssertTrue(out.contains("https://music.example.com/Audio/x/universal"))
+        XCTAssertFalse(out.contains("//Audio"))
+    }
+
+    func testM3UUnknownDurationEmitsNegativeOne() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "x", name: "T", artistName: "A", runtimeTicks: 0)],
+            serverURL: "https://m.example.com"
+        )
+        XCTAssertTrue(out.contains("#EXTINF:-1,A - T"))
+    }
+
+    func testM3UDropsArtistDashWhenArtistBlank() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "x", name: "Solo", artistName: "   ")],
+            serverURL: "https://m.example.com"
+        )
+        // "Artist - Title" collapses to just the title when artist is blank.
+        XCTAssertTrue(out.contains("#EXTINF:200,Solo\n"))
+        XCTAssertFalse(out.contains(" - Solo"))
+    }
+
+    func testM3USanitizesNewlinesInTitle() {
+        // A track name with an embedded newline must not be able to inject a
+        // fake directive line into the document.
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "x", name: "Evil\n#EXTM3U", artistName: "A")],
+            serverURL: "https://m.example.com"
+        )
+        let directiveLines = out.split(separator: "\n").filter { $0 == "#EXTM3U" }
+        XCTAssertEqual(directiveLines.count, 1, "only the header line should be #EXTM3U")
+    }
+
+    func testM3UEndsWithTrailingNewline() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "x", name: "T")],
+            serverURL: "https://m.example.com"
+        )
+        XCTAssertTrue(out.hasSuffix("\n"))
+    }
+
+    func testM3UEmptyTracksStillEmitsHeader() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Empty",
+            tracks: [],
+            serverURL: "https://m.example.com"
+        )
+        XCTAssertEqual(out, "#EXTM3U\n#PLAYLIST:Empty\n")
+    }
+
+    // MARK: - JSON
+
+    func testJSONRoundTripsThroughManifest() throws {
+        let tracks = [
+            makeTrack(id: "1", name: "First", artistName: "A", albumName: "Alb", albumId: "al-1", runtimeTicks: 1_800_000_000),
+            makeTrack(id: "2", name: "Second", artistName: "B", albumName: nil, albumId: nil, runtimeTicks: 0),
+        ]
+        let jsonString = try PlaylistExport.json(playlistId: "pl-7", playlistName: "Mix", tracks: tracks)
+        let data = Data(jsonString.utf8)
+        let decoded = try JSONDecoder().decode(PlaylistManifest.self, from: data)
+
+        XCTAssertEqual(decoded.schema, "lyrebird.playlist/v1")
+        XCTAssertEqual(decoded.id, "pl-7")
+        XCTAssertEqual(decoded.name, "Mix")
+        XCTAssertEqual(decoded.trackCount, 2)
+        XCTAssertEqual(decoded.tracks.count, 2)
+
+        XCTAssertEqual(decoded.tracks[0].id, "1")
+        XCTAssertEqual(decoded.tracks[0].name, "First")
+        XCTAssertEqual(decoded.tracks[0].artist, "A")
+        XCTAssertEqual(decoded.tracks[0].album, "Alb")
+        XCTAssertEqual(decoded.tracks[0].albumId, "al-1")
+        XCTAssertEqual(decoded.tracks[0].durationSeconds, 180)
+
+        // Second track: nil album fields, unknown duration.
+        XCTAssertEqual(decoded.tracks[1].album, nil)
+        XCTAssertEqual(decoded.tracks[1].albumId, nil)
+        XCTAssertEqual(decoded.tracks[1].durationSeconds, 0)
+    }
+
+    func testJSONPreservesTrackOrder() throws {
+        let tracks = (1...5).map { makeTrack(id: "\($0)", name: "T\($0)") }
+        let jsonString = try PlaylistExport.json(playlistId: "p", playlistName: "Ordered", tracks: tracks)
+        let decoded = try JSONDecoder().decode(PlaylistManifest.self, from: Data(jsonString.utf8))
+        XCTAssertEqual(decoded.tracks.map(\.id), ["1", "2", "3", "4", "5"])
+    }
+
+    func testJSONIsDeterministicAndPrettyPrinted() throws {
+        let tracks = [makeTrack(id: "1", name: "Song")]
+        let first = try PlaylistExport.json(playlistId: "p", playlistName: "Mix", tracks: tracks)
+        let second = try PlaylistExport.json(playlistId: "p", playlistName: "Mix", tracks: tracks)
+        // Sorted keys → byte-identical across runs.
+        XCTAssertEqual(first, second)
+        // Pretty-printed → contains a newline + indentation.
+        XCTAssertTrue(first.contains("\n  "))
+        XCTAssertTrue(first.hasSuffix("\n"))
+    }
+
+    func testJSONBlankArtistOmittedFromOutput() throws {
+        let jsonString = try PlaylistExport.json(
+            playlistId: "p",
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "1", name: "Solo", artistName: "  ")]
+        )
+        let decoded = try JSONDecoder().decode(PlaylistManifest.self, from: Data(jsonString.utf8))
+        XCTAssertNil(decoded.tracks[0].artist)
+    }
+
+    func testJSONDoesNotEscapeSlashes() throws {
+        // withoutEscapingSlashes keeps album names with slashes readable.
+        let jsonString = try PlaylistExport.json(
+            playlistId: "p",
+            playlistName: "AC/DC Hits",
+            tracks: [makeTrack(id: "1", name: "T")]
+        )
+        XCTAssertTrue(jsonString.contains("AC/DC Hits"))
+        XCTAssertFalse(jsonString.contains("AC\\/DC"))
+    }
+
+    // MARK: - Deep link / secret stripping
+
+    func testWebURLBuildsDetailsRoute() {
+        let url = PlaylistExport.webURL(serverURL: "https://music.example.com", itemId: "pl-42")
+        XCTAssertEqual(url?.absoluteString, "https://music.example.com/web/#/details?id=pl-42")
+    }
+
+    func testWebURLTrimsTrailingSlash() {
+        let url = PlaylistExport.webURL(serverURL: "https://music.example.com/", itemId: "pl-42")
+        XCTAssertEqual(url?.absoluteString, "https://music.example.com/web/#/details?id=pl-42")
+    }
+
+    func testWebURLStripsEmbeddedCredentials() {
+        // The stored server URL can carry basic-auth userinfo; the shared link
+        // must never leak it.
+        let url = PlaylistExport.webURL(
+            serverURL: "https://admin:hunter2@music.example.com",
+            itemId: "pl-42"
+        )
+        let str = url?.absoluteString ?? ""
+        XCTAssertFalse(str.contains("admin"))
+        XCTAssertFalse(str.contains("hunter2"))
+        XCTAssertEqual(str, "https://music.example.com/web/#/details?id=pl-42")
+    }
+
+    func testWebURLStripsQueryAndFragmentSecrets() {
+        let url = PlaylistExport.webURL(
+            serverURL: "https://music.example.com/?api_key=SECRET#frag",
+            itemId: "pl-42"
+        )
+        let str = url?.absoluteString ?? ""
+        XCTAssertFalse(str.contains("SECRET"))
+        XCTAssertFalse(str.contains("api_key"))
+        XCTAssertEqual(str, "https://music.example.com/web/#/details?id=pl-42")
+    }
+
+    func testWebURLPreservesPortAndSubpath() {
+        let url = PlaylistExport.webURL(
+            serverURL: "http://192.168.1.10:8096/jellyfin/",
+            itemId: "pl-9"
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "http://192.168.1.10:8096/jellyfin/web/#/details?id=pl-9"
+        )
+    }
+
+    func testWebURLNilForEmptyServer() {
+        XCTAssertNil(PlaylistExport.webURL(serverURL: "", itemId: "pl-1"))
+        XCTAssertNil(PlaylistExport.webURL(serverURL: "   ", itemId: "pl-1"))
+    }
+
+    func testWebURLNilForSchemelessOrHostlessString() {
+        XCTAssertNil(PlaylistExport.webURL(serverURL: "not a url", itemId: "pl-1"))
+    }
+}

--- a/macos/Tests/LyrebirdTests/RediscoverTests.swift
+++ b/macos/Tests/LyrebirdTests/RediscoverTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the Home "Rediscover" row (#57).
+///
+/// The shelf is a "dumb" Home section: it reads the `IsUnplayed`-driven
+/// `AppModel.rediscover` slice and hides itself when that slice is empty
+/// (the `@ViewBuilder` guards `if !model.rediscover.isEmpty`). These tests
+/// pin the three contracts the view depends on:
+///
+/// 1. A fresh model starts with no rediscover albums, so the row hides on
+///    first paint instead of punching an empty hole in the layout (and a
+///    fully-played library, which yields an empty `IsUnplayed` result,
+///    behaves the same way).
+/// 2. The slice is the single source the row renders, in order.
+/// 3. Signing out (`logout`) and forgetting the token (`forgetToken`) both
+///    clear the slice, so one account's unplayed albums never bleed into
+///    the next session's Home row.
+///
+/// Same isolation contract as the other Home/Favorites suites: `AppModel`
+/// is `@MainActor` and boots a live `LyrebirdCore` pointed at a throwaway
+/// data dir via `XDG_DATA_HOME`, so the test never touches the real app
+/// database and never hits the network (we drive the published slice
+/// directly rather than calling the live `refreshRediscover` fetch).
+@MainActor
+final class RediscoverTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-rediscover-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeAlbum(id: String, name: String) -> Album {
+        Album(
+            id: id, name: name, artistName: "Artist", artistId: nil, year: nil,
+            trackCount: 0, runtimeTicks: 0, genres: [], imageTag: nil, userData: nil
+        )
+    }
+
+    func testRediscoverStartsEmptySoRowHides() throws {
+        let model = try AppModel()
+        XCTAssertTrue(
+            model.rediscover.isEmpty,
+            "a fresh model (and a fully-played library) has no rediscover albums, so the Home row hides on first paint"
+        )
+    }
+
+    func testRediscoverSliceIsRenderedInOrder() throws {
+        let model = try AppModel()
+        let unplayed = [
+            makeAlbum(id: "u1", name: "Kind of Blue"),
+            makeAlbum(id: "u2", name: "A Love Supreme"),
+            makeAlbum(id: "u3", name: "Mingus Ah Um"),
+        ]
+        model.rediscover = unplayed
+
+        XCTAssertEqual(
+            model.rediscover.map(\.id),
+            ["u1", "u2", "u3"],
+            "the row renders exactly the rediscover slice, preserving the server's returned order"
+        )
+        XCTAssertFalse(
+            model.rediscover.isEmpty,
+            "a non-empty slice reveals the Home shelf"
+        )
+    }
+
+    func testLogoutClearsRediscover() throws {
+        let model = try AppModel()
+        model.rediscover = [makeAlbum(id: "u1", name: "Spiritual Unity")]
+
+        model.logout()
+
+        XCTAssertTrue(
+            model.rediscover.isEmpty,
+            "logout must drop the rediscover slice so the next account's Home row starts clean"
+        )
+    }
+
+    func testForgetTokenClearsRediscover() throws {
+        let model = try AppModel()
+        model.rediscover = [makeAlbum(id: "u1", name: "Ascension")]
+
+        model.forgetToken()
+
+        XCTAssertTrue(
+            model.rediscover.isEmpty,
+            "forgetting the token (auth expiry) must clear rediscover alongside the rest of session state"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/ScrobbleGateTests.swift
+++ b/macos/Tests/LyrebirdTests/ScrobbleGateTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the scrobble *trigger gate* (#46) — the pure decision layer
+/// that decides when to fire a ListenBrainz `playing_now` versus a durable
+/// `single` listen. The actual POST lives in the Rust core and is exercised by
+/// the Rust wiremock tests; here we pin the once-each, threshold-gated, and
+/// disabled-state behaviour without any networking by injecting the threshold
+/// predicate and the clock.
+final class ScrobbleGateTests: XCTestCase {
+
+    private func makeTrack(id: String, name: String = "Song", runtimeTicks: UInt64 = 1_800_000_000) -> Track {
+        Track(
+            id: id,
+            name: name,
+            albumId: nil,
+            albumName: "Album",
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: runtimeTicks,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    /// Threshold predicate that flips at a fixed position, so the tests don't
+    /// depend on the real half/four-minute rule (that lives in the Rust tests).
+    private func thresholdAt(_ at: Double) -> (Double, Double) -> Bool {
+        { position, _ in position >= at }
+    }
+
+    // MARK: - playing_now
+
+    func testNewTrackFiresPlayingNowOnce() {
+        var gate = ScrobbleGate()
+        let track = makeTrack(id: "a")
+
+        // First sighting -> playing_now.
+        let first = gate.noteTrack(
+            track, position: 0, duration: 180, enabled: true, now: 1000,
+            thresholdReached: thresholdAt(90))
+        XCTAssertEqual(first, .nowPlaying(track))
+
+        // Subsequent ticks for the same track (below threshold) -> nothing.
+        let second = gate.noteTrack(
+            track, position: 5, duration: 180, enabled: true, now: 1005,
+            thresholdReached: thresholdAt(90))
+        XCTAssertEqual(second, .none)
+    }
+
+    // MARK: - single (durable) listen
+
+    func testListenSubmittedOnceWhenThresholdCrossed() {
+        var gate = ScrobbleGate()
+        let track = makeTrack(id: "a")
+
+        // Start the track at t=1000 — captures the start time.
+        _ = gate.noteTrack(
+            track, position: 0, duration: 180, enabled: true, now: 1000,
+            thresholdReached: thresholdAt(90))
+
+        // Below threshold -> nothing.
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 89, duration: 180, enabled: true, now: 1089,
+                thresholdReached: thresholdAt(90)),
+            .none)
+
+        // Crossing the threshold -> one listen, keyed to the START time (1000),
+        // not the crossing time (1090).
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 90, duration: 180, enabled: true, now: 1090,
+                thresholdReached: thresholdAt(90)),
+            .submitListen(track, listenedAt: 1000))
+
+        // Already submitted -> no duplicate on later ticks.
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 120, duration: 180, enabled: true, now: 1120,
+                thresholdReached: thresholdAt(90)),
+            .none)
+    }
+
+    // MARK: - disabled state
+
+    func testDisabledNeverFiresButStillTracks() {
+        var gate = ScrobbleGate()
+        let track = makeTrack(id: "a")
+
+        // Scrobbling off: no playing_now even on a fresh track.
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 0, duration: 180, enabled: false, now: 1000,
+                thresholdReached: thresholdAt(90)),
+            .none)
+        // Off: no listen even past the threshold.
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 120, duration: 180, enabled: false, now: 1120,
+                thresholdReached: thresholdAt(90)),
+            .none)
+    }
+
+    /// Enabling mid-track must not retro-fire a `playing_now` for the track that
+    /// was already current while disabled — the gate already knows its id.
+    func testEnablingMidTrackDoesNotReplayPlayingNow() {
+        var gate = ScrobbleGate()
+        let track = makeTrack(id: "a")
+
+        _ = gate.noteTrack(track, position: 0, duration: 180, enabled: false, now: 1000,
+            thresholdReached: thresholdAt(90))
+        // Now enabled, same track, still below threshold -> nothing (no
+        // late playing_now).
+        XCTAssertEqual(
+            gate.noteTrack(track, position: 10, duration: 180, enabled: true, now: 1010,
+                thresholdReached: thresholdAt(90)),
+            .none)
+    }
+
+    // MARK: - track changes / reset
+
+    func testTrackChangeResetsAndFiresFreshPlayingNow() {
+        var gate = ScrobbleGate()
+        let a = makeTrack(id: "a")
+        let b = makeTrack(id: "b")
+
+        _ = gate.noteTrack(a, position: 0, duration: 180, enabled: true, now: 1000,
+            thresholdReached: thresholdAt(90))
+        // Scrobble A.
+        _ = gate.noteTrack(a, position: 90, duration: 180, enabled: true, now: 1090,
+            thresholdReached: thresholdAt(90))
+
+        // Switch to B -> fresh playing_now, new start time.
+        XCTAssertEqual(
+            gate.noteTrack(b, position: 0, duration: 180, enabled: true, now: 2000,
+                thresholdReached: thresholdAt(90)),
+            .nowPlaying(b))
+        // B can then earn its own listen, keyed to B's start (2000).
+        XCTAssertEqual(
+            gate.noteTrack(b, position: 90, duration: 180, enabled: true, now: 2090,
+                thresholdReached: thresholdAt(90)),
+            .submitListen(b, listenedAt: 2000))
+    }
+
+    func testNilTrackResetsState() {
+        var gate = ScrobbleGate()
+        let a = makeTrack(id: "a")
+
+        _ = gate.noteTrack(a, position: 0, duration: 180, enabled: true, now: 1000,
+            thresholdReached: thresholdAt(90))
+        // Playback stops.
+        XCTAssertEqual(
+            gate.noteTrack(nil, position: 0, duration: 0, enabled: true, now: 1010,
+                thresholdReached: thresholdAt(90)),
+            .none)
+        // Re-starting the SAME track id after a stop fires a fresh playing_now
+        // (the gate forgot it), so a replay is scrobbled as a new listen.
+        XCTAssertEqual(
+            gate.noteTrack(a, position: 0, duration: 180, enabled: true, now: 1020,
+                thresholdReached: thresholdAt(90)),
+            .nowPlaying(a))
+    }
+
+    func testEmptyTrackIdTreatedAsNoTrack() {
+        var gate = ScrobbleGate()
+        let empty = makeTrack(id: "")
+        XCTAssertEqual(
+            gate.noteTrack(empty, position: 0, duration: 180, enabled: true, now: 1000,
+                thresholdReached: thresholdAt(90)),
+            .none)
+    }
+}

--- a/macos/Tests/LyrebirdTests/SidebarAutoHideTests.swift
+++ b/macos/Tests/LyrebirdTests/SidebarAutoHideTests.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the resizable / auto-hiding sidebar (#318).
+///
+/// SwiftUI exposes no public hook to introspect `columnVisibility` transitions
+/// off a `some View` without booting a scene, so the behaviour lives in the
+/// pure `SidebarAutoHide` reducer and is exercised here directly. A second
+/// group asserts the structural wiring in `MainShell.swift` (read from source)
+/// so a regression that detaches the reducer from the view — or drops the
+/// drag-resize bounds — is caught here rather than in the field.
+final class SidebarAutoHideTests: XCTestCase {
+
+    // MARK: - Threshold reducer
+
+    /// A wide window with the sidebar shown and no manual override is a no-op:
+    /// the reducer returns `nil` (leave visibility untouched) and doesn't claim
+    /// an auto-collapse it never made.
+    func testWideWindowShownLeavesSidebarAlone() {
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold + 200,
+            visibility: .all,
+            state: SidebarAutoHide.State()
+        )
+        XCTAssertNil(decision.visibility)
+        XCTAssertFalse(decision.state.didAutoCollapse)
+        XCTAssertFalse(decision.state.userDidOverride)
+    }
+
+    /// Narrowing past the threshold collapses a shown sidebar and records that
+    /// the collapse was automatic (so it's eligible for auto-restore later).
+    func testNarrowWindowAutoCollapsesShownSidebar() {
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold - 100,
+            visibility: .all,
+            state: SidebarAutoHide.State()
+        )
+        XCTAssertEqual(decision.visibility, .detailOnly)
+        XCTAssertTrue(decision.state.didAutoCollapse)
+        XCTAssertFalse(decision.state.userDidOverride)
+    }
+
+    /// Widening past the threshold restores a sidebar that *we* auto-collapsed.
+    func testWideningRestoresAutoCollapsedSidebar() {
+        let collapsed = SidebarAutoHide.State(didAutoCollapse: true, userDidOverride: false)
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold + 100,
+            visibility: .detailOnly,
+            state: collapsed
+        )
+        XCTAssertEqual(decision.visibility, .all)
+        XCTAssertFalse(decision.state.didAutoCollapse)
+    }
+
+    /// A sidebar already collapsed on a narrow window stays collapsed and the
+    /// reducer doesn't retroactively claim it as an auto-collapse (which would
+    /// make a later widen reopen a rail the reducer never closed).
+    func testNarrowWindowAlreadyCollapsedIsNoOp() {
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold - 100,
+            visibility: .detailOnly,
+            state: SidebarAutoHide.State()
+        )
+        XCTAssertNil(decision.visibility)
+        XCTAssertFalse(decision.state.didAutoCollapse)
+    }
+
+    /// A wide window with the sidebar shown but no recorded auto-collapse has
+    /// nothing to restore — the reducer leaves it alone.
+    func testWideWindowWithoutAutoCollapseDoesNotRestore() {
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold + 100,
+            visibility: .all,
+            state: SidebarAutoHide.State(didAutoCollapse: false, userDidOverride: false)
+        )
+        XCTAssertNil(decision.visibility)
+    }
+
+    // MARK: - Manual override never fights auto-hide
+
+    /// Once the user has manually toggled the sidebar, narrowing the window
+    /// must NOT auto-collapse it — the explicit choice wins.
+    func testManualOverrideBlocksAutoCollapse() {
+        let overridden = SidebarAutoHide.State(didAutoCollapse: false, userDidOverride: true)
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold - 200,
+            visibility: .all,
+            state: overridden
+        )
+        XCTAssertNil(decision.visibility, "Manual override must not be auto-collapsed")
+        XCTAssertTrue(decision.state.userDidOverride, "Override flag must persist across width changes")
+    }
+
+    /// The fighting scenario: a user manually reveals the sidebar in a narrow
+    /// window. The next width tick must not immediately re-collapse it.
+    func testManualRevealInNarrowWindowIsNotReCollapsed() {
+        // Manual toggle records the override and clears any auto-collapse.
+        let afterToggle = SidebarAutoHide.registeringManualToggle(
+            SidebarAutoHide.State(didAutoCollapse: true, userDidOverride: false)
+        )
+        XCTAssertTrue(afterToggle.userDidOverride)
+        XCTAssertFalse(afterToggle.didAutoCollapse)
+
+        // A subsequent width change at a narrow width leaves the rail shown.
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold - 50,
+            visibility: .all,
+            state: afterToggle
+        )
+        XCTAssertNil(decision.visibility)
+    }
+
+    /// Symmetric guard: a user who manually hid the sidebar isn't force-reopened
+    /// when the window widens.
+    func testManualHideOnWideWindowIsNotAutoRestored() {
+        let overridden = SidebarAutoHide.State(didAutoCollapse: false, userDidOverride: true)
+        let decision = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold + 300,
+            visibility: .detailOnly,
+            state: overridden
+        )
+        XCTAssertNil(decision.visibility, "A user-hidden sidebar must not be auto-restored")
+    }
+
+    // MARK: - Threshold boundary
+
+    /// The boundary is inclusive on the collapse side (`<=`): a window exactly
+    /// at the threshold collapses, and one a single point wider restores.
+    func testThresholdBoundaryIsInclusiveOnCollapse() {
+        let atThreshold = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold,
+            visibility: .all,
+            state: SidebarAutoHide.State()
+        )
+        XCTAssertEqual(atThreshold.visibility, .detailOnly,
+                       "Width == threshold should collapse (inclusive boundary)")
+
+        let justAbove = SidebarAutoHide.decide(
+            width: SidebarAutoHide.collapseThreshold + 1,
+            visibility: .detailOnly,
+            state: SidebarAutoHide.State(didAutoCollapse: true, userDidOverride: false)
+        )
+        XCTAssertEqual(justAbove.visibility, .all,
+                       "Width one point above threshold should restore")
+    }
+
+    /// The threshold is a sane positive width — a zero/negative or absurd value
+    /// would either never auto-hide or always hide.
+    func testCollapseThresholdIsReasonable() {
+        XCTAssertGreaterThan(SidebarAutoHide.collapseThreshold, 252,
+                             "Threshold must exceed the ideal sidebar width or it could never show both columns")
+        XCTAssertLessThan(SidebarAutoHide.collapseThreshold, 1200,
+                          "Threshold should trigger only on genuinely cramped windows")
+    }
+
+    // MARK: - Manual-toggle folding
+
+    /// `registeringManualToggle` always lands in the "user owns it" state
+    /// regardless of the prior bookkeeping.
+    func testRegisteringManualToggleSetsOverrideAndClearsAutoCollapse() {
+        for prior in [
+            SidebarAutoHide.State(didAutoCollapse: false, userDidOverride: false),
+            SidebarAutoHide.State(didAutoCollapse: true, userDidOverride: false),
+            SidebarAutoHide.State(didAutoCollapse: false, userDidOverride: true),
+            SidebarAutoHide.State(didAutoCollapse: true, userDidOverride: true),
+        ] {
+            let folded = SidebarAutoHide.registeringManualToggle(prior)
+            XCTAssertTrue(folded.userDidOverride)
+            XCTAssertFalse(folded.didAutoCollapse)
+        }
+    }
+
+    // MARK: - Persistence key stability
+
+    /// The `@AppStorage` key is a stable on-disk identifier; renaming it
+    /// silently resets every user's manual-override preference.
+    func testSidebarOverrideKeyIsStable() {
+        XCTAssertEqual(SidebarDefaults.userDidOverrideAutoHideKey, "sidebar.userDidOverrideAutoHide")
+    }
+
+    // MARK: - MainShell source invariants
+
+    /// The sidebar column must be drag-resizable with explicit bounds (#318) —
+    /// the fixed `.navigationSplitViewColumnWidth(252)` is replaced by the
+    /// `min/ideal/max` overload so the separator can be dragged.
+    func testMainShellSidebarIsResizableWithBounds() throws {
+        let code = try mainShellSource()
+        XCTAssertTrue(
+            code.contains(".navigationSplitViewColumnWidth(min: 200, ideal: 252, max: 360)"),
+            "MainShell must declare a resizable sidebar with min/ideal/max bounds")
+        XCTAssertFalse(
+            code.contains(".navigationSplitViewColumnWidth(252)"),
+            "The fixed-width sidebar must be replaced by the resizable overload")
+    }
+
+    /// The width-driven auto-hide must be wired: MainShell observes its width
+    /// and feeds it to the `SidebarAutoHide` reducer (#318).
+    func testMainShellWiresWidthDrivenAutoHide() throws {
+        let code = try mainShellSource()
+        XCTAssertTrue(code.contains("GeometryReader"),
+                      "MainShell must observe its width via GeometryReader to drive auto-hide")
+        XCTAssertTrue(code.contains("SidebarAutoHide.decide("),
+                      "MainShell must run the SidebarAutoHide reducer on width changes")
+        XCTAssertTrue(code.contains("applySidebarAutoHide(width:"),
+                      "MainShell must apply the reducer's decision from a width observer")
+    }
+
+    /// The toolbar toggle must record a manual override so auto-hide stops
+    /// fighting the user (#318).
+    func testMainShellToggleRecordsManualOverride() throws {
+        let code = try mainShellSource()
+        XCTAssertTrue(code.contains("SidebarAutoHide.registeringManualToggle("),
+                      "The Toggle Sidebar button must register a manual override")
+        XCTAssertTrue(code.contains("userDidOverrideAutoHide = true"),
+                      "The manual override must be persisted via @AppStorage")
+    }
+
+    // MARK: - Helpers
+
+    /// Loads `MainShell.swift` relative to this test file via `#filePath`, so
+    /// the lookup is independent of the test runner's working directory.
+    private func mainShellSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let mainShell = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Screens/MainShell.swift")
+        guard let data = try? Data(contentsOf: mainShell),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read MainShell.swift at \(mainShell.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+}

--- a/macos/Tests/LyrebirdTests/WindowStateStoreTests.swift
+++ b/macos/Tests/LyrebirdTests/WindowStateStoreTests.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the window content-state persistence contract (#10).
+///
+/// `MainShell` persists the last-viewed tab, the sidebar column visibility,
+/// and the queue inspector via `@SceneStorage`, decoding through
+/// `WindowStateStore`. Those raw strings are an on-disk contract: renaming one
+/// silently resets every user's saved layout, and a broken fallback would
+/// strand a window in the wrong state. These tests pin the stable identifiers,
+/// the round-trips, and every branch of the restore-precedence logic so those
+/// regressions surface here rather than in the field.
+final class WindowStateStoreTests: XCTestCase {
+
+    // MARK: - Stable storage keys
+
+    /// The `@SceneStorage` keys are stable identifiers shared between the
+    /// writer (`MainShell`) and any future reader. A drift silently
+    /// disconnects the setting from the state it restores.
+    func testStorageKeysAreStable() {
+        XCTAssertEqual(WindowStateKeys.screen, "window.lastScreen")
+        XCTAssertEqual(WindowStateKeys.sidebar, "window.sidebarVisibility")
+        XCTAssertEqual(WindowStateKeys.inspector, "window.inspectorVisible")
+    }
+
+    // MARK: - Screen codec
+
+    /// Every `Screen` round-trips through its persisted raw value, so
+    /// `@SceneStorage` can decode whatever it wrote.
+    func testScreenRawValueRoundTrips() {
+        let all: [AppModel.Screen] = [.home, .discover, .library, .favorites, .search, .settings]
+        for screen in all {
+            XCTAssertEqual(
+                AppModel.Screen(persistedRawValue: screen.persistedRawValue),
+                screen,
+                "Screen.\(screen) failed to round-trip through its persisted raw value"
+            )
+        }
+    }
+
+    /// The stable on-disk identifiers for `Screen`. Renaming any of these is a
+    /// breaking change to persisted state and must come with a migration.
+    func testScreenStableRawValues() {
+        XCTAssertEqual(AppModel.Screen.home.persistedRawValue, "home")
+        XCTAssertEqual(AppModel.Screen.discover.persistedRawValue, "discover")
+        XCTAssertEqual(AppModel.Screen.library.persistedRawValue, "library")
+        XCTAssertEqual(AppModel.Screen.favorites.persistedRawValue, "favorites")
+        XCTAssertEqual(AppModel.Screen.search.persistedRawValue, "search")
+        XCTAssertEqual(AppModel.Screen.settings.persistedRawValue, "settings")
+    }
+
+    /// An unknown raw value (e.g. one written by a newer build) decodes to nil
+    /// so the caller's default applies rather than crashing.
+    func testScreenUnknownRawValueDecodesToNil() {
+        XCTAssertNil(AppModel.Screen(persistedRawValue: "not-a-real-screen"))
+        XCTAssertNil(AppModel.Screen(persistedRawValue: ""))
+    }
+
+    // MARK: - Sidebar visibility codec
+
+    /// The three visibilities the shell actually persists round-trip cleanly.
+    func testSidebarVisibilityRoundTrips() {
+        for visibility: NavigationSplitViewVisibility in [.all, .detailOnly, .automatic] {
+            XCTAssertEqual(
+                NavigationSplitViewVisibility(persistedRawValue: visibility.persistedRawValue),
+                visibility,
+                "NavigationSplitViewVisibility.\(visibility) failed to round-trip"
+            )
+        }
+    }
+
+    /// Stable on-disk identifiers for the sidebar column visibility.
+    func testSidebarVisibilityStableRawValues() {
+        XCTAssertEqual(NavigationSplitViewVisibility.all.persistedRawValue, "all")
+        XCTAssertEqual(NavigationSplitViewVisibility.detailOnly.persistedRawValue, "detailOnly")
+        XCTAssertEqual(NavigationSplitViewVisibility.automatic.persistedRawValue, "automatic")
+    }
+
+    /// States the two-column shell never drives collapse to `automatic` rather
+    /// than persisting something it can't honour on restore.
+    func testSidebarVisibilityUnsupportedStateCollapsesToAutomatic() {
+        XCTAssertEqual(NavigationSplitViewVisibility.doubleColumn.persistedRawValue, "automatic")
+    }
+
+    /// An unknown sidebar raw value decodes to nil so the caller's default
+    /// (or the Appearance preference) applies.
+    func testSidebarVisibilityUnknownRawValueDecodesToNil() {
+        XCTAssertNil(NavigationSplitViewVisibility(persistedRawValue: "left-and-right"))
+        XCTAssertNil(NavigationSplitViewVisibility(persistedRawValue: ""))
+    }
+
+    // MARK: - AppearanceSidebar preference -> default visibility
+
+    /// `.visible` and `.auto_hide` both open expanded; only `.hidden` starts
+    /// collapsed. (`.autoHide` reveals on hover but still starts shown.)
+    func testDefaultVisibilityForPreference() {
+        XCTAssertEqual(WindowStateStore.defaultVisibility(for: .visible), .all)
+        XCTAssertEqual(WindowStateStore.defaultVisibility(for: .autoHide), .all)
+        XCTAssertEqual(WindowStateStore.defaultVisibility(for: .hidden), .detailOnly)
+    }
+
+    // MARK: - initialSidebarVisibility precedence
+
+    /// A persisted per-scene visibility wins over the Appearance preference —
+    /// restoring the user's last layout is the point of #10.
+    func testInitialSidebarPrefersPersistedState() {
+        // Persisted `detailOnly` must win even though the preference says visible.
+        XCTAssertEqual(
+            WindowStateStore.initialSidebarVisibility(
+                persistedRaw: NavigationSplitViewVisibility.detailOnly.persistedRawValue,
+                preferenceRaw: AppearanceSidebar.visible.rawValue
+            ),
+            .detailOnly
+        )
+        // ...and the inverse: persisted `all` wins over a `hidden` preference.
+        XCTAssertEqual(
+            WindowStateStore.initialSidebarVisibility(
+                persistedRaw: NavigationSplitViewVisibility.all.persistedRawValue,
+                preferenceRaw: AppearanceSidebar.hidden.rawValue
+            ),
+            .all
+        )
+    }
+
+    /// With no persisted state (first launch in a scene), fall back to the
+    /// Appearance `Sidebar` preference — the wiring #10 adds for the
+    /// previously UI-only `AppearanceSidebar` enum.
+    func testInitialSidebarFallsBackToPreferenceWhenUnpersisted() {
+        XCTAssertEqual(
+            WindowStateStore.initialSidebarVisibility(
+                persistedRaw: "",
+                preferenceRaw: AppearanceSidebar.hidden.rawValue
+            ),
+            .detailOnly
+        )
+        XCTAssertEqual(
+            WindowStateStore.initialSidebarVisibility(
+                persistedRaw: "",
+                preferenceRaw: AppearanceSidebar.visible.rawValue
+            ),
+            .all
+        )
+    }
+
+    /// A garbage preference raw value falls back to `.visible` (expanded),
+    /// matching `AppearancePane`'s own default.
+    func testInitialSidebarUnknownPreferenceDefaultsToVisible() {
+        XCTAssertEqual(
+            WindowStateStore.initialSidebarVisibility(
+                persistedRaw: "",
+                preferenceRaw: "bogus-preference"
+            ),
+            .all
+        )
+    }
+
+    // MARK: - restoredScreen
+
+    /// A persisted tab is restored verbatim.
+    func testRestoredScreenReturnsPersistedTab() {
+        XCTAssertEqual(WindowStateStore.restoredScreen(persistedRaw: "search"), .search)
+        XCTAssertEqual(WindowStateStore.restoredScreen(persistedRaw: "home"), .home)
+    }
+
+    /// Empty or unknown raw values fall back to `.library`, the app's
+    /// cold-start default tab (`AppModel.screen`).
+    func testRestoredScreenDefaultsToLibrary() {
+        XCTAssertEqual(WindowStateStore.restoredScreen(persistedRaw: ""), .library)
+        XCTAssertEqual(WindowStateStore.restoredScreen(persistedRaw: "garbage"), .library)
+    }
+
+    // MARK: - restoredInspectorVisible
+
+    /// Only the literal "true" string reopens the inspector; everything else
+    /// (including the empty first-launch value and nil) leaves it closed.
+    func testRestoredInspectorVisible() {
+        XCTAssertTrue(WindowStateStore.restoredInspectorVisible(persistedRaw: "true"))
+        XCTAssertFalse(WindowStateStore.restoredInspectorVisible(persistedRaw: "false"))
+        XCTAssertFalse(WindowStateStore.restoredInspectorVisible(persistedRaw: ""))
+        XCTAssertFalse(WindowStateStore.restoredInspectorVisible(persistedRaw: nil))
+    }
+}


### PR DESCRIPTION
Second wave of the 2.0 push. Eight features, each built in isolation, adversarially reviewed, and integrated on a green base (clean build + 328 Swift tests + cargo test + clippy `-D warnings`, all passing locally; CI regenerates bindings via build-core.sh).

- **ListenBrainz scrobbling MVP** — new `core/src/scrobble.rs` submit-listens (playing_now + threshold listen), token in a new Scrobbling preferences pane, triggered off the playback-report path; token never logged or in the diagnostic bundle. Closes #46
- **Blurred artwork backdrop** behind the Full Player (coexists with the ambient palette wash; honors Reduce Transparency). Closes #21
- **Instant Mix seed-picker modal** — search/pick a track/artist/album/genre seed → Generate (engine FFI already existed). Closes #327
- **Share / export playlist** — M3U, JSON, and a credential-stripped deep link. Closes #237
- **Resizable + auto-hiding sidebar** — draggable 200–360pt, auto-collapse on narrow windows, manual override persists. Closes #318
- **Restore window state** across launches — last-viewed tab, sidebar + inspector visibility via @SceneStorage, wiring the Appearance Sidebar preference. Closes #10
- **Command palette recents + pinned** actions with right-click pin. Closes #308
- **Home "Rediscover" row** — unplayed / long-unplayed library surfacing. Closes #57