### PR TITLE
macOS 2.0 — Wave 4: ReplayGain, Dynamic Type reflow, LetsMove, About window, Recently-Discovered Artists, sidebar reorder

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -532,15 +532,47 @@ impl JellyfinClient {
     // ----- Library queries -----
 
     pub async fn artists(&self, paging: Paging) -> Result<PaginatedArtists> {
+        self.album_artists_sorted(ItemSortBy::SortName, SortOrder::Ascending, paging)
+            .await
+    }
+
+    /// Album artists most recently added to the library, sorted by
+    /// `DateCreated` descending. Powers the Home "Recently Discovered
+    /// Artists" row (#252) — the set of artists whose catalogue just landed
+    /// on the server, newest first.
+    ///
+    /// Same `/Artists/AlbumArtists` endpoint and field set as [`artists`],
+    /// only the sort differs. Jellyfin scopes the `DateCreated` of an
+    /// artist to when its first item was ingested, so descending order
+    /// surfaces freshly-imported artists. Verified live against
+    /// music.skalthoff.com — `SortBy=DateCreated&SortOrder=Descending`
+    /// returns a strictly descending `DateCreated` window.
+    ///
+    /// [`artists`]: JellyfinClient::artists
+    pub async fn recently_added_artists(&self, paging: Paging) -> Result<PaginatedArtists> {
+        self.album_artists_sorted(ItemSortBy::DateCreated, SortOrder::Descending, paging)
+            .await
+    }
+
+    /// Shared implementation behind [`artists`] and
+    /// [`recently_added_artists`]. `Artists/AlbumArtists` is a dedicated
+    /// endpoint, not a standard `/Items` query, so we issue the request
+    /// directly rather than going through [`ItemsQuery::execute`]. We still
+    /// format the params via the typed enum helpers so the set of allowed
+    /// values lives in one place.
+    ///
+    /// [`artists`]: JellyfinClient::artists
+    /// [`recently_added_artists`]: JellyfinClient::recently_added_artists
+    async fn album_artists_sorted(
+        &self,
+        sort_by: ItemSortBy,
+        sort_order: SortOrder,
+        paging: Paging,
+    ) -> Result<PaginatedArtists> {
         let user_id = self
             .user_id
             .as_ref()
             .ok_or(LyrebirdError::NotAuthenticated)?;
-        // `Artists/AlbumArtists` is a dedicated endpoint, not a standard
-        // `/Items` query, so we issue the request directly rather than
-        // going through [`ItemsQuery::execute`]. We still format the params
-        // via the typed enum helpers so the set of allowed values lives in
-        // one place.
         let mut url = self.endpoint("Artists/AlbumArtists")?;
         {
             let mut q = url.query_pairs_mut();
@@ -556,8 +588,8 @@ impl JellyfinClient {
             // endpoint returns the full artist list.
             q.append_pair("Limit", &paging.limit.max(1).to_string());
             q.append_pair("StartIndex", &paging.offset.to_string());
-            q.append_pair("SortBy", ItemSortBy::SortName.as_str());
-            q.append_pair("SortOrder", SortOrder::Ascending.as_str());
+            q.append_pair("SortBy", sort_by.as_str());
+            q.append_pair("SortOrder", sort_order.as_str());
             q.append_pair(
                 "Fields",
                 &enums::csv(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -367,6 +367,21 @@ impl LyrebirdCore {
         self.with_client(|c| self.runtime.block_on(c.artists(Paging::new(offset, limit))))
     }
 
+    /// Album artists most recently added to the library, sorted by
+    /// server-side `DateCreated` descending. Powers the Home "Recently
+    /// Discovered Artists" row (#252). Same shape as [`Self::list_artists`],
+    /// only the sort differs.
+    pub fn list_recently_added_artists(
+        &self,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedArtists, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.recently_added_artists(Paging::new(offset, limit)))
+        })
+    }
+
     /// Every album where the given artist is the primary (album) artist,
     /// paginated. Scopes by `AlbumArtistIds` on the server so compilations
     /// the artist only appears on don't leak into the Discography section.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -8285,3 +8285,134 @@ fn scrobble_core_threshold_predicate_matches_module() {
     assert!(core.scrobble_threshold_reached(90.0, 180.0));
     assert!(core.scrobble_threshold_reached(240.0, 0.0));
 }
+
+// ---- #252: Recently Discovered Artists (DateCreated-desc artists) ----
+
+#[tokio::test]
+async fn recently_added_artists_builds_query_and_parses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                {
+                    "Id": "ar1", "Name": "Zillion", "Type": "MusicArtist",
+                    "ImageTags": { "Primary": "img" }
+                }
+            ],
+            "TotalRecordCount": 3213
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .recently_added_artists(Paging::new(0, 12))
+        .await
+        .unwrap();
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total_count, 3213);
+    assert_eq!(page.items[0].name, "Zillion");
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    // The whole point of #252: newest-added artists first.
+    assert!(q.contains("SortBy=DateCreated"), "query: {q}");
+    assert!(q.contains("SortOrder=Descending"), "query: {q}");
+    // Otherwise identical to the plain `artists` query.
+    assert!(q.contains("Recursive=true"), "query: {q}");
+    assert!(q.contains("Limit=12"), "query: {q}");
+    assert!(q.contains("StartIndex=0"), "query: {q}");
+    assert!(q.contains("EnableUserData=true"), "query: {q}");
+    assert!(q.contains("EnableImages=true"), "query: {q}");
+    assert!(q.contains("ImageTypeLimit=1"), "query: {q}");
+    // Same `IncludeItemTypes`-absence contract as `artists` (see
+    // `artists_does_not_send_include_item_types_music_artist`).
+    assert!(!q.contains("IncludeItemTypes="), "unexpected IncludeItemTypes: {q}");
+}
+
+#[tokio::test]
+async fn recently_added_artists_honours_paging_offset() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client
+        .recently_added_artists(Paging::new(40, 20))
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("StartIndex=40"), "query: {q}");
+    assert!(q.contains("Limit=20"), "query: {q}");
+    assert!(q.contains("SortBy=DateCreated"), "query: {q}");
+}
+
+#[tokio::test]
+async fn plain_artists_query_still_sorts_by_sort_name_ascending() {
+    // Guards the #252 refactor: extracting `album_artists_sorted` must not
+    // change the default `artists()` sort away from SortName ascending.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let _ = client.artists(Paging::new(0, 50)).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    assert!(q.contains("SortBy=SortName"), "query: {q}");
+    assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+}

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -8346,7 +8346,10 @@ async fn recently_added_artists_builds_query_and_parses() {
     assert!(q.contains("ImageTypeLimit=1"), "query: {q}");
     // Same `IncludeItemTypes`-absence contract as `artists` (see
     // `artists_does_not_send_include_item_types_music_artist`).
-    assert!(!q.contains("IncludeItemTypes="), "unexpected IncludeItemTypes: {q}");
+    assert!(
+        !q.contains("IncludeItemTypes="),
+        "unexpected IncludeItemTypes: {q}"
+    );
 }
 
 #[tokio::test]

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -90,6 +90,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] _ in
             self?.handleWake()
         }
