### PR TITLE
macOS 2.0 — Wave 3: Radio section, AirPlay, liner notes, A–Z index, tour, full-screen, lyrics, mini-player nav

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -699,6 +699,29 @@ final class AppModel {
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
+    /// Drill the **main** window to a detail `Route` from the detached Mini
+    /// Player, raising the full window first so the navigation is visible.
+    ///
+    /// The Mini Player floats in its own borderless window (optionally
+    /// always-on-top), so a bare `navigate(to:)` would push onto the main
+    /// window's `NavigationStack` while that window stays buried behind
+    /// everything else — the user would tap album art and see nothing move.
+    /// Activating the app raises the main `WindowGroup` window back to the
+    /// foreground the same way `returnToFullWindow` does, *then* we drill.
+    /// Unlike `returnToFullWindow` this intentionally leaves
+    /// `isMiniPlayerVisible` untouched: clicking through to a detail page is
+    /// not a request to dismiss the mini player, so an always-on-top widget
+    /// keeps floating over the now-foregrounded detail view (the Apple Music /
+    /// Spotify mini-widget contract).
+    ///
+    /// Routing through one seam (rather than letting `MiniPlayerView` poke
+    /// `navPath` + `NSApp` itself) keeps the activate-then-navigate ordering in
+    /// a single testable place and matches `openLyrics` / `navigate(to:)`.
+    func openInMainWindowFromMiniPlayer(_ route: Route) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        navigate(to: route)
+    }
+
     // MARK: - Command Palette (⌘K)
 
     /// Whether the command-palette overlay is currently visible. Toggled by

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -29,7 +29,7 @@ final class AppModel {
     /// Active root tab. Drill destinations (album / artist / playlist /
     /// nowPlaying) live on `navPath` instead so back navigation is handled
     /// by `NavigationStack` natively. See #1 / #4.
-    enum Screen: Hashable { case home, discover, library, favorites, search, settings }
+    enum Screen: Hashable { case home, discover, radio, library, favorites, search, settings }
     var screen: Screen = .library
 
     /// Typed value-type for `NavigationStack` destinations. Root tabs and
@@ -39,6 +39,7 @@ final class AppModel {
     enum Route: Hashable {
         case home
         case discover
+        case radio
         case library
         case favorites
         case search

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -725,6 +725,22 @@ final class AppModel {
     /// See #327.
     var instantMixSeedLabel: String?
 
+    /// Whether the first-run feature tour (coach marks) overlay is presented.
+    /// `MainShell` also auto-shows the tour on first launch via its own
+    /// `@AppStorage` flag; this flag is the *explicit re-open* channel for the
+    /// Help ▸ "Show Tour" command, so a returning user can replay it without
+    /// resetting the persisted seen flag. Driven out of `AppModel` (like
+    /// `isCommandPaletteOpen`) so the menu command doesn't need a SwiftUI
+    /// environment round-trip. See #113 and `FeatureTour` / `FeatureTourOverlay`.
+    var isFeatureTourPresented: Bool = false
+
+    /// Re-open the feature tour on demand. Wired to the Help ▸ "Show Tour"
+    /// menu command; `MainShell` renders `FeatureTourOverlay` whenever this is
+    /// set and clears it on dismiss. See #113.
+    func presentFeatureTour() {
+        isFeatureTourPresented = true
+    }
+
     /// A single verb entry in the command palette's action list. See
     /// `paletteActions` for the live roster and `executePaletteAction(id:)`
     /// for the dispatcher. Actions are intentionally held by id + closure

--- a/macos/Sources/Lyrebird/Components/AirPlayRoutePicker.swift
+++ b/macos/Sources/Lyrebird/Components/AirPlayRoutePicker.swift
@@ -1,0 +1,105 @@
+import AVKit
+import SwiftUI
+
+/// SwiftUI wrapper around `AVRoutePickerView` so the `PlayerBar` can offer the
+/// system AirPlay / output-route picker without dropping to AppKit at the call
+/// site. Tapping the button presents the system's standard list of AirPlay
+/// receivers and output targets — the same popover Music.app shows.
+///
+/// Scope is **system audio routing only** (#326): this is the OS route picker,
+/// not Jellyfin SyncPlay / remote-session casting (tracked separately). It does
+/// not need a Jellyfin core FFI — `AVRoutePickerView` talks straight to the
+/// AirPlay / Core Audio routing stack.
+///
+/// Styled to sit flush in the transport row next to the volume slider: the
+/// chrome border is dropped (`isRoutePickerButtonBordered = false`) so the
+/// glyph reads as a bare transport control like the shuffle / repeat buttons,
+/// and the button colors track Lyrebird's ink tokens — `ink2` at rest, the
+/// brighter `ink` when a non-local route is active — instead of the default
+/// system blue. Mirrors the `VisualEffectView` representable pattern.
+struct AirPlayRoutePicker: NSViewRepresentable {
+    /// Resting glyph color. Matches the volume speaker glyph beside it.
+    var restingTint: Color = Theme.ink2
+    /// Glyph color while a route is engaged. Lifts to the brighter ink so an
+    /// active AirPlay destination reads as "on", echoing how the transport
+    /// row tints shuffle / repeat with the accent when engaged.
+    var activeTint: Color = Theme.ink
+
+    func makeNSView(context: Context) -> AVRoutePickerView {
+        let view = AVRoutePickerView()
+        Self.apply(colorPlan, to: view)
+        // The route glyph is square; pin it to the transport row's icon
+        // footprint so it lines up with the other 28×28 controls.
+        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return view
+    }
+
+    func updateNSView(_ nsView: AVRoutePickerView, context: Context) {
+        Self.apply(colorPlan, to: nsView)
+    }
+
+    /// The styling policy derived from this picker's tints.
+    var colorPlan: ButtonColorPlan {
+        ButtonColorPlan(restingTint: restingTint, activeTint: activeTint)
+    }
+
+    /// Apply a `ButtonColorPlan` to a live `AVRoutePickerView`. Factored out so
+    /// `makeNSView` and `updateNSView` can't drift, and so a smoke test can
+    /// drive the AVKit wrapper directly (no SwiftUI `Context` needed) and
+    /// assert the styling actually lands on a realized view.
+    static func apply(_ plan: ButtonColorPlan, to view: AVRoutePickerView) {
+        view.isRoutePickerButtonBordered = plan.bordered
+        for state in plan.states {
+            view.setRoutePickerButtonColor(NSColor(plan.color(for: state)), for: state.avState)
+        }
+    }
+
+    /// Pure description of how the picker button is painted across its four
+    /// `AVRoutePickerView.ButtonState`s. Splitting the policy out from the live
+    /// AppKit view keeps the resting-vs-active color decision deterministic and
+    /// testable without realizing an `AVRoutePickerView` (a window-server
+    /// dependency a headless test run doesn't have) — the same pure-helper
+    /// approach `MenuBarNowPlaying` uses for its transport-icon decision.
+    struct ButtonColorPlan: Equatable {
+        var restingTint: Color
+        var activeTint: Color
+        /// Borderless so the glyph reads as a bare transport control, not a
+        /// bezeled push button, next to the volume slider.
+        var bordered: Bool = false
+
+        /// The four button states the route picker paints, in a stable order.
+        var states: [ButtonState] { ButtonState.allCases }
+
+        /// Color for a given button state. `normal` / `normalHighlighted` use
+        /// the resting tint (no route, or local output); `active` /
+        /// `activeHighlighted` use the brighter active tint (a route engaged).
+        func color(for state: ButtonState) -> Color {
+            switch state {
+            case .normal, .normalHighlighted:
+                return restingTint
+            case .active, .activeHighlighted:
+                return activeTint
+            }
+        }
+    }
+
+    /// Local mirror of `AVRoutePickerView.ButtonState` so the color policy can
+    /// be enumerated and asserted without importing AVKit into a test that only
+    /// cares about the decision, and so `allCases` is guaranteed exhaustive.
+    enum ButtonState: CaseIterable {
+        case normal
+        case normalHighlighted
+        case active
+        case activeHighlighted
+
+        var avState: AVRoutePickerView.ButtonState {
+            switch self {
+            case .normal: return .normal
+            case .normalHighlighted: return .normalHighlighted
+            case .active: return .active
+            case .activeHighlighted: return .activeHighlighted
+            }
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Components/AlphabetScrollIndex.swift
+++ b/macos/Sources/Lyrebird/Components/AlphabetScrollIndex.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// Pure mapping logic for the Library A–Z fast-scroll rail (#216).
+///
+/// Extracted out of the SwiftUI layer so the letter → first-row arithmetic
+/// can be exercised by unit tests without a scene graph or an `AppModel`,
+/// mirroring the `TrackSelectionResolver` pattern in `LibraryView`. The view
+/// (`AlphabetScrollRail`) keeps only rendering + the gesture → `scrollTo`
+/// glue; everything that decides *which* letter a name buckets under, and
+/// *which* row a tapped letter resolves to, lives here.
+enum AlphabetScrollIndex {
+    /// The rail's letters, top to bottom: a leading `#` bucket for names that
+    /// don't start with a Latin letter (digits, symbols, CJK, …) followed by
+    /// A–Z. Stable order so the view can render it directly and tests can
+    /// assert against it.
+    static let letters: [Character] = ["#"] + (UnicodeScalar("A").value...UnicodeScalar("Z").value)
+        .compactMap { UnicodeScalar($0).map(Character.init) }
+
+    /// The index-rail bucket a sort-name belongs to.
+    ///
+    /// Folds diacritics first (so "Édith" → `E`, "Ángel" → `A`) to match the
+    /// way `localizedCaseInsensitiveCompare` — the comparator the Library's
+    /// alphabetical sorts use — collates accented Latin letters next to their
+    /// base form. A leading whitespace run is skipped; any name whose first
+    /// significant character isn't A–Z (digits like "2Pac", symbols, or a
+    /// non-Latin script) lands in the `#` bucket, again matching the rail's
+    /// leading entry.
+    static func bucket(for sortName: String) -> Character {
+        let folded = sortName.folding(
+            options: [.diacriticInsensitive, .caseInsensitive],
+            locale: nil
+        )
+        guard let first = folded.first(where: { !$0.isWhitespace }) else {
+            return "#"
+        }
+        let upper = Character(first.uppercased())
+        return (upper >= "A" && upper <= "Z") ? upper : "#"
+    }
+
+    /// The set of buckets that have at least one item in `sortNames`. Drives
+    /// the rail's emphasis: letters present in the data are inked, absent ones
+    /// are dimmed.
+    static func presentBuckets(in sortNames: [String]) -> Set<Character> {
+        Set(sortNames.map(bucket(for:)))
+    }
+
+    /// Resolve a tapped/dragged rail `letter` to the index of the first row it
+    /// should scroll to, within `sortNames` **in the order they are displayed**
+    /// (i.e. the already-sorted array).
+    ///
+    /// Behaviour matches the platform fast-scroll convention:
+    /// - If the letter has rows, return the first such row's index.
+    /// - If the letter is empty (e.g. the user drags across "Q" in a library
+    ///   with no Q artists), fall forward to the first row of the next
+    ///   non-empty bucket at or after it, so a drag always lands somewhere
+    ///   sensible rather than dead-ending.
+    /// - Returns `nil` only when there is no row at or after the letter (e.g.
+    ///   dragging onto "Z" when the last item is an "M"), letting the caller
+    ///   no-op instead of scrolling to a bogus index.
+    ///
+    /// Assumes `sortNames` is already sorted ascending (the contract the
+    /// Library upholds — the rail is only shown for the A–Z / Z–A name sorts,
+    /// see `AlphabetScrollRail`), so the first matching index is also the
+    /// top-most occurrence of the bucket.
+    static func firstIndex(for letter: Character, in sortNames: [String]) -> Int? {
+        guard let target = letters.firstIndex(of: letter) else { return nil }
+        // Walk the rail forward from the tapped letter; the first bucket that
+        // actually has a row wins. This gives the "snap to the next present
+        // section" behaviour without scanning `sortNames` once per rail letter.
+        for railIndex in target..<letters.count {
+            let bucket = letters[railIndex]
+            if let row = sortNames.firstIndex(where: { Self.bucket(for: $0) == bucket }) {
+                return row
+            }
+        }
+        return nil
+    }
+}
+
+/// Vertical A–Z fast-scroll rail overlaid on the right edge of the Library
+/// list (#216). ~20pt wide; renders `#` + A–Z stacked, emphasising letters
+/// present in the data and dimming the rest. A tap or a vertical drag reports
+/// the letter under the finger to `onSelect`, which the Library turns into a
+/// `ScrollViewProxy.scrollTo`.
+///
+/// The rail is intentionally dumb about *data*: it takes the present-letter
+/// set and a callback. All "which row does P map to" logic lives in
+/// `AlphabetScrollIndex` so it stays unit-testable. Drag tracking dedupes
+/// repeated callbacks for the same letter so a slow drag down the rail fires
+/// one `scrollTo` per section crossed rather than one per pixel.
+struct AlphabetScrollRail: View {
+    /// Buckets that have at least one row — inked; the rest render dimmed.
+    let presentBuckets: Set<Character>
+    /// Invoked with the rail letter under a tap or the current drag location.
+    /// Repeated calls for the same letter during a single drag are suppressed.
+    let onSelect: (Character) -> Void
+
+    /// The last letter reported during the in-flight drag, so we only call
+    /// `onSelect` when the finger crosses into a new letter's slot.
+    @State private var lastReported: Character?
+
+    private let letters = AlphabetScrollIndex.letters
+    /// Per-letter slot height. 13pt keeps the full `#`+A–Z column ≈ 350pt,
+    /// which fits a MacBook content height without scrolling the rail itself.
+    private let slotHeight: CGFloat = 13
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack(spacing: 0) {
+                ForEach(Array(letters.enumerated()), id: \.element) { _, letter in
+                    Text(String(letter))
+                        .font(Theme.font(9, weight: .bold))
+                        .foregroundStyle(
+                            presentBuckets.contains(letter) ? Theme.ink2 : Theme.ink3.opacity(0.4)
+                        )
+                        .frame(maxWidth: .infinity, minHeight: slotHeight, maxHeight: slotHeight)
+                        .contentShape(Rectangle())
+                }
+            }
+            .frame(maxHeight: .infinity, alignment: .center)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        report(at: value.location.y, in: geo.size.height)
+                    }
+                    .onEnded { _ in lastReported = nil }
+            )
+        }
+        .frame(width: 20)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Alphabet index")
+        .accessibilityHint("Drag to jump to a letter")
+    }
+
+    /// Map a vertical position inside the rail to a letter slot and report it
+    /// (once) to the callback. The column is centred vertically in the rail's
+    /// height, so the live column height — not the full geometry — defines the
+    /// hit zones.
+    private func report(at y: CGFloat, in totalHeight: CGFloat) {
+        let columnHeight = slotHeight * CGFloat(letters.count)
+        // The VStack is centre-aligned, so the column's top sits at this inset.
+        let top = max((totalHeight - columnHeight) / 2, 0)
+        let local = y - top
+        guard local >= 0, local < columnHeight else { return }
+        let slot = min(max(Int(local / slotHeight), 0), letters.count - 1)
+        let letter = letters[slot]
+        guard letter != lastReported else { return }
+        lastReported = letter
+        onSelect(letter)
+    }
+}

--- a/macos/Sources/Lyrebird/Components/FeatureTour.swift
+++ b/macos/Sources/Lyrebird/Components/FeatureTour.swift
@@ -1,0 +1,345 @@
+import SwiftUI
+
+/// First-run feature tour (coach marks) — issue #113.
+///
+/// A short, dismissible sequence of callout cards shown **once** on the
+/// first launch *after* the user connects a server, pointing out four power
+/// features that aren't obvious from the chrome alone: right-click context
+/// menus, the Space play/pause shortcut, ⌘F search, and the detachable mini
+/// player.
+///
+/// This is deliberately distinct from `OnboardingView` (the server *connect*
+/// flow, #291/#292/#293). Onboarding gets the user signed in; the tour
+/// teaches the app once they're in. They never appear at the same time —
+/// `MainShell` only mounts the tour, and `MainShell` only renders for a live
+/// `model.session`, which by definition means onboarding has already exited.
+///
+/// The whole surface is self-contained: a pure step model (`FeatureTourStep`
+/// + the `FeatureTour.steps` catalog), a tiny persistence wrapper
+/// (`FeatureTourSeenStore`) that records whether the tour has been shown, and
+/// a single overlay view (`FeatureTourOverlay`). The only outside touch is a
+/// one-line `@AppStorage` first-run flag plus a Help ▸ "Show Tour" entry that
+/// re-opens it on demand.
+
+// MARK: - Step model
+
+/// One coach-mark card in the tour. Pure value type — carries only display
+/// data so the catalog can be asserted in tests without booting any UI.
+struct FeatureTourStep: Identifiable, Equatable {
+    /// Stable identifier, also the dedupe / diff key.
+    let id: String
+    /// SF Symbol shown in the card's leading badge.
+    let symbol: String
+    /// Localization key for the card title (e.g. "Right-click for more").
+    let titleKey: LocalizedStringKey
+    /// Localization key for the explanatory body copy.
+    let bodyKey: LocalizedStringKey
+    /// Optional chord rendered as a glyph pill (e.g. "␣", "⌘F"). `nil` for
+    /// steps whose gesture isn't a keyboard shortcut (right-click).
+    let shortcut: String?
+
+    /// Raw title key string, retained separately from `titleKey` so tests can
+    /// assert catalog integrity without reflecting into the opaque
+    /// `LocalizedStringKey` type. Mirrors the `AppShortcuts.Shortcut`
+    /// `nameKeyString` / `nameKey` split.
+    let titleKeyString: String
+}
+
+/// The first-run feature tour catalog.
+///
+/// Static data, so it can be rendered (and tested) without a live
+/// `AppModel`. Adding a step is a single entry here; the overlay's
+/// progress dots, Next/Done button label, and step counter all derive from
+/// `steps.count`, so nothing else needs touching.
+enum FeatureTour {
+    /// Four cards, in presentation order. Each names a feature that's real
+    /// and wired today (see `LyrebirdCommands` for the Space / ⌘F / ⌘⌥P
+    /// bindings and the various `*ContextMenu` components for right-click).
+    static let steps: [FeatureTourStep] = [
+        FeatureTourStep(
+            id: "right_click",
+            symbol: "cursorarrow.click.2",
+            titleKey: "tour.right_click.title",
+            bodyKey: "tour.right_click.body",
+            shortcut: nil,
+            titleKeyString: "tour.right_click.title"
+        ),
+        FeatureTourStep(
+            id: "space_play_pause",
+            symbol: "playpause.fill",
+            titleKey: "tour.space.title",
+            bodyKey: "tour.space.body",
+            shortcut: "␣",
+            titleKeyString: "tour.space.title"
+        ),
+        FeatureTourStep(
+            id: "search",
+            symbol: "magnifyingglass",
+            titleKey: "tour.search.title",
+            bodyKey: "tour.search.body",
+            shortcut: "⌘F",
+            titleKeyString: "tour.search.title"
+        ),
+        FeatureTourStep(
+            id: "mini_player",
+            symbol: "pip.fill",
+            titleKey: "tour.mini_player.title",
+            bodyKey: "tour.mini_player.body",
+            shortcut: "⌘⌥P",
+            titleKeyString: "tour.mini_player.title"
+        ),
+    ]
+}
+
+// MARK: - Seen-persistence
+
+/// Records whether the first-run tour has already been shown.
+///
+/// Wraps a `UserDefaults` instance so the production path keys against the
+/// standard domain (same channel `@AppStorage` reads) while tests can inject
+/// an isolated suite and assert the persisted flag without polluting the real
+/// app's preferences — the same isolation pattern `MiniPlayerStateTests` uses
+/// for the always-on-top preference.
+///
+/// The store deliberately owns only the *primitive* read/write of the flag.
+/// Deciding *whether* to show the tour (first-run vs. an explicit Help ▸ Show
+/// Tour re-open) lives in `FeatureTourOverlay`, which composes this with the
+/// app's session/first-run state.
+struct FeatureTourSeenStore {
+    /// Stable on-disk key. Must not be renamed without a migration — a rename
+    /// re-shows the tour to every existing user. Namespaced under `tour.` to
+    /// sit alongside the other feature-scoped `@AppStorage` keys.
+    static let seenKey = "tour.firstRunSeen"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Whether the tour has been shown at least once.
+    var hasSeen: Bool {
+        defaults.bool(forKey: Self.seenKey)
+    }
+
+    /// Mark the tour as shown so it doesn't auto-appear on the next launch.
+    func markSeen() {
+        defaults.set(true, forKey: Self.seenKey)
+    }
+
+    /// Clear the flag. Used by tests; the production re-open path goes through
+    /// `AppModel.presentFeatureTour()` instead, which shows the tour without
+    /// disturbing the persisted first-run flag.
+    func reset() {
+        defaults.removeObject(forKey: Self.seenKey)
+    }
+}
+
+// MARK: - Overlay
+
+/// The dismissible coach-mark overlay. A single centered callout card that
+/// advances through `FeatureTour.steps`, dimming the rest of the shell behind
+/// it. Esc or "Skip" closes immediately; the last step's button reads "Done".
+///
+/// Closing always marks the tour seen (so it never re-auto-appears) and clears
+/// the presentation flag via `onClose`, which the host (`MainShell`) wires to
+/// `AppModel`. Honours Reduce Motion by dropping the card's slide transition.
+struct FeatureTourOverlay: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Invoked when the tour finishes or is skipped. The host clears whatever
+    /// flag drove presentation; the seen flag is persisted here before this
+    /// fires so a host that only flips a transient flag still records it.
+    let onClose: () -> Void
+
+    /// Persistence wrapper. Defaulted so the production overlay records into
+    /// the standard domain; tests construct the overlay with an isolated
+    /// store. The card view never reads this except to `markSeen()` on close.
+    var seenStore = FeatureTourSeenStore()
+
+    @State private var index: Int = 0
+
+    private var steps: [FeatureTourStep] { FeatureTour.steps }
+    private var step: FeatureTourStep { steps[min(index, steps.count - 1)] }
+    private var isLast: Bool { index >= steps.count - 1 }
+    private var isFirst: Bool { index == 0 }
+
+    var body: some View {
+        ZStack {
+            // Scrim. Tapping outside the card skips the tour, matching the
+            // command palette's tap-to-dismiss feel.
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { close() }
+                .accessibilityHidden(true)
+
+            card
+                .frame(width: 360)
+                .transition(
+                    reduceMotion
+                        ? .opacity
+                        : .move(edge: .bottom).combined(with: .opacity)
+                )
+                .id(step.id)
+        }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.22), value: index)
+        // Esc closes the tour. A hidden, zero-frame cancel button is the
+        // standard SwiftUI way to bind `.escape` without an explicit key
+        // handler; `.cancelAction` also routes Esc to it.
+        .background(
+            Button(action: close) { EmptyView() }
+                .keyboardShortcut(.cancelAction)
+                .frame(width: 0, height: 0)
+                .hidden()
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+        .accessibilityLabel(Text("tour.a11y.container"))
+    }
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            header
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(step.titleKey)
+                    .font(Theme.font(20, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+
+                Text(step.bodyKey)
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            footer
+        }
+        .padding(24)
+        .background(Theme.bgAlt)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Theme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.45), radius: 30, x: 0, y: 18)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.accent.opacity(0.18))
+                    .frame(width: 44, height: 44)
+                Image(systemName: step.symbol)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+            .accessibilityHidden(true)
+
+            if let shortcut = step.shortcut {
+                Spacer()
+                Text(shortcut)
+                    .font(Theme.font(13, weight: .bold))
+                    .monospaced()
+                    .foregroundStyle(Theme.ink)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Theme.surface2)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Theme.border, lineWidth: 1)
+                    )
+                    .accessibilityLabel(Text("tour.a11y.shortcut \(shortcut)"))
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            // Step dots — same affordance as the onboarding `ProgressDots`,
+            // reproduced here so this overlay stays self-contained.
+            HStack(spacing: 6) {
+                ForEach(steps.indices, id: \.self) { i in
+                    Circle()
+                        .fill(i == index ? Theme.accent : Theme.border)
+                        .frame(width: 6, height: 6)
+                }
+            }
+            .accessibilityElement()
+            .accessibilityLabel(Text("tour.a11y.progress \(index + 1) \(steps.count)"))
+
+            Spacer()
+
+            if !isFirst {
+                Button(action: back) {
+                    Text("tour.back")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink3)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text("tour.back"))
+            }
+
+            Button(action: advance) {
+                Text(isLast ? "tour.done" : "tour.next")
+                    .font(Theme.font(13, weight: .bold))
+                    .frame(minWidth: 72)
+                    .frame(height: 34)
+                    .padding(.horizontal, 14)
+                    .foregroundStyle(Theme.ink)
+                    .background(Theme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: 17))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel(isLast ? Text("tour.done") : Text("tour.next"))
+        }
+        .overlay(alignment: .center) {
+            // "Skip" sits centered under the dots only while there's still a
+            // step left to skip; on the last card "Done" already closes.
+            if !isLast {
+                Button(action: close) {
+                    Text("tour.skip")
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.ink3)
+                }
+                .buttonStyle(.plain)
+                .offset(y: 30)
+                .accessibilityLabel(Text("tour.skip"))
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func advance() {
+        if isLast {
+            close()
+        } else {
+            index += 1
+        }
+    }
+
+    private func back() {
+        guard !isFirst else { return }
+        index -= 1
+    }
+
+    /// Persist the seen flag and hand control back to the host. Idempotent —
+    /// marking an already-seen tour seen again is a harmless no-op.
+    private func close() {
+        seenStore.markSeen()
+        onClose()
+    }
+}
+
+#Preview("Feature tour") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        FeatureTourOverlay(onClose: {})
+    }
+    .frame(width: 900, height: 600)
+    .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Components/LyricsView.swift
+++ b/macos/Sources/Lyrebird/Components/LyricsView.swift
@@ -229,7 +229,7 @@ struct LyricsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     ForEach(lines) { line in
-                        LyricRow(line: line, isActive: line.id == activeId)
+                        LyricRow(line: line, isActive: line.id == activeId, reduceMotion: reduceMotion)
                             .id(line.id)
                             .modifier(TapToSeekModifier(timestamp: line.timestamp) { ts in
                                 model.seek(toSeconds: ts)
@@ -289,18 +289,95 @@ struct LyricsView: View {
     }
 }
 
-/// One rendered lyric row. Active rows bloom in size + brightness; past
-/// rows dim so the eye is pulled to the current line.
+/// Resolved visual state for a single lyric row. Pure value type so the
+/// Apple-Music-"Sing"-style active-line polish (#90) — the fade-in, the
+/// 99%→100% scale bloom, the soft glow, and the dim on inactive lines — is
+/// unit-testable without booting a SwiftUI scene (see `LyricsViewStyleTests`),
+/// matching the `NowPlayingBackdrop.showsArtworkLayer` testable-model pattern.
+///
+/// The font size / weight / colour contract is unchanged from the original
+/// highlight (active 22/bold/`ink`, inactive 18/medium/`ink3`) so the synced
+/// read doesn't regress; the scale + glow + opacity ride on top.
+struct LyricLineStyle: Equatable {
+    /// Point size handed to `Theme.font`.
+    let fontSize: CGFloat
+    /// Weight handed to `Theme.font`.
+    let weight: Font.Weight
+    /// Foreground tint. `ink` for the active line, the dimmer `ink3` for the
+    /// rest so the eye is pulled to the current line.
+    let color: Color
+    /// Whole-row opacity. Inactive lines sit slightly under full brightness
+    /// for a gentler dim than colour alone; the active line is fully opaque.
+    let opacity: Double
+    /// `scaleEffect` factor. Inactive lines rest at 99%; the active line
+    /// blooms to 100% as it becomes current. Pinned to 1.0 under Reduce
+    /// Motion so nothing scales.
+    let scale: CGFloat
+    /// Soft glow radius behind the active line. Zero for inactive lines and
+    /// under Reduce Motion (the bloom is the motion we're gating).
+    let glowRadius: CGFloat
+    /// Opacity of the glow colour. Drives the bloom in/out alongside
+    /// `glowRadius`; zero when there's no glow to draw.
+    let glowOpacity: Double
+    /// Whether the row's transition between states should animate. False
+    /// under Reduce Motion — the row then swaps font/colour instantly,
+    /// preserving the original pre-#90 instant-highlight behaviour.
+    let animates: Bool
+
+    /// Resolve the style for a row given whether it's the active line and the
+    /// system Reduce-Motion preference.
+    ///
+    /// Reduce Motion is the single gate for *all* motion: it pins `scale` to
+    /// 1.0, drops the glow to nothing, and sets `animates = false` so the
+    /// active row is highlighted with the instant font/colour swap the view
+    /// shipped before this polish landed.
+    static func resolve(isActive: Bool, reduceMotion: Bool) -> LyricLineStyle {
+        LyricLineStyle(
+            fontSize: isActive ? 22 : 18,
+            weight: isActive ? .bold : .medium,
+            color: isActive ? Theme.ink : Theme.ink3,
+            // Inactive lines dim a touch past colour alone; active is full.
+            opacity: isActive ? 1.0 : 0.55,
+            // Scale + glow only exist when motion is allowed.
+            scale: reduceMotion ? 1.0 : (isActive ? 1.0 : 0.99),
+            glowRadius: (isActive && !reduceMotion) ? 10 : 0,
+            glowOpacity: (isActive && !reduceMotion) ? 0.45 : 0,
+            animates: !reduceMotion
+        )
+    }
+}
+
+/// One rendered lyric row. Active rows bloom in size + brightness with a soft
+/// glow (#90); inactive rows dim and rest at 99% scale so the eye is pulled to
+/// the current line. All motion (scale bloom, glow, fade) is gated on Reduce
+/// Motion via `LyricLineStyle.resolve`, which falls back to the original
+/// instant font/colour highlight.
 private struct LyricRow: View {
     let line: LyricLine
     let isActive: Bool
+    let reduceMotion: Bool
 
     var body: some View {
+        let style = LyricLineStyle.resolve(isActive: isActive, reduceMotion: reduceMotion)
         Text(line.text)
-            .font(Theme.font(isActive ? 22 : 18, weight: isActive ? .bold : .medium))
-            .foregroundStyle(isActive ? Theme.ink : Theme.ink3)
+            .font(Theme.font(style.fontSize, weight: style.weight))
+            .foregroundStyle(style.color)
             .fixedSize(horizontal: false, vertical: true)
-            .animation(.easeInOut(duration: 0.2), value: isActive)
+            .opacity(style.opacity)
+            .scaleEffect(style.scale, anchor: .leading)
+            // Soft bloom behind the active line. Tinted with the active ink so
+            // the glow reads as the line lighting up rather than a drop shadow.
+            // Radius + opacity both go to zero off the active line and under
+            // Reduce Motion, so inactive rows draw no shadow at all.
+            .shadow(
+                color: Theme.ink.opacity(style.glowOpacity),
+                radius: style.glowRadius
+            )
+            // One animation driving the whole state change (font, colour,
+            // scale, glow) so the line fades/blooms in as a unit. Nil under
+            // Reduce Motion → the highlight swaps instantly, exactly as the
+            // view behaved before #90.
+            .animation(style.animates ? .easeInOut(duration: 0.2) : nil, value: isActive)
             .accessibilityAddTraits(isActive ? .isSelected : [])
     }
 }

--- a/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
+++ b/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
@@ -169,20 +169,50 @@ struct MiniPlayerView: View {
     // MARK: - Artwork (drag region)
 
     /// Square album art on the leading edge. The album-art region doubles as a
-    /// drag target, so it hosts a `MiniPlayerDragHandle` overlay that performs
-    /// `NSWindow.performDrag` — the rest of the window is also draggable via the
-    /// configurator's `isMovableByWindowBackground`, but the artwork is the
+    /// drag target *and* a click-through to the album page, so it hosts a
+    /// `MiniPlayerDragHandle` overlay that performs `NSWindow.performDrag` once
+    /// the pointer moves past a small threshold but reports a *tap* (press +
+    /// release without that movement) back through `onTap`. The rest of the
+    /// window is also draggable via the configurator's
+    /// `isMovableByWindowBackground`, but the artwork is the
     /// guaranteed-draggable target even where controls sit.
+    ///
+    /// A bare click opens the album in the main window (raising it first); the
+    /// `onTap` only fires for tracks that actually carry an `albumId`, so a
+    /// track with no album home stays a pure drag handle and doesn't navigate
+    /// to a dead route.
     @ViewBuilder
     private func artwork(for track: Track) -> some View {
+        let albumId = track.albumId
         Artwork(
             url: model.imageURL(for: track.albumId ?? track.id, tag: track.imageTag, maxWidth: 192),
             seed: track.name,
             size: 96,
             radius: 8
         )
-        .overlay(MiniPlayerDragHandle())
-        .accessibilityLabel(Text("mini_player.accessibility.drag_artwork"))
+        .overlay(
+            MiniPlayerDragHandle(onTap: albumId.map { id in
+                { model.openInMainWindowFromMiniPlayer(.album(id)) }
+            })
+        )
+        // Promote to a button trait + open-album hint only when the artwork is
+        // actually a link; otherwise keep the plain drag-handle label so VO
+        // doesn't advertise a tap that goes nowhere. The tap itself is handled
+        // by the AppKit drag handle (pointer path), so we also register a
+        // SwiftUI `.accessibilityAction` to give VoiceOver users an actionable
+        // activation that matches the `.isButton` trait.
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(albumId == nil ? [] : .isButton)
+        .accessibilityLabel(Text(
+            albumId == nil
+                ? "mini_player.accessibility.drag_artwork"
+                : "mini_player.accessibility.open_album"
+        ))
+        .accessibilityAction {
+            if let albumId {
+                model.openInMainWindowFromMiniPlayer(.album(albumId))
+            }
+        }
     }
 
     // MARK: - Header (title + artist + settings menu)
@@ -196,11 +226,28 @@ struct MiniPlayerView: View {
                     .foregroundStyle(Theme.ink)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Text(track.artistName)
-                    .font(Theme.font(11, weight: .medium))
-                    .foregroundStyle(Theme.ink2)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                // Artist name is a click-through to the artist page (raising
+                // the main window first), matching the full Now Playing view's
+                // tappable artist line. A plain `Button` (not a drag target)
+                // here is safe: it sits in the text column, not over the
+                // window-drag artwork, so `isMovableByWindowBackground` still
+                // moves the window from any empty space around it. Disabled —
+                // and so styled like inert text — when the track carries no
+                // `artistId`, so the affordance never routes nowhere.
+                Button {
+                    if let artistId = track.artistId {
+                        model.openInMainWindowFromMiniPlayer(.artist(artistId))
+                    }
+                } label: {
+                    Text(track.artistName)
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink2)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .buttonStyle(.plain)
+                .disabled(track.artistId == nil)
+                .accessibilityHint(track.artistId == nil ? Text("") : Text("mini_player.accessibility.open_artist"))
             }
             Spacer(minLength: 0)
             // Favorite heart + settings menu only join the header while the
@@ -567,21 +614,91 @@ private struct MiniPlayerWindowConfigurator: NSViewRepresentable {
 
 // MARK: - Drag handle
 
-/// Transparent overlay whose mouse-down forwards to `NSWindow.performDrag`, so
-/// the album-art region (and the idle placeholder) drags the borderless window
-/// even though there's no title bar. `isMovableByWindowBackground` already
-/// makes empty areas draggable; this guarantees the artwork is a drag target
-/// regardless of what sits on top of it.
-private struct MiniPlayerDragHandle: NSViewRepresentable {
+/// Transparent overlay over the album-art region (and the idle placeholder)
+/// that disambiguates a **window drag** from a **tap**:
+///
+/// * Press-and-move past `Self.dragThreshold` points hands off to
+///   `NSWindow.performDrag`, so the artwork still drags the borderless window
+///   exactly as before (`isMovableByWindowBackground` only covers empty areas;
+///   this guarantees the artwork is a drag target regardless of what sits on
+///   top of it).
+/// * Press-and-release without crossing that threshold is reported as a tap
+///   through `onTap` — the click-through to the album page (#110).
+///
+/// A `nil` `onTap` (e.g. the idle placeholder, or a track with no album)
+/// degenerates to the original pure-drag behaviour: any press immediately
+/// starts a window drag, so nothing changes for the no-link case.
+///
+/// The press is tracked with a synchronous `nextEvent` loop rather than
+/// SwiftUI gestures because the underlying interaction is `performDrag`, an
+/// AppKit-only call that must run off the original `mouseDown` event; mixing a
+/// SwiftUI `DragGesture` with `performDrag` races the two event streams.
+struct MiniPlayerDragHandle: NSViewRepresentable {
+    /// Invoked on a tap (press + release within the drag threshold). `nil`
+    /// when the region is drag-only.
+    var onTap: (() -> Void)?
+
     func makeNSView(context: Context) -> NSView {
         DraggingView()
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? DraggingView)?.onTap = onTap
+    }
 
-    private final class DraggingView: NSView {
+    /// Pointer travel (in window points) past which a press is treated as a
+    /// window drag rather than a tap. Generous enough that a normal click's
+    /// incidental jitter still registers as a tap, tight enough that a
+    /// deliberate reposition isn't swallowed as a click.
+    static let dragThreshold: CGFloat = 4
+
+    final class DraggingView: NSView {
+        var onTap: (() -> Void)?
+
         override func mouseDown(with event: NSEvent) {
-            window?.performDrag(with: event)
+            // No tap handler → preserve the original behaviour exactly: every
+            // press is a window drag.
+            guard onTap != nil, let window else {
+                window?.performDrag(with: event)
+                return
+            }
+
+            let start = event.locationInWindow
+            var didDrag = false
+
+            // Track the press until release. On the first move past the
+            // threshold, promote to a window drag and stop tracking (the
+            // window takes over the event stream). If release arrives first,
+            // it was a tap.
+            trackingLoop: while let next = window.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+                switch next.type {
+                case .leftMouseDragged:
+                    if MiniPlayerView_dragExceedsThreshold(from: start, to: next.locationInWindow) {
+                        didDrag = true
+                        window.performDrag(with: next)
+                        break trackingLoop
+                    }
+                case .leftMouseUp:
+                    break trackingLoop
+                default:
+                    break
+                }
+            }
+
+            if !didDrag {
+                onTap?()
+            }
         }
     }
+}
+
+/// Whether the pointer has travelled past `MiniPlayerDragHandle.dragThreshold`
+/// from `start` to `current` (window-space points). Factored to a free
+/// function — rather than buried in `DraggingView.mouseDown` — so the
+/// tap-vs-drag boundary can be unit-tested without a live window-server event
+/// stream. See `MiniPlayerClickThroughTests`.
+func MiniPlayerView_dragExceedsThreshold(from start: CGPoint, to current: CGPoint) -> Bool {
+    let dx = current.x - start.x
+    let dy = current.y - start.y
+    return (dx * dx + dy * dy) > (MiniPlayerDragHandle.dragThreshold * MiniPlayerDragHandle.dragThreshold)
 }

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -300,6 +300,19 @@ struct PlayerBar: View {
             .frame(width: 100)
             .accessibilityLabel("Volume")
             .accessibilityValue("\(Int((Double(model.status.volume) * 100).rounded())) percent")
+
+            // System AirPlay / output-route picker (#326). Tapping presents the
+            // OS list of AirPlay receivers and output targets — the same popover
+            // Music.app shows. Scope is system audio routing only, not Jellyfin
+            // SyncPlay (separate issue); `AVRoutePickerView` drives the routing
+            // stack directly, so this needs no core FFI. Sized to the 28×28
+            // transport-icon footprint so it lines up with the glyphs on the
+            // far side of the bar.
+            AirPlayRoutePicker()
+                .frame(width: 28, height: 28)
+                .accessibilityLabel("AirPlay")
+                .accessibilityHint("Choose an audio output device")
+                .help("AirPlay")
         }
     }
 

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -67,6 +67,7 @@ struct Sidebar: View {
                 navItem("house", label: "sidebar.nav.home", screen: .home)
                 navItem("music.note.list", label: "sidebar.nav.library", screen: .library)
                 navItem("sparkles", label: "sidebar.nav.discover", screen: .discover)
+                navItem("dot.radiowaves.left.and.right", label: "sidebar.nav.radio", screen: .radio)
                 navItem("magnifyingglass", label: "sidebar.nav.search", screen: .search)
             }
             .padding(.horizontal, 10)

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -453,6 +453,16 @@ struct LyrebirdCommands: Commands {
             }
             .keyboardShortcut("?", modifiers: .command)
 
+            // Re-open the first-run feature tour (coach marks) on demand
+            // (#113). Disabled while signed out — the tour points at the main
+            // shell's affordances, which only exist once the user is in.
+            // `MainShell` observes `model.isFeatureTourPresented` and mounts
+            // the overlay.
+            Button("menu.help.show_tour") {
+                model.presentFeatureTour()
+            }
+            .disabled(model.session == nil)
+
             Divider()
 
             // Export Diagnostic Bundle… (#455). Writes a sanitized .zip of

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -589,6 +589,14 @@ struct RootView: View {
             }
         }
         .background(Theme.bg)
+        // Full-screen chrome handling (#20). Mounted as an invisible
+        // background bridge so it reaches the host `NSWindow` and auto-hides
+        // the unified toolbar + menu bar on enter / restores the
+        // hidden-title-bar layout on exit — neither of which has a `Scene`
+        // hook. All decision logic lives in the testable `FullScreenChrome`
+        // reducer; this only installs the AppKit observers. See
+        // `FullScreenChromeController`.
+        .background(FullScreenChromeObserver())
         // Login <-> main shell swap (and restore-loading <-> either) is
         // instant under Reduce Motion.
         .animation(reduceMotion ? nil : .default, value: model.session != nil)

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1381,6 +1381,30 @@
         }
       }
     },
