### PR TITLE
style(core): rustfmt the scrobble module

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1122,7 +1122,10 @@ impl LyrebirdCore {
         token: Option<String>,
     ) -> std::result::Result<(), LyrebirdError> {
         let db = self.inner.lock().db.clone();
-        match token.map(|t| t.trim().to_string()).filter(|t| !t.is_empty()) {
+        match token
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+        {
             Some(t) => db.set_setting(SCROBBLE_TOKEN_KEY, &t)?,
             None => db.delete_setting(SCROBBLE_TOKEN_KEY)?,
         }
@@ -1147,14 +1150,10 @@ impl LyrebirdCore {
     /// No-op error (`InvalidInput`) when no token is configured, which the
     /// platform layer treats as "scrobbling disabled" and swallows. Other
     /// errors (network, 401) propagate so the UI can surface a token problem.
-    pub fn scrobble_now_playing(
-        &self,
-        track: Track,
-    ) -> std::result::Result<(), LyrebirdError> {
+    pub fn scrobble_now_playing(&self, track: Track) -> std::result::Result<(), LyrebirdError> {
         let token = self.scrobble_token()?;
         let scrobbler = scrobble::Scrobbler::new(token)?;
-        self.runtime
-            .block_on(scrobbler.submit_playing_now(&track))
+        self.runtime.block_on(scrobbler.submit_playing_now(&track))
     }
 
     /// Submit a durable ListenBrainz `single` listen for a track that has

--- a/core/src/scrobble.rs
+++ b/core/src/scrobble.rs
@@ -190,7 +190,11 @@ impl Scrobbler {
     /// the user their token is wrong; everything else surfaces as
     /// [`LyrebirdError::Server`].
     async fn submit(&self, body: Value) -> Result<()> {
-        let url = format!("{}{}", self.api_root.trim_end_matches('/'), SUBMIT_LISTENS_PATH);
+        let url = format!(
+            "{}{}",
+            self.api_root.trim_end_matches('/'),
+            SUBMIT_LISTENS_PATH
+        );
         let resp = self
             .http
             .post(&url)

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -8150,8 +8150,7 @@ async fn scrobble_submit_single_posts_to_listenbrainz() {
         .await;
 
     let track = scrobble_track("item-1", "Yona", "Saloli", Some("The Deep End"));
-    let scrobbler =
-        crate::scrobble::Scrobbler::with_root(server.uri(), "lb-secret-token").unwrap();
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "lb-secret-token").unwrap();
     scrobbler
         .submit_listen(&track, 1_700_000_000)
         .await
@@ -8228,7 +8227,8 @@ fn scrobble_token_persistence_and_configured_flag() {
     assert!(!core.is_scrobble_configured());
 
     // Set a token -> configured.
-    core.set_scrobble_token(Some("lb-user-token".into())).unwrap();
+    core.set_scrobble_token(Some("lb-user-token".into()))
+        .unwrap();
     assert!(core.is_scrobble_configured());
 
     // Blank/whitespace token clears it (treated as disconnect).
@@ -8236,7 +8236,8 @@ fn scrobble_token_persistence_and_configured_flag() {
     assert!(!core.is_scrobble_configured());
 
     // Set again, then explicit None clears.
-    core.set_scrobble_token(Some("lb-user-token".into())).unwrap();
+    core.set_scrobble_token(Some("lb-user-token".into()))
+        .unwrap();
     assert!(core.is_scrobble_configured());
     core.set_scrobble_token(None).unwrap();
     assert!(!core.is_scrobble_configured());
@@ -8264,10 +8265,13 @@ fn scrobble_token_survives_clear_user_data() {
     // Logout must NOT wipe the scrobble token (account-independent pref).
     let dir = tempfile::tempdir().unwrap();
     let db = Database::open(dir.path().join("lb.db")).unwrap();
-    db.set_setting("scrobble_listenbrainz_token", "keep-me").unwrap();
+    db.set_setting("scrobble_listenbrainz_token", "keep-me")
+        .unwrap();
     db.clear_user_data().unwrap();
     assert_eq!(
-        db.get_setting("scrobble_listenbrainz_token").unwrap().as_deref(),
+        db.get_setting("scrobble_listenbrainz_token")
+            .unwrap()
+            .as_deref(),
         Some("keep-me")
     );
 }


### PR DESCRIPTION
Wave 2 (#46) scrobbling Rust wasn't rustfmt-clean, failing the CI `cargo fmt --check` job (Coverage/E2E/tests/clippy all passed). Pure formatting, no behavior change.