+
+        // First-launch "move to Applications" prompt (LetsMove). Self-gates:
+        // shows only for a release build running from outside /Applications
+        // that isn't translocated/on a DMG and hasn't been suppressed. See #193.
+        MoveToApplications.promptIfNeeded()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -281,6 +281,16 @@ final class AppModel {
     /// section, so the two never drift. Hidden in the Home layout when
     /// empty — a fresh user with no favorited artists sees no shelf.
     var favoriteArtists: [Artist] = []
+    /// "Recently Discovered Artists" for the Home circle-card row (#252).
+    /// The album artists whose catalogue most recently landed on the
+    /// server, newest first — sorted server-side by `DateCreated`
+    /// descending via the `core.listRecentlyAddedArtists` FFI (the
+    /// `Artists/AlbumArtists` endpoint with a `DateCreated`-desc sort).
+    /// Distinct from `recentlyAdded`, which surfaces newly-added *albums*:
+    /// this row answers "whose music just showed up in my library?".
+    /// Reuses `ArtistCard`. Capped at a modest count for the carousel and
+    /// hidden when empty so a fresh / static library renders no shelf.
+    var recentlyDiscoveredArtists: [Artist] = []
     /// "Rediscover" — albums the user has never played, for the Home shelf
     /// of the same name (#57). Backed by an `/Items` query filtered to
     /// `IsUnplayed` and sorted `Random` so the row surfaces a fresh,
@@ -1254,6 +1264,7 @@ final class AppModel {
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
         favoriteArtists = []
+        recentlyDiscoveredArtists = []
         rediscover = []
         suggestions = []
         searchResults = nil
@@ -1327,6 +1338,7 @@ final class AppModel {
         favoriteAlbumsAll = []
         favoriteAlbumsVisible = []
         favoriteArtists = []
+        recentlyDiscoveredArtists = []
         rediscover = []
         suggestions = []
         searchResults = nil
@@ -1489,6 +1501,7 @@ final class AppModel {
         await refreshQuickPicks()
         await refreshFavoriteAlbums()
         await refreshFavoriteArtists()
+        await refreshRecentlyDiscoveredArtists()
         await refreshRediscover()
         await refreshSuggestions()
     }
@@ -2005,6 +2018,22 @@ final class AppModel {
     /// empty or errored result just leaves the shelf hidden.
     func refreshFavoriteArtists() async {
         self.favoriteArtists = await loadFavoriteArtists(limit: 100)
+    }
+
+    /// Refresh the "Recently Discovered Artists" carousel (#252). Calls the
+    /// `core.listRecentlyAddedArtists` FFI, which hits Jellyfin's
+    /// `Artists/AlbumArtists` endpoint sorted `DateCreated` descending, so
+    /// the row surfaces the album artists whose catalogue most recently
+    /// landed on the server. Runs off the MainActor per the gap-#2 pattern
+    /// so the Rust `Inner` mutex doesn't block the UI thread. Best-effort:
+    /// an empty or errored result just leaves the shelf hidden. We request a
+    /// few more than the view's display cap so the row stays full even if
+    /// the freshest entries dedupe against another shelf later.
+    func refreshRecentlyDiscoveredArtists() async {
+        let fetched = await Task.detached(priority: .userInitiated) { [core] in
+            (try? core.listRecentlyAddedArtists(offset: 0, limit: 24))?.items ?? []
+        }.value
+        self.recentlyDiscoveredArtists = fetched
     }
 
     /// Refresh the "You might like" discovery row (#145). Calls

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1116,6 +1116,11 @@ final class AppModel {
         // pane to mount. An empty/absent value means "follow system default".
         let savedDeviceUID = UserDefaults.standard.string(forKey: AudioOutputDevices.preferenceKey) ?? ""
         self.audio.outputDeviceUID = savedDeviceUID.isEmpty ? nil : savedDeviceUID
+        // Seed the engine with the persisted ReplayGain / pre-gain selection so
+        // the first track is normalized without waiting for the Preferences
+        // pane to mount (#42). `.off` (the default) leaves the level untouched.
+        self.audio.normalizationMode = AppModel.normalizationMode(forStoredValue: UserDefaults.standard.string(forKey: AppModel.normalizationKey))
+        self.audio.normalizationPreGainDb = UserDefaults.standard.double(forKey: AppModel.preGainKey)
         // Seed the scrobble-connected flag from the core's persisted token so
         // the Preferences pane shows the right state on first open.
         self.scrobbleConnected = core.isScrobbleConfigured()
@@ -5613,6 +5618,42 @@ final class AppModel {
                 }
             }
         }
+    }
+
+    /// `@AppStorage` key for the ReplayGain mode (`NormalizationMode` raw value).
+    /// Mirrors the literal used by `PreferencesPlayback`; kept here so the init
+    /// seed and the picker route never drift apart. See #42.
+    static let normalizationKey = "playback.normalization"
+
+    /// `@AppStorage` key for the user pre-gain in dB. See #42.
+    static let preGainKey = "playback.preGainDb"
+
+    /// Map the persisted `NormalizationMode` raw value onto the engine's
+    /// `ReplayGainMode`. Both enums share the same `off`/`track`/`album` tokens,
+    /// so the raw string round-trips; an unknown / absent value (e.g. a key
+    /// that was never written) falls back to `.off`, matching the picker's
+    /// default. Pure + static (and `nonisolated`, since it touches no
+    /// `@MainActor` state) so the test target — and the engine-seed path — can
+    /// exercise the mapping from any context without building an `AppModel`.
+    nonisolated static func normalizationMode(forStoredValue raw: String?) -> ReplayGainMode {
+        ReplayGainMode(rawValue: raw ?? "") ?? .off
+    }
+
+    /// Apply the chosen ReplayGain mode + pre-gain to the live engine (#42).
+    /// Persists both values and pushes them onto `AudioEngine`, which re-reads
+    /// the current item's loudness tags and re-applies (or clears) the gain on
+    /// the playing track immediately — the same eager-apply contract as
+    /// `setOutputDevice`. The Preferences picker routes through here so a change
+    /// takes effect on the current song, not just the next one.
+    ///
+    /// Pre-gain only matters while `mode != .off`; passing it through regardless
+    /// keeps the stored value and the engine in sync so flipping normalization
+    /// back on later already reflects the saved pre-gain.
+    func setNormalization(mode: NormalizationMode, preGainDb: Double) {
+        UserDefaults.standard.set(mode.rawValue, forKey: AppModel.normalizationKey)
+        UserDefaults.standard.set(preGainDb, forKey: AppModel.preGainKey)
+        audio.normalizationMode = AppModel.normalizationMode(forStoredValue: mode.rawValue)
+        audio.normalizationPreGainDb = preGainDb
     }
 
     /// Seek the current track by a relative offset (seconds). Negative rewinds,

--- a/macos/Sources/Lyrebird/Components/DynamicTypeReflow.swift
+++ b/macos/Sources/Lyrebird/Components/DynamicTypeReflow.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+/// Pure decision logic for Dynamic-Type-driven layout reflow of the persistent
+/// chrome — the `PlayerBar` and the `Sidebar` (#338).
+///
+/// `#337` made every `Theme.font` call scale with the user's
+/// System Settings → Display → Larger Text preference. That fixed the *type*,
+/// but the chrome around it still used fixed widths / heights: the player bar
+/// pins its left meta to 280pt, its right controls to 220pt, and the whole bar
+/// to a hard 78/96pt height; the sidebar nav / stat rows render their labels
+/// with no line limit. At the accessibility text sizes (`AX1`…`AX5`) the
+/// scaled glyphs overflow those frames and clip or shove the transport off the
+/// edge of the window.
+///
+/// The fix is layout reflow, not more font work: above a threshold text size
+/// the player bar stacks its three regions (meta / transport / volume)
+/// vertically instead of crowding them onto one fixed-width row, and the bar's
+/// fixed height becomes a *minimum* height so the taller stacked content can
+/// grow downward instead of truncating. The sidebar rows let their labels wrap
+/// to a second line rather than eliding to an unreadable ellipsis.
+///
+/// This type captures the "should we reflow, and to what metrics" contract as a
+/// single pure, allocation-free, side-effect-free function so the threshold
+/// behaviour is unit-testable without booting a SwiftUI scene or introspecting
+/// `some View`. The views own the `@Environment(\.dynamicTypeSize)` read and
+/// feed the value in here; everything visual downstream is a branch on the
+/// returned `Decision`.
+enum DynamicTypeReflow {
+    /// The smallest text size that triggers reflow. We reflow at the
+    /// *accessibility* sizes only (`.accessibility1` and up): the five
+    /// non-accessibility steps (`xSmall`…`xxxLarge`) keep the horizontal
+    /// layout because the design widths were sized with `xxxLarge` headroom in
+    /// mind and a premature stack would make the bar feel broken for users who
+    /// only nudged the slider one notch. `DynamicTypeSize` is `Comparable`, so
+    /// the gate is a single `>=` against this floor — and it lines up exactly
+    /// with the SDK's own `isAccessibilitySize`, which we assert in tests so a
+    /// future SDK reshuffle can't silently drift the two apart.
+    static let reflowFloor: DynamicTypeSize = .accessibility1
+
+    /// The player bar's resting height at the body text sizes, with no
+    /// "Playing from {source}" label present. Mirrors the historical hard
+    /// `frame(height: 78)`; now used as a *minimum* so the row can grow when
+    /// content needs more vertical space (see `Decision.minBarHeight`).
+    static let baseBarHeight: CGFloat = 78
+
+    /// The player bar's resting height when a "Playing from {source}" label is
+    /// present. Mirrors the historical hard `frame(height: 96)`.
+    static let contextBarHeight: CGFloat = 96
+
+    /// Minimum height for the player bar once its regions stack vertically.
+    /// Tall enough that the three stacked rows (meta, transport, scrubber +
+    /// volume) clear each other at `AX5` without the bar collapsing; the frame
+    /// is a `minHeight`, so real content taller than this still grows the bar
+    /// rather than clipping.
+    static let stackedMinBarHeight: CGFloat = 200
+
+    /// Maximum number of lines a sidebar nav / stat / playlist label may use.
+    /// At body sizes labels stay on one line (the design intent — these are
+    /// short nav nouns). Once reflow engages we allow a second line so a
+    /// scaled-up "Recently Added" / a long playlist name wraps instead of
+    /// eliding mid-word to an unreadable ellipsis.
+    static let sidebarLabelLineLimit = 1
+    static let sidebarReflowLabelLineLimit = 2
+
+    /// The outcome of a Dynamic Type size change for the persistent chrome.
+    /// Equatable so it slots cleanly into tests and into `onChange`-style
+    /// comparisons without bespoke equality.
+    struct Decision: Equatable {
+        /// True once the text size is at or above `reflowFloor`. Drives both
+        /// the player-bar axis switch and the sidebar wrap allowance.
+        var shouldReflow: Bool
+
+        /// Whether the player bar should lay its three regions out vertically
+        /// (`true`) or keep the historical single horizontal row (`false`).
+        /// Identical to `shouldReflow` today; kept as a distinct field so a
+        /// future intermediate breakpoint (e.g. a two-row hybrid) can diverge
+        /// the player bar from the sidebar without touching call sites.
+        var stackPlayerBar: Bool
+
+        /// The `minHeight` the player bar should adopt. When not reflowing this
+        /// is the historical fixed height for the current context-label state,
+        /// applied as a floor rather than an exact height so a one-notch glyph
+        /// overflow at the body sizes can still nudge the bar a couple of
+        /// points taller instead of clipping. When reflowing it jumps to
+        /// `stackedMinBarHeight` to seat the stacked rows.
+        var minBarHeight: CGFloat
+
+        /// Line limit for sidebar nav / stat / playlist labels. `1` at body
+        /// sizes (design intent), `2` once reflowing so long labels wrap.
+        var sidebarLabelLineLimit: Int
+    }
+
+    /// Pure reducer. Given the active `dynamicTypeSize` and whether the player
+    /// bar currently shows a "Playing from {source}" context label, returns the
+    /// reflow decision the chrome should adopt.
+    ///
+    /// Contract:
+    ///   * Below `reflowFloor` (every non-accessibility size): no reflow. The
+    ///     player bar keeps its horizontal layout and its historical
+    ///     context-dependent height as a `minHeight`; sidebar labels stay on
+    ///     one line.
+    ///   * At or above `reflowFloor`: reflow on. The player bar stacks and
+    ///     adopts `stackedMinBarHeight`; sidebar labels may wrap to two lines.
+    static func decide(
+        dynamicTypeSize: DynamicTypeSize,
+        hasContextLabel: Bool
+    ) -> Decision {
+        let reflow = dynamicTypeSize >= reflowFloor
+        let baseHeight = hasContextLabel ? contextBarHeight : baseBarHeight
+        return Decision(
+            shouldReflow: reflow,
+            stackPlayerBar: reflow,
+            minBarHeight: reflow ? stackedMinBarHeight : baseHeight,
+            sidebarLabelLineLimit: reflow
+                ? sidebarReflowLabelLineLimit
+                : sidebarLabelLineLimit
+        )
+    }
+}

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -8,6 +8,13 @@ struct PlayerBar: View {
     // accent-tinted transport icons clear 4.5:1 (#888). Decorative accents
     // (e.g. the play-button fill) keep the base token.
     @Environment(\.accessibleTheme) private var a11yTheme
+    // Dynamic Type size drives layout reflow (#338): at the accessibility text
+    // sizes the three fixed-width regions (meta / transport / volume) can't
+    // share one row without clipping, so we stack them vertically and let the
+    // bar grow taller. The decision is factored into the pure
+    // `DynamicTypeReflow.decide` helper so the threshold is unit-tested without
+    // a live scene; this view only reads the size and branches on the result.
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     /// Local scrubber position used while the user is actively dragging the
     /// Slider. We don't bind the Slider straight to `status.positionSeconds`
@@ -19,27 +26,29 @@ struct PlayerBar: View {
     @State private var isScrubbing: Bool = false
 
     var body: some View {
-        HStack(spacing: 16) {
-            leftMeta
-                .frame(width: 280, alignment: .leading)
-                // Tab order: primary metadata → transport → volume.
-                // See #334. Higher priority ships focus here first.
-                .accessibilitySortPriority(60)
-            Spacer(minLength: 16)
-            centerTransport
-                .frame(maxWidth: 640)
-                .accessibilitySortPriority(50)
-            Spacer(minLength: 16)
-            rightControls
-                .frame(width: 220, alignment: .trailing)
-                .accessibilitySortPriority(40)
+        // Reflow decision for the current text size (#338). `hasContextLabel`
+        // tracks the "Playing from {source}" affordance so the resting
+        // (non-reflowed) min-height still matches the historical 78/96pt chrome
+        // and the bar doesn't twitch when the label toggles between tracks.
+        let reflow = DynamicTypeReflow.decide(
+            dynamicTypeSize: dynamicTypeSize,
+            hasContextLabel: model.currentContext != nil
+        )
+        Group {
+            if reflow.stackPlayerBar {
+                stackedLayout
+            } else {
+                horizontalLayout
+            }
         }
         .padding(.horizontal, 16)
-        // Bar grows a few points taller when a "Playing from {source}"
-        // label is present (#82). Keeping both heights hard-coded preserves
-        // the stable bar chrome so the whole app doesn't shift a pixel
-        // when the label appears or disappears between tracks.
-        .frame(height: model.currentContext == nil ? 78 : 96)
+        // Below the accessibility sizes this is the historical fixed
+        // 78/96pt height, but applied as a *minimum* rather than an exact
+        // frame so a one-notch glyph overflow can nudge the bar a couple of
+        // points taller instead of clipping. At the accessibility sizes the
+        // floor jumps so the vertically stacked regions seat without overlap;
+        // real content taller than the floor grows the bar downward. See #338.
+        .frame(minHeight: reflow.minBarHeight)
         // HUD-style translucent material for the unified transport bar so
         // the chrome matches Music.app's bottom panel and reads as "system
         // chrome" rather than app content. Brand wash on top keeps Lyrebird's
@@ -56,6 +65,52 @@ struct PlayerBar: View {
         // before the persistent chrome at the bottom. See #334.
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Playback controls")
+    }
+
+    /// The default single-row layout used at the body text sizes (#338). The
+    /// three regions ride fixed widths with flexible spacers between them, the
+    /// historical chrome. `accessibilitySortPriority` keeps the #334 tab order
+    /// (meta → transport → volume) regardless of layout axis.
+    @ViewBuilder
+    private var horizontalLayout: some View {
+        HStack(spacing: 16) {
+            leftMeta
+                .frame(width: 280, alignment: .leading)
+                // Tab order: primary metadata → transport → volume.
+                // See #334. Higher priority ships focus here first.
+                .accessibilitySortPriority(60)
+            Spacer(minLength: 16)
+            centerTransport
+                .frame(maxWidth: 640)
+                .accessibilitySortPriority(50)
+            Spacer(minLength: 16)
+            rightControls
+                .frame(width: 220, alignment: .trailing)
+                .accessibilitySortPriority(40)
+        }
+    }
+
+    /// Accessibility-size layout (#338): the same three regions stacked
+    /// vertically so the Dynamic-Type-scaled glyphs each get the full bar
+    /// width instead of being squeezed into a 280 / 220pt column where they'd
+    /// clip. The regions drop their fixed widths and fill the width; the bar's
+    /// `minHeight` (from `DynamicTypeReflow`) grows to seat all three rows.
+    /// Sort priorities are preserved so VoiceOver / Tab traversal order is
+    /// identical to the horizontal layout — only the visual axis changes.
+    @ViewBuilder
+    private var stackedLayout: some View {
+        VStack(spacing: 10) {
+            leftMeta
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilitySortPriority(60)
+            centerTransport
+                .frame(maxWidth: .infinity)
+                .accessibilitySortPriority(50)
+            rightControls
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .accessibilitySortPriority(40)
+        }
+        .padding(.vertical, 10)
     }
 
     @ViewBuilder

--- a/macos/Sources/Lyrebird/Components/PlaylistSidebarOrder.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistSidebarOrder.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Pure ordering logic for the sidebar's drag-to-reorder Playlists list (#317).
+///
+/// The sidebar lets the user drag playlist rows into a personal order and
+/// collapse the whole section. Reorder persistence is deliberately
+/// **client-only**: rather than asking the server to renumber playlists (a
+/// `MoveItem` round-trip that can fail and is tracked separately), we keep an
+/// ordered list of playlist ids in `@AppStorage` and *sort the live
+/// `model.playlists` array by it* on every render. That makes the feature
+/// impossible to desync from the server — the stored order is just a view
+/// preference layered over whatever set of playlists the core hands us.
+///
+/// The hard parts are all set-reconciliation, not UI:
+///   * the server set drifts (new playlists appear, old ones get deleted), so
+///     the stored order must be reconciled against the current ids on every
+///     read — unknown ids append in their server order, deleted ids prune;
+///   * a `.onMove` from SwiftUI hands us `IndexSet` + destination against the
+///     *displayed* (already-sorted) order, which we fold back into a fresh id
+///     list to persist.
+///
+/// All of this is expressed as side-effect-free static functions over a CSV
+/// string (the `@AppStorage` value) so the contract is unit-testable without
+/// booting a SwiftUI scene or touching `UserDefaults`. The view owns the
+/// `@AppStorage` string and feeds it through `order(ids:by:)` to sort and
+/// through `applyingMove` / `reconciled` to compute the next stored value.
+enum PlaylistSidebarOrder {
+
+    // MARK: - CSV codec
+
+    /// Decode the stored `@AppStorage` value into an ordered id list.
+    ///
+    /// Stored as a comma-separated string because `@AppStorage` can't persist
+    /// an `[String]` directly. Empty / whitespace-only entries are dropped so a
+    /// stray trailing comma or a freshly-initialised `""` default decodes to an
+    /// empty list rather than a `[""]` ghost. Playlist ids are 32-char hex
+    /// GUIDs and never contain commas, so a plain split is unambiguous.
+    static func decode(_ raw: String) -> [String] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Encode an ordered id list back into the `@AppStorage` CSV value.
+    static func encode(_ ids: [String]) -> String {
+        ids.joined(separator: ",")
+    }
+
+    // MARK: - Reconciliation
+
+    /// Reconcile a stored order against the set of ids the server currently
+    /// knows about.
+    ///
+    /// Contract:
+    ///   * ids present in both `stored` and `current` keep their stored
+    ///     relative order;
+    ///   * ids in `current` but not `stored` (new playlists) append, in their
+    ///     `current` order, so a brand-new playlist lands at the bottom of the
+    ///     user's arrangement rather than jumping to the top;
+    ///   * ids in `stored` but not `current` (deleted playlists) are pruned;
+    ///   * the result is duplicate-free even if the stored value was corrupt.
+    ///
+    /// The returned array is a permutation of `current`, so sorting by it is
+    /// total — every live playlist has a slot.
+    static func reconciled(stored: [String], current: [String]) -> [String] {
+        let currentSet = Set(current)
+        var seen = Set<String>()
+        var result: [String] = []
+        // Keep the stored order for ids that still exist, de-duplicating.
+        for id in stored where currentSet.contains(id) && seen.insert(id).inserted {
+            result.append(id)
+        }
+        // Append any current ids the stored order didn't mention, in server
+        // order. `seen` also guards `current` against its own duplicates.
+        for id in current where seen.insert(id).inserted {
+            result.append(id)
+        }
+        return result
+    }
+
+    /// Sort `items` by the stored order, reconciling first so new items land at
+    /// the bottom and deleted ones can't strand a live item.
+    ///
+    /// Generic over the element so it works against the live `[Playlist]`
+    /// without importing the FFI type here — the view passes a key path /
+    /// closure to read each element's id. A stable partition preserves the
+    /// server's relative order for the appended (previously-unseen) tail.
+    static func order<Element>(
+        _ items: [Element],
+        by stored: [String],
+        id: (Element) -> String
+    ) -> [Element] {
+        guard !items.isEmpty else { return [] }
+        let currentIds = items.map(id)
+        let ranked = reconciled(stored: stored, current: currentIds)
+        // rank[id] → position; every live id is present because `reconciled`
+        // returns a permutation of `currentIds`.
+        var rank: [String: Int] = [:]
+        rank.reserveCapacity(ranked.count)
+        for (index, value) in ranked.enumerated() { rank[value] = index }
+        // `sorted(by:)` isn't guaranteed stable, so sort on the (rank, original
+        // index) pair to keep ties deterministic.
+        return items.enumerated()
+            .sorted { lhs, rhs in
+                let lr = rank[id(lhs.element)] ?? Int.max
+                let rr = rank[id(rhs.element)] ?? Int.max
+                if lr != rr { return lr < rr }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    // MARK: - Move
+
+    /// Fold a SwiftUI `.onMove(source:destination:)` into a fresh stored order.
+    ///
+    /// `displayedIds` is the id list in the order currently shown to the user
+    /// (i.e. already sorted by `order(_:by:)`), and `source` / `destination`
+    /// are exactly what `.onMove` hands the view. We apply the move to that
+    /// displayed order and return the new full id list to persist — encoding the
+    /// *entire* arrangement (not a sparse override) so the next reconcile is a
+    /// straight pass-through.
+    static func applyingMove(
+        displayedIds: [String],
+        source: IndexSet,
+        destination: Int
+    ) -> [String] {
+        var ids = displayedIds
+        ids.move(fromOffsets: source, toOffset: destination)
+        return ids
+    }
+}

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -16,6 +16,12 @@ struct Sidebar: View {
     // accent-tinted glyphs clear 4.5:1 (#888). The 3pt active-tab indicator
     // rail is decorative and keeps the base token.
     @Environment(\.accessibleTheme) private var a11yTheme
+    // Dynamic Type size drives row reflow (#338): at the accessibility text
+    // sizes the nav / stat / playlist labels would otherwise elide to an
+    // unreadable single-line ellipsis, so we let them wrap to a second line.
+    // The line-limit decision is factored into the pure `DynamicTypeReflow`
+    // helper (shared with `PlayerBar`) so the threshold is unit-tested.
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     /// The playlist row currently hovered by the pointer. Used to reveal
     /// the subtle trailing affordances (copying spinner slot); `nil` when
@@ -29,6 +35,18 @@ struct Sidebar: View {
     @AppStorage(LibraryDefaults.sidebarShowAlbumsKey) private var showAlbums = true
     @AppStorage(LibraryDefaults.sidebarShowArtistsKey) private var showArtists = true
     @AppStorage(LibraryDefaults.sidebarShowPlaylistsKey) private var showPlaylists = true
+
+    /// Max lines a nav / stat / playlist label may use at the current text
+    /// size (#338): `1` at body sizes (these are short nav nouns by design),
+    /// `2` once Dynamic Type reaches the accessibility range so a scaled-up
+    /// label wraps gracefully instead of eliding mid-word. `hasContextLabel`
+    /// is irrelevant to the sidebar, so we pass `false`.
+    private var labelLineLimit: Int {
+        DynamicTypeReflow.decide(
+            dynamicTypeSize: dynamicTypeSize,
+            hasContextLabel: false
+        ).sidebarLabelLineLimit
+    }
 
     var body: some View {
         @Bindable var model = model
@@ -225,7 +243,10 @@ struct Sidebar: View {
                 Text(playlist.name)
                     .font(Theme.font(12, weight: isActiveScreen ? .bold : .medium))
                     .foregroundStyle(isActiveScreen ? Theme.ink : Theme.ink2)
-                    .lineLimit(1)
+                    // #338: a long playlist name elides on one line at body
+                    // sizes but is allowed a second line at accessibility
+                    // sizes before tail-eliding, so it stays readable.
+                    .lineLimit(labelLineLimit)
                     .truncationMode(.tail)
             }
 
@@ -298,6 +319,9 @@ struct Sidebar: View {
                 Text(label)
                     .font(Theme.font(13, weight: active ? .bold : .semibold))
                     .foregroundStyle(active ? Theme.ink : Theme.ink2)
+                    // #338: wrap to a second line at accessibility sizes
+                    // instead of eliding; one line at body sizes by design.
+                    .lineLimit(labelLineLimit)
                 Spacer()
             }
             .padding(.horizontal, 10)
@@ -341,6 +365,7 @@ struct Sidebar: View {
                 Text("sidebar.stats.favorites")
                     .font(Theme.font(13, weight: .semibold))
                     .foregroundStyle(Theme.ink2)
+                    .lineLimit(labelLineLimit)
                 Spacer()
             }
             .padding(.horizontal, 10)
@@ -375,11 +400,18 @@ struct Sidebar: View {
                 Text(label)
                     .font(Theme.font(13, weight: .semibold))
                     .foregroundStyle(Theme.ink2)
-                Spacer()
+                    // #338: wrap rather than elide at accessibility sizes.
+                    .lineLimit(labelLineLimit)
+                Spacer(minLength: 8)
                 if let c = count {
                     Text("\(c)")
                         .font(Theme.font(10, weight: .bold))
                         .foregroundStyle(Theme.ink3)
+                        // The count is a short numeral; keep it on one line so
+                        // it never wraps under the label, even when the label
+                        // itself wraps to two lines.
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
             }
             .padding(.horizontal, 10)

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -30,6 +30,17 @@ struct Sidebar: View {
     @AppStorage(LibraryDefaults.sidebarShowArtistsKey) private var showArtists = true
     @AppStorage(LibraryDefaults.sidebarShowPlaylistsKey) private var showPlaylists = true
 
+    // #317: collapse state + manual drag-reorder for the Playlists section.
+    // `playlistsCollapsed` hides the rows behind the header's disclosure
+    // chevron; `playlistOrderRaw` is a CSV of playlist ids that the live list
+    // is sorted by (see `PlaylistSidebarOrder`). Both persist via @AppStorage.
+    @AppStorage(LibraryDefaults.sidebarPlaylistsCollapsedKey) private var playlistsCollapsed = false
+    @AppStorage(LibraryDefaults.sidebarPlaylistOrderKey) private var playlistOrderRaw = ""
+
+    // Disclosure-chevron rotation + row reveal honour Reduce Motion, matching
+    // the rest of the component library (e.g. AmbientWash, ArtistCard).
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         @Bindable var model = model
         VStack(alignment: .leading, spacing: 0) {
@@ -153,12 +164,41 @@ struct Sidebar: View {
     @ViewBuilder
     private var playlistsSection: some View {
         let editingNew = model.sidebarEditingPlaylistId == AppModel.sidebarNewPlaylistSentinel
+        // Sort the live playlists by the persisted manual order. New playlists
+        // append; deleted ones prune — see `PlaylistSidebarOrder`.
+        let orderedPlaylists = PlaylistSidebarOrder.order(
+            model.playlists,
+            by: PlaylistSidebarOrder.decode(playlistOrderRaw),
+            id: \.id
+        )
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {
-                Text("PLAYLISTS")
-                    .font(Theme.font(10, weight: .bold))
-                    .foregroundStyle(Theme.ink3)
-                    .tracking(1.5)
+                // #317: header is a disclosure toggle. Clicking the chevron /
+                // label collapses the rows while keeping the header in place.
+                Button {
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.18)) {
+                        playlistsCollapsed.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(Theme.ink3)
+                            .rotationEffect(.degrees(playlistsCollapsed ? 0 : 90))
+                            .frame(width: 10)
+                        Text("PLAYLISTS")
+                            .font(Theme.font(10, weight: .bold))
+                            .foregroundStyle(Theme.ink3)
+                            .tracking(1.5)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Playlists")
+                .accessibilityValue(playlistsCollapsed ? "Collapsed" : "Expanded")
+                .accessibilityHint("Show or hide your playlists")
+                .accessibilityAddTraits(.isButton)
+
                 Spacer()
                 Button { model.beginNewPlaylist() } label: {
                     Image(systemName: "plus")
@@ -175,26 +215,56 @@ struct Sidebar: View {
             .padding(.top, 2)
             .padding(.bottom, 4)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 1) {
+            if !playlistsCollapsed {
+                // A `List` (rather than a ScrollView+VStack) is what unlocks
+                // SwiftUI's native `.onMove` drag-reorder. It's styled down to
+                // match the rest of the sidebar: plain rows, no separators, a
+                // clear background so the sidebar material shows through.
+                List {
                     // In-progress new-playlist row, shown at the top so the
-                    // user sees where the new item will land.
+                    // user sees where the new item will land. Not movable.
                     if editingNew {
                         newPlaylistEditRow
+                            .listRowSidebarStyling()
+                            .moveDisabled(true)
                     }
-                    ForEach(model.playlists, id: \.id) { playlist in
+                    ForEach(orderedPlaylists, id: \.id) { playlist in
                         playlistRow(playlist)
+                            .listRowSidebarStyling()
+                    }
+                    .onMove { source, destination in
+                        moveSidebarPlaylists(
+                            displayed: orderedPlaylists,
+                            from: source,
+                            to: destination
+                        )
                     }
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .environment(\.defaultMinListRowHeight, 0)
+                // Reasonable ceiling so a user with hundreds of playlists
+                // doesn't push the server footer off-screen. Scroll handles
+                // the overflow.
+                .frame(maxHeight: 280)
             }
-            // Reasonable ceiling so a user with hundreds of playlists
-            // doesn't push the server footer off-screen. Scroll handles
-            // the overflow.
-            .frame(maxHeight: 280)
         }
         // #585: Allow space-bar input in the inline rename / new-playlist
         // TextField even while the global Play/Pause ⎵ shortcut is active.
         .spaceKeyGuardForTextField()
+    }
+
+    /// Fold a `.onMove` from the Playlists list into the persisted order
+    /// (#317). `displayed` is the already-sorted list the user sees, so the
+    /// move offsets line up; we re-encode the whole arrangement to AppStorage.
+    /// Pure list math — no server round-trip (see `PlaylistSidebarOrder`).
+    private func moveSidebarPlaylists(displayed: [Playlist], from source: IndexSet, to destination: Int) {
+        let next = PlaylistSidebarOrder.applyingMove(
+            displayedIds: displayed.map(\.id),
+            source: source,
+            destination: destination
+        )
+        playlistOrderRaw = PlaylistSidebarOrder.encode(next)
     }
 
     // MARK: - Playlist row (display + inline edit)
@@ -408,6 +478,22 @@ struct Sidebar: View {
             .padding(.horizontal, 18)
             .padding(.top, 20)
             .padding(.bottom, 6)
+    }
+}
+
+// MARK: - #317: List-row chrome reset for the reorderable Playlists list
+
+private extension View {
+    /// Strip a `List` row's default insets / background / separator so a
+    /// playlist row drawn inside the reorderable `List` renders identically to
+    /// the previous ScrollView+VStack layout. The row already paints its own
+    /// 1pt vertical spacing and rounded hover/active background, so the List
+    /// must contribute nothing but the drag affordance.
+    func listRowSidebarStyling() -> some View {
+        self
+            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 1, trailing: 0))
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
     }
 }
 

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -110,6 +110,21 @@ struct LyrebirdApp: App {
         .defaultSize(width: 480, height: 560)
         .windowResizability(.contentSize)
 
+        // Dedicated About window (#25). A single-instance `Window` (not a
+        // `WindowGroup`) so the app-menu "About Lyrebird" item — rebound via
+        // `CommandGroup(replacing: .appInfo)` above — summons exactly one
+        // panel. `AboutView` reads version / credits from the shared
+        // `AboutInfo` and the connected-server host from the live `AppModel`,
+        // so it needs the model in its environment. `.contentSize` lets the
+        // fixed-width column size itself to its content.
+        Window("about.window.title", id: AboutView.windowID) {
+            AboutView()
+                .environment(model)
+                .preferredColorScheme(preferredColorScheme)
+        }
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
+
         // Status-bar "Now Playing" extra. A `MenuBarExtra` lives in the system
         // menu bar, so this transport surface stays reachable even when every
         // Lyrebird window is closed or the app is hidden. The `.window`
@@ -186,6 +201,19 @@ struct LyrebirdCommands: Commands {
     @Environment(\.openWindow) private var openWindow
 
     var body: some Commands {
+        // MARK: App menu — About Lyrebird (#25)
+        //
+        // Replace the stock AppKit about box with our branded About window.
+        // `replacing: .appInfo` keeps the item in its standard top-of-app-menu
+        // position; the button summons the single-instance `Window(id:)` scene
+        // declared below. The sibling `after: .appInfo` group (Check for
+        // Updates…) still anchors right beneath it.
+        CommandGroup(replacing: .appInfo) {
+            Button("menu.app.about") {
+                openWindow(id: AboutView.windowID)
+            }
+        }
+
         // MARK: App menu — Check for Updates… (Sparkle, #864)
         //
         // Standard Sparkle placement: just after the "About Lyrebird" item in

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1,6 +1,18 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "about.window.title" : {
+      "comment" : "Window title for the dedicated About Lyrebird window (#25).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About Lyrebird"
+          }
+        }
+      }
+    },
     "app.name" : {
       "comment" : "Brand name shown in the sidebar header and splash screens.",
       "extractionState" : "manual",
@@ -657,6 +669,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Password"
+          }
+        }
+      }
+    },
+    "menu.app.about" : {
+      "comment" : "App menu \u201cAbout Lyrebird\u201d item that opens the dedicated About window (#25).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About Lyrebird"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Screens/AboutView.swift
+++ b/macos/Sources/Lyrebird/Screens/AboutView.swift
@@ -1,0 +1,172 @@
+import AppKit
+import SwiftUI
+
+/// Dedicated **About Lyrebird** window (#25).
+///
+/// Summoned from the app menu's standard "About Lyrebird" item, which
+/// `LyrebirdApp` rebinds via `CommandGroup(replacing: .appInfo)` so it opens
+/// this branded panel instead of AppKit's stock about box. The window shows the
+/// app mark, name, version + build, the connected server (host only), a short
+/// copyright line, and an acknowledgements list.
+///
+/// All textual payload comes from ``AboutInfo`` — the same source the
+/// Preferences → About pane reads — so the menu's About box and the Settings
+/// pane can never advertise different versions or credits. The connected-server
+/// row reads the live `serverURL` off `AppModel` and routes it through
+/// `AboutInfo.connectedServerHost` (host only, no path / token), then hides
+/// itself entirely when signed out.
+struct AboutView: View {
+    @Environment(AppModel.self) private var model
+
+    /// Resolved once per appearance — these are bundle reads that never change
+    /// for the lifetime of the process, so there's no reason to recompute them
+    /// on every body pass.
+    private let version = AboutInfo.version()
+    private let build = AboutInfo.build()
+    private let copyright = AboutInfo.copyright()
+
+    /// Connected server host (host only) or `nil` when signed out, in which
+    /// case the row is omitted.
+    private var serverHost: String? {
+        AboutInfo.connectedServerHost(from: model.serverURL)
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            appIcon
+
+            VStack(spacing: 6) {
+                Text(AboutInfo.appName)
+                    .font(Theme.font(26, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+
+                Text(AboutInfo.tagline)
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .multilineTextAlignment(.center)
+            }
+
+            versionBlock
+
+            if let serverHost {
+                serverRow(host: serverHost)
+            }
+
+            Divider()
+                .overlay(Theme.border)
+                .padding(.horizontal, 24)
+
+            creditsBlock
+
+            Text(copyright)
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 28)
+        .frame(width: 360)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(Theme.bg)
+    }
+
+    // MARK: - Pieces
+
+    /// The brand mark — a rounded-square accent gradient with a stylised "J",
+    /// matching the Preferences About pane and the login screen. Rendered in
+    /// code so the window needs no asset-catalog dependency.
+    private var appIcon: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 18)
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.primary, Theme.accent],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Text("J")
+                .font(Theme.font(46, weight: .black, italic: true))
+                .foregroundStyle(.white)
+        }
+        .frame(width: 84, height: 84)
+        .accessibilityHidden(true)
+    }
+
+    private var versionBlock: some View {
+        VStack(spacing: 2) {
+            Text("Version \(version)")
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .monospacedDigit()
+                .textSelection(.enabled)
+            Text("Build \(build)")
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .monospacedDigit()
+                .textSelection(.enabled)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Version \(version), build \(build)")
+    }
+
+    private func serverRow(host: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "externaldrive.connected.to.line.below")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+            Text(host)
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Theme.surface)
+        .clipShape(Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Connected to \(host)")
+    }
+
+    private var creditsBlock: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Acknowledgements")
+                .font(Theme.font(11, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .textCase(.uppercase)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            ForEach(AboutInfo.credits) { credit in
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(credit.name)
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.ink)
+                    Text(credit.role)
+                        .font(Theme.font(11, weight: .regular))
+                        .foregroundStyle(Theme.ink3)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(credit.name). \(credit.role)")
+            }
+        }
+    }
+
+    // MARK: - Scene identity
+
+    /// Scene identity for the dedicated About `Window`. Centralised so the
+    /// scene declaration in `LyrebirdApp` and the `openWindow(id:)` call site
+    /// in the `.appInfo` command agree on the id, matching the
+    /// `AppShortcuts.windowID` / `MiniPlayerScene.id` convention.
+    static let windowID = "about-lyrebird"
+}
+
+#Preview {
+    // Real rendering requires an `AppModel` in the environment; the dedicated
+    // About `Window` in `LyrebirdApp` injects one. Previews without a model
+    // will crash on `@Environment(AppModel.self)` — this preview is kept as
+    // documentation for where the view lives, matching `PreferencesServer` /
+    // `PreferencesAccount`.
+    AboutView()
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -31,6 +31,7 @@ struct HomeView: View {
                 // land (#206, #209).
                 recentlyPlayedSection
                 artistsYouLoveSection
+                recentlyDiscoveredArtistsSection
                 jumpBackInSection
                 recentlyPlayedTracksSection
                 yourPlaylistsSection
@@ -438,6 +439,50 @@ struct HomeView: View {
     /// horizontal scroll bounded for users with a large favorites set; the
     /// "See All" button routes to the full Favorites screen for the rest.
     private var artistsYouLoveLimit: Int { 18 }
+
+    /// "Recently Discovered Artists" — a circle-card carousel of the album
+    /// artists whose catalogue most recently landed on the library (#252).
+    /// Reads `model.recentlyDiscoveredArtists`, which the core sorts by
+    /// `DateCreated` descending (newest arrivals first) via the
+    /// `listRecentlyAddedArtists` FFI. Reuses `ArtistCard` — the same circular
+    /// tile the Library Artists grid, Favorites screen, and "Artists You Love"
+    /// row render — so the visual language stays consistent and tapping a card
+    /// pushes `Route.artist` through `ArtistCard`'s own button. "See All"
+    /// jumps to the Library tab's Artists list. Hidden when the slice is empty
+    /// so a fresh or static library renders no shelf rather than a blank band.
+    ///
+    /// As with "Artists You Love", `ArtistCard` is built for a grid cell and
+    /// stretches to `maxWidth: .infinity`, so each card is pinned to a fixed
+    /// width here — otherwise the cards would collapse inside the horizontal
+    /// `HStack`. The row is capped so it stays bounded.
+    @ViewBuilder
+    private var recentlyDiscoveredArtistsSection: some View {
+        if !model.recentlyDiscoveredArtists.isEmpty {
+            carouselSection(
+                icon: "person.crop.circle.badge.plus",
+                iconColor: Theme.primary,
+                title: "Recently Discovered Artists",
+                subtitle: "New names that just landed in your library",
+                onSeeAll: {
+                    model.libraryTab = .artists
+                    model.selectTab(.library)
+                }
+            ) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(model.recentlyDiscoveredArtists.prefix(recentlyDiscoveredArtistsLimit), id: \.id) { artist in
+                        ArtistCard(artist: artist)
+                            .frame(width: 150)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    /// Cap on how many circles the "Recently Discovered Artists" row renders.
+    /// Keeps the horizontal scroll bounded; the "See All" button routes to the
+    /// full Library Artists list for the rest.
+    private var recentlyDiscoveredArtistsLimit: Int { 18 }
 
     /// Pick a short list of artists to surface as radio seeds. Prefer
     /// favorites → top-listened → library order. Favorites and top-listened

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -1099,6 +1099,16 @@ enum LibraryDefaults {
     static let sidebarShowAlbumsKey = "library.sidebar.showAlbums"
     static let sidebarShowArtistsKey = "library.sidebar.showArtists"
     static let sidebarShowPlaylistsKey = "library.sidebar.showPlaylists"
+    /// `Bool` — collapse (hide the rows of) the sidebar Playlists section via
+    /// its disclosure chevron, keeping the header visible. Defaults to expanded.
+    /// See #317.
+    static let sidebarPlaylistsCollapsedKey = "library.sidebar.playlistsCollapsed"
+    /// `String` — comma-separated playlist ids capturing the user's manual
+    /// drag-reorder of the sidebar Playlists list. The live `model.playlists`
+    /// array is sorted by this on every render; new ids append and deleted ids
+    /// prune. Empty default = server order. Encoded via `PlaylistSidebarOrder`.
+    /// See #317.
+    static let sidebarPlaylistOrderKey = "library.sidebar.playlistOrder"
 }
 
 /// Persisted selection for the Library list/grid toggle. Stored via

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAbout.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAbout.swift
@@ -146,33 +146,12 @@ struct PreferencesAbout: View {
 
     // MARK: - Bundle values
 
-    /// Marketing version (`CFBundleShortVersionString`). Falls back to a
-    /// dev-only placeholder when the bundle key is missing — e.g. when
-    /// running from Xcode against an unconfigured Info.plist.
-    private var versionText: String {
-        bundleString(for: "CFBundleShortVersionString") ?? "0.0.0 (dev)"
-    }
-
-    /// Build number (`CFBundleVersion`). Similar fallback reasoning.
-    private var buildText: String {
-        bundleString(for: "CFBundleVersion") ?? "—"
-    }
-
-    /// Copyright string (`NSHumanReadableCopyright`). When missing, render a
-    /// generic attribution for Skyler Althoff + Lyrebird contributors rather
-    /// than an empty row.
-    private var copyrightText: String {
-        bundleString(for: "NSHumanReadableCopyright")
-            ?? "Copyright © Skyler Althoff and Lyrebird contributors."
-    }
-
-    private func bundleString(for key: String) -> String? {
-        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
-              !value.isEmpty else {
-            return nil
-        }
-        return value
-    }
+    /// Version / build / copyright all resolve through ``AboutInfo`` — the same
+    /// shared source the dedicated About window (#25) reads — so the Settings
+    /// pane and the app-menu About box can never advertise different values.
+    private var versionText: String { AboutInfo.version() }
+    private var buildText: String { AboutInfo.build() }
+    private var copyrightText: String { AboutInfo.copyright() }
 
     // MARK: - Actions
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -33,6 +33,8 @@ import SwiftUI
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 68 and GitHub issues #260 / #116.
 struct PreferencesPlayback: View {
+    @Environment(AppModel.self) private var model
+
     @AppStorage("playback.streamingQuality") private var streamingQuality: PlaybackQuality = .automatic
     @AppStorage("playback.downloadQuality") private var downloadQuality: PlaybackQuality = .lossless
     @AppStorage("playback.preferredCodec") private var preferredCodec: PreferredAudioCodec = .automatic
@@ -47,10 +49,32 @@ struct PreferencesPlayback: View {
     @AppStorage("playback.preGainDb") private var preGainDb: Double = 0
     @AppStorage("playback.stopAfterCurrent") private var stopAfterCurrent: Bool = false
 
+    /// Normalization picker binding. Reads `@AppStorage` for instant UI, and
+    /// routes the change through `AppModel` so the live player re-reads the
+    /// current track's ReplayGain tags and re-applies the gain immediately
+    /// rather than only on the next track (#42). Pre-gain rides along so the
+    /// engine always sees a consistent (mode, pre-gain) pair.
     private var normalization: Binding<NormalizationMode> {
         Binding(
             get: { NormalizationMode(rawValue: normalizationRaw) ?? .off },
-            set: { normalizationRaw = $0.rawValue }
+            set: { newMode in
+                normalizationRaw = newMode.rawValue
+                model.setNormalization(mode: newMode, preGainDb: preGainDb)
+            }
+        )
+    }
+
+    /// Pre-gain slider binding. Writes `@AppStorage` for instant UI and pushes
+    /// the new pre-gain onto the engine via `AppModel`, alongside the current
+    /// normalization mode (#42).
+    private var preGain: Binding<Double> {
+        Binding(
+            get: { preGainDb },
+            set: { newValue in
+                preGainDb = newValue
+                let mode = NormalizationMode(rawValue: normalizationRaw) ?? .off
+                model.setNormalization(mode: mode, preGainDb: newValue)
+            }
         )
     }
 
@@ -145,7 +169,7 @@ struct PreferencesPlayback: View {
                     label: "Pre-gain",
                     help: preGainHelp
                 ) {
-                    PreGainSlider(db: $preGainDb)
+                    PreGainSlider(db: preGain)
                 }
             }
 
@@ -502,10 +526,8 @@ struct PreferenceRow<Control: View>: View {
     }
 }
 
-#Preview {
-    PreferencesPlayback()
-        .frame(width: 560, height: 520)
-        .padding(32)
-        .background(Theme.bg)
-        .preferredColorScheme(.dark)
-}
+// Note: real rendering requires an `AppModel` in the environment — the pane
+// reads `@Environment(AppModel.self)` to route normalization / pre-gain changes
+// onto the live engine (#42). The Settings scene injects it at runtime; a bare
+// `#Preview` would crash on the missing environment value, so it's intentionally
+// omitted here — matching `PreferencesAudio`.

--- a/macos/Sources/Lyrebird/System/AboutInfo.swift
+++ b/macos/Sources/Lyrebird/System/AboutInfo.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Shared, side-effect-free source of truth for the app's "about" payload.
+///
+/// Two surfaces show the same identity block:
+///
+/// 1. The Preferences → About pane (`PreferencesAbout`), which users reach
+///    inside Settings, and
+/// 2. The dedicated **About Lyrebird** window (`AboutView`) summoned from the
+///    app menu's standard `.appInfo` slot (#25).
+///
+/// Both render version / build / copyright / connected-server / credits from
+/// *this* enum so the two can never drift. Before this existed each surface
+/// reimplemented `Bundle.main.object(forInfoDictionaryKey:)` lookups inline,
+/// which is exactly the kind of duplicate that rots when one is bumped and the
+/// other forgotten.
+///
+/// ## Testability
+///
+/// Everything here is a pure function over its inputs. The bundle lookups take
+/// an injectable ``BundleReading`` so tests assert on a fake bundle without
+/// touching `Bundle.main`, and ``connectedServerHost(from:)`` reuses the same
+/// host-only redaction contract as `DiagnosticBundle` (host only — no scheme,
+/// userinfo, port, path, or query). The static ``credits`` list is plain data.
+enum AboutInfo {
+
+    // MARK: - Bundle reading seam
+
+    /// Minimal read seam over `Bundle`'s Info.plist lookup so the version /
+    /// build / copyright accessors are unit-testable without `Bundle.main`.
+    protocol BundleReading {
+        func infoString(for key: String) -> String?
+    }
+
+    /// `Bundle` conformance: reads `Info.plist` string values, treating an
+    /// empty string as absent so callers fall back to a placeholder rather
+    /// than rendering a blank row.
+    struct AppBundle: BundleReading {
+        let bundle: Bundle
+        init(_ bundle: Bundle = .main) { self.bundle = bundle }
+
+        func infoString(for key: String) -> String? {
+            guard let value = bundle.object(forInfoDictionaryKey: key) as? String,
+                  !value.isEmpty else {
+                return nil
+            }
+            return value
+        }
+    }
+
+    // MARK: - Identity
+
+    /// Display name. A literal rather than a bundle lookup so the About
+    /// surfaces stay correct even running unbundled from Xcode (where
+    /// `CFBundleName` can be the executable name).
+    static let appName = "Lyrebird"
+
+    /// One-line product description, shared by both About surfaces.
+    static let tagline = "A native macOS music player for Jellyfin."
+
+    /// Marketing version (`CFBundleShortVersionString`). Falls back to a
+    /// dev-only placeholder when the bundle key is missing — e.g. when running
+    /// from Xcode against an unconfigured Info.plist.
+    static func version(bundle: BundleReading = AppBundle()) -> String {
+        bundle.infoString(for: "CFBundleShortVersionString") ?? "0.0.0 (dev)"
+    }
+
+    /// Build number (`CFBundleVersion`). Same fallback reasoning as
+    /// ``version(bundle:)``.
+    static func build(bundle: BundleReading = AppBundle()) -> String {
+        bundle.infoString(for: "CFBundleVersion") ?? "—"
+    }
+
+    /// Copyright string (`NSHumanReadableCopyright`). When missing, render a
+    /// generic attribution rather than an empty row.
+    static func copyright(bundle: BundleReading = AppBundle()) -> String {
+        bundle.infoString(for: "NSHumanReadableCopyright")
+            ?? "Copyright © Skyler Althoff and Lyrebird contributors."
+    }
+
+    // MARK: - Connected server
+
+    /// Bare host of the connected server, dropping scheme, userinfo, port,
+    /// path, and query. Returns `nil` for an empty / signed-out URL so callers
+    /// can hide the row entirely rather than print a placeholder.
+    ///
+    /// Mirrors `DiagnosticBundle.redactServerHost`'s contract: the About window
+    /// is a user-facing, screenshot-prone surface, so it deliberately shows the
+    /// host only — never a reverse-proxy path, token query, or basic-auth
+    /// userinfo that the full `serverURL` can carry.
+    ///
+    /// Examples:
+    /// - `https://music.example.com/jellyfin` → `music.example.com`
+    /// - `https://user:pw@host:8443/x?token=abc` → `host`
+    /// - `music.example.com:8096` → `music.example.com`
+    /// - `""` → `nil`
+    static func connectedServerHost(from urlString: String) -> String? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Structured parse first: `URLComponents` cleanly separates host from
+        // userinfo / port / path / query.
+        if let host = URLComponents(string: trimmed)?.host, !host.isEmpty {
+            return host
+        }
+
+        // Fallback for bare `host[:port][/path]` strings with no scheme, which
+        // `URLComponents` parses as a path rather than a host. Strip any
+        // `scheme://`, then any `user:pw@` userinfo, then cut at the first
+        // `/`, `:`, or `?`.
+        var rest = trimmed
+        if let schemeRange = rest.range(of: "://") {
+            rest = String(rest[schemeRange.upperBound...])
+        }
+        if let atIndex = rest.firstIndex(of: "@") {
+            rest = String(rest[rest.index(after: atIndex)...])
+        }
+        let host = rest.prefix { $0 != "/" && $0 != ":" && $0 != "?" }
+        return host.isEmpty ? nil : String(host)
+    }
+
+    // MARK: - Credits
+
+    /// A single acknowledgement row: the named project plus a one-line note on
+    /// what it does for Lyrebird. `Identifiable` so the About window can drive
+    /// a `ForEach` directly off the catalog.
+    struct Credit: Identifiable, Equatable {
+        var id: String { name }
+        let name: String
+        let role: String
+    }
+
+    /// Short acknowledgements list shown in the About window. Hand-curated (the
+    /// open-source projects Lyrebird leans on most directly) rather than a
+    /// scraped dependency dump, so it stays a readable credit rather than a
+    /// license manifest. Kept here, not in the view, so it's assertable.
+    static let credits: [Credit] = [
+        Credit(name: "Jellyfin", role: "The free software media server Lyrebird connects to."),
+        Credit(name: "Nuke", role: "Artwork loading, caching, and decoding."),
+        Credit(name: "Sparkle", role: "Secure in-app software updates."),
+        Credit(name: "Mozilla UniFFI", role: "Swift bindings over the Rust core."),
+    ]
+}

--- a/macos/Sources/Lyrebird/System/MoveToApplications.swift
+++ b/macos/Sources/Lyrebird/System/MoveToApplications.swift
@@ -1,0 +1,246 @@
+import AppKit
+
+/// First-launch "move to Applications" helper — the LetsMove flow (#193).
+///
+/// When a user opens Lyrebird straight from the DMG (or from `~/Downloads`),
+/// the app runs from a read-only / temporary location: Sparkle self-updates
+/// can't write back into a mounted disk image, Gatekeeper App Translocation
+/// hides the real path, and the icon never settles into the Dock. The clean
+/// fix is the well-trodden LetsMove pattern: on the very first launch, if we
+/// detect we're running from outside `/Applications`, offer to move ourselves
+/// there and relaunch.
+///
+/// This type owns three concerns, deliberately split so the *decision* is
+/// pure and unit-testable without a window server:
+///
+/// - `Environment` — a value snapshot of everything the decision depends on
+///   (the bundle path, whether it's already installed, whether the path looks
+///   translocated/quarantined, the build configuration, and the persisted
+///   "don't ask again" flag). Captured from the live process in
+///   `promptIfNeeded()`, or hand-built in tests.
+/// - `shouldPrompt(_:)` — the pure rule. Given an `Environment`, returns
+///   whether to surface the prompt. No side effects, no AppKit, no globals.
+/// - `promptIfNeeded()` / `move(...)` — the runtime side: snapshot the
+///   environment, run `shouldPrompt`, and on a yes show a native `NSAlert`
+///   and perform the move + relaunch. These are the only parts that touch
+///   `NSWorkspace`, the Dock, or `UserDefaults`.
+///
+/// Called once from `AppDelegate.applicationDidFinishLaunching`. Skipped
+/// entirely in `DEBUG` so a `swift run` / Xcode debug session from
+/// `.build/` or `DerivedData` never nags the developer.
+enum MoveToApplications {
+    /// Stable on-disk key for the "don't ask again" choice. Namespaced under
+    /// `install.` alongside the other feature-scoped preference keys. Renaming
+    /// it re-arms the prompt for every existing user, so it's pinned by tests.
+    static let suppressKey = "install.suppressMoveToApplicationsPrompt"
+
+    /// The canonical install root. A bundle whose path is anchored here (the
+    /// user's `~/Applications` is intentionally *not* treated as installed —
+    /// see `isInsideApplications`) needs no move.
+    static let applicationsRoot = "/Applications"
+
+    // MARK: - Decision inputs
+
+    /// Immutable snapshot of everything `shouldPrompt(_:)` reasons about.
+    /// Built from the live `Bundle` / `UserDefaults` in `promptIfNeeded()`;
+    /// constructed directly in tests so the path-based rule can be exercised
+    /// headlessly.
+    struct Environment {
+        /// Absolute filesystem path of the running `.app` bundle.
+        var bundlePath: String
+
+        /// Whether the bundle already lives under `/Applications`.
+        var isInsideApplications: Bool
+
+        /// Whether the bundle path looks like a Gatekeeper App Translocation
+        /// mount, a still-mounted disk image, or a quarantined download.
+        /// Moving is futile (translocated) or premature (the real copy hasn't
+        /// landed yet) in these cases, so the prompt is suppressed — the user
+        /// will get a clean shot once they drag the app out of the DMG.
+        var isTranslocatedOrEphemeral: Bool
+
+        /// True for `DEBUG` builds. The prompt never shows for developers
+        /// running out of `.build/` or DerivedData.
+        var isDebugBuild: Bool
+
+        /// The persisted "don't ask again" choice.
+        var userSuppressed: Bool
+    }
+
+    /// Pure first-launch decision: should we offer to move the app into
+    /// `/Applications`?
+    ///
+    /// Returns `false` (no prompt) when any of the following hold, in order of
+    /// precedence:
+    /// - it's a `DEBUG` build,
+    /// - the user previously chose "don't ask again",
+    /// - the app is already installed under `/Applications`,
+    /// - the path is translocated / on a mounted DMG / quarantined.
+    ///
+    /// Only a release build, running from a real on-disk location outside
+    /// `/Applications`, with no prior suppression, yields `true`.
+    ///
+    /// Factored out of the AppKit flow so the path-based logic is verifiable
+    /// without realizing an `NSAlert` (which a headless test run can't do).
+    static func shouldPrompt(_ env: Environment) -> Bool {
+        if env.isDebugBuild { return false }
+        if env.userSuppressed { return false }
+        if env.isInsideApplications { return false }
+        if env.isTranslocatedOrEphemeral { return false }
+        return true
+    }
+
+    // MARK: - Path classification (pure)
+
+    /// Whether `path` is anchored under `/Applications`. A strict prefix match
+    /// on the path *component* boundary so a sibling like
+    /// `/ApplicationsArchive/Lyrebird.app` is not mistaken for an install, and
+    /// the user-domain `~/Applications` (which Sparkle/Gatekeeper treat
+    /// differently and which we still want to migrate to the system root)
+    /// returns `false`.
+    static func isInsideApplications(path: String) -> Bool {
+        let root = applicationsRoot
+        return path == root || path.hasPrefix(root + "/")
+    }
+
+    /// Heuristic for "this path is a translocation mount, a still-mounted disk
+    /// image, or a quarantined download we shouldn't try to relocate yet".
+    ///
+    /// - **App Translocation**: Gatekeeper runs quarantined apps from a
+    ///   randomized, read-only mount under
+    ///   `/private/var/folders/.../AppTranslocation/`. The move is pointless
+    ///   there — the bytes are a shadow copy.
+    /// - **Mounted DMG**: a path under `/Volumes/` means the user double-
+    ///   clicked the app inside the disk image. We don't move *out* of a DMG
+    ///   (the source is read-only and the user expects to drag it themselves),
+    ///   so we hold the prompt until they've copied it somewhere writable.
+    static func isTranslocatedOrEphemeral(path: String) -> Bool {
+        path.contains("/AppTranslocation/")
+            || path.hasPrefix("/Volumes/")
+            || path.contains("/.dmg/")
+    }
+
+    // MARK: - Runtime entry point
+
+    /// Snapshot the live process environment and, if the rule says so, present
+    /// the native move-to-Applications prompt. Safe to call unconditionally
+    /// from `applicationDidFinishLaunching`; it self-gates via `shouldPrompt`.
+    @MainActor
+    static func promptIfNeeded(
+        bundle: Bundle = .main,
+        defaults: UserDefaults = .standard
+    ) {
+        let env = currentEnvironment(bundle: bundle, defaults: defaults)
+        guard shouldPrompt(env) else { return }
+        presentPrompt(bundlePath: env.bundlePath, defaults: defaults)
+    }
+
+    /// Build an `Environment` from the running process. `isDebugBuild` is
+    /// resolved here (not in the pure rule) so the decision stays a value
+    /// function the tests can drive across both configurations.
+    static func currentEnvironment(
+        bundle: Bundle = .main,
+        defaults: UserDefaults = .standard
+    ) -> Environment {
+        let path = bundle.bundlePath
+        #if DEBUG
+        let debug = true
+        #else
+        let debug = false
+        #endif
+        return Environment(
+            bundlePath: path,
+            isInsideApplications: isInsideApplications(path: path),
+            isTranslocatedOrEphemeral: isTranslocatedOrEphemeral(path: path),
+            isDebugBuild: debug,
+            userSuppressed: defaults.bool(forKey: suppressKey)
+        )
+    }
+
+    // MARK: - AppKit prompt + move
+
+    /// Show the modal `NSAlert`. "Move to Applications Folder" performs the
+    /// move + relaunch; "Do Not Move" dismisses for this launch; the
+    /// "Don't ask again" checkbox persists the suppression flag regardless of
+    /// which button is chosen.
+    @MainActor
+    private static func presentPrompt(bundlePath: String, defaults: UserDefaults) {
+        let alert = NSAlert()
+        alert.messageText = "Move Lyrebird to your Applications folder?"
+        alert.informativeText = """
+        Lyrebird works best from the Applications folder — it keeps automatic \
+        updates working and prevents macOS from running it from a temporary \
+        location. You can move it now and Lyrebird will reopen from there.
+        """
+        alert.alertStyle = .informational
+        let moveButton = alert.addButton(withTitle: "Move to Applications Folder")
+        moveButton.keyEquivalent = "\r"
+        alert.addButton(withTitle: "Do Not Move")
+
+        let suppress = NSButton(checkboxWithTitle: "Don't ask again", target: nil, action: nil)
+        suppress.state = .off
+        alert.accessoryView = suppress
+
+        let response = alert.runModal()
+
+        if suppress.state == .on {
+            defaults.set(true, forKey: suppressKey)
+        }
+
+        guard response == .alertFirstButtonReturn else { return }
+
+        move(fromBundlePath: bundlePath)
+    }
+
+    /// Move the running bundle into `/Applications` and relaunch from the new
+    /// location, then terminate the current (old-location) instance.
+    ///
+    /// Uses `FileManager` for the copy/replace and `NSWorkspace` to relaunch.
+    /// On any failure the move is abandoned and the app keeps running from its
+    /// current location — a failed move must never strand the user without a
+    /// running app. Errors surface in Console under the `app` category.
+    @MainActor
+    private static func move(fromBundlePath bundlePath: String) {
+        let fileManager = FileManager.default
+        let sourceURL = URL(fileURLWithPath: bundlePath)
+        let appName = sourceURL.lastPathComponent
+        let destURL = URL(fileURLWithPath: applicationsRoot).appendingPathComponent(appName)
+
+        do {
+            // Replace any stale copy already sitting at the destination
+            // (e.g. an older version the user dragged over before) so the
+            // copy below doesn't fail with "file exists".
+            if fileManager.fileExists(atPath: destURL.path) {
+                try fileManager.removeItem(at: destURL)
+            }
+            try fileManager.copyItem(at: sourceURL, to: destURL)
+        } catch {
+            Log.app.error(
+                "MoveToApplications copy failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return
+        }
+
+        // Relaunch from the installed copy, then quit this instance. The new
+        // process opening is what lets us tear the old one down cleanly.
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: destURL, configuration: configuration) { _, error in
+            if let error {
+                Log.app.error(
+                    "MoveToApplications relaunch failed: \(error.localizedDescription, privacy: .public)"
+                )
+                // The copy already succeeded; leaving the old instance running
+                // is the safe fallback rather than terminating into nothing.
+                return
+            }
+            DispatchQueue.main.async {
+                // Best-effort cleanup of the old (source) copy once the new
+                // instance is up. A failure here is cosmetic — the installed
+                // copy is already running — so it's logged, not surfaced.
+                try? fileManager.removeItem(at: sourceURL)
+                NSApp.terminate(nil)
+            }
+        }
+    }
+}

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -171,6 +171,38 @@ public final class AudioEngine: NSObject {
         didSet { applyOutputDevice(to: player) }
     }
 
+    /// ReplayGain / loudness-normalization mode (#42). Mirrors the
+    /// `playback.normalization` preference; the owner (`AppModel`) seeds it at
+    /// startup and updates it from the Preferences picker. Changing it re-reads
+    /// the current item's tags and re-applies (or clears) the gain on the live
+    /// player immediately, and every player built afterwards picks it up via
+    /// `applyReplayGain(to:)`. `.off` is a true no-op — the item's `audioMix`
+    /// is cleared so playback runs at the raw stream level.
+    public var normalizationMode: ReplayGainMode = .off {
+        didSet {
+            guard normalizationMode != oldValue else { return }
+            reapplyReplayGainToCurrentItem()
+        }
+    }
+
+    /// User pre-gain in dB (`playback.preGainDb`), summed on top of the
+    /// resolved ReplayGain value before the linear multiplier is computed. Only
+    /// takes effect while `normalizationMode != .off`; on its own it does not
+    /// turn normalization on (matching the Preferences copy, which frames
+    /// pre-gain as an adjustment to the normalization result).
+    public var normalizationPreGainDb: Double = 0 {
+        didSet {
+            guard normalizationPreGainDb != oldValue else { return }
+            reapplyReplayGainToCurrentItem()
+        }
+    }
+
+    /// Monotonic counter so a slow metadata-driven gain resolve can't clobber a
+    /// newer item. Each `applyReplayGain(to:)` captures the value at dispatch
+    /// time and bails on the marshal-back if a newer apply (track change, mode
+    /// flip) has superseded it.
+    private var replayGainGeneration: Int = 0
+
     public init(core: LyrebirdCore) {
         self.core = core
         super.init()
@@ -340,6 +372,68 @@ public final class AudioEngine: NSObject {
         }
     }
 
+    /// Resolve the ReplayGain tags on `item`'s asset and apply the matching
+    /// linear gain through an `AVAudioMix` (#42). No-ops cleanly to "no
+    /// adjustment" in three cases: normalization off, item has no audio track,
+    /// or the asset carries no usable loudness tag — in all of them the item's
+    /// `audioMix` is cleared so the stream plays at its natural level.
+    ///
+    /// The metadata load crosses into AVFoundation's async asset machinery
+    /// (network I/O for a remote stream), so it runs off the main actor; only
+    /// the cheap `AVMutableAudioMix` build + assignment marshals back to main.
+    /// A generation check drops the result if a newer item or a mode change has
+    /// superseded this resolve in the meantime.
+    private func applyReplayGain(to item: AVPlayerItem) {
+        replayGainGeneration &+= 1
+        let generation = replayGainGeneration
+        let mode = normalizationMode
+        let preGainDb = normalizationPreGainDb
+
+        // Off: clear any prior mix synchronously and skip the metadata read
+        // entirely. Cheap, and guarantees flipping the picker to "Off"
+        // immediately restores the raw level.
+        guard mode != .off else {
+            item.audioMix = nil
+            return
+        }
+
+        let asset = item.asset
+        Task.detached { [weak self] in
+            let gains = await ReplayGain.gains(for: asset)
+            guard let volume = ReplayGain.linearVolume(mode: mode, gains: gains, preGainDb: preGainDb) else {
+                // No usable tag — leave the level alone (clear any stale mix).
+                await MainActor.run {
+                    guard let self, generation == self.replayGainGeneration else { return }
+                    item.audioMix = nil
+                }
+                return
+            }
+            guard let audioTrack = try? await asset.loadTracks(withMediaType: .audio).first else {
+                await MainActor.run {
+                    guard let self, generation == self.replayGainGeneration else { return }
+                    item.audioMix = nil
+                }
+                return
+            }
+            await MainActor.run {
+                guard let self, generation == self.replayGainGeneration else { return }
+                let params = AVMutableAudioMixInputParameters(track: audioTrack)
+                params.setVolume(volume, at: .zero)
+                let mix = AVMutableAudioMix()
+                mix.inputParameters = [params]
+                item.audioMix = mix
+            }
+        }
+    }
+
+    /// Re-run gain resolution against the player's current item after a mode /
+    /// pre-gain change so the live track responds without waiting for the next
+    /// track. No-op when nothing is loaded.
+    private func reapplyReplayGainToCurrentItem() {
+        guard let item = player?.currentItem else { return }
+        applyReplayGain(to: item)
+    }
+
     // MARK: - Public
 
     public func play(track: Track) async throws {
@@ -380,6 +474,9 @@ public final class AudioEngine: NSObject {
         // device is selected or the saved one is gone.
         self.player = newPlayer
         applyOutputDevice(to: newPlayer)
+        // Resolve + apply ReplayGain for the new item (#42). No-ops when
+        // normalization is off or the stream carries no loudness tags.
+        applyReplayGain(to: item)
 
         // Remember the stream so `recoverFromStall` can rebuild a fresh
         // `AVPlayerItem` without re-asking the core for a URL (which would
@@ -582,6 +679,10 @@ public final class AudioEngine: NSObject {
                     // Append the new item after the current one (or as the only item if
                     // the player was empty — shouldn't happen in normal flow but safe).
                     player.insert(nextItem, after: player.currentItem)
+                    // Pre-resolve ReplayGain for the queued item so the gain is
+                    // already applied when it becomes current at the gapless
+                    // transition (#42). No-ops when normalization is off.
+                    self.applyReplayGain(to: nextItem)
                 }
             } catch {
                 engineLog.error("preload skipped: failed to resolve track \(track.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -913,6 +1014,10 @@ public final class AudioEngine: NSObject {
         attachItemFailureObservers(to: item)
 
         player.replaceCurrentItem(with: item)
+        // Re-apply ReplayGain to the rebuilt item — the swap drops the old
+        // item's audioMix, so without this a normalized track would lose its
+        // gain after a stall recovery (#42).
+        applyReplayGain(to: item)
         player.play()
         delegate?.audioEngineDidRecover()
     }

--- a/macos/Sources/LyrebirdAudio/ReplayGain.swift
+++ b/macos/Sources/LyrebirdAudio/ReplayGain.swift
@@ -1,0 +1,276 @@
+import AVFoundation
+import Foundation
+import os
+
+private let replayGainLog = Logger(subsystem: "org.lyrebird.desktop", category: "replaygain")
+
+/// Loudness-normalization mode mirrored from the app's `NormalizationMode`
+/// preference. Kept local to `LyrebirdAudio` so the engine has no reverse
+/// dependency on the `Lyrebird` app target — `AppModel` maps its
+/// `@AppStorage("playback.normalization")` value onto this enum when it seeds
+/// the engine. See issue #42.
+public enum ReplayGainMode: String, Sendable {
+    /// No gain is applied. The engine leaves `AVAudioMix` untouched so the
+    /// player runs at the raw stream level.
+    case off
+    /// Use `REPLAYGAIN_TRACK_GAIN` (per-track loudness match).
+    case track
+    /// Use `REPLAYGAIN_ALBUM_GAIN`, preserving the relative levels of tracks
+    /// within an album. Falls back to track gain when no album gain is tagged.
+    case album
+}
+
+/// ReplayGain tag parsing + dB→linear conversion.
+///
+/// This is the **interim** normalization path for issue #42: rather than
+/// rewriting the engine around `AVAudioEngine`, we read the loudness metadata
+/// that already rides along with the stream (`AVAsset` exposes Vorbis comments,
+/// iTunes atoms, and ID3 `TXXX` frames) and apply a single linear gain through
+/// an `AVAudioMix` on the playing `AVPlayerItem`. When no usable tag is present
+/// the resolver returns `nil` and the engine simply leaves the level alone — a
+/// graceful no-op, never a volume change.
+///
+/// Everything except `gain(for:asset:)` is pure and side-effect free so the
+/// parsing + math can be unit-tested without a live `AVAsset` or the network.
+public enum ReplayGain {
+    /// The loudness gains (in dB) parsed from a single item's metadata. Any
+    /// field is `nil` when the corresponding tag was absent or unparseable.
+    public struct Gains: Equatable, Sendable {
+        /// `REPLAYGAIN_TRACK_GAIN`, in dB. Negative attenuates a loud track.
+        public var trackGainDb: Double?
+        /// `REPLAYGAIN_ALBUM_GAIN`, in dB.
+        public var albumGainDb: Double?
+        /// Best-effort dB derived from an iTunes `iTunNORM` atom, used only as
+        /// a fallback when no ReplayGain tag is present.
+        public var iTunNormDb: Double?
+
+        public init(trackGainDb: Double? = nil, albumGainDb: Double? = nil, iTunNormDb: Double? = nil) {
+            self.trackGainDb = trackGainDb
+            self.albumGainDb = albumGainDb
+            self.iTunNormDb = iTunNormDb
+        }
+
+        /// `true` when no loudness information of any kind was found.
+        public var isEmpty: Bool {
+            trackGainDb == nil && albumGainDb == nil && iTunNormDb == nil
+        }
+    }
+
+    /// Hard clamp applied to the *total* gain (ReplayGain + pre-gain) before it
+    /// is turned into a linear multiplier. ReplayGain payloads are occasionally
+    /// garbage (e.g. a mis-scanned `+60 dB`); clamping keeps a bad tag from
+    /// blowing the user's speakers or driving the output to silence. ±15 dB
+    /// comfortably covers every legitimate ReplayGain value (real-world track
+    /// gains sit within roughly ±12 dB) while still bounding the worst case.
+    public static let maxAbsGainDb: Double = 15.0
+
+    // MARK: - dB ↔ linear
+
+    /// Convert a dB gain to a linear amplitude multiplier (`10^(dB/20)`).
+    ///
+    /// 0 dB → 1.0 (unchanged), −6 dB → ~0.501, +6 dB → ~1.995.
+    public static func linearGain(fromDb db: Double) -> Float {
+        Float(pow(10.0, db / 20.0))
+    }
+
+    // MARK: - Resolution
+
+    /// Resolve the linear volume multiplier to hand to
+    /// `AVAudioMixInputParameters.setVolume` for the given mode, parsed gains,
+    /// and user pre-gain.
+    ///
+    /// Returns `nil` when normalization is off, or when the selected mode has
+    /// no usable tag — the caller treats `nil` as "leave the level untouched"
+    /// so an untagged track plays at its natural volume rather than being
+    /// silently adjusted. The combined dB (ReplayGain + pre-gain) is clamped to
+    /// ±``maxAbsGainDb`` before conversion.
+    public static func linearVolume(
+        mode: ReplayGainMode,
+        gains: Gains,
+        preGainDb: Double = 0
+    ) -> Float? {
+        guard mode != .off else { return nil }
+        guard let replayGainDb = replayGainDb(mode: mode, gains: gains) else { return nil }
+        let total = (replayGainDb + preGainDb).clamped(to: -maxAbsGainDb...maxAbsGainDb)
+        return linearGain(fromDb: total)
+    }
+
+    /// Pick the ReplayGain dB value for `mode`, applying the documented
+    /// fallbacks: album mode falls back to the track gain when no album gain is
+    /// tagged; both modes fall back to the iTunNORM-derived value when no
+    /// ReplayGain tag exists at all. `nil` when nothing usable is present.
+    static func replayGainDb(mode: ReplayGainMode, gains: Gains) -> Double? {
+        switch mode {
+        case .off:
+            return nil
+        case .track:
+            return gains.trackGainDb ?? gains.iTunNormDb
+        case .album:
+            // Preserve intra-album dynamics: prefer the album gain, but a file
+            // tagged with only a track gain still normalizes sensibly.
+            return gains.albumGainDb ?? gains.trackGainDb ?? gains.iTunNormDb
+        }
+    }
+
+    // MARK: - Tag parsing
+
+    /// Parse loudness gains from a flat list of `(key, value)` metadata pairs.
+    ///
+    /// Keys are matched case-insensitively and tolerate the `com.apple.iTunes.`
+    /// namespace prefix that AVFoundation prepends to iTunes-atom ReplayGain
+    /// tags, so all of these resolve to the track gain:
+    ///   * `REPLAYGAIN_TRACK_GAIN`         (Vorbis comment / FLAC)
+    ///   * `replaygain_track_gain`         (lower-case Vorbis variant)
+    ///   * `com.apple.iTunes.replaygain_track_gain` (iTunes atom)
+    ///   * ID3 `TXXX` descriptions surface with the same `REPLAYGAIN_*` text.
+    ///
+    /// Values like `"-7.60 dB"`, `"-7.60"`, or `"+3 dB"` all parse; the unit
+    /// suffix and leading sign are tolerated. An `iTunNORM` atom is parsed as a
+    /// best-effort fallback (see ``iTunNormDb(from:)``).
+    public static func parseGains<S: StringProtocol>(
+        from pairs: [(key: S, value: S)]
+    ) -> Gains {
+        var gains = Gains()
+        for (rawKey, rawValue) in pairs {
+            let key = normalizedKey(String(rawKey))
+            let value = String(rawValue)
+            switch key {
+            case "replaygain_track_gain":
+                if let db = parseGainDb(value) { gains.trackGainDb = db }
+            case "replaygain_album_gain":
+                if let db = parseGainDb(value) { gains.albumGainDb = db }
+            case "itunnorm":
+                if let db = iTunNormDb(from: value) { gains.iTunNormDb = db }
+            default:
+                continue
+            }
+        }
+        return gains
+    }
+
+    /// Lower-cased key with the iTunes namespace prefix stripped so Vorbis,
+    /// ID3, and iTunes spellings collapse onto one canonical token.
+    private static func normalizedKey(_ key: String) -> String {
+        var k = key.lowercased()
+        let prefix = "com.apple.itunes."
+        if k.hasPrefix(prefix) {
+            k.removeFirst(prefix.count)
+        }
+        return k
+    }
+
+    /// Parse a ReplayGain dB string (`"-7.60 dB"`, `"+3"`, `"-7.60dB"`). The
+    /// numeric prefix is taken up to the first non-numeric character so a
+    /// trailing `" dB"` (or none) is handled uniformly. `nil` for a value with
+    /// no leading number or a non-finite parse.
+    static func parseGainDb(_ raw: String) -> Double? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        var numeric = ""
+        for (index, ch) in trimmed.enumerated() {
+            if ch.isNumber || ch == "." {
+                numeric.append(ch)
+            } else if (ch == "+" || ch == "-") && index == 0 {
+                numeric.append(ch)
+            } else {
+                break
+            }
+        }
+        guard let value = Double(numeric), value.isFinite else { return nil }
+        return value
+    }
+
+    /// Derive a best-effort dB adjustment from an iTunes `iTunNORM` atom.
+    ///
+    /// `iTunNORM` is a string of ten space-separated 8-digit hex values; the
+    /// first two are the per-channel loudness measurements on a scale where
+    /// `1000` ≈ 0 dB. The volume adjustment for a channel is
+    /// `-10 * log10(value / 1000)` — a value above 1000 means a loud channel
+    /// that should be attenuated. We take the *smaller-magnitude* (less
+    /// aggressive) of the two channels so a single hot channel can't drive the
+    /// whole track to silence, then clamp.
+    ///
+    /// This is intentionally a fallback only — `iTunNORM` is iTunes' own
+    /// loudness scheme, not ReplayGain, and is less precise. `nil` when the
+    /// atom is malformed or the channels read as zero.
+    static func iTunNormDb(from raw: String) -> Double? {
+        let fields = raw.split(whereSeparator: { $0 == " " || $0 == "\t" })
+        guard fields.count >= 2 else { return nil }
+        guard
+            let left = UInt32(fields[0], radix: 16),
+            let right = UInt32(fields[1], radix: 16)
+        else { return nil }
+        guard left > 0, right > 0 else { return nil }
+        let leftDb = -10.0 * log10(Double(left) / 1000.0)
+        let rightDb = -10.0 * log10(Double(right) / 1000.0)
+        // Less aggressive of the two channels (smaller absolute adjustment).
+        let chosen = abs(leftDb) <= abs(rightDb) ? leftDb : rightDb
+        guard chosen.isFinite else { return nil }
+        return chosen.clamped(to: -maxAbsGainDb...maxAbsGainDb)
+    }
+
+    // MARK: - AVFoundation bridge
+
+    /// Load `asset`'s metadata across every available format and parse the
+    /// loudness gains out of it. Runs the async `AVAsset` metadata loads; safe
+    /// to call off the main actor (it never touches `@MainActor` state).
+    ///
+    /// AVFoundation surfaces ReplayGain under format-specific metadata, not
+    /// `commonMetadata`: Vorbis comments (`org.xiph.vorbis-comment`) carry the
+    /// raw `REPLAYGAIN_*` keys, iTunes atoms (`com.apple.itunes`) carry the
+    /// namespaced spelling plus `iTunNORM`, and ID3 `TXXX` frames carry the
+    /// description text. We read them all and let ``parseGains(from:)`` sort
+    /// the keys out. Returns empty `Gains` (never throws) on any failure so the
+    /// caller falls back to "no adjustment".
+    public static func gains(for asset: AVAsset) async -> Gains {
+        var pairs: [(key: String, value: String)] = []
+        do {
+            let formats = try await asset.load(.availableMetadataFormats)
+            for format in formats {
+                let items = (try? await asset.loadMetadata(for: format)) ?? []
+                for item in items {
+                    guard let key = await metadataKey(of: item) else { continue }
+                    // `load(.stringValue)` is `String?`; `try?` flattens the
+                    // throwing+optional result to a single `String?`, so one
+                    // optional-bind unwraps both the error and the nil case.
+                    guard let value = try? await item.load(.stringValue) else { continue }
+                    pairs.append((key: key, value: value))
+                }
+            }
+        } catch {
+            replayGainLog.debug("metadata load failed; treating as untagged: \(error.localizedDescription, privacy: .public)")
+            return Gains()
+        }
+        return parseGains(from: pairs)
+    }
+
+    /// Best string identifier for a metadata item. Vorbis comments expose the
+    /// raw tag name via `.key` (e.g. `REPLAYGAIN_TRACK_GAIN`); iTunes atoms
+    /// expose it via `.identifier` (`itlk/com.apple.iTunes.iTunNORM`), so we
+    /// fall back to the trailing path component of the identifier. Returns the
+    /// canonical lookup token for ``parseGains(from:)``.
+    private static func metadataKey(of item: AVMetadataItem) async -> String? {
+        // `.key` is the unprocessed tag name for Vorbis/ID3 — exactly the
+        // REPLAYGAIN_* / iTunNORM token we want.
+        if let key = item.key as? String, !key.isEmpty {
+            return key
+        }
+        if let key = item.key as? NSString {
+            return key as String
+        }
+        // iTunes atoms expose the tag through the identifier's keyspace-scoped
+        // string (e.g. `itlk/com.apple.iTunes.iTunNORM`). Take the part after
+        // the last `/` so the namespace-prefixed token reaches the parser.
+        if let identifier = item.identifier?.rawValue, let tail = identifier.split(separator: "/").last {
+            return String(tail)
+        }
+        return nil
+    }
+}
+
+private extension Comparable {
+    /// Clamp `self` into `range`.
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/macos/Tests/LyrebirdTests/AboutInfoTests.swift
+++ b/macos/Tests/LyrebirdTests/AboutInfoTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `AboutInfo` — the shared, side-effect-free payload behind both
+/// the Preferences → About pane and the dedicated About window (#25). Keeping
+/// these two surfaces reading from one source is the whole point of the type,
+/// so the tests defend the contracts each surface relies on:
+///
+/// 1. Version / build / copyright read the right Info.plist keys, trim empty
+///    values to `nil`, and fall back to a non-blank placeholder when absent —
+///    asserted against a fake bundle so no assertion touches `Bundle.main`.
+/// 2. `connectedServerHost(from:)` reduces a server URL to its bare host
+///    (no scheme / userinfo / port / path / query) and returns `nil` when
+///    signed out, matching `DiagnosticBundle.redactServerHost`'s redaction so
+///    the screenshot-prone About window never leaks a token or proxy path.
+/// 3. The static `credits` catalog is non-empty, fully populated, and has
+///    stable unique ids so the About window's `ForEach` can't collide.
+final class AboutInfoTests: XCTestCase {
+
+    // MARK: - Test double
+
+    /// In-memory `BundleReading` so version / build / copyright are asserted
+    /// without `Bundle.main`. Mirrors `AppBundle`'s empty-string-is-absent
+    /// rule: an explicit `""` value reads back as `nil`.
+    private struct FakeBundle: AboutInfo.BundleReading {
+        var values: [String: String]
+        func infoString(for key: String) -> String? {
+            guard let value = values[key], !value.isEmpty else { return nil }
+            return value
+        }
+    }
+
+    // MARK: - Identity literals
+
+    func testIdentityLiteralsAreStable() {
+        XCTAssertEqual(AboutInfo.appName, "Lyrebird")
+        XCTAssertFalse(AboutInfo.tagline.isEmpty)
+    }
+
+    // MARK: - Version / build / copyright lookups
+
+    func testVersionAndBuildReadInfoPlistKeys() {
+        let bundle = FakeBundle(values: [
+            "CFBundleShortVersionString": "2.0.1",
+            "CFBundleVersion": "447",
+        ])
+        XCTAssertEqual(AboutInfo.version(bundle: bundle), "2.0.1")
+        XCTAssertEqual(AboutInfo.build(bundle: bundle), "447")
+    }
+
+    func testCopyrightReadsHumanReadableKey() {
+        let bundle = FakeBundle(values: [
+            "NSHumanReadableCopyright": "Copyright © 2026 Skyler Althoff.",
+        ])
+        XCTAssertEqual(AboutInfo.copyright(bundle: bundle), "Copyright © 2026 Skyler Althoff.")
+    }
+
+    func testMissingKeysFallBackToNonBlankPlaceholders() {
+        let empty = FakeBundle(values: [:])
+        // The placeholders matter: a blank version / build / copyright row in
+        // the About window reads as a bug, so each accessor must return
+        // something printable rather than "".
+        XCTAssertEqual(AboutInfo.version(bundle: empty), "0.0.0 (dev)")
+        XCTAssertEqual(AboutInfo.build(bundle: empty), "—")
+        XCTAssertFalse(AboutInfo.copyright(bundle: empty).isEmpty)
+    }
+
+    func testEmptyStringValuesAreTreatedAsAbsent() {
+        // A present-but-empty Info.plist value (seen when running unbundled
+        // from Xcode against an unconfigured plist) must fall back rather than
+        // render a blank row.
+        let blanks = FakeBundle(values: [
+            "CFBundleShortVersionString": "",
+            "CFBundleVersion": "",
+            "NSHumanReadableCopyright": "",
+        ])
+        XCTAssertEqual(AboutInfo.version(bundle: blanks), "0.0.0 (dev)")
+        XCTAssertEqual(AboutInfo.build(bundle: blanks), "—")
+        XCTAssertFalse(AboutInfo.copyright(bundle: blanks).isEmpty)
+    }
+
+    func testDefaultBundleArgumentResolvesWithoutCrashing() {
+        // Exercises the `AppBundle(.main)` default path so the production
+        // accessor is covered end-to-end. We don't assert the values (they
+        // depend on the test host's plist) — only that they're non-empty,
+        // which the placeholder fallbacks guarantee.
+        XCTAssertFalse(AboutInfo.version().isEmpty)
+        XCTAssertFalse(AboutInfo.build().isEmpty)
+        XCTAssertFalse(AboutInfo.copyright().isEmpty)
+    }
+
+    // MARK: - Connected-server host redaction
+
+    func testHostStripsSchemePathAndQuery() {
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "https://music.example.com/jellyfin"),
+            "music.example.com"
+        )
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "http://music.example.com/?x=1"),
+            "music.example.com"
+        )
+    }
+
+    func testHostStripsUserinfoAndPort() {
+        // The screenshot-safety contract: basic-auth userinfo, port, and any
+        // token query must never survive into the rendered host row.
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "https://user:pw@host.example.com:8443/x?token=abc"),
+            "host.example.com"
+        )
+    }
+
+    func testHostHandlesSchemelessAuthority() {
+        // Bare `host[:port][/path]` with no scheme — `URLComponents` parses the
+        // whole thing as a path, so the manual fallback must kick in.
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "music.example.com:8096"),
+            "music.example.com"
+        )
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "music.example.com/jellyfin"),
+            "music.example.com"
+        )
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "user:pw@bare.example.com:9000"),
+            "bare.example.com"
+        )
+    }
+
+    func testHostTrimsSurroundingWhitespace() {
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "  https://music.example.com  "),
+            "music.example.com"
+        )
+    }
+
+    func testEmptyOrWhitespaceURLReturnsNil() {
+        // The About window hides the server row entirely when signed out, so
+        // an empty / blank URL must map to `nil` (not a placeholder string).
+        XCTAssertNil(AboutInfo.connectedServerHost(from: ""))
+        XCTAssertNil(AboutInfo.connectedServerHost(from: "   "))
+        XCTAssertNil(AboutInfo.connectedServerHost(from: "\n\t"))
+    }
+
+    /// The host extraction must agree with `DiagnosticBundle.redactServerHost`
+    /// on every non-empty input — they document the identical redaction. The
+    /// only intentional divergence is the empty case (About → `nil`, the
+    /// bundle → `"(not signed in)"`), which is covered separately above.
+    func testHostMatchesDiagnosticBundleRedactionForNonEmptyInputs() {
+        let inputs = [
+            "https://music.example.com/jellyfin",
+            "https://user:pw@host.example.com:8443/x?token=abc",
+            "music.example.com:8096",
+            "http://10.0.0.5:8096/",
+            "https://sub.domain.example.org/path/deeper?a=b&c=d",
+        ]
+        for input in inputs {
+            XCTAssertEqual(
+                AboutInfo.connectedServerHost(from: input),
+                DiagnosticBundle.redactServerHost(input),
+                "About host extraction diverged from DiagnosticBundle for \(input)"
+            )
+        }
+    }
+
+    // MARK: - Credits catalog
+
+    func testCreditsCatalogIsPopulated() {
+        XCTAssertFalse(AboutInfo.credits.isEmpty)
+        for credit in AboutInfo.credits {
+            XCTAssertFalse(credit.name.isEmpty, "A credit has an empty name")
+            XCTAssertFalse(credit.role.isEmpty, "Credit \(credit.name) has an empty role")
+            XCTAssertEqual(credit.id, credit.name, "Credit id must derive from its name")
+        }
+    }
+
+    func testCreditIdsAreUnique() {
+        // The About window drives a `ForEach` straight off `credits`, so
+        // duplicate ids would silently drop or duplicate rows.
+        let ids = AboutInfo.credits.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "Credit ids are not unique")
+    }
+}

--- a/macos/Tests/LyrebirdTests/DynamicTypeReflowTests.swift
+++ b/macos/Tests/LyrebirdTests/DynamicTypeReflowTests.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `DynamicTypeReflow.decide` — the pure reducer that decides
+/// whether the persistent chrome (PlayerBar + Sidebar) should reflow at large
+/// Dynamic Type sizes (#338).
+///
+/// The decision is exercised through the pure helper so the threshold and the
+/// resulting metrics are verified without realizing a SwiftUI scene or reading
+/// back a rendered `some View` — the player bar's stacked layout and the
+/// sidebar's wrap allowance both branch on exactly these fields.
+final class DynamicTypeReflowTests: XCTestCase {
+
+    // MARK: - Non-accessibility sizes keep the horizontal layout
+
+    /// Every standard (non-accessibility) step — `xSmall`…`xxxLarge` — must
+    /// leave the chrome in its historical horizontal layout. The design widths
+    /// were sized with `xxxLarge` headroom, so reflowing before the
+    /// accessibility range would make the bar feel broken for a one-notch bump.
+    func testStandardSizesDoNotReflow() {
+        let standard: [DynamicTypeSize] = [
+            .xSmall, .small, .medium, .large,
+            .xLarge, .xxLarge, .xxxLarge,
+        ]
+        for size in standard {
+            let decision = DynamicTypeReflow.decide(
+                dynamicTypeSize: size,
+                hasContextLabel: false
+            )
+            XCTAssertFalse(
+                decision.shouldReflow,
+                "\(size) is below the accessibility range and must not reflow"
+            )
+            XCTAssertFalse(
+                decision.stackPlayerBar,
+                "\(size): player bar stays horizontal below the accessibility range"
+            )
+            XCTAssertEqual(
+                decision.sidebarLabelLineLimit,
+                DynamicTypeReflow.sidebarLabelLineLimit,
+                "\(size): sidebar labels stay on one line below the accessibility range"
+            )
+        }
+    }
+
+    // MARK: - Accessibility sizes reflow
+
+    /// Every accessibility step — `accessibility1`…`accessibility5` — must
+    /// flip the chrome into its reflowed layout: player bar stacks, sidebar
+    /// labels may wrap.
+    func testAccessibilitySizesReflow() {
+        let accessibility: [DynamicTypeSize] = [
+            .accessibility1, .accessibility2, .accessibility3,
+            .accessibility4, .accessibility5,
+        ]
+        for size in accessibility {
+            let decision = DynamicTypeReflow.decide(
+                dynamicTypeSize: size,
+                hasContextLabel: false
+            )
+            XCTAssertTrue(
+                decision.shouldReflow,
+                "\(size) is in the accessibility range and must reflow"
+            )
+            XCTAssertTrue(
+                decision.stackPlayerBar,
+                "\(size): player bar stacks vertically in the accessibility range"
+            )
+            XCTAssertEqual(
+                decision.sidebarLabelLineLimit,
+                DynamicTypeReflow.sidebarReflowLabelLineLimit,
+                "\(size): sidebar labels may wrap to a second line"
+            )
+        }
+    }
+
+    // MARK: - The reflow floor lines up with the SDK's accessibility flag
+
+    /// The reflow gate is a `>=` against `reflowFloor`. That floor must align
+    /// exactly with the SDK's own `isAccessibilitySize` partition: every size
+    /// the SDK calls an accessibility size reflows, and no size it calls a
+    /// standard size does. Asserting it here means a future SDK reshuffle of
+    /// the enum can't silently drift our threshold off the accessibility
+    /// boundary without a red test.
+    func testReflowDecisionMatchesSDKAccessibilityFlag() {
+        for size in DynamicTypeSize.allCases {
+            let decision = DynamicTypeReflow.decide(
+                dynamicTypeSize: size,
+                hasContextLabel: false
+            )
+            XCTAssertEqual(
+                decision.shouldReflow,
+                size.isAccessibilitySize,
+                "\(size): reflow must match the SDK's isAccessibilitySize"
+            )
+        }
+    }
+
+    /// `accessibility1` is the exact boundary — the first size that reflows.
+    /// The step just below it (`xxxLarge`) must not. Pinning both sides of the
+    /// edge guards against an off-by-one in the `>=` comparison.
+    func testBoundaryIsAccessibilityOne() {
+        XCTAssertEqual(DynamicTypeReflow.reflowFloor, .accessibility1)
+        XCTAssertFalse(
+            DynamicTypeReflow.decide(dynamicTypeSize: .xxxLarge, hasContextLabel: false)
+                .shouldReflow,
+            "the step below the floor must not reflow"
+        )
+        XCTAssertTrue(
+            DynamicTypeReflow.decide(dynamicTypeSize: .accessibility1, hasContextLabel: false)
+                .shouldReflow,
+            "the floor itself must reflow"
+        )
+    }
+
+    // MARK: - Min bar height tracks the context label below the floor
+
+    /// Below the reflow floor the bar's `minHeight` is the historical fixed
+    /// height, which depends on whether the "Playing from {source}" label is
+    /// present (78 without, 96 with). Applying that as a floor — rather than an
+    /// exact frame — preserves the stable chrome while still letting a one-notch
+    /// glyph overflow nudge the bar taller.
+    func testMinBarHeightTracksContextLabelBelowFloor() {
+        let noLabel = DynamicTypeReflow.decide(
+            dynamicTypeSize: .large,
+            hasContextLabel: false
+        )
+        XCTAssertEqual(
+            noLabel.minBarHeight,
+            DynamicTypeReflow.baseBarHeight,
+            "no context label: bar floors at the base height"
+        )
+
+        let withLabel = DynamicTypeReflow.decide(
+            dynamicTypeSize: .large,
+            hasContextLabel: true
+        )
+        XCTAssertEqual(
+            withLabel.minBarHeight,
+            DynamicTypeReflow.contextBarHeight,
+            "with a context label: bar floors a few points taller"
+        )
+        XCTAssertGreaterThan(
+            withLabel.minBarHeight,
+            noLabel.minBarHeight,
+            "the context label must only ever grow the bar, never shrink it"
+        )
+    }
+
+    /// Once reflowing, the bar adopts the taller stacked floor regardless of
+    /// the context label — the three stacked rows dominate the height, so the
+    /// label's couple of points no longer move the floor and both cases land on
+    /// `stackedMinBarHeight`.
+    func testReflowUsesStackedMinHeightRegardlessOfContextLabel() {
+        let noLabel = DynamicTypeReflow.decide(
+            dynamicTypeSize: .accessibility3,
+            hasContextLabel: false
+        )
+        let withLabel = DynamicTypeReflow.decide(
+            dynamicTypeSize: .accessibility3,
+            hasContextLabel: true
+        )
+        XCTAssertEqual(noLabel.minBarHeight, DynamicTypeReflow.stackedMinBarHeight)
+        XCTAssertEqual(withLabel.minBarHeight, DynamicTypeReflow.stackedMinBarHeight)
+    }
+
+    /// The stacked floor must be taller than either resting height, otherwise
+    /// reflowing would shrink the bar and re-introduce the clipping the reflow
+    /// exists to fix.
+    func testStackedMinHeightExceedsRestingHeights() {
+        XCTAssertGreaterThan(
+            DynamicTypeReflow.stackedMinBarHeight,
+            DynamicTypeReflow.contextBarHeight,
+            "the stacked layout needs more vertical room than the tallest resting bar"
+        )
+    }
+
+    // MARK: - Decision is a pure function of its inputs
+
+    /// The reducer is side-effect-free: same inputs, same `Decision`. Equatable
+    /// conformance backs the `onChange`-style comparisons the views rely on to
+    /// avoid redundant layout churn.
+    func testDecisionIsDeterministic() {
+        let a = DynamicTypeReflow.decide(dynamicTypeSize: .accessibility2, hasContextLabel: true)
+        let b = DynamicTypeReflow.decide(dynamicTypeSize: .accessibility2, hasContextLabel: true)
+        XCTAssertEqual(a, b)
+    }
+}

--- a/macos/Tests/LyrebirdTests/MoveToApplicationsTests.swift
+++ b/macos/Tests/LyrebirdTests/MoveToApplicationsTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the LetsMove first-launch "move to Applications" decision
+/// (`MoveToApplications`, #193).
+///
+/// The choice of whether to surface the prompt is path-based and pure, so it's
+/// exercised through `shouldPrompt(_:)` and the two path classifiers without
+/// realizing an `NSAlert` or moving any files — a headless test run can do
+/// neither. The persisted "don't ask again" flag is verified against an
+/// isolated `UserDefaults` suite so the real app's preferences are never
+/// touched (the same isolation pattern `FeatureTourSeenStore` tests use).
+final class MoveToApplicationsTests: XCTestCase {
+
+    // A release-build environment running from a writable location outside
+    // /Applications with no prior suppression — the one case that prompts.
+    private func promptable() -> MoveToApplications.Environment {
+        MoveToApplications.Environment(
+            bundlePath: "/Users/jane/Downloads/Lyrebird.app",
+            isInsideApplications: false,
+            isTranslocatedOrEphemeral: false,
+            isDebugBuild: false,
+            userSuppressed: false
+        )
+    }
+
+    // MARK: - shouldPrompt
+
+    func testPromptsFromDownloadsInReleaseBuild() {
+        XCTAssertTrue(
+            MoveToApplications.shouldPrompt(promptable()),
+            "a release build running from ~/Downloads should offer to move itself"
+        )
+    }
+
+    func testNoPromptWhenAlreadyInstalled() {
+        var env = promptable()
+        env.bundlePath = "/Applications/Lyrebird.app"
+        env.isInsideApplications = true
+        XCTAssertFalse(
+            MoveToApplications.shouldPrompt(env),
+            "an app already in /Applications must never prompt"
+        )
+    }
+
+    func testNoPromptForTranslocatedOrEphemeralPath() {
+        var env = promptable()
+        env.isTranslocatedOrEphemeral = true
+        XCTAssertFalse(
+            MoveToApplications.shouldPrompt(env),
+            "a translocated / DMG-mounted copy must not try to move itself"
+        )
+    }
+
+    func testNoPromptInDebugBuild() {
+        var env = promptable()
+        env.isDebugBuild = true
+        XCTAssertFalse(
+            MoveToApplications.shouldPrompt(env),
+            "DEBUG builds (swift run / Xcode) must never nag the developer"
+        )
+    }
+
+    func testNoPromptWhenUserSuppressed() {
+        var env = promptable()
+        env.userSuppressed = true
+        XCTAssertFalse(
+            MoveToApplications.shouldPrompt(env),
+            "the 'don't ask again' choice must suppress the prompt on later launches"
+        )
+    }
+
+    func testDebugSuppressionWinsEvenWhenOtherwisePromptable() {
+        // DEBUG short-circuits ahead of every other input: even an otherwise
+        // perfectly promptable environment stays silent under DEBUG.
+        var env = promptable()
+        env.isDebugBuild = true
+        env.userSuppressed = false
+        env.isInsideApplications = false
+        env.isTranslocatedOrEphemeral = false
+        XCTAssertFalse(MoveToApplications.shouldPrompt(env))
+    }
+
+    // MARK: - isInsideApplications
+
+    func testInsideApplicationsExactRoot() {
+        XCTAssertTrue(MoveToApplications.isInsideApplications(path: "/Applications/Lyrebird.app"))
+    }
+
+    func testInsideApplicationsNestedSubfolder() {
+        XCTAssertTrue(
+            MoveToApplications.isInsideApplications(path: "/Applications/Utilities/Lyrebird.app"),
+            "an app inside an /Applications subfolder still counts as installed"
+        )
+    }
+
+    func testUserApplicationsIsNotSystemApplications() {
+        XCTAssertFalse(
+            MoveToApplications.isInsideApplications(path: "/Users/jane/Applications/Lyrebird.app"),
+            "~/Applications is a different domain and should still be migrated"
+        )
+    }
+
+    func testSimilarlyNamedSiblingIsNotApplications() {
+        // A component-boundary match: /ApplicationsArchive must not be treated
+        // as /Applications just because it shares the prefix.
+        XCTAssertFalse(
+            MoveToApplications.isInsideApplications(path: "/ApplicationsArchive/Lyrebird.app"),
+            "prefix match must respect the path-component boundary"
+        )
+    }
+
+    func testDownloadsIsNotApplications() {
+        XCTAssertFalse(
+            MoveToApplications.isInsideApplications(path: "/Users/jane/Downloads/Lyrebird.app")
+        )
+    }
+
+    // MARK: - isTranslocatedOrEphemeral
+
+    func testTranslocatedMountIsEphemeral() {
+        let path = "/private/var/folders/ab/cd/X/AppTranslocation/EF-12/d/Lyrebird.app"
+        XCTAssertTrue(
+            MoveToApplications.isTranslocatedOrEphemeral(path: path),
+            "a Gatekeeper App Translocation mount must be treated as ephemeral"
+        )
+    }
+
+    func testMountedDMGVolumeIsEphemeral() {
+        XCTAssertTrue(
+            MoveToApplications.isTranslocatedOrEphemeral(path: "/Volumes/Lyrebird 2.0/Lyrebird.app"),
+            "an app opened from a mounted DMG (/Volumes) must not move out of it"
+        )
+    }
+
+    func testRealDownloadsPathIsNotEphemeral() {
+        XCTAssertFalse(
+            MoveToApplications.isTranslocatedOrEphemeral(path: "/Users/jane/Downloads/Lyrebird.app"),
+            "a normal writable download location is a valid move source"
+        )
+    }
+
+    func testInstalledPathIsNotEphemeral() {
+        XCTAssertFalse(
+            MoveToApplications.isTranslocatedOrEphemeral(path: "/Applications/Lyrebird.app")
+        )
+    }
+
+    // MARK: - Suppress flag persistence
+
+    func testSuppressKeyIsStable() {
+        // On-disk contract: renaming this key re-arms the prompt for every
+        // existing user, so it's pinned here exactly as shipped.
+        XCTAssertEqual(
+            MoveToApplications.suppressKey,
+            "install.suppressMoveToApplicationsPrompt"
+        )
+    }
+
+    func testCurrentEnvironmentReadsSuppressFlagFromDefaults() {
+        let suiteName = "MoveToApplicationsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Unset → not suppressed.
+        let before = MoveToApplications.currentEnvironment(defaults: defaults)
+        XCTAssertFalse(before.userSuppressed, "an unset flag reads as not-suppressed")
+
+        // Set → suppressed, and the snapshot picks it up.
+        defaults.set(true, forKey: MoveToApplications.suppressKey)
+        let after = MoveToApplications.currentEnvironment(defaults: defaults)
+        XCTAssertTrue(after.userSuppressed, "currentEnvironment must reflect the persisted flag")
+    }
+
+    func testCurrentEnvironmentIsDebugUnderTestBuild() {
+        // The unit-test bundle is compiled in the DEBUG configuration, so the
+        // captured environment reports a debug build — which also means a live
+        // promptIfNeeded() call from a test run can never pop an alert.
+        let env = MoveToApplications.currentEnvironment()
+        XCTAssertTrue(env.isDebugBuild, "test builds are DEBUG; the prompt is inert under test")
+        XCTAssertFalse(
+            MoveToApplications.shouldPrompt(env),
+            "a DEBUG environment never prompts regardless of path"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaylistSidebarOrderTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistSidebarOrderTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for `PlaylistSidebarOrder` — the pure ordering logic behind the
+/// sidebar's drag-to-reorder + section-collapse Playlists list (#317).
+///
+/// Reorder persistence is intentionally client-only: the sidebar sorts the
+/// live `model.playlists` array by a stored id list, so the contract that
+/// matters is set-reconciliation, not any server round-trip. These tests pin:
+///   * the CSV codec (`decode` / `encode`) the `@AppStorage` value rides on;
+///   * `reconciled` — stored ids keep their order, new ids append, deleted ids
+///     prune, duplicates collapse;
+///   * `order` — the generic sort the sidebar applies to `[Playlist]`;
+///   * `applyingMove` — folding a SwiftUI `.onMove` back into the stored order.
+final class PlaylistSidebarOrderTests: XCTestCase {
+
+    // MARK: - CSV codec
+
+    /// A round trip through encode → decode preserves the id list verbatim.
+    func testEncodeDecodeRoundTrip() {
+        let ids = ["alpha", "bravo", "charlie"]
+        XCTAssertEqual(PlaylistSidebarOrder.encode(ids), "alpha,bravo,charlie")
+        XCTAssertEqual(PlaylistSidebarOrder.decode("alpha,bravo,charlie"), ids)
+    }
+
+    /// The empty `@AppStorage` default decodes to an empty list, not `[""]`.
+    func testDecodeEmptyStringYieldsEmptyList() {
+        XCTAssertEqual(PlaylistSidebarOrder.decode(""), [])
+        XCTAssertEqual(PlaylistSidebarOrder.encode([]), "")
+    }
+
+    /// Stray / trailing commas and whitespace from a corrupt or hand-edited
+    /// value are dropped rather than producing empty ghost ids.
+    func testDecodeDropsBlankAndWhitespaceEntries() {
+        XCTAssertEqual(PlaylistSidebarOrder.decode("a,,b, ,c,"), ["a", "b", "c"])
+        XCTAssertEqual(PlaylistSidebarOrder.decode(" a , b "), ["a", "b"])
+    }
+
+    // MARK: - Reconciliation
+
+    /// Ids present in both the stored order and the current server set keep
+    /// their stored relative order — the whole point of persisting a reorder.
+    func testReconcileKeepsStoredOrderForSurvivingIds() {
+        let result = PlaylistSidebarOrder.reconciled(
+            stored: ["c", "a", "b"],
+            current: ["a", "b", "c"]
+        )
+        XCTAssertEqual(result, ["c", "a", "b"])
+    }
+
+    /// A brand-new playlist (in `current`, not in `stored`) appends at the
+    /// bottom in server order rather than jumping to the top.
+    func testReconcileAppendsNewIdsInServerOrder() {
+        let result = PlaylistSidebarOrder.reconciled(
+            stored: ["b", "a"],
+            current: ["a", "b", "x", "y"]
+        )
+        XCTAssertEqual(result, ["b", "a", "x", "y"])
+    }
+
+    /// A deleted playlist (in `stored`, not in `current`) is pruned, and the
+    /// survivors keep their order.
+    func testReconcilePrunesDeletedIds() {
+        let result = PlaylistSidebarOrder.reconciled(
+            stored: ["a", "gone", "b"],
+            current: ["a", "b"]
+        )
+        XCTAssertEqual(result, ["a", "b"])
+    }
+
+    /// The result is a permutation of `current` even when both lists are
+    /// mangled: stored has a duplicate and a stale id, current has its own
+    /// duplicate. Every live id appears exactly once.
+    func testReconcileIsDuplicateFreePermutationOfCurrent() {
+        let result = PlaylistSidebarOrder.reconciled(
+            stored: ["b", "b", "stale", "a"],
+            current: ["a", "b", "c", "c"]
+        )
+        XCTAssertEqual(result, ["b", "a", "c"])
+        XCTAssertEqual(Set(result), Set(["a", "b", "c"]))
+        XCTAssertEqual(result.count, Set(result).count, "no duplicates")
+    }
+
+    /// An empty stored order is the "server order" default: current passes
+    /// straight through.
+    func testReconcileEmptyStoredYieldsServerOrder() {
+        let result = PlaylistSidebarOrder.reconciled(
+            stored: [],
+            current: ["a", "b", "c"]
+        )
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    // MARK: - order(_:by:id:)
+
+    /// The generic sort reorders a `[Playlist]` by the stored ids and appends
+    /// an unranked (new) playlist at the bottom — the exact call the sidebar
+    /// makes against `model.playlists`.
+    func testOrderSortsPlaylistsByStoredOrderAppendingNew() {
+        let playlists = [pl("a", "Alpha"), pl("b", "Bravo"), pl("c", "Charlie")]
+        let ordered = PlaylistSidebarOrder.order(
+            playlists,
+            by: ["c", "a"],
+            id: \.id
+        )
+        XCTAssertEqual(ordered.map(\.id), ["c", "a", "b"])
+    }
+
+    /// Sorting an empty list is a no-op (and doesn't trap on the rank lookup).
+    func testOrderEmptyListReturnsEmpty() {
+        let ordered = PlaylistSidebarOrder.order([Playlist](), by: ["a"], id: \.id)
+        XCTAssertTrue(ordered.isEmpty)
+    }
+
+    /// With no stored order, playlists render in their incoming (server) order.
+    func testOrderWithEmptyStoredPreservesInputOrder() {
+        let playlists = [pl("a", "Alpha"), pl("b", "Bravo")]
+        let ordered = PlaylistSidebarOrder.order(playlists, by: [], id: \.id)
+        XCTAssertEqual(ordered.map(\.id), ["a", "b"])
+    }
+
+    // MARK: - applyingMove
+
+    /// Moving the last row to the front (drag up) produces the new full id list
+    /// to persist. Mirrors SwiftUI's `.onMove(source:destination:)` semantics,
+    /// where the destination is the index *before* removal.
+    func testApplyingMoveReordersDisplayedIds() {
+        let next = PlaylistSidebarOrder.applyingMove(
+            displayedIds: ["a", "b", "c"],
+            source: IndexSet(integer: 2),
+            destination: 0
+        )
+        XCTAssertEqual(next, ["c", "a", "b"])
+    }
+
+    /// Moving the first row down past the second: `.onMove` destination is the
+    /// post-removal target index, so source 0 → destination 2 lands "a" between
+    /// "b" and "c".
+    func testApplyingMoveDownShiftsCorrectly() {
+        let next = PlaylistSidebarOrder.applyingMove(
+            displayedIds: ["a", "b", "c"],
+            source: IndexSet(integer: 0),
+            destination: 2
+        )
+        XCTAssertEqual(next, ["b", "a", "c"])
+    }
+
+    /// A move folded back through the codec then reconciled is a stable
+    /// pass-through: persisting the whole arrangement means the next render
+    /// reproduces exactly the order the user dropped into.
+    func testMovePersistsAsStableOrderThroughReconcile() {
+        let moved = PlaylistSidebarOrder.applyingMove(
+            displayedIds: ["a", "b", "c"],
+            source: IndexSet(integer: 2),
+            destination: 0
+        )
+        let raw = PlaylistSidebarOrder.encode(moved)
+        let reconciled = PlaylistSidebarOrder.reconciled(
+            stored: PlaylistSidebarOrder.decode(raw),
+            current: ["a", "b", "c"]
+        )
+        XCTAssertEqual(reconciled, ["c", "a", "b"])
+    }
+
+    // MARK: - Fixture
+
+    /// Minimal `Playlist` fixture — only `id` and `name` are load-bearing for
+    /// ordering; the rest are zero/`nil`.
+    private func pl(_ id: String, _ name: String) -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            trackCount: 0,
+            runtimeTicks: 0,
+            imageTag: nil,
+            userData: nil
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/RecentlyDiscoveredArtistsTests.swift
+++ b/macos/Tests/LyrebirdTests/RecentlyDiscoveredArtistsTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the Home "Recently Discovered Artists" row (#252).
+///
+/// The shelf is a "dumb" Home section: it reads the
+/// `AppModel.recentlyDiscoveredArtists` slice — the album artists whose
+/// catalogue most recently landed on the server, sorted `DateCreated`
+/// descending by the core's `listRecentlyAddedArtists` FFI — and hides
+/// itself when that slice is empty (the `@ViewBuilder` guards
+/// `if !model.recentlyDiscoveredArtists.isEmpty`). These tests pin the
+/// contracts the view depends on:
+///
+/// 1. A fresh model starts with no discovered artists, so the row hides on
+///    first paint instead of punching an empty hole in the layout.
+/// 2. The slice is the single source the row renders, in order. Because the
+///    core hands the list back already sorted newest-first, the view must
+///    not reorder it — it renders the slice verbatim.
+/// 3. The view's display cap is large enough that a typical fetch isn't
+///    silently truncated below what the row promises.
+/// 4. Signing out (`logout`) and forgetting the token (`forgetToken`) both
+///    clear the slice, so one account's newly-added artists never bleed into
+///    the next session's Home row.
+///
+/// Same isolation contract as the other Home suites: `AppModel` is
+/// `@MainActor` and boots a live `LyrebirdCore` pointed at a throwaway data
+/// dir via `XDG_DATA_HOME`, so the test never touches the real app database
+/// and never hits the network (we drive the published slice directly rather
+/// than calling the live `refreshRecentlyDiscoveredArtists` fetch).
+@MainActor
+final class RecentlyDiscoveredArtistsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-recently-discovered-artists-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeArtist(id: String, name: String) -> Artist {
+        Artist(
+            id: id, name: name, albumCount: 0, songCount: 0, genres: [],
+            imageTag: nil, userData: nil
+        )
+    }
+
+    func testRecentlyDiscoveredArtistsStartEmptySoRowHides() throws {
+        let model = try AppModel()
+        XCTAssertTrue(
+            model.recentlyDiscoveredArtists.isEmpty,
+            "a fresh model has no discovered artists, so the Home row hides on first paint"
+        )
+    }
+
+    func testRecentlyDiscoveredArtistsSliceIsRenderedInServerOrder() throws {
+        let model = try AppModel()
+        // The core returns these already sorted DateCreated-descending
+        // (newest arrivals first). The row renders the slice verbatim — it
+        // must not re-sort, so the freshest artist stays in the lead slot.
+        let discovered = [
+            makeArtist(id: "newest", name: "Just Arrived"),
+            makeArtist(id: "middle", name: "Last Week"),
+            makeArtist(id: "oldest", name: "Last Month"),
+        ]
+        model.recentlyDiscoveredArtists = discovered
+
+        XCTAssertEqual(
+            model.recentlyDiscoveredArtists.map(\.id),
+            ["newest", "middle", "oldest"],
+            "the row renders exactly the recentlyDiscoveredArtists slice, preserving the core's newest-first order"
+        )
+        XCTAssertFalse(
+            model.recentlyDiscoveredArtists.isEmpty,
+            "a non-empty slice reveals the Home shelf"
+        )
+    }
+
+    func testRecentlyDiscoveredArtistsDisplayCapKeepsTypicalFetchIntact() throws {
+        let model = try AppModel()
+        // The Home row caps how many circles it renders
+        // (HomeView's `recentlyDiscoveredArtistsLimit`). A modest fetch must
+        // survive that cap untouched — only oversized fetches get trimmed,
+        // with "See All" routing to the full Library Artists list.
+        let discovered = (1...12).map { makeArtist(id: "a\($0)", name: "Artist \($0)") }
+        model.recentlyDiscoveredArtists = discovered
+
+        XCTAssertGreaterThanOrEqual(
+            model.recentlyDiscoveredArtists.prefix(18).count,
+            12,
+            "a 12-artist fetch renders in full under the row's display cap"
+        )
+    }
+
+    func testRecentlyDiscoveredArtistsIsDistinctFromFavoriteArtists() throws {
+        let model = try AppModel()
+        // The two artist circle-rows read independent slices — "Recently
+        // Discovered" (newly-added) must never alias "Artists You Love"
+        // (favorited), or one shelf would mirror the other.
+        model.recentlyDiscoveredArtists = [makeArtist(id: "fresh", name: "New Signing")]
+        model.favoriteArtists = [makeArtist(id: "loved", name: "Old Favorite")]
+
+        XCTAssertEqual(model.recentlyDiscoveredArtists.map(\.id), ["fresh"])
+        XCTAssertEqual(model.favoriteArtists.map(\.id), ["loved"])
+    }
+
+    func testLogoutClearsRecentlyDiscoveredArtists() throws {
+        let model = try AppModel()
+        model.recentlyDiscoveredArtists = [makeArtist(id: "a1", name: "Fresh Find")]
+
+        model.logout()
+
+        XCTAssertTrue(
+            model.recentlyDiscoveredArtists.isEmpty,
+            "logout must drop the discovered-artists slice so the next account's Home row starts clean"
+        )
+    }
+
+    func testForgetTokenClearsRecentlyDiscoveredArtists() throws {
+        let model = try AppModel()
+        model.recentlyDiscoveredArtists = [makeArtist(id: "a1", name: "Fresh Find")]
+
+        model.forgetToken()
+
+        XCTAssertTrue(
+            model.recentlyDiscoveredArtists.isEmpty,
+            "forgetting the token (auth expiry) must clear discovered artists alongside the rest of session state"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/ReplayGainTests.swift
+++ b/macos/Tests/LyrebirdTests/ReplayGainTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import Lyrebird
+@testable import LyrebirdAudio
+
+/// Coverage for the pure ReplayGain / volume-normalization logic behind #42:
+/// the dB→linear conversion, tag parsing across the Vorbis / ID3 / iTunes
+/// spellings, the track/album fallback chain, the `iTunNORM` fallback, and the
+/// clamping that keeps a garbage tag from blowing up the output level. These
+/// are deliberately `AVAsset`-free and network-free — `ReplayGain.gains(for:)`
+/// is the only impure entry point and it just funnels metadata pairs into
+/// `parseGains`, which is exercised here directly.
+///
+/// Also covers the `AppModel`↔engine raw-value bridge so the persisted
+/// `NormalizationMode` maps onto the engine's `ReplayGainMode` without drift.
+final class ReplayGainTests: XCTestCase {
+
+    // MARK: - dB ↔ linear
+
+    func testLinearGainZeroDbIsUnity() {
+        XCTAssertEqual(ReplayGain.linearGain(fromDb: 0), 1.0, accuracy: 1e-6)
+    }
+
+    func testLinearGainKnownPoints() {
+        // -6 dB ≈ 0.5012, +6 dB ≈ 1.9953, -20 dB = 0.1, +20 dB = 10.
+        XCTAssertEqual(ReplayGain.linearGain(fromDb: -6), 0.5012, accuracy: 1e-3)
+        XCTAssertEqual(ReplayGain.linearGain(fromDb: 6), 1.9953, accuracy: 1e-3)
+        XCTAssertEqual(ReplayGain.linearGain(fromDb: -20), 0.1, accuracy: 1e-5)
+        XCTAssertEqual(ReplayGain.linearGain(fromDb: 20), 10.0, accuracy: 1e-4)
+    }
+
+    func testLinearGainIsMonotonic() {
+        XCTAssertLessThan(ReplayGain.linearGain(fromDb: -3), ReplayGain.linearGain(fromDb: 0))
+        XCTAssertLessThan(ReplayGain.linearGain(fromDb: 0), ReplayGain.linearGain(fromDb: 3))
+    }
+
+    // MARK: - dB string parsing
+
+    func testParseGainDbWithUnitSuffix() {
+        XCTAssertEqual(ReplayGain.parseGainDb("-7.60 dB") ?? .nan, -7.60, accuracy: 1e-9)
+    }
+
+    func testParseGainDbNoSpaceBeforeUnit() {
+        XCTAssertEqual(ReplayGain.parseGainDb("-7.60dB") ?? .nan, -7.60, accuracy: 1e-9)
+    }
+
+    func testParseGainDbBareNumber() {
+        XCTAssertEqual(ReplayGain.parseGainDb("3.21") ?? .nan, 3.21, accuracy: 1e-9)
+    }
+
+    func testParseGainDbExplicitPlusSign() {
+        XCTAssertEqual(ReplayGain.parseGainDb("+3 dB") ?? .nan, 3.0, accuracy: 1e-9)
+    }
+
+    func testParseGainDbLeadingWhitespace() {
+        XCTAssertEqual(ReplayGain.parseGainDb("  -2.5 dB") ?? .nan, -2.5, accuracy: 1e-9)
+    }
+
+    func testParseGainDbRejectsNonNumeric() {
+        XCTAssertNil(ReplayGain.parseGainDb("dB"))
+        XCTAssertNil(ReplayGain.parseGainDb(""))
+        XCTAssertNil(ReplayGain.parseGainDb("   "))
+        XCTAssertNil(ReplayGain.parseGainDb("loud"))
+    }
+
+    // MARK: - Tag parsing (key spellings)
+
+    func testParseGainsVorbisUppercase() {
+        let gains = ReplayGain.parseGains(from: [
+            (key: "REPLAYGAIN_TRACK_GAIN", value: "-7.60 dB"),
+            (key: "REPLAYGAIN_ALBUM_GAIN", value: "-5.40 dB"),
+        ])
+        XCTAssertEqual(gains.trackGainDb ?? .nan, -7.60, accuracy: 1e-9)
+        XCTAssertEqual(gains.albumGainDb ?? .nan, -5.40, accuracy: 1e-9)
+        XCTAssertNil(gains.iTunNormDb)
+        XCTAssertFalse(gains.isEmpty)
+    }
+
+    func testParseGainsVorbisLowercase() {
+        let gains = ReplayGain.parseGains(from: [
+            (key: "replaygain_track_gain", value: "+2.00 dB"),
+        ])
+        XCTAssertEqual(gains.trackGainDb ?? .nan, 2.0, accuracy: 1e-9)
+    }
+
+    func testParseGainsITunesNamespacePrefixStripped() {
+        // AVFoundation prepends `com.apple.iTunes.` to iTunes-atom keys.
+        let gains = ReplayGain.parseGains(from: [
+            (key: "com.apple.iTunes.replaygain_track_gain", value: "-3.10 dB"),
+            (key: "com.apple.iTunes.REPLAYGAIN_ALBUM_GAIN", value: "-1.00 dB"),
+        ])
+        XCTAssertEqual(gains.trackGainDb ?? .nan, -3.10, accuracy: 1e-9)
+        XCTAssertEqual(gains.albumGainDb ?? .nan, -1.00, accuracy: 1e-9)
+    }
+
+    func testParseGainsIgnoresUnrelatedKeys() {
+        let gains = ReplayGain.parseGains(from: [
+            (key: "TITLE", value: "Some Song"),
+            (key: "REPLAYGAIN_TRACK_PEAK", value: "0.98"),  // peak, not gain
+            (key: "ARTIST", value: "Someone"),
+        ])
+        XCTAssertTrue(gains.isEmpty)
+    }
+
+    func testParseGainsEmptyInput() {
+        let gains = ReplayGain.parseGains(from: [(key: String, value: String)]())
+        XCTAssertTrue(gains.isEmpty)
+        XCTAssertNil(gains.trackGainDb)
+        XCTAssertNil(gains.albumGainDb)
+        XCTAssertNil(gains.iTunNormDb)
+    }
+
+    // MARK: - iTunNORM fallback
+
+    func testITunNormParsesFirstTwoFields() {
+        // 1000 (hex 0x3E8) ≈ 0 dB. A value of 2000 (0x7D0) is twice as loud →
+        // -10*log10(2) ≈ -3.01 dB of attenuation.
+        let db = ReplayGain.iTunNormDb(from: "000007D0 000007D0 00000000 00000000")
+        XCTAssertNotNil(db)
+        XCTAssertEqual(db ?? .nan, -3.0103, accuracy: 1e-3)
+    }
+
+    func testITunNormPicksLessAggressiveChannel() {
+        // Left = 0x7D0 (2000 → -3.01 dB), right = 0x3E8 (1000 → 0 dB). The
+        // less-aggressive (smaller magnitude) channel wins so a single hot
+        // channel can't drag the whole track down: 0 dB.
+        let db = ReplayGain.iTunNormDb(from: "000007D0 000003E8")
+        XCTAssertEqual(db ?? .nan, 0.0, accuracy: 1e-6)
+    }
+
+    func testITunNormRejectsMalformed() {
+        XCTAssertNil(ReplayGain.iTunNormDb(from: ""))
+        XCTAssertNil(ReplayGain.iTunNormDb(from: "000003E8"))          // only one field
+        XCTAssertNil(ReplayGain.iTunNormDb(from: "00000000 00000000")) // both zero
+        XCTAssertNil(ReplayGain.iTunNormDb(from: "ZZ YY"))             // non-hex
+    }
+
+    func testParseGainsITunNorm() {
+        let gains = ReplayGain.parseGains(from: [
+            (key: "com.apple.iTunes.iTunNORM", value: " 000007D0 000007D0 00000000 00000000"),
+        ])
+        XCTAssertNil(gains.trackGainDb)
+        XCTAssertNil(gains.albumGainDb)
+        XCTAssertEqual(gains.iTunNormDb ?? .nan, -3.0103, accuracy: 1e-3)
+    }
+
+    // MARK: - replayGainDb mode selection + fallbacks
+
+    func testTrackModePrefersTrackGain() {
+        let gains = ReplayGain.Gains(trackGainDb: -7, albumGainDb: -5)
+        XCTAssertEqual(ReplayGain.replayGainDb(mode: .track, gains: gains), -7)
+    }
+
+    func testTrackModeFallsBackToITunNorm() {
+        let gains = ReplayGain.Gains(iTunNormDb: -2)
+        XCTAssertEqual(ReplayGain.replayGainDb(mode: .track, gains: gains), -2)
+    }
+
+    func testAlbumModePrefersAlbumGain() {
+        let gains = ReplayGain.Gains(trackGainDb: -7, albumGainDb: -5)
+        XCTAssertEqual(ReplayGain.replayGainDb(mode: .album, gains: gains), -5)
+    }
+
+    func testAlbumModeFallsBackToTrackGain() {
+        // No album gain tagged — album mode still normalizes off the track gain.
+        let gains = ReplayGain.Gains(trackGainDb: -7)
+        XCTAssertEqual(ReplayGain.replayGainDb(mode: .album, gains: gains), -7)
+    }
+
+    func testAlbumModeFallsBackToITunNormWhenNoReplayGain() {
+        let gains = ReplayGain.Gains(iTunNormDb: -1.5)
+        XCTAssertEqual(ReplayGain.replayGainDb(mode: .album, gains: gains), -1.5)
+    }
+
+    func testOffModeNeverResolvesGain() {
+        let gains = ReplayGain.Gains(trackGainDb: -7, albumGainDb: -5, iTunNormDb: -2)
+        XCTAssertNil(ReplayGain.replayGainDb(mode: .off, gains: gains))
+    }
+
+    func testEmptyGainsResolveNil() {
+        let gains = ReplayGain.Gains()
+        XCTAssertNil(ReplayGain.replayGainDb(mode: .track, gains: gains))
+        XCTAssertNil(ReplayGain.replayGainDb(mode: .album, gains: gains))
+    }
+
+    // MARK: - linearVolume (the value the engine hands to setVolume)
+
+    func testLinearVolumeOffIsNoOp() {
+        let gains = ReplayGain.Gains(trackGainDb: -6)
+        // Off must return nil — the engine treats nil as "leave the level
+        // alone" and never touches volume.
+        XCTAssertNil(ReplayGain.linearVolume(mode: .off, gains: gains))
+    }
+
+    func testLinearVolumeUntaggedIsNoOp() {
+        // Mode is on, but the track carries no usable loudness tag → nil so the
+        // engine plays the stream at its natural volume rather than guessing.
+        XCTAssertNil(ReplayGain.linearVolume(mode: .track, gains: ReplayGain.Gains()))
+    }
+
+    func testLinearVolumeAppliesTrackGain() {
+        let gains = ReplayGain.Gains(trackGainDb: -6)
+        let v = ReplayGain.linearVolume(mode: .track, gains: gains)
+        XCTAssertNotNil(v)
+        XCTAssertEqual(v ?? .nan, 0.5012, accuracy: 1e-3)
+    }
+
+    func testLinearVolumeAddsPreGain() {
+        // -6 dB track gain + +6 dB pre-gain = 0 dB total = unity.
+        let gains = ReplayGain.Gains(trackGainDb: -6)
+        let v = ReplayGain.linearVolume(mode: .track, gains: gains, preGainDb: 6)
+        XCTAssertEqual(v ?? .nan, 1.0, accuracy: 1e-4)
+    }
+
+    func testLinearVolumeClampsRunawayPositiveGain() {
+        // A mis-scanned +60 dB tag must clamp to +maxAbsGainDb, not 1000x.
+        let gains = ReplayGain.Gains(trackGainDb: 60)
+        let v = ReplayGain.linearVolume(mode: .track, gains: gains)
+        let ceiling = ReplayGain.linearGain(fromDb: ReplayGain.maxAbsGainDb)
+        XCTAssertEqual(v ?? .nan, ceiling, accuracy: 1e-4)
+    }
+
+    func testLinearVolumeClampsRunawayNegativeGain() {
+        let gains = ReplayGain.Gains(trackGainDb: -60)
+        let v = ReplayGain.linearVolume(mode: .track, gains: gains)
+        let floorValue = ReplayGain.linearGain(fromDb: -ReplayGain.maxAbsGainDb)
+        XCTAssertEqual(v ?? .nan, floorValue, accuracy: 1e-4)
+    }
+
+    func testLinearVolumeClampIncludesPreGain() {
+        // +10 dB tag + +10 dB pre-gain = +20 dB requested, clamped to the ceiling.
+        let gains = ReplayGain.Gains(trackGainDb: 10)
+        let v = ReplayGain.linearVolume(mode: .track, gains: gains, preGainDb: 10)
+        let ceiling = ReplayGain.linearGain(fromDb: ReplayGain.maxAbsGainDb)
+        XCTAssertEqual(v ?? .nan, ceiling, accuracy: 1e-4)
+    }
+
+    // MARK: - AppModel ↔ engine raw-value bridge
+
+    func testNormalizationModeBridgeRoundTrips() {
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: "off"), .off)
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: "track"), .track)
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: "album"), .album)
+    }
+
+    func testNormalizationModeBridgeDefaultsToOff() {
+        // A nil (never-written) key or a stale/unknown raw value falls back to
+        // .off so a missing preference never silently alters volume.
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: nil), .off)
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: ""), .off)
+        XCTAssertEqual(AppModel.normalizationMode(forStoredValue: "bogus"), .off)
+    }
+
+    func testNormalizationModeBridgeMatchesAppEnumRawValues() {
+        // Guard against the two enums drifting apart: every NormalizationMode
+        // raw value must map to the same-named ReplayGainMode.
+        for mode in NormalizationMode.allCases {
+            let bridged = AppModel.normalizationMode(forStoredValue: mode.rawValue)
+            XCTAssertEqual(bridged.rawValue, mode.rawValue)
+        }
+    }
+}


### PR DESCRIPTION
Fourth wave of the 2.0 push. Six features, built in isolation, adversarially reviewed, integrated on a green base (clean build + 511 Swift tests + cargo test + clippy + `cargo fmt --check`, all passing).

- **ReplayGain / volume normalization** — reads ReplayGain tags from stream metadata and applies linear gain via `AVMutableAudioMixInputParameters` (no engine rewrite; graceful no-op when untagged). Closes #42
- **Dynamic Type safe layouts** — Player Bar + Sidebar reflow at accessibility text sizes instead of clipping. Closes #338
- **LetsMove prompt** — first-launch offer to move into /Applications (DEBUG/translocation/already-installed aware). Closes #193
- **Dedicated About window** — `CommandGroup(replacing: .appInfo)` with version/build/server/credits, sharing one source with the Preferences About pane. Closes #25
- **Recently Discovered Artists row** — DateCreated-sorted artists query (core FFI) surfaced on Home. Closes #252
- **Sidebar playlist reorder + collapse** — drag-reorder (local persisted order) + collapsible Playlists section. Closes #317