+    "mini_player.accessibility.open_album" : {
+      "comment" : "VoiceOver label for the Mini Player album-art region when it links to the album page (a click opens the album in the main window). A drag still repositions the window.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album art. Tap to open the album; drag to move the Mini Player."
+          }
+        }
+      }
+    },
+    "mini_player.accessibility.open_artist" : {
+      "comment" : "VoiceOver hint for the Mini Player artist-name button, which opens the artist page in the main window.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open artist page"
+          }
+        }
+      }
+    },
     "mini_player.expand" : {
       "comment" : "Accessibility label for the expand button in the Mini Player hover overlay that returns to the full window.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -997,6 +997,18 @@
         }
       }
     },
+    "sidebar.nav.radio" : {
+      "comment" : "Sidebar primary nav item: Radio.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Radio"
+          }
+        }
+      }
+    },
     "sidebar.nav.library" : {
       "comment" : "Sidebar primary nav item: Library.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1801,6 +1801,198 @@
           }
         }
       }
+    },
+    "menu.help.show_tour" : {
+      "comment" : "Help menu entry that re-opens the first-run feature tour (coach marks).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Tour"
+          }
+        }
+      }
+    },
+    "tour.a11y.container" : {
+      "comment" : "Accessibility label for the feature-tour overlay container.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feature tour"
+          }
+        }
+      }
+    },
+    "tour.a11y.progress %lld %lld" : {
+      "comment" : "Accessibility label for the feature-tour progress dots; first number is the current step, second is the total.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Step %1$lld of %2$lld"
+          }
+        }
+      }
+    },
+    "tour.a11y.shortcut %@" : {
+      "comment" : "Accessibility label for a feature-tour card's keyboard-shortcut pill; %@ is the chord, e.g. ⌘F.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keyboard shortcut %@"
+          }
+        }
+      }
+    },
+    "tour.back" : {
+      "comment" : "Feature-tour button: go to the previous card.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        }
+      }
+    },
+    "tour.done" : {
+      "comment" : "Feature-tour button: close the tour on the final card.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "tour.mini_player.body" : {
+      "comment" : "Feature-tour card body: detachable mini player.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Press ⌘⌥P for a compact, always-on-top player you can tuck into a corner while you work."
+          }
+        }
+      }
+    },
+    "tour.mini_player.title" : {
+      "comment" : "Feature-tour card title: detachable mini player.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop out the mini player"
+          }
+        }
+      }
+    },
+    "tour.next" : {
+      "comment" : "Feature-tour button: advance to the next card.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        }
+      }
+    },
+    "tour.right_click.body" : {
+      "comment" : "Feature-tour card body: right-click context menus.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right-click any track, album, artist, or playlist for quick actions — play next, add to a playlist, start a radio station, and more."
+          }
+        }
+      }
+    },
+    "tour.right_click.title" : {
+      "comment" : "Feature-tour card title: right-click context menus.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right-click for more"
+          }
+        }
+      }
+    },
+    "tour.search.body" : {
+      "comment" : "Feature-tour card body: search shortcut.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Press ⌘F to jump straight to search and find any song, album, or artist in your library."
+          }
+        }
+      }
+    },
+    "tour.search.title" : {
+      "comment" : "Feature-tour card title: search shortcut.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find anything fast"
+          }
+        }
+      }
+    },
+    "tour.skip" : {
+      "comment" : "Feature-tour button: dismiss the tour without finishing.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip"
+          }
+        }
+      }
+    },
+    "tour.space.body" : {
+      "comment" : "Feature-tour card body: Space play/pause shortcut.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the Space bar anywhere outside a text field to play or pause the current track."
+          }
+        }
+      }
+    },
+    "tour.space.title" : {
+      "comment" : "Feature-tour card title: Space play/pause shortcut.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play and pause with Space"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -17,6 +17,11 @@ import SwiftUI
 ///   `detail` is empty — the liner-note section falls back to cached fields.
 struct AlbumDetailView: View {
     @Environment(AppModel.self) private var model
+    /// Honour the system "Reduce Motion" setting for the liner-notes drawer
+    /// slide (#221) — when set, the panel appears/disappears with an opacity
+    /// crossfade instead of a horizontal slide. Matches the shell's
+    /// queue-inspector and the artist-page hover treatments.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let albumID: String
 
     @State private var tracks: [Track] = []
@@ -28,6 +33,11 @@ struct AlbumDetailView: View {
     /// Whether the full editorial blurb popover is open (#68). Mirrors the
     /// artist About section's "Read more" affordance.
     @State private var isAboutExpanded = false
+    /// Whether the right-side liner-notes drawer is presented (#221). The
+    /// liner-note fields + credits also live inline at the bottom of the page
+    /// (#65); the drawer surfaces the same structured data without a scroll to
+    /// the foot of a long tracklist. Reset on album change in the `.task`.
+    @State private var isLinerNotesDrawerPresented = false
 
     /// Cache-first lookup against the paged `albums` list, then fall
     /// back to the record the `.task` block fetched. Missing after both
@@ -50,11 +60,18 @@ struct AlbumDetailView: View {
             }
         }
         .background(Theme.bg)
+        // Right-side liner-notes drawer (#221). Layered above the scroll view
+        // so it slides in over the page rather than reflowing it. Mounted only
+        // while presented so it costs nothing when closed.
+        .overlay(alignment: .trailing) { linerNotesDrawer }
         .task(id: albumID) {
             isLoading = true
             // Reset the editorial-blurb popover so a prior album's expanded
             // "About this album" never bleeds into this page (#68).
             isAboutExpanded = false
+            // Close any open liner-notes drawer so it doesn't carry a prior
+            // album's data into this page (#221).
+            isLinerNotesDrawerPresented = false
             if model.albums.first(where: { $0.id == albumID }) == nil {
                 fetchedAlbum = await model.resolveAlbum(id: albumID)
             }
@@ -191,6 +208,7 @@ struct AlbumDetailView: View {
             shuffleButton
             radioButton
             downloadButton
+            linerNotesButton
 
             Divider()
                 .frame(height: 22)
@@ -252,6 +270,21 @@ struct AlbumDetailView: View {
             }
             .accessibilityLabel("Download album")
         }
+    }
+
+    /// Opens the right-side liner-notes drawer (#221). Uses the same
+    /// secondary-CTA pill as Shuffle / Radio / Download so it reads as a peer
+    /// affordance and Tab focus walks it in row order. The toggle is wrapped
+    /// in a reduce-motion-aware animation so the panel slides (or crossfades)
+    /// in consistently with the close paths.
+    private var linerNotesButton: some View {
+        secondaryCTA(icon: "doc.text", label: "Liner Notes") {
+            withAnimation(LinerNotesDrawerPresentation.animation(reduceMotion: reduceMotion)) {
+                isLinerNotesDrawerPresented = true
+            }
+        }
+        .accessibilityLabel("Show liner notes")
+        .accessibilityHint("Opens a panel with release details and credits")
     }
 
     private var favouriteButton: some View {
@@ -505,34 +538,47 @@ struct AlbumDetailView: View {
                     .tracking(2)
                     .padding(.bottom, 12)
 
-                VStack(alignment: .leading, spacing: 10) {
-                    linerRow(label: "Released", value: releasedSummary(album: album))
-                    linerRow(label: "Label", value: detail.label ?? "—")
-                    linerRow(label: "Format", value: formatSummary(tracks: tracks))
-                    linerRow(label: "Runtime", value: runtimeSummary(album: album))
-                    linerRow(label: "Tracks", value: tracksSummary(album: album))
-                }
-                .textSelection(.enabled)
-
-                let creditRows = ExtendedCredit.rows(from: detail.people)
-                if !creditRows.isEmpty {
-                    Text("CREDITS")
-                        .font(Theme.font(10, weight: .bold))
-                        .foregroundStyle(Theme.ink3)
-                        .tracking(2)
-                        .padding(.top, 28)
-                        .padding(.bottom, 10)
-
-                    VStack(alignment: .leading, spacing: 14) {
-                        ForEach(creditRows, id: \.label) { row in
-                            creditRowView(row: row)
-                        }
-                    }
-                }
+                linerNotesContent(album: album)
             }
             .padding(.horizontal, 40)
             .padding(.top, 36)
             .padding(.bottom, 48)
+        }
+    }
+
+    /// The structured liner-note body — the field rows plus the optional
+    /// Credits subsection — without the section header or page padding. Shared
+    /// verbatim between the inline bottom-of-page block (#65) and the slide-in
+    /// drawer (#221) so the two surfaces can never drift in what they show.
+    /// Reads only the already-loaded `detail` / `tracks`, so it's free to
+    /// render in both places at once.
+    @ViewBuilder
+    private func linerNotesContent(album: Album) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 10) {
+                linerRow(label: "Released", value: releasedSummary(album: album))
+                linerRow(label: "Label", value: detail.label ?? "—")
+                linerRow(label: "Format", value: formatSummary(tracks: tracks))
+                linerRow(label: "Runtime", value: runtimeSummary(album: album))
+                linerRow(label: "Tracks", value: tracksSummary(album: album))
+            }
+            .textSelection(.enabled)
+
+            let creditRows = ExtendedCredit.rows(from: detail.people)
+            if !creditRows.isEmpty {
+                Text("CREDITS")
+                    .font(Theme.font(10, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(2)
+                    .padding(.top, 28)
+                    .padding(.bottom, 10)
+
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(creditRows, id: \.label) { row in
+                        creditRowView(row: row)
+                    }
+                }
+            }
         }
     }
 
@@ -566,6 +612,113 @@ struct AlbumDetailView: View {
                     }
                 }
             }
+        }
+    }
+
+    // MARK: - Liner notes drawer (#221)
+
+    /// Right-side slide-in drawer surfacing the same structured liner-note
+    /// fields + credits as the inline block (#65), reachable from the hero
+    /// without scrolling past a long tracklist. Closes on Escape, a tap on the
+    /// dimmed scrim, or the panel's close button. Honours Reduce Motion: the
+    /// panel crossfades instead of sliding when the setting is on.
+    ///
+    /// Mounted only while presented (`if`-gated) so it adds no cost to a
+    /// closed page, and renders nothing when the album hasn't resolved yet so
+    /// the panel never shows an empty shell.
+    @ViewBuilder
+    private var linerNotesDrawer: some View {
+        if isLinerNotesDrawerPresented, let album = album {
+            ZStack(alignment: .trailing) {
+                // Dimmed tap-out scrim. `contentShape` + a plain Button keeps
+                // the whole backdrop a single dismiss target without stealing
+                // VoiceOver focus from the panel (it's hidden from the
+                // accessibility tree — the panel's close button is the
+                // assistive-tech dismiss path).
+                Color.black.opacity(0.32)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { dismissLinerNotesDrawer() }
+                    .accessibilityHidden(true)
+                    .transition(.opacity)
+
+                linerNotesPanel(album: album)
+                    .transition(LinerNotesDrawerPresentation.transition(reduceMotion: reduceMotion))
+            }
+            // An invisible cancel-action button gives the drawer an Escape
+            // handler without a focusable on-screen control — the same idiom
+            // the command palette uses to close on Escape.
+            .background {
+                Button("", action: dismissLinerNotesDrawer)
+                    .keyboardShortcut(.cancelAction)
+                    .opacity(0)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    /// The drawer's opaque panel: a fixed-width column pinned to the trailing
+    /// edge with a header (title + close) over a scrollable liner-note body.
+    @ViewBuilder
+    private func linerNotesPanel(album: Album) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("LINER NOTES")
+                        .font(Theme.font(10, weight: .bold))
+                        .foregroundStyle(Theme.ink3)
+                        .tracking(2)
+                    Text(album.name)
+                        .font(Theme.font(16, weight: .heavy))
+                        .foregroundStyle(Theme.ink)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 16)
+                Button(action: dismissLinerNotesDrawer) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .frame(width: 24, height: 24)
+                        .background(Circle().fill(Theme.surface))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close liner notes")
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(Theme.border).frame(height: 1)
+            }
+
+            ScrollView {
+                linerNotesContent(album: album)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 24)
+            }
+        }
+        .frame(width: 360)
+        .frame(maxHeight: .infinity)
+        .background(Theme.bgAlt)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Theme.border).frame(width: 1)
+        }
+        .shadow(color: Color.black.opacity(0.28), radius: 18, x: -8, y: 0)
+        // Group the panel as one container so VoiceOver treats it as a
+        // self-contained dialog rather than letting focus wander onto the
+        // dimmed page behind it.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Liner notes for \(album.name)")
+        .accessibilityAddTraits(.isModal)
+    }
+
+    /// Single dismiss path for every close affordance (Escape / scrim tap /
+    /// close button) so the slide-out animation stays consistent and honours
+    /// Reduce Motion regardless of how the user closed the panel.
+    private func dismissLinerNotesDrawer() {
+        withAnimation(LinerNotesDrawerPresentation.animation(reduceMotion: reduceMotion)) {
+            isLinerNotesDrawerPresented = false
         }
     }
 
@@ -686,6 +839,39 @@ struct AlbumDetailView: View {
             }
         }
         return ordered.joined(separator: " · ")
+    }
+}
+
+// MARK: - Liner-notes drawer presentation (#221)
+
+/// Pure presentation policy for the album liner-notes drawer. SwiftUI exposes
+/// no way to introspect a `transition` / `animation` off a `some View` without
+/// booting a scene, so — mirroring the `SidebarAutoHide` reducer — the two
+/// motion decisions that depend on the system "Reduce Motion" setting are
+/// hoisted into static functions here where they can be unit-tested directly:
+///
+/// - `transition(reduceMotion:)` — the panel slides in from the trailing edge
+///   normally, and crossfades (`.opacity`) when Reduce Motion is on so no
+///   horizontal travel occurs.
+/// - `animation(reduceMotion:)` — the `withAnimation` curve driving every
+///   open/close path; `nil` under Reduce Motion so the state flips instantly.
+///
+/// Keeping both in one type guarantees the open button, the Escape handler,
+/// the scrim tap, and the close button all animate identically.
+enum LinerNotesDrawerPresentation {
+    /// Trailing-edge slide normally; opacity-only crossfade under Reduce
+    /// Motion. The combined `.move + .opacity` keeps the slide from popping a
+    /// hard rectangle in at full alpha.
+    static func transition(reduceMotion: Bool) -> AnyTransition {
+        reduceMotion
+            ? .opacity
+            : .move(edge: .trailing).combined(with: .opacity)
+    }
+
+    /// The curve for the present/dismiss `withAnimation`. `nil` disables the
+    /// animation entirely so Reduce Motion users get an instant state change.
+    static func animation(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : .easeInOut(duration: 0.22)
     }
 }
 

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -114,27 +114,43 @@ struct LibraryView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    header
-                    chipRow
-                    if model.isLoadingLibrary && model.albums.isEmpty {
-                        ProgressView()
-                            .tint(Theme.ink2)
-                            .padding(.top, 40)
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        content
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        header
+                        chipRow
+                        if model.isLoadingLibrary && model.albums.isEmpty {
+                            ProgressView()
+                                .tint(Theme.ink2)
+                                .padding(.top, 40)
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            content
+                        }
+                        Spacer(minLength: 24)
                     }
-                    Spacer(minLength: 24)
+                    .padding(.horizontal, 32)
+                    .padding(.top, 28)
+                    // Leave room for the floating selection banner so the last
+                    // rows aren't occluded while a selection is active.
+                    .padding(.bottom, selectedTracks.isEmpty ? 32 : 88)
                 }
-                .padding(.horizontal, 32)
-                .padding(.top, 28)
-                // Leave room for the floating selection banner so the last
-                // rows aren't occluded while a selection is active.
-                .padding(.bottom, selectedTracks.isEmpty ? 32 : 88)
+                .background(backgroundWash)
+                // A–Z fast-scroll rail (#216). Only shown for large, A–Z-sorted
+                // lists where alphabetical position is meaningful; see
+                // `showAlphabetRail`. Centred on the trailing edge; a tap or
+                // drag scrolls to the first row in the chosen letter's bucket.
+                .overlay(alignment: .trailing) {
+                    if showAlphabetRail {
+                        AlphabetScrollRail(
+                            presentBuckets: alphabetPresentBuckets,
+                            onSelect: { letter in scrollToLetter(letter, using: proxy) }
+                        )
+                        .padding(.trailing, 6)
+                        .transition(.opacity)
+                    }
+                }
             }
-            .background(backgroundWash)
 
             if !selectedTracks.isEmpty {
                 TrackSelectionBanner(
@@ -202,6 +218,66 @@ struct LibraryView: View {
         .onChange(of: defaultSongSort) { _, _ in
             reapplyDefaultSort(for: .tracks)
         }
+    }
+
+    // MARK: - A–Z fast scroll (#216)
+
+    /// Threshold above which the alphabet rail is worth showing. Below a couple
+    /// hundred rows a flick scroll is faster than aiming at a letter, and the
+    /// rail would just clutter the trailing edge.
+    private let alphabetRailMinItems = 200
+
+    /// The `name` of every row in the active tab, in the exact order it's
+    /// displayed. Reuses the same `sorted*` arrays the grid/list render so the
+    /// rail's letter → index mapping can't drift from what's on screen.
+    /// Downloaded has no backing list yet, so it contributes nothing.
+    private var displayedSortNames: [String] {
+        switch selectedTab {
+        case .albums: return sortedAlbums.map(\.name)
+        case .artists: return sortedArtists.map(\.name)
+        case .tracks: return sortedTracks.map(\.name)
+        case .playlists: return sortedPlaylists.map(\.name)
+        case .downloaded: return []
+        }
+    }
+
+    /// The `id` of every row in the active tab, in display order. Paired
+    /// positionally with `displayedSortNames` so a resolved bucket index maps
+    /// straight to a `scrollTo` target — `ForEach(_, id: \.element.id)` registers
+    /// these ids as scroll anchors.
+    private var displayedItemIds: [String] {
+        switch selectedTab {
+        case .albums: return sortedAlbums.map(\.id)
+        case .artists: return sortedArtists.map(\.id)
+        case .tracks: return sortedTracks.map(\.id)
+        case .playlists: return sortedPlaylists.map(\.id)
+        case .downloaded: return []
+        }
+    }
+
+    /// Whether to show the rail for the current tab + sort. Gated on a large
+    /// row count (`alphabetRailMinItems`) **and** an A–Z name sort — under any
+    /// other sort the displayed order doesn't track the alphabet, so a letter
+    /// wouldn't correspond to a position. (`AlphabetScrollIndex.firstIndex`
+    /// assumes an ascending sort.)
+    private var showAlphabetRail: Bool {
+        sortOrder == .nameAscending && displayedSortNames.count > alphabetRailMinItems
+    }
+
+    /// Buckets present in the displayed list, for the rail's emphasis/dimming.
+    private var alphabetPresentBuckets: Set<Character> {
+        AlphabetScrollIndex.presentBuckets(in: displayedSortNames)
+    }
+
+    /// Resolve a tapped/dragged rail letter to the first row in its bucket and
+    /// scroll there. No-op when nothing sits at or after the letter (the helper
+    /// returns `nil`). Snaps the target row to the top of the viewport.
+    private func scrollToLetter(_ letter: Character, using proxy: ScrollViewProxy) {
+        guard
+            let index = AlphabetScrollIndex.firstIndex(for: letter, in: displayedSortNames),
+            displayedItemIds.indices.contains(index)
+        else { return }
+        proxy.scrollTo(displayedItemIds[index], anchor: .top)
     }
 
     /// The selected tracks resolved against the currently-sorted list, in

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -377,6 +377,8 @@ struct MainShell: View {
             HomeView()
         case .discover:
             DiscoverView()
+        case .radio:
+            RadioView()
         case .library:
             LibraryView()
         case .favorites:
@@ -447,6 +449,8 @@ struct MainShell: View {
             FavoritesView()
         case .discover:
             DiscoverView()
+        case .radio:
+            RadioView()
         case .search:
             SearchView()
         case .settings:
@@ -486,6 +490,7 @@ struct MainShell: View {
         switch model.screen {
         case .home: segments.append("Home")
         case .discover: segments.append("Discover")
+        case .radio: segments.append("Radio")
         case .library: segments.append("Library")
         case .favorites: segments.append("Favorites")
         case .search: segments.append("Search")
@@ -531,7 +536,7 @@ struct MainShell: View {
             segments.append("Now Playing")
         case .fullQueue?:
             segments.append("Play Queue")
-        case .home?, .discover?, .library?, .favorites?, .search?, .settings?, nil:
+        case .home?, .discover?, .radio?, .library?, .favorites?, .search?, .settings?, nil:
             break
         }
         return segments

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -51,6 +51,14 @@ struct MainShell: View {
     /// `AppearanceSidebar` enum into real behaviour (#10).
     @AppStorage(AppearanceKeys.sidebar) private var sidebarPreferenceRaw: String = AppearanceSidebar.visible.rawValue
 
+    /// First-run feature-tour flag (#113). `false` until the coach-mark tour
+    /// has been shown once; flipped `true` when it closes (either path). The
+    /// key is owned by `FeatureTourSeenStore`, so this `@AppStorage` and the
+    /// store read/write the same on-disk bool. Distinct from
+    /// `hasCompletedOnboarding`: that gates the *connect* flow, this gates the
+    /// post-connect *teaching* overlay.
+    @AppStorage(FeatureTourSeenStore.seenKey) private var hasSeenFeatureTour: Bool = false
+
     var body: some View {
         @Bindable var model = model
         VStack(spacing: 0) {
@@ -253,6 +261,25 @@ struct MainShell: View {
                 .opacity(0)
                 .accessibilityHidden(true)
         )
+        // First-run feature tour (coach marks) — see #113. Auto-appears once
+        // on the first launch after connect (`!hasSeenFeatureTour`) and can be
+        // replayed any time via Help ▸ "Show Tour"
+        // (`model.isFeatureTourPresented`). `MainShell` only renders for a live
+        // session, so the tour can never collide with the connect onboarding.
+        // The overlay persists the seen flag itself on close; we clear the
+        // explicit re-open flag here so a second Help invocation re-triggers.
+        .overlay {
+            if shouldShowFeatureTour {
+                FeatureTourOverlay(onClose: {
+                    model.isFeatureTourPresented = false
+                })
+                .transition(.opacity)
+            }
+        }
+        .animation(
+            reduceMotion ? nil : .easeOut(duration: 0.12),
+            value: shouldShowFeatureTour
+        )
         // Auth-expired prompt — see #303. One-shot modal; on "Sign in" we
         // drop the stored token and clear the session so `RootView` routes
         // back to `LoginView`, which prefills the remembered server URL and
@@ -306,6 +333,15 @@ struct MainShell: View {
             Text(verbatim: "\u{201C}\(playlist.name)\u{201D}\n")
                 + Text("playlist.delete.message")
         }
+    }
+
+    /// Whether the feature-tour overlay should be on screen right now (#113).
+    /// True on the very first launch after connect (the persisted seen flag is
+    /// still `false`) or whenever the user explicitly re-opens it from
+    /// Help ▸ "Show Tour". Either path renders the same `FeatureTourOverlay`,
+    /// which records the seen flag when it closes.
+    private var shouldShowFeatureTour: Bool {
+        !hasSeenFeatureTour || model.isFeatureTourPresented
     }
 
     /// Toolbar `Toggle Sidebar` handler (#318). Flips `columnVisibility` and

--- a/macos/Sources/Lyrebird/Screens/RadioView.swift
+++ b/macos/Sources/Lyrebird/Screens/RadioView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Radio / Mixes — the dedicated "press play and keep going" surface (#93).
+///
+/// This screen does not introduce any new radio mechanic; it *aggregates* the
+/// radio surfaces that already live scattered across Home and Discover into one
+/// destination reachable from the sidebar:
+///
+/// - **Instant Mix** + **Song Radio** CTAs in the header — the same actions the
+///   Discover header drives (`startInstantMix` / `regenerateInstantMix` /
+///   `presentInstantMixPicker` / `startDiscoverSongRadio`).
+/// - **Artist Radio** — the circular `ArtistRadioTile` row from Home, seeded by
+///   the same `radioArtists` fallback (library artists until the
+///   favorites/top-listened signals in #133/#229 land).
+/// - **Genre / Decade / Mood radio** — the shared `RadioStationRows` component
+///   (#256), reused verbatim so the stations read identically here and on
+///   Discover.
+///
+/// All of the heavy lifting (the `.task`-driven genre/mood probes, the
+/// per-tile artwork resolution, the Instant Mix FFI dispatch) already lives in
+/// the reused components and `AppModel`, so this screen stays a thin composition
+/// layer with no synchronous FFI on the render path.
+struct RadioView: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                header
+                artistRadioSection
+                RadioStationRows()
+                Spacer(minLength: 24)
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 28)
+            .padding(.bottom, 32)
+        }
+        .background(backgroundWash)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("RADIO")
+                    .font(Theme.font(12, weight: .bold))
+                    .foregroundStyle(Theme.ink2)
+                    .tracking(2)
+                Text("sidebar.nav.radio")
+                    .font(Theme.font(34, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+                Text("Endless stations and mixes from your library — pick one and keep going.")
+                    .font(Theme.font(14, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+            }
+            Spacer()
+            HStack(spacing: 10) {
+                songRadioButton
+
+                Button {
+                    model.startInstantMix()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 14, weight: .bold))
+                        Text("Start Instant Mix")
+                            .font(Theme.font(13, weight: .bold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .background(
+                        Capsule().fill(Theme.accent)
+                    )
+                    .shadow(color: Theme.accent.opacity(0.35), radius: 12, y: 6)
+                }
+                .buttonStyle(.plain)
+                .help("Start an Instant Mix from your library")
+
+                Button {
+                    model.presentInstantMixPicker()
+                } label: {
+                    Text("Pick a seed…")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(
+                            Capsule()
+                                .stroke(Theme.borderStrong, lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Choose a song, album, artist, or genre to seed a mix")
+            }
+        }
+    }
+
+    /// "Song Radio" CTA — the Radio-screen twin of Discover's button and
+    /// `TrackContextMenu`'s "Start Song Radio". Kept always-enabled so the
+    /// surface never presents a dead button: with no current track it seeds
+    /// from `startInstantMix`'s own library fallback instead.
+    private var songRadioButton: some View {
+        let current = model.status.currentTrack
+        return Button {
+            model.startDiscoverSongRadio()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .font(.system(size: 14, weight: .bold))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Song Radio")
+                        .font(Theme.font(13, weight: .bold))
+                    if let current {
+                        Text(current.name)
+                            .font(Theme.font(10, weight: .medium))
+                            .foregroundStyle(Theme.ink2)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .foregroundStyle(Theme.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                Capsule()
+                    .stroke(Theme.borderStrong, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(
+            current.map { "Start a radio station based on \($0.name)" }
+                ?? "Start a radio station from your library"
+        )
+        .accessibilityLabel(
+            current.map { "Song Radio, based on \($0.name)" } ?? "Song Radio"
+        )
+        .accessibilityHint("Starts a radio station seeded by the current song")
+    }
+
+    // MARK: - Artist Radio
+
+    /// Circular "<Artist> Radio" tiles, lifted from Home (#254). Hidden when
+    /// there are no artists to seed from so a brand-new library never shows a
+    /// blank band.
+    @ViewBuilder
+    private var artistRadioSection: some View {
+        let artists = radioArtists
+        if !artists.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "dot.radiowaves.left.and.right")
+                        .foregroundStyle(Theme.accent)
+                        .font(.system(size: 14, weight: .bold))
+                    Text("Artist Radio")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("Tap to start a radio station")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                // Eager `HStack` (not `LazyHStack`) per the rc9 macOS 26.4
+                // `LazyHStack` UAF noted in CLAUDE.md — `ArtistRadioTile` does
+                // the same on Home.
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: 18) {
+                        ForEach(artists, id: \.id) { artist in
+                            ArtistRadioTile(artist: artist)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Artist Radio")
+        }
+    }
+
+    /// Artists to surface as radio seeds. Mirrors Home's `radioArtists`: the
+    /// favorites (#133) and top-listened (#229) signals aren't wired in the
+    /// core yet, so this falls through to the library's first few artists.
+    /// Capped at 20 so the horizontal row doesn't grow unbounded once the
+    /// richer signals are available.
+    private var radioArtists: [Artist] {
+        Array(model.artists.prefix(20))
+    }
+
+    private var backgroundWash: some View {
+        LinearGradient(
+            colors: [Theme.accent.opacity(0.15), .clear],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .blur(radius: 80)
+        .frame(height: 400)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Theme.bg)
+    }
+}

--- a/macos/Sources/Lyrebird/System/FullScreenChromeController.swift
+++ b/macos/Sources/Lyrebird/System/FullScreenChromeController.swift
@@ -1,0 +1,190 @@
+import AppKit
+import SwiftUI
+
+/// Full-screen chrome handling for the main window (#20).
+///
+/// The main `WindowGroup` runs with `.windowStyle(.hiddenTitleBar)` +
+/// `.windowToolbarStyle(.unifiedCompact)`, which flips
+/// `titlebarAppearsTransparent` on and adds `.fullSizeContentView` so the
+/// sidebar/content flow edge-to-edge under the traffic lights (see
+/// `LyrebirdApp`). That layout is right in a windowed frame, but on the
+/// full-screen transition it leaves two rough edges:
+///
+///   1. The unified toolbar + menu bar stay pinned at the top of the
+///      full-screen space, eating vertical room the content should own.
+///   2. The transparent title bar keeps a `fullSizeContentView` inset, so the
+///      content sits a hair below where the now-absent traffic lights were
+///      rather than filling the space cleanly.
+///
+/// macOS gives no `Scene` hook for either, so — exactly like
+/// `MiniPlayerWindowConfigurator` reaches the host `NSWindow` for the mini
+/// player's borderless chrome — we bridge through an invisible
+/// `NSViewRepresentable` (`FullScreenChromeObserver`) mounted at the root.
+/// It watches `NSWindow.willEnterFullScreenNotification` /
+/// `willExitFullScreenNotification` for *its own* host window and applies the
+/// chrome the pure `FullScreenChrome` reducer decides for each phase:
+///
+///   * **Enter**: request `[.autoHideToolbar, .autoHideMenuBar]` so the
+///     unified toolbar and menu bar slide away and reveal on a top-edge
+///     hover (the standard full-screen reveal), and drop the transparent
+///     title bar so the content fills the full-screen surface without the
+///     windowed inset.
+///   * **Exit**: clear the presentation options back to `.default` and
+///     restore `titlebarAppearsTransparent` so the windowed
+///     hidden-title-bar layout returns intact.
+///
+/// All of the decision logic lives in `FullScreenChrome` so the chrome state
+/// machine is unit-testable headlessly — realizing a live full-screen
+/// `NSWindow` needs a window-server connection a CI run doesn't have.
+enum FullScreenChrome {
+    /// Which chrome phase the host window is in. Driven by the full-screen
+    /// enter/exit notifications; `.windowed` is the resting state.
+    enum Phase: Equatable {
+        case windowed
+        case fullScreen
+    }
+
+    /// The concrete chrome to apply for a phase. Split out of the AppKit
+    /// side-effects so the mapping is a pure function and can be asserted
+    /// without a window server.
+    struct Decision: Equatable {
+        /// Application presentation options to install. In full-screen this
+        /// auto-hides the toolbar + menu bar (they reveal on a top-edge
+        /// hover); windowed it's `.default` (empty) so the normal menu bar
+        /// and toolbar stay put.
+        var presentationOptions: NSApplication.PresentationOptions
+
+        /// Whether the host window's title bar should be transparent. The
+        /// hidden-title-bar windowed layout wants this `true` so content flows
+        /// under the traffic lights; full-screen wants it `false` so the
+        /// `fullSizeContentView` inset collapses and the content fills cleanly.
+        var titlebarAppearsTransparent: Bool
+    }
+
+    /// Pure reducer: map a chrome `phase` to the `Decision` the observer
+    /// applies to `NSApp` + the host `NSWindow`.
+    ///
+    /// Contract:
+    ///   * `.fullScreen` -> auto-hide toolbar + menu bar, opaque title bar.
+    ///   * `.windowed`   -> no presentation overrides, transparent title bar
+    ///     (the `.hiddenTitleBar` resting look).
+    ///
+    /// Side-effect-free and allocation-free beyond the returned value; the
+    /// observer owns all AppKit mutation and feeds the phase in.
+    static func decide(phase: Phase) -> Decision {
+        switch phase {
+        case .fullScreen:
+            return Decision(
+                presentationOptions: [.autoHideToolbar, .autoHideMenuBar],
+                titlebarAppearsTransparent: false
+            )
+        case .windowed:
+            return Decision(
+                presentationOptions: [],
+                titlebarAppearsTransparent: true
+            )
+        }
+    }
+}
+
+/// Invisible `NSViewRepresentable` that observes the host window's full-screen
+/// transitions and applies `FullScreenChrome`'s decision. Mounted as a
+/// `.background` in `RootView` so it contributes no visual element of its own —
+/// the same one-shot AppKit-bridge shape `MiniPlayerWindowConfigurator` uses.
+///
+/// Observation is scoped to the *specific* host window (the notification's
+/// `object`), not all windows, so the detached mini player / preferences /
+/// shortcuts windows entering full-screen never drive the main window's chrome.
+struct FullScreenChromeObserver: NSViewRepresentable {
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        // The view isn't attached to a window yet during `makeNSView`
+        // (`view.window` is nil until SwiftUI mounts it), so resolve the host
+        // window on the next runloop tick — the same deferral
+        // `MiniPlayerWindowConfigurator` relies on.
+        DispatchQueue.main.async { [weak view] in
+            guard let window = view?.window else { return }
+            context.coordinator.attach(to: window)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // If SwiftUI moves the view to a different window (rare, but possible
+        // across scene rebuilds), re-target the observers at the new host.
+        guard let window = nsView.window else { return }
+        context.coordinator.attach(to: window)
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    /// Owns the notification observers + the host-window weak reference, and
+    /// performs the AppKit mutation the reducer decides. A class (not the
+    /// struct `NSViewRepresentable`) so the observers have a stable lifetime
+    /// across SwiftUI re-evaluations.
+    final class Coordinator {
+        private weak var window: NSWindow?
+        private var enterObserver: NSObjectProtocol?
+        private var exitObserver: NSObjectProtocol?
+
+        /// Begin observing full-screen transitions for `window`. Idempotent:
+        /// re-attaching to the same window is a no-op; attaching to a new one
+        /// tears down the old observers first.
+        func attach(to window: NSWindow) {
+            guard self.window !== window else { return }
+            detach()
+            self.window = window
+
+            let center = NotificationCenter.default
+            enterObserver = center.addObserver(
+                forName: NSWindow.willEnterFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.apply(phase: .fullScreen)
+            }
+            exitObserver = center.addObserver(
+                forName: NSWindow.willExitFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.apply(phase: .windowed)
+            }
+        }
+
+        /// Stop observing and clear any presentation overrides this observer
+        /// installed, so a windowed teardown never leaves the menu bar hidden.
+        func detach() {
+            if let observer = enterObserver {
+                NotificationCenter.default.removeObserver(observer)
+                enterObserver = nil
+            }
+            if let observer = exitObserver {
+                NotificationCenter.default.removeObserver(observer)
+                exitObserver = nil
+            }
+            // Defensive: if we're torn down mid-full-screen, restore default
+            // presentation so the app never gets stuck with a hidden menu bar.
+            if NSApp.presentationOptions != [] {
+                NSApp.presentationOptions = []
+            }
+            window = nil
+        }
+
+        /// Apply the reducer's decision for `phase` to `NSApp` + the host
+        /// window. `NSApp.presentationOptions` only accepts auto-hide options
+        /// while a full-screen window exists and must be cleared on exit, so
+        /// the empty windowed set is exactly what AppKit wants back.
+        private func apply(phase: FullScreenChrome.Phase) {
+            let decision = FullScreenChrome.decide(phase: phase)
+            NSApp.presentationOptions = decision.presentationOptions
+            window?.titlebarAppearsTransparent = decision.titlebarAppearsTransparent
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/System/WindowStateStore.swift
+++ b/macos/Sources/Lyrebird/System/WindowStateStore.swift
@@ -36,6 +36,7 @@ extension AppModel.Screen {
         switch self {
         case .home: return "home"
         case .discover: return "discover"
+        case .radio: return "radio"
         case .library: return "library"
         case .favorites: return "favorites"
         case .search: return "search"
@@ -49,6 +50,7 @@ extension AppModel.Screen {
         switch raw {
         case "home": self = .home
         case "discover": self = .discover
+        case "radio": self = .radio
         case "library": self = .library
         case "favorites": self = .favorites
         case "search": self = .search

--- a/macos/Tests/LyrebirdTests/AirPlayRoutePickerTests.swift
+++ b/macos/Tests/LyrebirdTests/AirPlayRoutePickerTests.swift
@@ -1,0 +1,130 @@
+import AVKit
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the `AirPlayRoutePicker` representable (#326): the resting-vs-
+/// active button-color policy and the borderless transport styling.
+///
+/// The color decision is exercised through the pure `ButtonColorPlan` value so
+/// the mapping is verified without realizing a live `AVRoutePickerView`, which
+/// needs a window-server connection a headless test run doesn't have. A single
+/// lightweight smoke test then confirms the representable's `makeNSView`
+/// actually vends an `AVRoutePickerView` so the AVKit wrapper can't silently
+/// rot — mirroring the static-helper approach in `MenuBarNowPlayingTests`.
+final class AirPlayRoutePickerTests: XCTestCase {
+
+    // MARK: - Button color policy
+
+    func testRestingStatesUseRestingTint() {
+        let plan = AirPlayRoutePicker.ButtonColorPlan(
+            restingTint: .green,
+            activeTint: .red
+        )
+        XCTAssertEqual(
+            plan.color(for: .normal), .green,
+            "at rest (no route / local output) the glyph uses the resting tint"
+        )
+        XCTAssertEqual(
+            plan.color(for: .normalHighlighted), .green,
+            "hovering the resting button keeps the resting tint"
+        )
+    }
+
+    func testActiveStatesUseActiveTint() {
+        let plan = AirPlayRoutePicker.ButtonColorPlan(
+            restingTint: .green,
+            activeTint: .red
+        )
+        XCTAssertEqual(
+            plan.color(for: .active), .red,
+            "with a route engaged the glyph lifts to the active tint"
+        )
+        XCTAssertEqual(
+            plan.color(for: .activeHighlighted), .red,
+            "hovering the active button keeps the active tint"
+        )
+    }
+
+    func testPlanIsBorderlessByDefault() {
+        let plan = AirPlayRoutePicker.ButtonColorPlan(
+            restingTint: Theme.ink2,
+            activeTint: Theme.ink
+        )
+        XCTAssertFalse(
+            plan.bordered,
+            "the picker reads as a bare transport control, not a bezeled button"
+        )
+    }
+
+    // MARK: - Button-state enumeration
+
+    func testButtonStatesAreExhaustive() {
+        // All four AVRoutePickerView states must be covered so no state falls
+        // through to AppKit's default (system blue) styling.
+        XCTAssertEqual(
+            AirPlayRoutePicker.ButtonState.allCases.count, 4,
+            "the picker styles every AVRoutePickerView.ButtonState"
+        )
+    }
+
+    func testButtonStateMapsToMatchingAVState() {
+        XCTAssertEqual(AirPlayRoutePicker.ButtonState.normal.avState, .normal)
+        XCTAssertEqual(AirPlayRoutePicker.ButtonState.normalHighlighted.avState, .normalHighlighted)
+        XCTAssertEqual(AirPlayRoutePicker.ButtonState.active.avState, .active)
+        XCTAssertEqual(AirPlayRoutePicker.ButtonState.activeHighlighted.avState, .activeHighlighted)
+    }
+
+    // MARK: - Representable smoke test
+
+    /// Drive the AVKit wrapper end to end: build a live `AVRoutePickerView`,
+    /// apply the picker's plan via the same entry point `makeNSView` /
+    /// `updateNSView` use, and assert the styling lands. Realizing the view
+    /// directly (rather than through `makeNSView(context:)`) avoids fabricating
+    /// a `NSViewRepresentableContext`, which has no public initializer, while
+    /// still exercising the real AVKit type and its `setRoutePickerButtonColor`
+    /// surface so the wrapper can't silently rot against an SDK change.
+    @MainActor
+    func testApplyStylesRealRoutePickerView() {
+        let view = AVRoutePickerView()
+        // Start bordered so we can prove `apply` flips it off.
+        view.isRoutePickerButtonBordered = true
+
+        let plan = AirPlayRoutePicker().colorPlan
+        AirPlayRoutePicker.apply(plan, to: view)
+
+        XCTAssertFalse(
+            view.isRoutePickerButtonBordered,
+            "applying the plan leaves the realized picker borderless"
+        )
+
+        // The default picker tints rest with Theme.ink2 (a purple) and lift to
+        // Theme.ink (white) when a route is engaged. Compare resolved sRGB
+        // components rather than NSColor identity — both tokens are dynamic
+        // `NSColor(name:)` providers whose `==` is unreliable, and AVKit may
+        // normalize the color it stores. What must hold deterministically is
+        // that the two states resolve to *different* colors, so the active
+        // state is visibly distinct from rest.
+        let resting = view.routePickerButtonColor(for: .normal).usingColorSpace(.sRGB)
+        let active = view.routePickerButtonColor(for: .active).usingColorSpace(.sRGB)
+        XCTAssertNotNil(resting, "resting tint resolves to an sRGB color")
+        XCTAssertNotNil(active, "active tint resolves to an sRGB color")
+        if let resting, let active {
+            XCTAssertFalse(
+                Self.sRGBEqual(resting, active),
+                "active route tint must read distinctly from the resting tint"
+            )
+        }
+    }
+
+    /// Component-wise sRGB equality within a small tolerance — robust against
+    /// the float round-tripping AVKit / NSColor do when storing a button color.
+    private static func sRGBEqual(_ a: NSColor, _ b: NSColor) -> Bool {
+        let tol: CGFloat = 0.01
+        return abs(a.redComponent - b.redComponent) < tol
+            && abs(a.greenComponent - b.greenComponent) < tol
+            && abs(a.blueComponent - b.blueComponent) < tol
+            && abs(a.alphaComponent - b.alphaComponent) < tol
+    }
+}

--- a/macos/Tests/LyrebirdTests/AlphabetScrollIndexTests.swift
+++ b/macos/Tests/LyrebirdTests/AlphabetScrollIndexTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Pure-logic coverage for the Library A–Z fast-scroll rail (#216). Locks down
+/// `AlphabetScrollIndex` — the name → bucket bucketing and the tapped-letter →
+/// first-row mapping that `LibraryView.scrollToLetter` turns into a
+/// `ScrollViewProxy.scrollTo`. Deliberately `AppModel`-free and View-free,
+/// mirroring `TrackSelectionResolverTests` / `LibraryFilterTests`.
+final class AlphabetScrollIndexTests: XCTestCase {
+
+    // MARK: - Rail letters
+
+    func testLettersAreHashThenAToZ() {
+        let letters = AlphabetScrollIndex.letters
+        XCTAssertEqual(letters.count, 27, "Expected '#' + 26 letters")
+        XCTAssertEqual(letters.first, "#")
+        XCTAssertEqual(letters.last, "Z")
+        XCTAssertEqual(letters[1], "A")
+        // No gaps or repeats in the A–Z run.
+        XCTAssertEqual(Array(letters.dropFirst()), Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+    }
+
+    // MARK: - bucket(for:)
+
+    func testBucketUppercasesLeadingLetter() {
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "Abbey Road"), "A")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "zeppelin"), "Z")
+    }
+
+    func testBucketIsCaseInsensitive() {
+        XCTAssertEqual(
+            AlphabetScrollIndex.bucket(for: "the wall"),
+            AlphabetScrollIndex.bucket(for: "The Wall")
+        )
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "the wall"), "T")
+    }
+
+    func testBucketFoldsDiacriticsToBaseLetter() {
+        // Matches localizedCaseInsensitiveCompare collation — accented Latin
+        // letters land under their base letter, not in '#'.
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "Édith Piaf"), "E")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "Ángel"), "A")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "Über"), "U")
+    }
+
+    func testBucketSkipsLeadingWhitespace() {
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "   Radiohead"), "R")
+    }
+
+    func testDigitLeadingNameBucketsToHash() {
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "2Pac"), "#")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "50 Cent"), "#")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "1999"), "#")
+    }
+
+    func testSymbolLeadingAndNonLatinNameBucketsToHash() {
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "...And Justice for All"), "#")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "中島美嘉"), "#")
+    }
+
+    func testEmptyAndWhitespaceOnlyNameBucketsToHash() {
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: ""), "#")
+        XCTAssertEqual(AlphabetScrollIndex.bucket(for: "   "), "#")
+    }
+
+    // MARK: - presentBuckets(in:)
+
+    func testPresentBucketsReflectsLeadingLetters() {
+        let names = ["Abba", "Air", "Beck", "2Pac", "Zappa"]
+        XCTAssertEqual(
+            AlphabetScrollIndex.presentBuckets(in: names),
+            Set<Character>(["A", "B", "#", "Z"])
+        )
+    }
+
+    func testPresentBucketsEmptyForEmptyInput() {
+        XCTAssertTrue(AlphabetScrollIndex.presentBuckets(in: []).isEmpty)
+    }
+
+    // MARK: - firstIndex(for:in:)
+
+    /// Sorted ascending the way the Library hands the helper its data.
+    private let names = [
+        "2Pac",          // 0  → '#'
+        "ABBA",          // 1  → 'A'
+        "Adele",         // 2  → 'A'
+        "Beck",          // 3  → 'B'
+        "Coldplay",      // 4  → 'C'
+        "Muse",          // 5  → 'M'
+        "Radiohead",     // 6  → 'R'
+    ]
+
+    func testFirstIndexReturnsFirstRowOfBucket() {
+        // Two A's — the topmost wins.
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "A", in: names), 1)
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "B", in: names), 3)
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "R", in: names), 6)
+    }
+
+    func testHashBucketResolvesToNonAlphaLeadingRows() {
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "#", in: names), 0)
+    }
+
+    func testAbsentLetterFallsForwardToNextPresentBucket() {
+        // No 'D'..'L' rows → forward scan from 'D' lands on the next present
+        // bucket, 'M' (Muse, index 5).
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "D", in: names), 5)
+        // No 'N'..'Q' rows → forward scan lands on 'R' (Radiohead, index 6).
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "N", in: names), 6)
+        XCTAssertEqual(AlphabetScrollIndex.firstIndex(for: "Q", in: names), 6)
+    }
+
+    func testLetterBeyondLastRowReturnsNil() {
+        // Last row is Radiohead ('R'); dragging onto 'S'–'Z' has nothing at or
+        // after it, so the caller should no-op rather than scroll bogusly.
+        XCTAssertNil(AlphabetScrollIndex.firstIndex(for: "S", in: names))
+        XCTAssertNil(AlphabetScrollIndex.firstIndex(for: "Z", in: names))
+    }
+
+    func testEmptyListReturnsNilForEveryLetter() {
+        for letter in AlphabetScrollIndex.letters {
+            XCTAssertNil(AlphabetScrollIndex.firstIndex(for: letter, in: []))
+        }
+    }
+
+    func testUnknownLetterReturnsNil() {
+        // A letter that isn't on the rail (lowercase, multi-char) can't resolve.
+        XCTAssertNil(AlphabetScrollIndex.firstIndex(for: "a", in: names))
+        XCTAssertNil(AlphabetScrollIndex.firstIndex(for: "1", in: names))
+    }
+
+    /// Every present bucket must resolve to an index whose own bucket matches —
+    /// i.e. tapping a present letter never lands you in the wrong section.
+    func testEveryPresentBucketResolvesToAMatchingRow() {
+        for bucket in AlphabetScrollIndex.presentBuckets(in: names) {
+            guard let index = AlphabetScrollIndex.firstIndex(for: bucket, in: names) else {
+                XCTFail("present bucket \(bucket) resolved to nil")
+                continue
+            }
+            XCTAssertEqual(AlphabetScrollIndex.bucket(for: names[index]), bucket)
+        }
+    }
+}

--- a/macos/Tests/LyrebirdTests/FeatureTourTests.swift
+++ b/macos/Tests/LyrebirdTests/FeatureTourTests.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the first-run feature tour (#113):
+///
+/// 1. The static step catalog (`FeatureTour.steps`) — count, uniqueness, and
+///    the right-click-has-no-shortcut / everything-else-does invariant the
+///    overlay's chord pill relies on.
+/// 2. The seen-persistence wrapper (`FeatureTourSeenStore`) — first read is
+///    `false`, `markSeen()` flips and persists it, `reset()` clears it.
+///
+/// The persistence assertions run against an isolated `UserDefaults` suite so
+/// they never touch the real app's preferences — the same isolation pattern
+/// `MiniPlayerStateTests` uses for the mini-player always-on-top flag.
+final class FeatureTourTests: XCTestCase {
+
+    // MARK: - Step catalog
+
+    func testCatalogHasThreeToFourSteps() {
+        // Spec calls for a "3-4 step" tour. Guard both ends so a future edit
+        // can't silently grow it into a slideshow or shrink it to nothing.
+        let count = FeatureTour.steps.count
+        XCTAssertGreaterThanOrEqual(count, 3, "tour should have at least 3 steps")
+        XCTAssertLessThanOrEqual(count, 4, "tour should have at most 4 steps")
+    }
+
+    func testStepIDsAreUnique() {
+        let ids = FeatureTour.steps.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "duplicate step id in tour catalog")
+    }
+
+    func testCatalogCoversTheFourAdvertisedFeatures() {
+        // The issue names four features: right-click options, Space play/pause,
+        // ⌘F search, and the mini player. Assert each has a card so a reorder
+        // or rename can't quietly drop one.
+        let ids = Set(FeatureTour.steps.map(\.id))
+        XCTAssertEqual(
+            ids,
+            ["right_click", "space_play_pause", "search", "mini_player"],
+            "tour must cover exactly the four advertised features"
+        )
+    }
+
+    func testEveryStepHasSymbolAndTitleKey() {
+        for step in FeatureTour.steps {
+            XCTAssertFalse(step.symbol.isEmpty, "empty SF Symbol for \(step.id)")
+            XCTAssertFalse(
+                step.titleKeyString.isEmpty,
+                "empty title key for \(step.id)"
+            )
+            // The raw title key and the LocalizedStringKey-backing string must
+            // agree, mirroring the AppShortcuts nameKeyString/nameKey split.
+            XCTAssertEqual(step.titleKey, LocalizedStringKey(step.titleKeyString))
+        }
+    }
+
+    func testOnlyTheRightClickStepLacksAShortcutPill() {
+        // The overlay only renders the chord pill when `shortcut != nil`. The
+        // right-click step is gesture-driven (no key equivalent), so it's the
+        // sole step that should omit the pill; the keyboard-driven steps must
+        // all carry one.
+        for step in FeatureTour.steps {
+            if step.id == "right_click" {
+                XCTAssertNil(step.shortcut, "right-click step should not show a chord pill")
+            } else {
+                XCTAssertNotNil(step.shortcut, "\(step.id) should advertise a chord")
+                XCTAssertFalse(step.shortcut!.isEmpty, "\(step.id) chord is empty")
+            }
+        }
+    }
+
+    // MARK: - Seen-persistence
+
+    /// A throwaway `UserDefaults` suite, wiped on every test so reads start
+    /// from a known-clean slate and writes never leak into the standard domain.
+    private func makeIsolatedDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "FeatureTourTests.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    func testFreshStoreReportsNotSeen() {
+        let store = FeatureTourSeenStore(defaults: makeIsolatedDefaults())
+        XCTAssertFalse(store.hasSeen, "a fresh install must show the tour on first run")
+    }
+
+    func testMarkSeenFlipsAndPersists() {
+        let defaults = makeIsolatedDefaults()
+        let store = FeatureTourSeenStore(defaults: defaults)
+
+        store.markSeen()
+        XCTAssertTrue(store.hasSeen, "marking seen must flip the flag")
+        XCTAssertTrue(
+            defaults.bool(forKey: FeatureTourSeenStore.seenKey),
+            "the seen flag must persist so the tour doesn't reappear next launch"
+        )
+
+        // A second store reading the same domain observes the persisted value —
+        // i.e. the next launch (a fresh store) won't re-show the tour.
+        let nextLaunch = FeatureTourSeenStore(defaults: defaults)
+        XCTAssertTrue(nextLaunch.hasSeen, "the persisted flag must survive a fresh store")
+    }
+
+    func testMarkSeenIsIdempotent() {
+        let store = FeatureTourSeenStore(defaults: makeIsolatedDefaults())
+        store.markSeen()
+        store.markSeen()
+        XCTAssertTrue(store.hasSeen, "marking seen twice stays seen")
+    }
+
+    func testResetClearsTheFlag() {
+        let defaults = makeIsolatedDefaults()
+        let store = FeatureTourSeenStore(defaults: defaults)
+
+        store.markSeen()
+        XCTAssertTrue(store.hasSeen)
+
+        store.reset()
+        XCTAssertFalse(store.hasSeen, "reset must clear the seen flag")
+        XCTAssertFalse(
+            defaults.bool(forKey: FeatureTourSeenStore.seenKey),
+            "reset must clear the persisted value too"
+        )
+    }
+
+    /// The store and the `MainShell` `@AppStorage` read/write the same on-disk
+    /// key. Guard the constant so a rename (which would re-show the tour to
+    /// every existing user, and desync the store from the menu/overlay) is a
+    /// deliberate, test-breaking change rather than a silent one.
+    func testSeenKeyIsStable() {
+        XCTAssertEqual(FeatureTourSeenStore.seenKey, "tour.firstRunSeen")
+    }
+}

--- a/macos/Tests/LyrebirdTests/FullScreenChromeTests.swift
+++ b/macos/Tests/LyrebirdTests/FullScreenChromeTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for full-screen chrome handling (#20).
+///
+/// The chrome state machine lives in the pure `FullScreenChrome` reducer so its
+/// per-phase decision (presentation options + title-bar transparency) is
+/// verified without realizing a live full-screen `NSWindow`, which would need a
+/// window-server connection a headless run doesn't have — the same constraint
+/// `MenuBarVisibilityTests` / `SidebarAutoHideTests` work around. A second
+/// group asserts the observer stays wired into `RootView` (read from source) so
+/// a regression that drops the `.background(FullScreenChromeObserver())` mount
+/// is caught here rather than in the field.
+final class FullScreenChromeTests: XCTestCase {
+
+    // MARK: - Reducer: full-screen phase
+
+    /// Entering full-screen auto-hides the toolbar *and* the menu bar so the
+    /// content owns the whole space and both reveal on a top-edge hover.
+    func testFullScreenAutoHidesToolbarAndMenuBar() {
+        let decision = FullScreenChrome.decide(phase: .fullScreen)
+        XCTAssertTrue(
+            decision.presentationOptions.contains(.autoHideToolbar),
+            "full-screen must auto-hide the unified toolbar"
+        )
+        XCTAssertTrue(
+            decision.presentationOptions.contains(.autoHideMenuBar),
+            "full-screen must auto-hide the menu bar"
+        )
+    }
+
+    /// In full-screen the transparent title bar is dropped so the
+    /// `fullSizeContentView` inset collapses and the content fills cleanly
+    /// rather than sitting below where the (now absent) traffic lights were.
+    func testFullScreenDropsTransparentTitlebar() {
+        let decision = FullScreenChrome.decide(phase: .fullScreen)
+        XCTAssertFalse(
+            decision.titlebarAppearsTransparent,
+            "full-screen should make the title bar opaque so content fills the space"
+        )
+    }
+
+    /// Full-screen must not request options it has no business holding
+    /// (e.g. `.hideDock` or `.disableProcessSwitching`) — only the two
+    /// auto-hide flags, so the reveal-on-hover behaviour stays standard.
+    func testFullScreenRequestsExactlyTheTwoAutoHideOptions() {
+        let decision = FullScreenChrome.decide(phase: .fullScreen)
+        XCTAssertEqual(
+            decision.presentationOptions,
+            [.autoHideToolbar, .autoHideMenuBar],
+            "full-screen should request exactly the toolbar + menu-bar auto-hide pair"
+        )
+    }
+
+    // MARK: - Reducer: windowed phase
+
+    /// Exiting to the windowed phase clears every presentation override.
+    /// `NSApp.presentationOptions` only accepts the auto-hide flags while a
+    /// full-screen window exists and must be emptied on exit, so the windowed
+    /// decision has to be the empty set — anything else would leave AppKit
+    /// rejecting the assignment or the menu bar stuck hidden.
+    func testWindowedClearsPresentationOptions() {
+        let decision = FullScreenChrome.decide(phase: .windowed)
+        XCTAssertEqual(
+            decision.presentationOptions,
+            [],
+            "the windowed phase must clear all presentation overrides"
+        )
+    }
+
+    /// The windowed phase restores the transparent title bar so the
+    /// `.hiddenTitleBar` edge-to-edge sidebar/content layout returns intact.
+    func testWindowedRestoresTransparentTitlebar() {
+        let decision = FullScreenChrome.decide(phase: .windowed)
+        XCTAssertTrue(
+            decision.titlebarAppearsTransparent,
+            "windowed should restore the transparent title bar for the hidden-title-bar layout"
+        )
+    }
+
+    // MARK: - Reducer: round-trip symmetry
+
+    /// Enter → exit must be a true round trip: whatever full-screen changed,
+    /// the windowed decision restores. Pins the symmetry so a future tweak to
+    /// one phase can't silently leave the other stranded (e.g. an opaque title
+    /// bar that never goes transparent again, or lingering presentation
+    /// options).
+    func testEnterExitRoundTripIsSymmetric() {
+        let entered = FullScreenChrome.decide(phase: .fullScreen)
+        let exited = FullScreenChrome.decide(phase: .windowed)
+
+        XCTAssertNotEqual(
+            entered.titlebarAppearsTransparent,
+            exited.titlebarAppearsTransparent,
+            "the title-bar transparency must actually flip between the two phases"
+        )
+        XCTAssertNotEqual(
+            entered.presentationOptions,
+            exited.presentationOptions,
+            "the two phases must request distinct presentation options"
+        )
+        // The windowed leg is the resting state the app launches in, so it must
+        // be the no-override baseline.
+        XCTAssertEqual(exited.presentationOptions, [])
+        XCTAssertTrue(exited.titlebarAppearsTransparent)
+    }
+
+    // MARK: - Structural wiring (source-read)
+
+    /// `RootView` must mount the observer as a background bridge, or none of
+    /// the full-screen handling runs. Asserted against source because the mount
+    /// lives inside a `some View` body that can't be introspected headlessly.
+    func testRootViewMountsFullScreenChromeObserver() throws {
+        let source = try Self.readSource("Sources/Lyrebird/LyrebirdApp.swift")
+        XCTAssertTrue(
+            source.contains(".background(FullScreenChromeObserver())"),
+            "RootView must mount FullScreenChromeObserver as a background bridge"
+        )
+    }
+
+    /// The observer must scope its observation to the *specific* host window
+    /// (the notification's `object`), not all windows — otherwise the mini
+    /// player / preferences windows entering full-screen would drive the main
+    /// window's chrome. Both transition notifications must be observed.
+    func testObserverScopesNotificationsToHostWindow() throws {
+        let source = try Self.readSource("Sources/Lyrebird/System/FullScreenChromeController.swift")
+        XCTAssertTrue(
+            source.contains("NSWindow.willEnterFullScreenNotification"),
+            "observer must watch the enter-full-screen notification"
+        )
+        XCTAssertTrue(
+            source.contains("NSWindow.willExitFullScreenNotification"),
+            "observer must watch the exit-full-screen notification"
+        )
+        XCTAssertTrue(
+            source.contains("object: window"),
+            "observation must be scoped to the host window, not nil (all windows)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Resolve a repo-relative source path from this test file's location so
+    /// the structural assertions don't depend on the CWD of the test runner.
+    /// `#filePath` points at `<repo>/macos/Tests/LyrebirdTests/<this>.swift`;
+    /// walk up to `macos/` and join `relativePath`.
+    private static func readSource(_ relativePath: String) throws -> String {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let macosDir = thisFile
+            .deletingLastPathComponent() // LyrebirdTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // macos
+        let url = macosDir.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/macos/Tests/LyrebirdTests/LinerNotesDrawerTests.swift
+++ b/macos/Tests/LyrebirdTests/LinerNotesDrawerTests.swift
@@ -1,0 +1,208 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the album liner-notes drawer (#221): the slide-in panel
+/// reachable from a "Liner Notes" button in the album hero CTA row, surfacing
+/// the same structured fields + credits as the inline block (#65).
+///
+/// SwiftUI exposes no public hook to introspect a `transition` / `animation`
+/// off a `some View` without booting a scene, so — mirroring the
+/// `SidebarAutoHide` reducer + its `SidebarAutoHideTests` — the motion policy
+/// lives in the pure `LinerNotesDrawerPresentation` type and is exercised here
+/// directly. A second group asserts the structural wiring in
+/// `AlbumDetailView.swift` (read from source) so a regression that detaches the
+/// button or the drawer — or drops Reduce-Motion / dismiss handling — is caught
+/// here rather than in the field.
+final class LinerNotesDrawerTests: XCTestCase {
+
+    // MARK: - Reduce Motion: transition
+
+    /// With motion allowed, the panel slides in from the trailing edge. The
+    /// transition must NOT be the plain opacity crossfade — a horizontal slide
+    /// is the default presentation.
+    func testTransitionSlidesWhenMotionAllowed() {
+        let slide = LinerNotesDrawerPresentation.transition(reduceMotion: false)
+        let crossfade = LinerNotesDrawerPresentation.transition(reduceMotion: true)
+        // `AnyTransition` isn't `Equatable`, so we assert the two branches are
+        // distinguishable via their reflected descriptions: the motion path
+        // carries a `move`, the reduce-motion path is opacity-only.
+        XCTAssertNotEqual(
+            String(describing: slide),
+            String(describing: crossfade),
+            "Motion-allowed and reduce-motion transitions must differ")
+        XCTAssertTrue(
+            String(describing: slide).contains("move") ||
+                String(describing: slide).contains("Move"),
+            "Motion-allowed transition should be a trailing-edge move")
+    }
+
+    /// Under Reduce Motion the panel must NOT travel horizontally — it appears
+    /// with an opacity-only crossfade so there's no slide animation.
+    func testTransitionCrossfadesUnderReduceMotion() {
+        let crossfade = LinerNotesDrawerPresentation.transition(reduceMotion: true)
+        let described = String(describing: crossfade)
+        XCTAssertFalse(
+            described.contains("move") || described.contains("Move"),
+            "Reduce-motion transition must not slide (no horizontal move)")
+        XCTAssertEqual(
+            described,
+            String(describing: AnyTransition.opacity),
+            "Reduce-motion transition should be a plain opacity crossfade")
+    }
+
+    // MARK: - Reduce Motion: animation curve
+
+    /// With motion allowed the present/dismiss paths animate with a real curve
+    /// so the slide reads as a smooth transition rather than a hard cut.
+    func testAnimationHasCurveWhenMotionAllowed() {
+        XCTAssertNotNil(
+            LinerNotesDrawerPresentation.animation(reduceMotion: false),
+            "Motion-allowed open/close must carry an animation curve")
+    }
+
+    /// Under Reduce Motion the animation collapses to `nil` so the drawer's
+    /// presented state flips instantly with no in-between motion. This is the
+    /// contract the `withAnimation(...)` call sites rely on to honour the
+    /// system setting.
+    func testAnimationIsNilUnderReduceMotion() {
+        XCTAssertNil(
+            LinerNotesDrawerPresentation.animation(reduceMotion: true),
+            "Reduce Motion must disable the drawer animation entirely")
+    }
+
+    /// The two motion knobs agree: when one says "animate" the other says
+    /// "slide", and when one says "don't animate" the other says "crossfade".
+    /// A future edit that flips only one of the two would desync the open
+    /// affordance from its close affordances — this pins them together.
+    func testMotionKnobsAreConsistent() {
+        // Reduce Motion on → no curve AND no slide.
+        XCTAssertNil(LinerNotesDrawerPresentation.animation(reduceMotion: true))
+        XCTAssertEqual(
+            String(describing: LinerNotesDrawerPresentation.transition(reduceMotion: true)),
+            String(describing: AnyTransition.opacity))
+
+        // Reduce Motion off → a curve AND a slide.
+        XCTAssertNotNil(LinerNotesDrawerPresentation.animation(reduceMotion: false))
+        XCTAssertTrue(
+            String(describing: LinerNotesDrawerPresentation.transition(reduceMotion: false))
+                .lowercased().contains("move"))
+    }
+
+    // MARK: - AlbumDetailView source invariants
+
+    /// The drawer is presentation-state driven by a single `@State` flag (#221)
+    /// — the open button sets it true, the dismiss paths set it false.
+    func testAlbumDetailDeclaresDrawerPresentationFlag() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains("@State private var isLinerNotesDrawerPresented = false"),
+            "AlbumDetailView must own the drawer's presentation flag, default closed")
+    }
+
+    /// A "Liner Notes" button must live in the hero CTA row and open the
+    /// drawer. Asserts both the row wiring (`linerNotesButton` in `ctaRow`) and
+    /// that the button flips the presentation flag true.
+    func testAlbumDetailHasLinerNotesButtonInCtaRow() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(code.contains("linerNotesButton"),
+                      "ctaRow must include a Liner Notes button")
+        XCTAssertTrue(code.contains("\"Liner Notes\""),
+                      "The CTA must be labelled \"Liner Notes\"")
+        XCTAssertTrue(code.contains("isLinerNotesDrawerPresented = true"),
+                      "The Liner Notes button must open the drawer")
+    }
+
+    /// The drawer must mount as a trailing-edge overlay over the scroll view
+    /// (slide-in over the page), not reflow the layout.
+    func testAlbumDetailMountsDrawerAsTrailingOverlay() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains(".overlay(alignment: .trailing) { linerNotesDrawer }"),
+            "The drawer must be layered as a trailing overlay over the page")
+    }
+
+    /// All three close affordances must exist and funnel through the single
+    /// `dismissLinerNotesDrawer()` path: the Escape handler (`.cancelAction`),
+    /// the scrim tap, and the panel's close button.
+    func testAlbumDetailWiresAllDismissPaths() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(code.contains("func dismissLinerNotesDrawer()"),
+                      "A single dismiss helper must back every close path")
+        XCTAssertTrue(code.contains("isLinerNotesDrawerPresented = false"),
+                      "Dismiss must clear the presentation flag")
+        // Escape: a cancel-action keyboard shortcut closes the drawer.
+        XCTAssertTrue(code.contains(".keyboardShortcut(.cancelAction)"),
+                      "Escape must close the drawer via a cancel-action shortcut")
+        // Tap-out: the dimmed scrim is a tap target that dismisses.
+        XCTAssertTrue(code.contains(".onTapGesture { dismissLinerNotesDrawer() }"),
+                      "Tapping the scrim must close the drawer")
+        // Close button: the panel header carries an explicit close control.
+        XCTAssertTrue(code.contains("\"Close liner notes\""),
+                      "The panel must have an explicit close button")
+    }
+
+    /// The drawer's motion must route through `LinerNotesDrawerPresentation`
+    /// for both the transition and the animation — never an inline literal that
+    /// could ignore Reduce Motion. This keeps the tested policy as the single
+    /// source of truth for the view's motion.
+    func testAlbumDetailRoutesMotionThroughPolicy() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains("LinerNotesDrawerPresentation.transition(reduceMotion: reduceMotion)"),
+            "The panel transition must come from the reduce-motion-aware policy")
+        XCTAssertTrue(
+            code.contains("LinerNotesDrawerPresentation.animation(reduceMotion: reduceMotion)"),
+            "The open/close animation must come from the reduce-motion-aware policy")
+        XCTAssertTrue(
+            code.contains("@Environment(\\.accessibilityReduceMotion) private var reduceMotion"),
+            "AlbumDetailView must read the system Reduce Motion setting")
+    }
+
+    /// Opening the page (or switching albums) must reset the drawer closed so a
+    /// prior album's panel never bleeds onto the next — the same hygiene the
+    /// About popover gets.
+    func testAlbumDetailResetsDrawerOnAlbumChange() throws {
+        let code = try albumDetailSource()
+        let taskMarker = "isAboutExpanded = false"
+        XCTAssertTrue(code.contains(taskMarker),
+                      "Sanity: the About-popover reset still lives in the .task")
+        XCTAssertTrue(code.contains("isLinerNotesDrawerPresented = false"),
+                      "The .task must close the drawer on album (re)load")
+    }
+
+    /// The structured liner-note body must be rendered through a shared
+    /// `linerNotesContent(album:)` helper so the inline block (#65) and the
+    /// drawer (#221) can never drift in what they show.
+    func testLinerNotesContentIsSharedBetweenInlineAndDrawer() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(code.contains("func linerNotesContent(album: Album)"),
+                      "A shared content builder must back both liner-note surfaces")
+        // It must be invoked from both the inline block and the drawer panel.
+        let invocations = code.components(separatedBy: "linerNotesContent(album:").count - 1
+        // One definition + two call sites = three textual occurrences.
+        XCTAssertGreaterThanOrEqual(
+            invocations, 3,
+            "linerNotesContent must be called from both the inline block and the drawer")
+    }
+
+    // MARK: - Helpers
+
+    /// Loads `AlbumDetailView.swift` relative to this test file via `#filePath`
+    /// so the lookup is independent of the test runner's working directory.
+    private func albumDetailSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let source = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Screens/AlbumDetailView.swift")
+        guard let data = try? Data(contentsOf: source),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read AlbumDetailView.swift at \(source.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+}

--- a/macos/Tests/LyrebirdTests/LyricsViewStyleTests.swift
+++ b/macos/Tests/LyrebirdTests/LyricsViewStyleTests.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Apple-Music-"Sing"-style active-line styling (#90). The
+/// per-line fade-in, the 99%→100% scale bloom, the soft glow, and the dim on
+/// inactive lines are all resolved by the pure `LyricLineStyle.resolve` value
+/// type so they can be asserted without rendering a SwiftUI scene — the same
+/// testable-model shape `NowPlayingBackdrop.showsArtworkLayer` uses.
+final class LyricsViewStyleTests: XCTestCase {
+
+    // MARK: - Active line (motion allowed)
+
+    func testActiveLineUsesLargeBoldType() {
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        XCTAssertEqual(style.fontSize, 22)
+        XCTAssertEqual(style.weight, .bold)
+    }
+
+    func testActiveLineIsFullyOpaque() {
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        XCTAssertEqual(style.opacity, 1.0, accuracy: 0.0001)
+    }
+
+    func testActiveLineBloomsToFullScale() {
+        // The active line settles at 100% — it's the inactive lines that rest
+        // at 99%, so the active line reads as the one that bloomed forward.
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        XCTAssertEqual(style.scale, 1.0, accuracy: 0.0001)
+    }
+
+    func testActiveLineHasSoftGlow() {
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        XCTAssertGreaterThan(style.glowRadius, 0)
+        XCTAssertGreaterThan(style.glowOpacity, 0)
+    }
+
+    func testActiveLineAnimatesWhenMotionAllowed() {
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        XCTAssertTrue(style.animates)
+    }
+
+    // MARK: - Inactive line (motion allowed)
+
+    func testInactiveLineUsesSmallerMediumType() {
+        let style = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertEqual(style.fontSize, 18)
+        XCTAssertEqual(style.weight, .medium)
+    }
+
+    func testInactiveLineIsDimmed() {
+        // Gentle dim on inactive lines: both a dimmer colour *and* sub-full
+        // opacity, so the active line stands out beyond the colour swap alone.
+        let style = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertLessThan(style.opacity, 1.0)
+    }
+
+    func testInactiveLineRestsAtNinetyNinePercentScale() {
+        let style = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertEqual(style.scale, 0.99, accuracy: 0.0001)
+    }
+
+    func testInactiveLineHasNoGlow() {
+        let style = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertEqual(style.glowRadius, 0)
+        XCTAssertEqual(style.glowOpacity, 0, accuracy: 0.0001)
+    }
+
+    func testActiveLineIsMoreOpaqueThanInactive() {
+        let active = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        let inactive = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertGreaterThan(active.opacity, inactive.opacity)
+    }
+
+    func testActiveLineScalesLargerThanInactive() {
+        let active = LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        let inactive = LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        XCTAssertGreaterThan(active.scale, inactive.scale)
+    }
+
+    // MARK: - Reduce Motion gate
+
+    func testReduceMotionPinsActiveScaleToFull() {
+        // No scale bloom under Reduce Motion — the active line stays at 1.0.
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        XCTAssertEqual(style.scale, 1.0, accuracy: 0.0001)
+    }
+
+    func testReduceMotionPinsInactiveScaleToFull() {
+        // Inactive lines also stop resting at 99% under Reduce Motion, so no
+        // line moves at all.
+        let style = LyricLineStyle.resolve(isActive: false, reduceMotion: true)
+        XCTAssertEqual(style.scale, 1.0, accuracy: 0.0001)
+    }
+
+    func testReduceMotionDropsActiveGlow() {
+        // The bloom is the motion we're gating — Reduce Motion removes it.
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        XCTAssertEqual(style.glowRadius, 0)
+        XCTAssertEqual(style.glowOpacity, 0, accuracy: 0.0001)
+    }
+
+    func testReduceMotionDisablesAnimationForActiveAndInactive() {
+        let active = LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        let inactive = LyricLineStyle.resolve(isActive: false, reduceMotion: true)
+        XCTAssertFalse(active.animates)
+        XCTAssertFalse(inactive.animates)
+    }
+
+    func testReduceMotionPreservesFontAndColourContract() {
+        // The instant-highlight fallback must keep the original 22/bold vs
+        // 18/medium size+weight contract so the synced read still works with
+        // motion off — only the scale/glow/animation are suppressed.
+        let active = LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        let inactive = LyricLineStyle.resolve(isActive: false, reduceMotion: true)
+
+        XCTAssertEqual(active.fontSize, 22)
+        XCTAssertEqual(active.weight, .bold)
+        XCTAssertEqual(inactive.fontSize, 18)
+        XCTAssertEqual(inactive.weight, .medium)
+    }
+
+    func testReduceMotionKeepsActiveOpacityFull() {
+        // Dimming inactive lines is a static contrast cue, not motion, so the
+        // active line stays fully opaque even with motion off.
+        let style = LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        XCTAssertEqual(style.opacity, 1.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Equatable / determinism
+
+    func testResolveIsDeterministic() {
+        XCTAssertEqual(
+            LyricLineStyle.resolve(isActive: true, reduceMotion: false),
+            LyricLineStyle.resolve(isActive: true, reduceMotion: false)
+        )
+        XCTAssertEqual(
+            LyricLineStyle.resolve(isActive: false, reduceMotion: true),
+            LyricLineStyle.resolve(isActive: false, reduceMotion: true)
+        )
+    }
+
+    func testActiveAndInactiveStylesDiffer() {
+        XCTAssertNotEqual(
+            LyricLineStyle.resolve(isActive: true, reduceMotion: false),
+            LyricLineStyle.resolve(isActive: false, reduceMotion: false)
+        )
+    }
+
+    func testMotionAndReduceMotionStylesDifferForActiveLine() {
+        XCTAssertNotEqual(
+            LyricLineStyle.resolve(isActive: true, reduceMotion: false),
+            LyricLineStyle.resolve(isActive: true, reduceMotion: true)
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/MiniPlayerClickThroughTests.swift
+++ b/macos/Tests/LyrebirdTests/MiniPlayerClickThroughTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Mini Player click-through-to-detail feature (#110):
+///
+/// 1. The **tap-vs-drag discrimination** boundary used by
+///    `MiniPlayerDragHandle` to tell a click (open the album page) from a
+///    window reposition. Exercised through the pure
+///    `MiniPlayerView_dragExceedsThreshold` helper so the threshold is
+///    verified without a live window-server event stream, which a headless
+///    test run doesn't have.
+/// 2. The **nav routing** the artwork / artist taps invoke
+///    (`AppModel.openInMainWindowFromMiniPlayer`): that it drills the main
+///    window's `navPath` to the right `Route`, and — unlike
+///    `returnToFullWindow` — leaves the mini player open so an always-on-top
+///    widget keeps floating over the now-foregrounded detail page.
+///
+/// `AppModel` is `@MainActor`, so the routing half of the suite is
+/// main-actor isolated. Constructing it boots a live `LyrebirdCore`; we
+/// redirect the core's data directory to a throwaway temp dir via
+/// `XDG_DATA_HOME` (honoured by `storage::default_data_dir()`) so the test
+/// never touches the real app's database.
+@MainActor
+final class MiniPlayerClickThroughTests: XCTestCase {
+
+    /// Point the core at a unique temp data dir before the first `AppModel()`
+    /// in the process, mirroring `MiniPlayerStateTests`.
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Tap-vs-drag threshold
+
+    func testReleaseInPlaceIsATap() {
+        // Press and release at the same point: zero travel → a tap.
+        let start = CGPoint(x: 100, y: 100)
+        XCTAssertFalse(
+            MiniPlayerView_dragExceedsThreshold(from: start, to: start),
+            "a press released in place must read as a tap, not a drag"
+        )
+    }
+
+    func testSubThresholdJitterIsStillATap() {
+        // A couple of points of incidental jitter during a click must not be
+        // promoted to a window drag, or the click-through would never fire.
+        let start = CGPoint(x: 100, y: 100)
+        let jittered = CGPoint(x: 100 + 2, y: 100 - 2) // |(2,-2)| ≈ 2.83 < 4
+        XCTAssertFalse(
+            MiniPlayerView_dragExceedsThreshold(from: start, to: jittered),
+            "movement under the \(MiniPlayerDragHandle.dragThreshold)pt threshold stays a tap"
+        )
+    }
+
+    func testMovementJustPastThresholdIsADrag() {
+        // Travel comfortably past the threshold on one axis → a drag.
+        let start = CGPoint(x: 100, y: 100)
+        let dragged = CGPoint(x: 100 + MiniPlayerDragHandle.dragThreshold + 1, y: 100)
+        XCTAssertTrue(
+            MiniPlayerView_dragExceedsThreshold(from: start, to: dragged),
+            "horizontal travel past the threshold must read as a window drag"
+        )
+    }
+
+    func testDiagonalMovementPastThresholdIsADrag() {
+        // Euclidean distance, not per-axis: (3,3) ≈ 4.24 > 4 even though
+        // neither axis alone clears the 4pt bar.
+        let start = CGPoint(x: 0, y: 0)
+        let dragged = CGPoint(x: 3, y: 3)
+        XCTAssertTrue(
+            MiniPlayerView_dragExceedsThreshold(from: start, to: dragged),
+            "diagonal travel is measured by distance, so (3,3) clears a 4pt threshold"
+        )
+    }
+
+    func testVerticalDragIsDetectedRegardlessOfDirection() {
+        // Dragging upward (negative dy) is just as much a drag as downward.
+        let start = CGPoint(x: 50, y: 50)
+        let up = CGPoint(x: 50, y: 50 - (MiniPlayerDragHandle.dragThreshold + 2))
+        XCTAssertTrue(
+            MiniPlayerView_dragExceedsThreshold(from: start, to: up),
+            "upward travel past the threshold is a drag too — sign must not matter"
+        )
+    }
+
+    // MARK: - Nav routing
+
+    func testArtworkTapDrillsMainWindowToAlbumRoute() throws {
+        let model = try AppModel()
+        XCTAssertTrue(model.navPath.isEmpty, "precondition: fresh model has an empty drill stack")
+
+        model.openInMainWindowFromMiniPlayer(.album("album-42"))
+
+        XCTAssertEqual(
+            model.navPath.last,
+            AppModel.Route.album("album-42"),
+            "tapping mini-player artwork must push the album route onto the main window"
+        )
+    }
+
+    func testArtistTapDrillsMainWindowToArtistRoute() throws {
+        let model = try AppModel()
+
+        model.openInMainWindowFromMiniPlayer(.artist("artist-7"))
+
+        XCTAssertEqual(
+            model.navPath.last,
+            AppModel.Route.artist("artist-7"),
+            "tapping the mini-player artist name must push the artist route"
+        )
+    }
+
+    /// The defining difference from `returnToFullWindow`: a click-through is
+    /// navigation, not a dismissal, so the mini player must stay open (an
+    /// always-on-top widget keeps floating over the detail page it just
+    /// opened).
+    func testClickThroughDoesNotCloseTheMiniPlayer() throws {
+        let model = try AppModel()
+        model.isMiniPlayerVisible = true
+
+        model.openInMainWindowFromMiniPlayer(.album("album-1"))
+
+        XCTAssertTrue(
+            model.isMiniPlayerVisible,
+            "click-through navigates without dismissing the mini player"
+        )
+    }
+
+    /// Two successive click-throughs stack as two drill entries — the seam is
+    /// a plain push (matching `navigate(to:)`), not a replace, so back returns
+    /// to the prior detail page.
+    func testSuccessiveClickThroughsStackOnTheDrillPath() throws {
+        let model = try AppModel()
+
+        model.openInMainWindowFromMiniPlayer(.artist("artist-1"))
+        model.openInMainWindowFromMiniPlayer(.album("album-2"))
+
+        XCTAssertEqual(model.navPath.count, 2, "each click-through pushes a fresh drill entry")
+        XCTAssertEqual(model.navPath.first, AppModel.Route.artist("artist-1"))
+        XCTAssertEqual(model.navPath.last, AppModel.Route.album("album-2"))
+    }
+}

--- a/macos/Tests/LyrebirdTests/RadioSectionRoutingTests.swift
+++ b/macos/Tests/LyrebirdTests/RadioSectionRoutingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the dedicated Radio / Mixes sidebar destination (#93).
+///
+/// The feature adds a `.radio` root tab reachable from the sidebar. Two
+/// contracts must hold for the destination to behave like every other root
+/// tab:
+///
+/// 1. `selectTab(.radio)` sets `screen` to `.radio` and clears any active drill
+///    stack — the same invariant `selectTab` enforces for Home / Discover /
+///    Library so drill state never leaks across a tab change.
+/// 2. The `.radio` screen survives a `@SceneStorage` round-trip through
+///    `WindowStateStore`'s stable String codec, so a user who quits on the
+///    Radio tab is restored to it. The raw string is an on-disk contract;
+///    renaming it silently resets saved window state, so it is pinned here
+///    alongside the other tabs in `WindowStateStoreTests`.
+///
+/// Same isolation contract as `DiscoverSongRadioRouteTests`: `AppModel` is
+/// `@MainActor` and boots a live core pointed at a throwaway data dir.
+@MainActor
+final class RadioSectionRoutingTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-radio-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - selectTab routing
+
+    /// Selecting the Radio tab from any other tab flips `screen` to `.radio`.
+    func testSelectTabRoutesToRadio() throws {
+        let model = try AppModel()
+        // Start somewhere else so the assertion proves a real transition.
+        model.selectTab(.library)
+        XCTAssertEqual(model.screen, .library)
+
+        model.selectTab(.radio)
+        XCTAssertEqual(model.screen, .radio, "selecting the Radio tab must set screen to .radio")
+    }
+
+    /// Switching to the Radio tab clears the current drill stack, so a user who
+    /// drilled into an album and then taps Radio lands on the Radio root rather
+    /// than a stale detail page. This is the shared `selectTab` invariant.
+    func testSelectingRadioClearsDrillStack() throws {
+        let model = try AppModel()
+        model.selectTab(.library)
+        model.navPath = [.album("album-1"), .artist("artist-1")]
+        XCTAssertFalse(model.navPath.isEmpty)
+
+        model.selectTab(.radio)
+        XCTAssertEqual(model.screen, .radio)
+        XCTAssertTrue(model.navPath.isEmpty, "switching to Radio must clear the drill stack")
+    }
+
+    /// Leaving the Radio tab for another root behaves symmetrically — no Radio
+    /// state lingers on `screen`.
+    func testLeavingRadioSwitchesScreen() throws {
+        let model = try AppModel()
+        model.selectTab(.radio)
+        XCTAssertEqual(model.screen, .radio)
+
+        model.selectTab(.discover)
+        XCTAssertEqual(model.screen, .discover, "leaving Radio must switch screen to the new tab")
+    }
+
+    // MARK: - Persisted-state codec
+
+    /// `.radio` round-trips through its persisted raw value so `@SceneStorage`
+    /// can decode whatever it wrote when the user quits on the Radio tab.
+    func testRadioScreenRawValueRoundTrips() {
+        XCTAssertEqual(
+            AppModel.Screen(persistedRawValue: AppModel.Screen.radio.persistedRawValue),
+            .radio
+        )
+    }
+
+    /// The stable on-disk identifier for the Radio tab. Renaming this is a
+    /// breaking change to persisted window state and must come with a migration.
+    func testRadioScreenStableRawValue() {
+        XCTAssertEqual(AppModel.Screen.radio.persistedRawValue, "radio")
+    }
+
+    /// A window persisted on the Radio tab is restored to it verbatim, rather
+    /// than collapsing to the `.library` cold-start default.
+    func testRestoredScreenReturnsRadio() {
+        XCTAssertEqual(WindowStateStore.restoredScreen(persistedRaw: "radio"), .radio)
+    }
+}

--- a/macos/Tests/LyrebirdTests/WindowStateStoreTests.swift
+++ b/macos/Tests/LyrebirdTests/WindowStateStoreTests.swift
@@ -30,7 +30,7 @@ final class WindowStateStoreTests: XCTestCase {
     /// Every `Screen` round-trips through its persisted raw value, so
     /// `@SceneStorage` can decode whatever it wrote.
     func testScreenRawValueRoundTrips() {
-        let all: [AppModel.Screen] = [.home, .discover, .library, .favorites, .search, .settings]
+        let all: [AppModel.Screen] = [.home, .discover, .radio, .library, .favorites, .search, .settings]
         for screen in all {
             XCTAssertEqual(
                 AppModel.Screen(persistedRawValue: screen.persistedRawValue),
@@ -45,6 +45,7 @@ final class WindowStateStoreTests: XCTestCase {
     func testScreenStableRawValues() {
         XCTAssertEqual(AppModel.Screen.home.persistedRawValue, "home")
         XCTAssertEqual(AppModel.Screen.discover.persistedRawValue, "discover")
+        XCTAssertEqual(AppModel.Screen.radio.persistedRawValue, "radio")
         XCTAssertEqual(AppModel.Screen.library.persistedRawValue, "library")
         XCTAssertEqual(AppModel.Screen.favorites.persistedRawValue, "favorites")
         XCTAssertEqual(AppModel.Screen.search.persistedRawValue, "search")


### PR DESCRIPTION
Third wave of the 2.0 push. Eight UI features, each built in isolation, adversarially reviewed, integrated on a green base (clean build + 416 Swift tests passing).

- **Radio / Mixes sidebar section** aggregating instant mix, song/artist radio, and genre/decade/mood rows. Closes #93
- **AirPlay route picker** in the player bar (AVRoutePickerView). Closes #326
- **Liner-notes drawer** on the album page (slide-in, Reduce-Motion aware). Closes #221
- **A–Z fast-scroll index** in the Library (gated > 200 items, name-sorted). Closes #216
- **First-run feature tour** — dismissible coach marks, re-openable from Help. Closes #113
- **Full-screen mode chrome** — correct traffic-light / toolbar handling. Closes #20
- **Apple Music–style lyrics polish** — active-line fade/scale/glow, Reduce-Motion gated. Closes #90
- **Mini-player click-through** — tap artwork → album, artist name → artist (activates main window). Closes #110