### PR TITLE
fix: 2.0 polish — resolve audit findings (security, bugs, error-handling, perf)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -6,6 +6,7 @@ use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client as HttpClient, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -114,6 +115,12 @@ pub struct JellyfinClient {
     /// sleep between retry attempts and returns
     /// [`LyrebirdError::Other`]`("cancelled")` immediately. See issue #605.
     pub cancel: CancellationToken,
+    /// Monotonically-incrementing counter mixed into the backoff jitter seed
+    /// so two retries that fire in the same sub-millisecond window get
+    /// *decorrelated* jitter (the system clock alone returns near-identical
+    /// values for concurrent calls, defeating the thundering-herd purpose of
+    /// jitter). Bumped once per `backoff_for` call. See `backoff_for`.
+    jitter_counter: AtomicU64,
 }
 
 impl JellyfinClient {
@@ -139,6 +146,7 @@ impl JellyfinClient {
             library_cache: Mutex::new(LibraryCache::default()),
             refresh_cb: Mutex::new(None),
             cancel: CancellationToken::new(),
+            jitter_counter: AtomicU64::new(0),
         })
     }
 
@@ -199,11 +207,15 @@ impl JellyfinClient {
             .map(|t| format!(", Token=\"{t}\""))
             .unwrap_or_default();
         let safe_device = Self::sanitize_header_field(&self.device_name, 100);
+        // `device_id` is interpolated into the same header value, so it must
+        // be hardened identically — an embedded CRLF here would inject a
+        // header just as a malicious `device_name` could (#608).
+        let safe_device_id = Self::sanitize_header_field(&self.device_id, 100);
         format!(
             "MediaBrowser Client=\"{client}\", Device=\"{device}\", DeviceId=\"{device_id}\", Version=\"{version}\"{token}",
             client = CLIENT_NAME,
             device = safe_device,
-            device_id = self.device_id,
+            device_id = safe_device_id,
             version = CLIENT_VERSION,
             token = token_part,
         )
@@ -301,19 +313,41 @@ impl JellyfinClient {
 
     /// Backoff for attempt `n` (1-indexed: attempt 1 is the first *retry*,
     /// i.e. the backoff *after* the initial send failed). Applies ±15%
-    /// symmetric jitter seeded from the system clock.
-    fn backoff_for(attempt: u32) -> Duration {
+    /// symmetric jitter.
+    ///
+    /// The jitter must *decorrelate* concurrent retries to break up
+    /// thundering herds. Seeding from the system clock alone fails that goal:
+    /// two retries firing in the same sub-millisecond window read
+    /// near-identical clock values and so get near-identical jitter. We
+    /// instead mix a per-client monotonic counter into the clock and run the
+    /// result through the splitmix64 finalizer, which avalanches adjacent
+    /// seeds into well-spread outputs. This keeps the "no `rand` dependency"
+    /// property while giving each retry independent jitter even when called
+    /// back-to-back.
+    fn backoff_for(&self, attempt: u32) -> Duration {
         let idx = (attempt.saturating_sub(1) as usize).min(BACKOFF_BASE_MS.len() - 1);
         let base = BACKOFF_BASE_MS[idx] as f64;
-        // Cheap `±15%` jitter: the high bits of the system clock's
-        // subsecond nanos are plenty random for breaking up synchronized
-        // retries. Pulling in `rand` for this would be overkill.
-        let seed = std::time::SystemTime::now()
+
+        let clock = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
+            .map(|d| d.as_nanos() as u64)
             .unwrap_or(0);
-        // Map nanos [0, 1e9) onto jitter factor [0.85, 1.15].
-        let jitter = 0.85 + (seed as f64 / 1_000_000_000.0) * 0.30;
+        // `fetch_add` returns the previous value, so each call gets a unique
+        // counter even when two fire in the same clock tick.
+        let counter = self.jitter_counter.fetch_add(1, Ordering::Relaxed);
+
+        // splitmix64 finalizer — strong avalanche so adjacent seeds map to
+        // well-separated outputs.
+        let mut z = clock
+            .wrapping_add(counter.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+            .wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+
+        // Map the hashed bits onto a jitter factor in [0.85, 1.15].
+        let unit = (z >> 11) as f64 / (1u64 << 53) as f64; // [0, 1)
+        let jitter = 0.85 + unit * 0.30;
         Duration::from_millis((base * jitter).round() as u64)
     }
 
@@ -374,7 +408,7 @@ impl JellyfinClient {
 
                     if Self::is_retriable_status(status) && attempt < MAX_ATTEMPTS {
                         let delay = Self::parse_retry_after(resp.headers())
-                            .unwrap_or_else(|| Self::backoff_for(attempt));
+                            .unwrap_or_else(|| self.backoff_for(attempt));
                         tracing::warn!(
                             attempt,
                             status = status.as_u16(),
@@ -399,7 +433,7 @@ impl JellyfinClient {
                 }
                 Err(err) => {
                     if Self::is_retriable_transport_error(&err) && attempt < MAX_ATTEMPTS {
-                        let delay = Self::backoff_for(attempt);
+                        let delay = self.backoff_for(attempt);
                         tracing::warn!(
                             attempt,
                             error = %err,
@@ -435,6 +469,54 @@ impl JellyfinClient {
     {
         let resp = self.send_with_retry_raw(build).await?;
         Self::check(resp).await
+    }
+
+    /// Send a **non-idempotent, resource-mutating** request exactly once on
+    /// the wire (per logical attempt), with the silent-401 re-auth retry but
+    /// **without** the transport-error / 5xx automatic retry that
+    /// [`Self::send_with_retry`] applies.
+    ///
+    /// The blanket retry in `send_with_retry` is safe for idempotent verbs
+    /// (GET/HEAD/PUT/DELETE) but dangerous for POSTs that create or append
+    /// server state: if the first POST reaches the server and commits, then
+    /// the response is lost to a timeout (or the server answers 5xx after a
+    /// partial commit), a retry duplicates the side effect — a second
+    /// playlist, the same tracks appended twice, etc. (see #282-adjacent
+    /// audit). Such callers route here instead so a post-send failure
+    /// surfaces to the user rather than silently double-applying.
+    ///
+    /// A `401` is still retried once: an unauthorized request was rejected
+    /// before it could mutate anything, so re-authenticating and re-sending
+    /// is side-effect-free. Everything else (5xx, transport error) is
+    /// returned to the caller without a retry.
+    async fn send_mutation_no_retry<F>(&self, mut build: F) -> Result<Response>
+    where
+        F: FnMut() -> Result<RequestBuilder>,
+    {
+        let mut reauth_attempted = false;
+        loop {
+            let builder = build()?;
+            let resp = builder.send().await?;
+
+            if resp.status() == StatusCode::UNAUTHORIZED && !reauth_attempted {
+                reauth_attempted = true;
+                match self.try_refresh_token() {
+                    Ok(true) => {
+                        tracing::warn!(
+                            "jellyfin 401 on mutation — refreshed token from keyring, retrying once"
+                        );
+                        continue;
+                    }
+                    Ok(false) => return Err(LyrebirdError::AuthExpired),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "token refresh failed");
+                        return Err(LyrebirdError::AuthExpired);
+                    }
+                }
+            }
+
+            return Self::check(resp).await;
+        }
     }
 
     /// GET the given URL through the retry + silent re-auth pipeline, returning
@@ -699,9 +781,17 @@ impl JellyfinClient {
     /// [`JellyfinClient::albums`] instead; `latest_albums` is optimized for
     /// the Home "Recently Added" row.
     ///
-    /// `total_count` on the returned [`PaginatedAlbums`] is the number of
-    /// items the server returned for this request, NOT the library total —
-    /// `/Items/Latest` does not report `TotalRecordCount`.
+    /// `/Items/Latest` does **not** report a `TotalRecordCount`, so there is
+    /// no server-authoritative library total to surface here. To avoid
+    /// callers mistaking this for a paginatable total (and computing a wrong
+    /// "has more pages" — the old behaviour returned the pre-slice window
+    /// length, which could never exceed `offset + limit` and so falsely
+    /// implied more pages), `total_count` is set to the number of items
+    /// **actually returned in this page** (`items.len()`). It is therefore
+    /// self-consistent (`total_count == items.len()`) and signals "this is
+    /// the whole set the Latest shelf is showing", not a paginatable total.
+    /// Callers that need true catalog pagination must use
+    /// [`JellyfinClient::albums`].
     pub async fn latest_albums(&self, library_id: &str, paging: Paging) -> Result<PaginatedAlbums> {
         let user_id = self
             .user_id
@@ -737,13 +827,16 @@ impl JellyfinClient {
             .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
             .await?;
         let items: Vec<RawItem> = resp.json().await?;
-        let total_count = items.len() as u32;
         let sliced: Vec<Album> = items
             .into_iter()
             .skip(paging.offset as usize)
             .take(limit as usize)
             .map(Album::from)
             .collect();
+        // `total_count` mirrors the size of *this page* (post-slice), not the
+        // pre-slice fetch window — there's no server total for /Items/Latest,
+        // and reporting the window length implied phantom extra pages.
+        let total_count = sliced.len() as u32;
         Ok(PaginatedAlbums {
             items: sliced,
             total_count,
@@ -851,24 +944,6 @@ impl JellyfinClient {
         })
     }
 
-    /// Same implementation as [`JellyfinClient::user_playlists`] until a
-    /// reliable user-vs-public discriminator is wired. Kept as a distinct
-    /// method so callers that care about the intent — a future "Community
-    /// Playlists" surface — don't have to change when the split lands.
-    ///
-    /// Previous behaviour filtered on `!Path.contains("/data/")`. That was a
-    /// false discriminator (returned everything when the Playlists library
-    /// was mounted outside the user profile dir, returned nothing when it
-    /// was). Same fix rationale as `user_playlists`.
-    pub async fn public_playlists(
-        &self,
-        playlist_library_id: &str,
-        paging: Paging,
-    ) -> Result<PaginatedPlaylists> {
-        // Same query today; see doc comment. Avoid duplicating the HTTP call.
-        self.user_playlists(playlist_library_id, paging).await
-    }
-
     /// Playlists in the user's Playlists library whose track list features the
     /// given artist, capped at `limit` results.
     ///
@@ -883,23 +958,33 @@ impl JellyfinClient {
     /// just album-artist credits — which is what the Artist-detail rail wants.
     ///
     /// Cost: one playlist-list request plus one items request per playlist
-    /// scanned. We stop scanning as soon as `limit` matches are found, and cap
-    /// the playlists scanned at `MAX_PLAYLISTS_SCANNED` so a pathological
-    /// library can't turn this into an unbounded fan-out. Per-playlist we ask
-    /// for up to `PLAYLIST_TRACK_PROBE_LIMIT` items, which covers ordinary
-    /// playlists in a single round-trip; longer playlists are probed by their
-    /// leading window (a featured artist in a multi-hundred-track playlist is
-    /// overwhelmingly present in that window, and the rail is a discovery
-    /// affordance, not an exhaustive index).
+    /// scanned. We cap the playlists scanned at `MAX_PLAYLISTS_SCANNED` so a
+    /// pathological library can't turn this into an unbounded fan-out, and we
+    /// probe in **bounded-concurrency batches** (`PROBE_CONCURRENCY` requests
+    /// in flight) rather than strictly sequentially — the old one-at-a-time
+    /// loop serialized ~200 round-trips behind the FFI mutex and made the
+    /// Artist-detail rail crawl. Candidate order is preserved in the result,
+    /// and we stop launching new batches once `limit` matches are found.
+    /// Per-playlist we ask for up to `PLAYLIST_TRACK_PROBE_LIMIT` items, which
+    /// covers ordinary playlists in a single round-trip; longer playlists are
+    /// probed by their leading window (a featured artist in a multi-hundred-
+    /// track playlist is overwhelmingly present in that window, and the rail
+    /// is a discovery affordance, not an exhaustive index).
     pub async fn playlists_containing_artist(
         &self,
         playlist_library_id: &str,
         artist_id: &str,
         limit: u32,
     ) -> Result<Vec<Playlist>> {
+        use futures::stream::{self, StreamExt};
+
         // Upper bounds that keep the fan-out predictable on large libraries.
         const MAX_PLAYLISTS_SCANNED: u32 = 200;
         const PLAYLIST_TRACK_PROBE_LIMIT: u32 = 500;
+        // How many per-playlist probes to run at once. Bounded so we neither
+        // hammer the server nor hold the runtime hostage; tuned to keep the
+        // rail snappy without a connection stampede.
+        const PROBE_CONCURRENCY: usize = 8;
 
         if limit == 0 {
             return Ok(Vec::new());
@@ -913,16 +998,50 @@ impl JellyfinClient {
         let candidates = self
             .playlists_items(playlist_library_id, Paging::new(0, MAX_PLAYLISTS_SCANNED))
             .await?;
+        let candidate_items = candidates.items;
 
+        // First pass: probe membership for each candidate concurrently
+        // (bounded), recording a parallel `Vec<bool>` so we can map results
+        // back onto the owned candidate list in order without cloning the
+        // (large) RawItem. Process in chunks and stop probing once we've found
+        // enough matches.
+        let mut features: Vec<bool> = vec![false; candidate_items.len()];
+        let mut found = 0u32;
+        for (chunk_start, chunk) in candidate_items.chunks(PROBE_CONCURRENCY).enumerate() {
+            if found >= limit {
+                break;
+            }
+            let base = chunk_start * PROBE_CONCURRENCY;
+            let results: Vec<bool> = stream::iter(chunk.iter().map(|raw| async move {
+                self.playlist_features_artist(
+                    &raw.id,
+                    user_id,
+                    artist_id,
+                    PLAYLIST_TRACK_PROBE_LIMIT,
+                )
+                .await
+            }))
+            .buffered(PROBE_CONCURRENCY)
+            .collect::<Vec<Result<bool>>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<bool>>>()?;
+            for (offset, hit) in results.into_iter().enumerate() {
+                features[base + offset] = hit;
+                if hit {
+                    found += 1;
+                }
+            }
+        }
+
+        // Second pass: consume the owned candidates in order, keeping the
+        // ones that matched, capped at `limit`.
         let mut matches: Vec<Playlist> = Vec::new();
-        for raw in candidates.items {
+        for (i, raw) in candidate_items.into_iter().enumerate() {
             if matches.len() as u32 >= limit {
                 break;
             }
-            if self
-                .playlist_features_artist(&raw.id, user_id, artist_id, PLAYLIST_TRACK_PROBE_LIMIT)
-                .await?
-            {
+            if features[i] {
                 matches.push(Playlist::from(raw));
             }
         }
@@ -964,10 +1083,10 @@ impl JellyfinClient {
     }
 
     /// Shared `GET /Items` request that returns all playlists under the
-    /// given Playlists library view. `user_playlists` / `public_playlists`
-    /// partition the result by `Path`. Returns the raw [`RawItems`] wrapper
-    /// so callers can forward `total_record_count` to their paginated
-    /// response shape.
+    /// given Playlists library view. [`Self::user_playlists`] maps the raw
+    /// items to [`Playlist`]; [`Self::playlists_containing_artist`] probes
+    /// them. Returns the raw [`RawItems`] wrapper so callers can forward
+    /// `total_record_count` to their paginated response shape.
     async fn playlists_items(
         &self,
         playlist_library_id: &str,
@@ -1121,8 +1240,14 @@ impl JellyfinClient {
                 q.append_pair("StartIndex", &pos.to_string());
             }
         }
-        self.send_with_retry(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
-            .await?;
+        // Append is non-idempotent: a blanket transport/5xx retry could
+        // append the same items twice (the first POST commits, its response
+        // is lost, the retry re-appends). Route through the no-retry mutation
+        // path so a post-send failure surfaces instead of double-applying.
+        self.send_mutation_no_retry(|| {
+            Ok(self.http.post(url.clone()).headers(self.build_headers()?))
+        })
+        .await?;
         Ok(())
     }
 
@@ -1988,23 +2113,24 @@ impl JellyfinClient {
     /// method returns the new playlist id so callers can refetch the full
     /// record (e.g. via [`JellyfinClient::fetch_item`]) if they need it.
     ///
+    /// There is intentionally no positional-insert parameter: `POST
+    /// /Playlists` has no server-side `StartIndex` semantics (the seed items
+    /// are appended in `Ids` order), so a position hint would be silently
+    /// dropped. Positional insert is a separate primitive on
+    /// `POST /Playlists/{id}/Items` (deferred; see #282).
+    ///
+    /// Sent via [`Self::send_mutation_no_retry`] because it creates a
+    /// resource: a blanket transport/5xx retry could create a *duplicate*
+    /// playlist if the first POST committed but its response was lost.
+    ///
     /// Requires an authenticated session; returns
     /// [`LyrebirdError::NotAuthenticated`] if no `user_id` is set.
-    pub async fn create_playlist(
-        &self,
-        name: &str,
-        item_ids: &[&str],
-        position: Option<u32>,
-    ) -> Result<String> {
+    pub async fn create_playlist(&self, name: &str, item_ids: &[&str]) -> Result<String> {
         let user_id = self
             .user_id
             .as_ref()
             .ok_or(LyrebirdError::NotAuthenticated)?;
-        let mut url = self.endpoint("Playlists")?;
-        if let Some(pos) = position {
-            url.query_pairs_mut()
-                .append_pair("StartIndex", &pos.to_string());
-        }
+        let url = self.endpoint("Playlists")?;
         let body = CreatePlaylistBody {
             name: name.to_string(),
             ids: item_ids.iter().map(|s| s.to_string()).collect(),
@@ -2012,7 +2138,7 @@ impl JellyfinClient {
             media_type: "Audio".to_string(),
         };
         let resp = self
-            .send_with_retry(|| {
+            .send_mutation_no_retry(|| {
                 Ok(self
                     .http
                     .post(url.clone())
@@ -2421,9 +2547,18 @@ impl JellyfinClient {
 
     /// Rename a playlist by updating its `Name` field via `POST /Items/{id}`.
     ///
-    /// The `POST /Items/{id}` endpoint requires the full item body, so we first
-    /// fetch the existing item with `GET /Items/{id}` and then re-POST with only
-    /// `Name` changed. Responds 204 on success.
+    /// The `POST /Items/{id}` (UpdateItem) endpoint does a *blind assign* of
+    /// the posted [`BaseItemDto`] onto the stored item: every editable field
+    /// it reads is overwritten with whatever the body carries, and fields
+    /// absent from the body are reset. So we must fetch the existing item with
+    /// the full editable field projection first and round-trip it intact,
+    /// changing only `Name` — otherwise a rename silently *wipes* the
+    /// playlist's Genres, Overview, Tags, sort name, etc.
+    ///
+    /// `GET /Items` returns the sort name under `SortName`, but UpdateItem
+    /// reads it from `ForcedSortName`, so we map it across before posting (a
+    /// bare `SortName` in the body would leave `ForcedSortName` unset and
+    /// clear the custom sort). Responds 204 on success.
     ///
     /// Requires an authenticated session; returns
     /// [`LyrebirdError::NotAuthenticated`] if no token is set.
@@ -2432,11 +2567,35 @@ impl JellyfinClient {
             .user_id
             .as_ref()
             .ok_or(LyrebirdError::NotAuthenticated)?;
-        // Fetch the current item to prefill required fields.
-        let existing = self.fetch_item(playlist_id, &[]).await?;
+        // Fetch the current item with the full editable field set so the
+        // blind-assign UpdateItem echoes the existing values instead of
+        // clearing them.
+        let existing = self
+            .fetch_item(
+                playlist_id,
+                &[
+                    "Genres",
+                    "Tags",
+                    "Overview",
+                    "SortName",
+                    "ProviderIds",
+                    "DateCreated",
+                    "ProductionYear",
+                    "OfficialRating",
+                ],
+            )
+            .await?;
         // Build the update body from the existing item, overwriting Name.
         let mut body = existing;
         body["Name"] = serde_json::Value::String(new_name.to_string());
+        // UpdateItem reads the custom sort name from `ForcedSortName`; the GET
+        // projection exposes it as `SortName`. Map it so the round-trip
+        // preserves the playlist's sort name instead of clearing it.
+        if let Some(sort_name) = body.get("SortName").cloned() {
+            if sort_name.is_string() {
+                body["ForcedSortName"] = sort_name;
+            }
+        }
         let mut url = self.endpoint(&format!("Items/{playlist_id}"))?;
         url.query_pairs_mut().append_pair("UserId", user_id);
         self.send_with_retry(|| {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -39,7 +39,7 @@ pub enum LyrebirdError {
     #[error("not found: {0}")]
     NotFound(String),
 
-    #[error("rate limited (retry after {retry_after:?}s)")]
+    #[error("rate limited{}", retry_after.map(|s| format!(" (retry after {s}s)")).unwrap_or_default())]
     RateLimit { retry_after: Option<u64> },
 
     #[error("server returned an error: {status} {body}")]
@@ -110,13 +110,19 @@ impl LyrebirdError {
     /// ```
     pub fn user_message(&self) -> String {
         match self {
-            // Authentication failures — user needs to re-login.
+            // Session expiry / missing session — user needs to re-login.
             LyrebirdError::Auth(_)
             | LyrebirdError::AuthExpired
             | LyrebirdError::NotAuthenticated
-            | LyrebirdError::NoSession
-            | LyrebirdError::InvalidCredentials => {
+            | LyrebirdError::NoSession => {
                 "Your session expired. Please sign in again.".to_string()
+            }
+
+            // Blank credentials at *login* time — not an expired session.
+            // Telling a user who left a field empty that their "session
+            // expired" is misleading, so give it its own arm.
+            LyrebirdError::InvalidCredentials => {
+                "Please enter your username and password.".to_string()
             }
 
             // Permission denied — the user's account lacks access.
@@ -134,9 +140,13 @@ impl LyrebirdError {
                 "Couldn't reach the server. Check your connection and try again.".to_string()
             }
 
-            // TLS / certificate issues — connectivity problem with extra context.
-            LyrebirdError::SelfSignedCertificate { .. } => {
-                "Couldn't reach the server. Check your connection and try again.".to_string()
+            // TLS / certificate issues — name the host and hint at the trust
+            // action so the UI can route to a "Trust this server" prompt
+            // instead of looking like a generic connectivity failure.
+            LyrebirdError::SelfSignedCertificate { host } => {
+                format!(
+                    "The server at {host} uses a certificate that couldn't be verified. You may need to trust it."
+                )
             }
 
             // Rate-limiting — tell the user to wait.
@@ -182,10 +192,16 @@ impl LyrebirdError {
 
     /// Should the caller retry the request after an exponential backoff?
     ///
-    /// Returns `true` for:
-    /// - [`Self::RateLimit`] — the server asked us to slow down; the
+    /// This is the error-typed mirror of the HTTP-status predicate in
+    /// `client.rs` (`is_retriable_status`); the two MUST agree so the
+    /// retry decision is identical whether a caller has a raw `StatusCode`
+    /// or an already-mapped [`LyrebirdError`]. Returns `true` for:
+    /// - [`Self::RateLimit`] (429) — the server asked us to slow down; the
     ///   `retry_after` (when set) is an upper bound on the wait.
-    /// - [`Self::Server`] with a 5xx status — transient server-side issue.
+    /// - [`Self::Server`] with a `408 Request Timeout` — the server gave up
+    ///   before we did, so a retry can succeed.
+    /// - [`Self::Server`] with a 5xx status **except** `501 Not Implemented`,
+    ///   which is a semantic "we don't do that" and will never succeed.
     /// - [`Self::Network`] — transport fault (DNS, TLS, timeout); usually
     ///   resolves on its own.
     ///
@@ -197,7 +213,11 @@ impl LyrebirdError {
         match self {
             LyrebirdError::RateLimit { .. } => true,
             LyrebirdError::Network(_) => true,
-            LyrebirdError::Server { status, .. } => (500..600).contains(status),
+            // Mirror client.rs `is_retriable_status`: 408 is retriable even
+            // though it isn't a 5xx; 501 is NOT retriable even though it is.
+            LyrebirdError::Server { status, .. } => {
+                *status == 408 || ((500..600).contains(status) && *status != 501)
+            }
             _ => false,
         }
     }
@@ -244,6 +264,15 @@ impl From<reqwest::Error> for LyrebirdError {
 /// Returns `true` when the error chain contains a TLS certificate-validation
 /// failure.  Compatible with both rustls 0.22 and 0.23.
 pub(crate) fn is_cert_error(e: &reqwest::Error) -> bool {
+    error_chain_is_cert_failure(e)
+}
+
+/// Walk an error's `source` chain looking for a TLS certificate-validation
+/// failure marker. Split out from [`is_cert_error`] (which is fixed to
+/// `reqwest::Error`) so the substring logic — the load-bearing, version-
+/// sensitive part — is unit-testable against a synthetic error chain without a
+/// live TLS server, covering the positive branch on CI.
+pub(crate) fn error_chain_is_cert_failure(e: &(dyn std::error::Error + 'static)) -> bool {
     use std::error::Error as StdError;
     let mut source: Option<&(dyn StdError + 'static)> = Some(e);
     while let Some(err) = source {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,10 +34,11 @@ use uuid::Uuid;
 
 uniffi::setup_scaffolding!();
 
-/// Settings-table key under which the ListenBrainz user token is persisted.
-/// Deliberately *not* on the diagnostic-bundle allowlist and *not* cleared by
-/// [`storage::Database::clear_user_data`], so the secret never leaks into a
-/// support bundle and survives logout like other account-independent prefs.
+/// **Legacy** settings-table key under which pre-keyring builds persisted the
+/// ListenBrainz token in plaintext. The token now lives in the OS keyring (see
+/// [`storage::CredentialStore::save_scrobble_token`]); this key is retained
+/// only so [`LyrebirdCore::set_scrobble_token`] can scrub a leftover plaintext
+/// value from an upgraded install.
 const SCROBBLE_TOKEN_KEY: &str = "scrobble_listenbrainz_token";
 
 /// Handle for a running heartbeat task.  Dropping or calling [`stop`] cancels
@@ -627,20 +628,6 @@ impl LyrebirdCore {
         })
     }
 
-    /// Public / community playlists visible to the current user — anything
-    /// under the Playlists library whose `Path` does NOT contain `/data/`.
-    pub fn public_playlists(
-        &self,
-        playlist_library_id: String,
-        offset: u32,
-        limit: u32,
-    ) -> std::result::Result<PaginatedPlaylists, LyrebirdError> {
-        self.with_client(|c| {
-            self.runtime
-                .block_on(c.public_playlists(&playlist_library_id, Paging::new(offset, limit)))
-        })
-    }
-
     /// Playlists in the user's Playlists library whose track list features the
     /// given artist, capped at `limit`. Powers the "Playlists featuring this
     /// artist" rail on the Artist detail screen. Matching is track-level
@@ -809,18 +796,18 @@ impl LyrebirdCore {
     /// `item_ids` may be empty to create an empty playlist. Errors with
     /// [`LyrebirdError::NotAuthenticated`] if no session is active.
     ///
-    /// When `position` is `Some(n)`, the Jellyfin `StartIndex` query param is
-    /// set so the server inserts the initial items starting at index `n`.
+    /// There is no positional-insert parameter: `POST /Playlists` has no
+    /// server-side `StartIndex` semantics, so the seed `item_ids` are
+    /// appended in order. Positional insert is deferred to a dedicated
+    /// `Playlists/{id}/Items` primitive (#282).
     pub fn create_playlist(
         &self,
         name: String,
         item_ids: Vec<String>,
-        position: Option<u32>,
     ) -> std::result::Result<String, LyrebirdError> {
         self.with_client(|c| {
             let id_refs: Vec<&str> = item_ids.iter().map(String::as_str).collect();
-            self.runtime
-                .block_on(c.create_playlist(&name, &id_refs, position))
+            self.runtime.block_on(c.create_playlist(&name, &id_refs))
         })
     }
 
@@ -926,15 +913,18 @@ impl LyrebirdCore {
     /// Insert `tracks` immediately after the currently-playing entry.
     /// "Play Next" semantics, per #282. Returns the new queue length.
     ///
-    /// No-op when either the queue is empty or `tracks` is empty — callers
-    /// that want to prime the queue with the new tracks should fall back to
-    /// [`Self::set_queue`] when the queue length stays at zero.
+    /// When the queue is empty there is no playhead to insert after, so this
+    /// starts a fresh queue (priming `current` to the first track) — "Play
+    /// Next" on a cold queue plays rather than dropping the tracks. A
+    /// zero-length `tracks` is a no-op.
     pub fn play_next(&self, tracks: Vec<Track>) -> u32 {
         self.player.insert_next(tracks)
     }
 
     /// Append `tracks` to the end of the queue. "Add to Queue" semantics,
     /// per #282. Returns the new queue length. No-op when `tracks` is empty.
+    /// When the queue was empty, the playhead is primed to the first appended
+    /// track so the queue is immediately playable.
     pub fn add_to_queue(&self, tracks: Vec<Track>) -> u32 {
         self.player.append_to_queue(tracks)
     }
@@ -947,10 +937,20 @@ impl LyrebirdCore {
         self.player.clear_queue();
     }
 
+    /// Mark `track` as the now-playing entry. Called from `AudioEngine.load`
+    /// on every track transition, on the main thread.
+    ///
+    /// This only updates in-memory player state. It deliberately does NOT
+    /// write a local play-history row: the server is the authority on play
+    /// counts (incremented via `/Sessions/Playing*`, see CLAUDE.md
+    /// "Resolved"), so a local `play_history` table was write-only dead
+    /// storage that also (a) ran a synchronous SQLite INSERT under the
+    /// `Inner` mutex on the main-thread load path and (b) counted a "play"
+    /// on every load — including quick-skips — inflating counts relative to
+    /// the server's threshold-based PlayCount. The table and its accessors
+    /// were removed in the audit pass.
     pub fn mark_track_started(&self, track: Track) {
-        self.player.set_current(track.clone());
-        let now = chrono::Utc::now().timestamp();
-        let _ = self.inner.lock().db.record_play(&track.id, now);
+        self.player.set_current(track);
     }
 
     /// Store the `PlaySessionId` returned by `PlaybackInfo` on the current
@@ -1027,7 +1027,7 @@ impl LyrebirdCore {
     }
 
     /// Resolve (and cache) the user's playlists library id. Used as the
-    /// `ParentId` for `user_playlists` / `public_playlists`.
+    /// `ParentId` for `user_playlists`.
     pub fn playlist_library_id(&self) -> std::result::Result<String, LyrebirdError> {
         self.with_client(|c| self.runtime.block_on(c.playlist_library_id()))
     }
@@ -1126,12 +1126,15 @@ impl LyrebirdCore {
     /// Persist the user's ListenBrainz token. Pass `None` (or an empty/blank
     /// string) to disconnect scrobbling and clear the stored token.
     ///
-    /// The token is a secret: it lives in the local settings table only, is
-    /// never written to logs, and is intentionally excluded from the
-    /// diagnostic bundle (which reads an allowlist of non-secret keys). It is
-    /// also *not* cleared on logout — like shuffle/repeat it is an
+    /// The token is a secret and is stored in the **OS keyring** (the same
+    /// secure store as the Jellyfin access token) — never in plaintext in the
+    /// settings table. It is never written to logs and is intentionally
+    /// excluded from the diagnostic bundle. Like shuffle/repeat it is an
     /// account-independent preference, so signing out of a Jellyfin server
     /// leaves the scrobble connection intact for the next sign-in.
+    ///
+    /// Any legacy plaintext token under the old settings key is removed on
+    /// write so an upgraded install doesn't leave the secret on disk.
     pub fn set_scrobble_token(
         &self,
         token: Option<String>,
@@ -1141,9 +1144,12 @@ impl LyrebirdCore {
             .map(|t| t.trim().to_string())
             .filter(|t| !t.is_empty())
         {
-            Some(t) => db.set_setting(SCROBBLE_TOKEN_KEY, &t)?,
-            None => db.delete_setting(SCROBBLE_TOKEN_KEY)?,
+            Some(t) => CredentialStore::save_scrobble_token(&t)?,
+            None => CredentialStore::delete_scrobble_token()?,
         }
+        // Belt-and-suspenders: scrub any plaintext token a pre-keyring build
+        // may have written to the settings table.
+        let _ = db.delete_setting(SCROBBLE_TOKEN_KEY);
         Ok(())
     }
 
@@ -1151,10 +1157,7 @@ impl LyrebirdCore {
     /// rather than the token itself so the UI can render connected / not-
     /// connected state without the secret ever crossing the FFI boundary.
     pub fn is_scrobble_configured(&self) -> bool {
-        self.inner
-            .lock()
-            .db
-            .get_setting(SCROBBLE_TOKEN_KEY)
+        CredentialStore::load_scrobble_token()
             .ok()
             .flatten()
             .map(|t| !t.trim().is_empty())
@@ -1229,6 +1232,20 @@ impl LyrebirdCore {
                 ticker.tick().await;
 
                 let status = core.player.status();
+                // Don't heartbeat when playback is over (or hasn't begun).
+                // The `current_track` can still be `Some` after a track ends
+                // — without this guard the loop would keep POSTing
+                // `/Sessions/Playing/Progress` with `is_paused=false`,
+                // freezing a ghost "Now Playing" at the final position on the
+                // server (and every other Jellyfin client) indefinitely.
+                if matches!(
+                    status.state,
+                    crate::player::PlaybackState::Ended
+                        | crate::player::PlaybackState::Stopped
+                        | crate::player::PlaybackState::Idle
+                ) {
+                    continue;
+                }
                 // Only send a heartbeat when there is an active track —
                 // sending progress with an empty `item_id` would confuse
                 // the server.
@@ -1342,17 +1359,15 @@ impl LyrebirdCore {
 }
 
 impl LyrebirdCore {
-    /// Read the stored ListenBrainz token, mapping "absent or blank" to a
-    /// clean [`LyrebirdError::InvalidInput`] so submit paths share one guard.
+    /// Read the stored ListenBrainz token from the OS keyring, mapping "absent
+    /// or blank" to a clean [`LyrebirdError::InvalidInput`] so submit paths
+    /// share one guard.
     ///
     /// Deliberately **not** part of the `#[uniffi::export]` block: the raw
     /// token must never cross the FFI boundary. Platform code learns *whether*
     /// a token is set via [`Self::is_scrobble_configured`], never its value.
     fn scrobble_token(&self) -> std::result::Result<String, LyrebirdError> {
-        self.inner
-            .lock()
-            .db
-            .get_setting(SCROBBLE_TOKEN_KEY)
+        CredentialStore::load_scrobble_token()
             .ok()
             .flatten()
             .filter(|t| !t.trim().is_empty())

--- a/core/src/migrations/001_initial.sql
+++ b/core/src/migrations/001_initial.sql
@@ -18,16 +18,12 @@ CREATE TABLE IF NOT EXISTS users (
     FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS play_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    track_id TEXT NOT NULL,
-    played_at INTEGER NOT NULL,
-    duration_seconds REAL,
-    completed INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE INDEX IF NOT EXISTS idx_play_history_track ON play_history(track_id);
-CREATE INDEX IF NOT EXISTS idx_play_history_at ON play_history(played_at);
+-- NOTE: a `play_history` table lived here in earlier builds. It was removed
+-- in the audit pass: the server is the authority on play counts (incremented
+-- via /Sessions/Playing*), so local play history was write-only dead storage
+-- that grew unbounded and ran a synchronous INSERT on the main-thread track
+-- load path. Existing installs may still carry an (empty) orphan table; that
+-- is harmless and intentionally not migrated away.
 
 CREATE TABLE IF NOT EXISTS track_cache (
     id TEXT PRIMARY KEY,

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -146,12 +146,9 @@ pub struct PaginatedTracks {
     pub total_count: u32,
 }
 
-/// Page of playlists returned by `user_playlists` and `public_playlists`.
-/// Note: these two endpoints filter the server's response client-side by
-/// `Path`, so `total_count` is the server-reported total across BOTH user
-/// and public playlists (i.e. what Jellyfin would return without the
-/// client-side partition). Callers should treat it as an upper bound on the
-/// page size they need to fetch, not as `items.len()`'s true total.
+/// Page of playlists returned by `user_playlists`. `total_count` is the
+/// server-reported `TotalRecordCount` for the Playlists library view, so it
+/// can drive "N of M" sublines and load-more triggers directly.
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct PaginatedPlaylists {
     pub items: Vec<Playlist>,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -246,18 +246,29 @@ impl Player {
 
     /// Insert `tracks` into the queue immediately after the currently-playing
     /// entry without disturbing what's already playing. "Play Next" semantics,
-    /// matching Apple Music / Spotify. No-op when the queue is empty — the
-    /// caller should fall back to [`Player::set_queue`] for that case so the
-    /// playhead actually starts.
+    /// matching Apple Music / Spotify.
+    ///
+    /// When the queue is **empty** there is no playhead to insert after, so
+    /// this behaves like a fresh [`Player::set_queue`]: the queue becomes
+    /// `tracks`, `queue_index` resets to 0, and `current` is primed to the
+    /// first track. That makes "Play Next" do the obvious thing on a cold
+    /// queue instead of silently dropping the tracks.
+    ///
+    /// A `tracks` of zero length is a genuine no-op.
     ///
     /// Returns the new queue length. Closes #282 for the Play Next flows
     /// (album / playlist / track context menu, Up Next panel drag-drop).
     pub fn insert_next(&self, tracks: Vec<Track>) -> u32 {
         let mut s = self.shared.lock();
-        if s.queue.is_empty() || tracks.is_empty() {
-            // Nothing currently playing — the caller is better served by
-            // `set_queue` which also primes `current`. Return the queue's
-            // untouched length so the caller can detect the no-op.
+        if tracks.is_empty() {
+            return s.queue.len() as u32;
+        }
+        if s.queue.is_empty() {
+            // No playhead to insert after — start a fresh queue so the
+            // tracks are actually playable (mirrors `set_queue`).
+            s.current = tracks.first().cloned();
+            s.queue = tracks;
+            s.queue_index = 0;
             return s.queue.len() as u32;
         }
         let insert_at = (s.queue_index + 1).min(s.queue.len());
@@ -265,8 +276,15 @@ impl Player {
         s.queue.len() as u32
     }
 
-    /// Append `tracks` to the end of the queue without touching the playhead.
-    /// "Add to Queue" semantics. No-op when `tracks` is empty.
+    /// Append `tracks` to the end of the queue. "Add to Queue" semantics.
+    /// No-op when `tracks` is empty.
+    ///
+    /// When the queue was **empty** before the append there is no playhead,
+    /// so `queue_index` is set to 0 and `current` is primed to the first
+    /// appended track — otherwise the queue would be non-empty with
+    /// `current == None`, and `skip_next` could never reach the appended
+    /// tracks. When the queue already had entries the playhead is left
+    /// untouched.
     ///
     /// Returns the new queue length. Closes #282 for Add-to-Queue flows.
     pub fn append_to_queue(&self, tracks: Vec<Track>) -> u32 {
@@ -274,7 +292,12 @@ impl Player {
         if tracks.is_empty() {
             return s.queue.len() as u32;
         }
+        let was_empty = s.queue.is_empty();
         s.queue.extend(tracks);
+        if was_empty {
+            s.queue_index = 0;
+            s.current = s.queue.first().cloned();
+        }
         s.queue.len() as u32
     }
 
@@ -295,8 +318,17 @@ impl Player {
         }
     }
 
+    /// Mark `track` as the currently-playing entry and force state to
+    /// `Playing`. When `track` is present in the queue, `queue_index` is
+    /// advanced to its position so `current` never diverges from
+    /// `queue[queue_index]` (which drives `current_in_queue()` and the
+    /// skip/peek cursor). When it is not in the queue (e.g. a one-off play of
+    /// an item that was never enqueued) the index is left untouched.
     pub fn set_current(&self, track: Track) {
         let mut s = self.shared.lock();
+        if let Some(i) = s.queue.iter().position(|t| t.id == track.id) {
+            s.queue_index = i;
+        }
         s.current = Some(track);
         s.state = PlaybackState::Playing;
     }
@@ -413,11 +445,15 @@ mod tests {
     }
 
     #[test]
-    fn shuffle_and_repeat_are_preserved_across_queue_changes() {
+    fn shuffle_and_repeat_flags_are_preserved_across_queue_changes() {
         // Callers (e.g. the macOS AppModel) set shuffle/repeat once and
         // expect the flags to survive a fresh `set_queue` call — otherwise
         // dropping a new album onto the dock would silently disable the
         // user's chosen repeat mode. Validate that invariant here.
+        //
+        // NOTE: this asserts only that the *flags* survive, NOT that shuffle
+        // reorders playback. See `shuffle_is_a_flag_and_does_not_reorder_the_queue`
+        // for the no-reorder contract.
         let player = Player::new();
         player.set_shuffle(true);
         player.set_repeat_mode(RepeatMode::All);
@@ -426,6 +462,28 @@ mod tests {
         assert!(status.shuffle);
         assert_eq!(status.repeat_mode, RepeatMode::All);
         assert_eq!(status.queue_length, 2);
+    }
+
+    #[test]
+    fn shuffle_is_a_flag_and_does_not_reorder_the_queue() {
+        // Contract (#34): `set_shuffle` is intentionally a flag only. The
+        // core never reorders the stored queue — callers that want a
+        // shuffled listening session hand pre-shuffled tracks to
+        // `set_queue`. This test pins that contract explicitly so the
+        // "shuffle flag survives" test above can't be mistaken for proof
+        // that shuffle changes navigation order. If core ever grows real
+        // in-core shuffling, this test (and the docs) must change together.
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+        player.set_shuffle(true);
+        // Navigation order is unchanged by the flag: skip/peek still walk the
+        // queue in its stored order.
+        assert_eq!(player.peek_next().unwrap().id, "b");
+        assert_eq!(player.skip_next().unwrap().id, "b");
+        assert_eq!(player.skip_next().unwrap().id, "c");
+        assert!(player.status().shuffle, "flag is still reported as engaged");
     }
 
     // ---- #591: set_queue OOB start_index ----
@@ -558,11 +616,18 @@ mod tests {
     }
 
     #[test]
-    fn insert_next_on_empty_queue_is_noop() {
+    fn insert_next_on_empty_queue_starts_fresh_queue() {
+        // With no playhead to insert after, insert_next behaves like a fresh
+        // set_queue: the tracks become the queue and the first is primed as
+        // current, so "Play Next" on a cold queue actually plays.
         let player = Player::new();
-        let new_len = player.insert_next(vec![track("x")]);
-        assert_eq!(new_len, 0, "no current track => insert_next must no-op");
-        assert!(player.status().current_track.is_none());
+        let new_len = player.insert_next(vec![track("x"), track("y")]);
+        assert_eq!(new_len, 2);
+        let status = player.status();
+        assert_eq!(status.current_track.unwrap().id, "x");
+        assert_eq!(status.queue_position, 0);
+        // The whole inserted set is reachable.
+        assert_eq!(player.skip_next().unwrap().id, "y");
     }
 
     #[test]
@@ -589,12 +654,17 @@ mod tests {
     }
 
     #[test]
-    fn append_to_queue_on_empty_queue_just_extends() {
+    fn append_to_queue_on_empty_queue_primes_current() {
         let player = Player::new();
         let new_len = player.append_to_queue(vec![track("x"), track("y")]);
-        // `append_to_queue` does not prime `current`; that's `set_queue`'s job.
+        // Appending onto an empty queue primes the playhead so the queue is
+        // actually playable (otherwise current would be None with a
+        // non-empty queue and skip_next could never reach the tracks).
         assert_eq!(new_len, 2);
-        assert!(player.status().current_track.is_none());
+        let status = player.status();
+        assert_eq!(status.current_track.unwrap().id, "x");
+        assert_eq!(status.queue_position, 0);
+        assert_eq!(player.skip_next().unwrap().id, "y");
     }
 
     #[test]
@@ -759,7 +829,7 @@ mod tests {
     }
 
     #[test]
-    fn peek_next_matches_skip_next_across_repeated_calls() {
+    fn peek_next_is_idempotent_and_does_not_advance() {
         let player = Player::new();
         player
             .set_queue(vec![track("a"), track("b"), track("c")], 0)
@@ -768,6 +838,31 @@ mod tests {
         assert_eq!(player.peek_next().unwrap().id, "b");
         assert_eq!(player.peek_next().unwrap().id, "b");
         assert_eq!(player.status().queue_position, 0);
+    }
+
+    #[test]
+    fn peek_next_predicts_skip_next_across_queue_including_wrap() {
+        // The peek/skip consistency contract: peek_next must predict exactly
+        // what the next skip_next yields. Walk the whole queue, and include
+        // the RepeatMode::All wrap boundary where divergence is most likely.
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+        player.set_repeat_mode(RepeatMode::All);
+
+        // Walk one full lap plus the wrap, asserting peek == the subsequent
+        // skip at every step.
+        for _ in 0..4 {
+            let peeked = player.peek_next().unwrap().id;
+            let skipped = player.skip_next().unwrap().id;
+            assert_eq!(
+                peeked, skipped,
+                "peek_next must predict the next skip_next exactly"
+            );
+        }
+        // After a→b→c→(wrap)a→b we should be sitting on "b".
+        assert_eq!(player.status().current_track.unwrap().id, "b");
     }
 
     #[test]
@@ -813,5 +908,148 @@ mod tests {
     fn peek_next_on_empty_queue_is_none() {
         let player = Player::new();
         assert!(player.peek_next().is_none());
+    }
+
+    // ---- Coverage for previously-untested Player methods + PlayerStatus
+    //      fields (set_volume / mark_position clamps, mark_state, set_current,
+    //      clear, current_in_queue, play_session_id, and the snapshot
+    //      duration/position/volume/state plumbing). ----
+
+    #[test]
+    fn set_volume_clamps_to_unit_range() {
+        let player = Player::new();
+        player.set_volume(2.0);
+        assert_eq!(
+            player.status().volume,
+            1.0,
+            "above-range volume clamps to 1.0"
+        );
+        player.set_volume(-1.0);
+        assert_eq!(
+            player.status().volume,
+            0.0,
+            "below-range volume clamps to 0.0"
+        );
+        player.set_volume(0.5);
+        assert_eq!(
+            player.status().volume,
+            0.5,
+            "in-range volume passes through"
+        );
+    }
+
+    #[test]
+    fn mark_position_clamps_negative_to_zero() {
+        let player = Player::new();
+        player.mark_position(-5.0);
+        assert_eq!(player.status().position_seconds, 0.0);
+        player.mark_position(42.5);
+        assert_eq!(player.status().position_seconds, 42.5);
+    }
+
+    #[test]
+    fn mark_state_sets_state_on_status() {
+        let player = Player::new();
+        player.mark_state(PlaybackState::Paused);
+        assert_eq!(player.status().state, PlaybackState::Paused);
+        player.mark_state(PlaybackState::Loading);
+        assert_eq!(player.status().state, PlaybackState::Loading);
+    }
+
+    #[test]
+    fn set_current_sets_track_and_forces_playing_state() {
+        let player = Player::new();
+        player.set_current(track("z"));
+        let status = player.status();
+        assert_eq!(status.current_track.unwrap().id, "z");
+        assert_eq!(status.state, PlaybackState::Playing);
+    }
+
+    #[test]
+    fn set_current_advances_queue_index_when_track_in_queue() {
+        // Regression: set_current used to leave queue_index stale, letting
+        // current diverge from queue[queue_index] / current_in_queue().
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 0)
+            .unwrap();
+        player.set_current(track("c"));
+        assert_eq!(player.status().queue_position, 2);
+        assert_eq!(player.current_in_queue().unwrap().id, "c");
+        // And skip_next from there honours the realigned cursor.
+        assert!(player.skip_next().is_none(), "c is the last entry");
+    }
+
+    #[test]
+    fn set_current_leaves_index_untouched_for_track_not_in_queue() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 1).unwrap();
+        player.set_current(track("offqueue"));
+        // The cursor stays where it was; only `current` changes.
+        assert_eq!(player.status().queue_position, 1);
+        assert_eq!(player.status().current_track.unwrap().id, "offqueue");
+        assert_eq!(player.current_in_queue().unwrap().id, "b");
+    }
+
+    #[test]
+    fn current_in_queue_returns_indexed_track() {
+        let player = Player::new();
+        player
+            .set_queue(vec![track("a"), track("b"), track("c")], 2)
+            .unwrap();
+        assert_eq!(player.current_in_queue().unwrap().id, "c");
+    }
+
+    #[test]
+    fn play_session_id_round_trips() {
+        let player = Player::new();
+        assert!(player.play_session_id().is_none());
+        player.set_play_session_id(Some("sess-123".to_string()));
+        assert_eq!(player.play_session_id().as_deref(), Some("sess-123"));
+        assert_eq!(player.status().play_session_id.as_deref(), Some("sess-123"));
+        player.set_play_session_id(None);
+        assert!(player.play_session_id().is_none());
+    }
+
+    #[test]
+    fn clear_resets_all_playback_bookkeeping() {
+        let player = Player::new();
+        player.set_queue(vec![track("a"), track("b")], 1).unwrap();
+        player.set_play_session_id(Some("sess".to_string()));
+        player.mark_position(30.0);
+        player.mark_state(PlaybackState::Playing);
+
+        player.clear();
+
+        let status = player.status();
+        assert_eq!(status.state, PlaybackState::Stopped);
+        assert!(status.current_track.is_none());
+        assert_eq!(status.position_seconds, 0.0);
+        assert!(status.play_session_id.is_none());
+        assert_eq!(status.queue_length, 0);
+        assert_eq!(status.queue_position, 0);
+    }
+
+    #[test]
+    fn status_duration_reflects_current_track_and_zero_when_empty() {
+        let player = Player::new();
+        // No current track => duration defaults to 0.0.
+        assert_eq!(player.status().duration_seconds, 0.0);
+        // `track()` is 1_800_000_000 ticks = 180s.
+        player.set_queue(vec![track("a")], 0).unwrap();
+        assert!((player.status().duration_seconds - 180.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn status_reports_position_volume_and_state_fields() {
+        let player = Player::new();
+        player.set_queue(vec![track("a")], 0).unwrap();
+        player.mark_position(12.0);
+        player.set_volume(0.25);
+        player.mark_state(PlaybackState::Paused);
+        let status = player.status();
+        assert_eq!(status.position_seconds, 12.0);
+        assert_eq!(status.volume, 0.25);
+        assert_eq!(status.state, PlaybackState::Paused);
     }
 }

--- a/core/src/scrobble.rs
+++ b/core/src/scrobble.rs
@@ -186,9 +186,12 @@ impl Scrobbler {
     /// POST a pre-built submission body to `/1/submit-listens`.
     ///
     /// On a non-2xx response the body is read for diagnostics but the token is
-    /// never logged. A 401 maps to [`LyrebirdError::Auth`] so the UI can tell
-    /// the user their token is wrong; everything else surfaces as
-    /// [`LyrebirdError::Server`].
+    /// never logged. The whole non-success path is routed through
+    /// [`LyrebirdError::from_status`] so 401/403/404/429 map to the same
+    /// concrete variants as the rest of the client — in particular a `429`
+    /// surfaces as [`LyrebirdError::RateLimit`] carrying the parsed
+    /// `Retry-After` instead of being flattened into a generic `Server`
+    /// error. (401 stays `LyrebirdError::Auth`, which `from_status` produces.)
     async fn submit(&self, body: Value) -> Result<()> {
         let url = format!(
             "{}{}",
@@ -208,29 +211,49 @@ impl Scrobbler {
         if status.is_success() {
             return Ok(());
         }
+        // Parse `Retry-After` (integer-seconds form) before consuming the body
+        // so a 429 can carry the server's backoff hint.
+        let retry_after = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
         // Read the body for the error message but keep it short; never echo
         // the request (which carries the token).
         let snippet = resp.text().await.unwrap_or_default();
         let snippet: String = snippet.chars().take(500).collect();
-        if status.as_u16() == 401 {
-            return Err(LyrebirdError::Auth(
-                "ListenBrainz rejected the token".into(),
-            ));
-        }
-        Err(LyrebirdError::Server {
-            status: status.as_u16(),
-            body: snippet,
-        })
+        Err(LyrebirdError::from_status(
+            status.as_u16(),
+            snippet,
+            retry_after,
+        ))
     }
 
     /// Submit a `playing_now` for the given track.
     pub async fn submit_playing_now(&self, track: &Track) -> Result<()> {
+        validate_scrobble_track(track)?;
         self.submit(playing_now_payload(track)).await
     }
 
     /// Submit a durable `single` listen for the given track, keyed to the Unix
     /// `listened_at` start time.
     pub async fn submit_listen(&self, track: &Track, listened_at: i64) -> Result<()> {
+        validate_scrobble_track(track)?;
         self.submit(single_listen_payload(track, listened_at)).await
     }
+}
+
+/// Reject a track that can't form a valid ListenBrainz listen *before* we
+/// spend a round-trip on it. ListenBrainz requires both `artist_name` and
+/// `track_name` to be present and non-empty; a payload missing either is
+/// rejected server-side, so guard at the boundary and surface a clear
+/// [`LyrebirdError::InvalidInput`] the caller can swallow as "nothing to
+/// scrobble".
+fn validate_scrobble_track(track: &Track) -> Result<()> {
+    if track.name.trim().is_empty() || track.artist_name.trim().is_empty() {
+        return Err(LyrebirdError::InvalidInput(
+            "track missing name/artist for scrobble".into(),
+        ));
+    }
+    Ok(())
 }

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -43,18 +43,23 @@ impl Database {
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)",
             [],
         )?;
-        let current: i32 = tx
-            .query_row(
-                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap_or(0);
+        // Propagate the read error with `?` rather than `.unwrap_or(0)`: the
+        // `schema_version` table was just created in this same transaction, so
+        // a successful read is expected. Swallowing a transient failure (e.g.
+        // a momentary lock) to `0` would re-enter the `current < 1` branch on
+        // an already-migrated DB and crash on the version insert.
+        let current: i32 = tx.query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+            [],
+            |r| r.get(0),
+        )?;
 
         if current < 1 {
             tx.execute_batch(include_str!("migrations/001_initial.sql"))?;
+            // `OR IGNORE` keeps the version stamp idempotent so a re-run can't
+            // crash on the PRIMARY KEY constraint.
             tx.execute(
-                "INSERT INTO schema_version (version) VALUES (?1)",
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
                 params![1],
             )?;
         }
@@ -79,8 +84,15 @@ impl Database {
     pub fn get_setting(&self, key: &str) -> Result<Option<String>> {
         let conn = self.conn.lock();
         let mut stmt = conn.prepare("SELECT value FROM settings WHERE key = ?1")?;
-        let row = stmt.query_row(params![key], |r| r.get::<_, String>(0)).ok();
-        Ok(row)
+        // Discriminate "no such key" (a legitimate `Ok(None)`) from a genuine
+        // DB fault (locked / I/O / corruption). The old `.ok()` collapsed both
+        // into `None`, silently reporting a real fault as "setting absent" —
+        // the same NoEntry-vs-error split `CredentialStore::load_token` does.
+        match stmt.query_row(params![key], |r| r.get::<_, String>(0)) {
+            Ok(value) => Ok(Some(value)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub fn delete_setting(&self, key: &str) -> Result<()> {
@@ -122,10 +134,10 @@ impl Database {
 
     /// Clear all user-scoped data after a logout or server switch.
     ///
-    /// Truncates `play_history`, `track_cache`, `album_cache`, and
-    /// `artist_cache`, and removes the session-identity settings
-    /// (`last_server_url`, `last_username`, `last_server_id`, `last_user_id`)
-    /// that would cause `resume_session` to succeed on next launch.
+    /// Truncates `track_cache`, `album_cache`, and `artist_cache`, and removes
+    /// the session-identity settings (`last_server_url`, `last_username`,
+    /// `last_server_id`, `last_user_id`) that would cause `resume_session` to
+    /// succeed on next launch.
     ///
     /// Preserves: `device_id`, `device_name`, `shuffle_enabled`,
     /// `repeat_mode`, and `schema_version` rows so the login screen
@@ -133,8 +145,7 @@ impl Database {
     pub fn clear_user_data(&self) -> Result<()> {
         let conn = self.conn.lock();
         conn.execute_batch(
-            "DELETE FROM play_history;
-             DELETE FROM track_cache;
+            "DELETE FROM track_cache;
              DELETE FROM album_cache;
              DELETE FROM artist_cache;",
         )?;
@@ -151,21 +162,6 @@ impl Database {
             )?;
         }
         Ok(())
-    }
-
-    pub fn record_play(&self, track_id: &str, played_at: i64) -> Result<()> {
-        self.conn.lock().execute(
-            "INSERT INTO play_history (track_id, played_at) VALUES (?1, ?2)",
-            params![track_id, played_at],
-        )?;
-        Ok(())
-    }
-
-    pub fn play_count(&self, track_id: &str) -> Result<u64> {
-        let conn = self.conn.lock();
-        let mut stmt = conn.prepare("SELECT COUNT(*) FROM play_history WHERE track_id = ?1")?;
-        let count: i64 = stmt.query_row(params![track_id], |r| r.get(0))?;
-        Ok(count as u64)
     }
 }
 
@@ -213,6 +209,13 @@ fn dirs_next_like() -> Option<PathBuf> {
 
 const SERVICE: &str = "org.lyrebird.desktop";
 
+/// Keyring account under which the (account-independent) ListenBrainz scrobble
+/// token is stored. A fixed, non-`{server}/{user}` key because the token is a
+/// machine-level preference, not a per-Jellyfin-session credential. Kept in
+/// the OS keyring like the Jellyfin access token rather than in plaintext in
+/// the settings table.
+const SCROBBLE_ACCOUNT: &str = "scrobble/listenbrainz";
+
 pub struct CredentialStore;
 
 impl CredentialStore {
@@ -233,6 +236,34 @@ impl CredentialStore {
 
     pub fn delete_token(server_id: &str, username: &str) -> Result<()> {
         let entry = keyring::Entry::new(SERVICE, &format!("{server_id}/{username}"))?;
+        match entry.delete_credential() {
+            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Persist the ListenBrainz scrobble token in the OS keyring (same secure
+    /// store as the Jellyfin access token), keyed on [`SCROBBLE_ACCOUNT`].
+    pub fn save_scrobble_token(token: &str) -> Result<()> {
+        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
+        entry.set_password(token)?;
+        Ok(())
+    }
+
+    /// Read the stored ListenBrainz scrobble token, or `None` when none is
+    /// stored. Discriminates a missing entry from a real keyring fault.
+    pub fn load_scrobble_token() -> Result<Option<String>> {
+        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
+        match entry.get_password() {
+            Ok(t) => Ok(Some(t)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Remove the stored ListenBrainz scrobble token. A no-op when absent.
+    pub fn delete_scrobble_token() -> Result<()> {
+        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
         match entry.delete_credential() {
             Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
             Err(e) => Err(e.into()),

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -36,6 +36,12 @@ fn test_credentials() -> (&'static str, &'static str) {
 /// Tests still need to pick distinct `(server_id, username)` pairs — the
 /// harness intentionally does NOT clear the map between tests because tearing
 /// it down is racy under `cargo test`'s default parallelism.
+/// Username substring that makes the mock keyring's `set_secret` fail
+/// deterministically (see `SharedMockCredential::set_secret`). Used by
+/// `login_keyring_write_is_not_silenced` to exercise the `KeyringWrite` error
+/// path without a process-global flag that would race parallel logins.
+const KEYRING_FAIL_SENTINEL: &str = "KEYRING_FAIL_SENTINEL";
+
 fn install_mock_keyring() {
     use keyring::credential::{
         Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi, CredentialPersistence,
@@ -60,6 +66,17 @@ fn install_mock_keyring() {
 
     impl CredentialApi for SharedMockCredential {
         fn set_secret(&self, password: &[u8]) -> keyring::Result<()> {
+            // Deterministic failure injection for the keyring-write-not-silenced
+            // test: any entry whose key contains this sentinel fails the write,
+            // without a process-global flag that would race parallel logins.
+            // Only the test that logs in as a `KEYRING_FAIL_SENTINEL` user trips
+            // it.
+            if self.user.contains(KEYRING_FAIL_SENTINEL) {
+                return Err(keyring::Error::Invalid(
+                    "set_secret".into(),
+                    "injected keyring write failure".into(),
+                ));
+            }
             self.store
                 .lock()
                 .unwrap()
@@ -120,6 +137,20 @@ fn install_mock_keyring() {
         let builder: Box<CredentialBuilder> = Box::new(SharedMockBuilder);
         keyring::set_default_credential_builder(builder);
     });
+}
+
+/// Serialize the handful of tests that touch the *single, fixed* scrobble
+/// keyring entry (`scrobble/listenbrainz`). Unlike the per-`(server,user)`
+/// Jellyfin token entries, every scrobble test shares one key, so they'd race
+/// on the shared mock store under `cargo test`'s parallelism. Hold this guard
+/// for the duration of any scrobble-keyring test. Poisoning is ignored so one
+/// failing test doesn't cascade.
+fn scrobble_keyring_guard() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
 }
 
 #[tokio::test]
@@ -210,6 +241,20 @@ async fn album_tracks_parses() {
     assert!(t.is_favorite);
     assert_eq!(t.play_count, 7);
     assert!((t.duration_seconds() - 222.0).abs() < 0.001);
+    // album_tracks is the only Track-producing path that exercises these
+    // mappings end-to-end; lock them so a regression in the RawItem -> Track
+    // projection is caught (incl. ParentIndexNumber -> disc_number, which is
+    // otherwise untested across the whole suite).
+    assert_eq!(t.album_id.as_deref(), Some("a1"));
+    assert_eq!(t.album_name.as_deref(), Some("The Deep End"));
+    assert_eq!(t.index_number, Some(3));
+    assert_eq!(
+        t.disc_number,
+        Some(1),
+        "ParentIndexNumber must map to disc_number"
+    );
+    assert_eq!(t.year, Some(2020));
+    assert_eq!(t.image_tag.as_deref(), Some("abcd"));
 }
 
 /// Asserts the query parameters sent by `album_tracks` (#570, #571, rc7):
@@ -815,7 +860,7 @@ async fn instant_mix_builds_query_and_parses() {
                     "AlbumId": "a1", "Album": "Starter",
                     "AlbumArtist": "DJ Seed", "Artists": ["DJ Seed"],
                     "RunTimeTicks": 2000000000u64,
-                    "UserData": { "IsFavorite": false, "PlayCount": 0 },
+                    "UserData": { "IsFavorite": true, "PlayCount": 9 },
                     "ImageTags": { "Primary": "imgA" }
                 }
             ],
@@ -829,6 +874,14 @@ async fn instant_mix_builds_query_and_parses() {
     let tracks = client.instant_mix("seed-1", 25).await.unwrap();
     assert_eq!(tracks.len(), 1);
     assert_eq!(tracks[0].name, "Radio One");
+    // The fixture populates the full UserData / album / artist / image
+    // projection, so verify the field mapping (not just len + name) — a
+    // regression dropping any of these from the InstantMix parse is caught.
+    assert_eq!(tracks[0].album_id.as_deref(), Some("a1"));
+    assert_eq!(tracks[0].artist_name, "DJ Seed");
+    assert_eq!(tracks[0].play_count, 9);
+    assert!(tracks[0].is_favorite);
+    assert_eq!(tracks[0].image_tag.as_deref(), Some("imgA"));
 
     let requests = server.received_requests().await.unwrap();
     let get = requests
@@ -872,9 +925,16 @@ async fn suggestions_builds_query_and_parses() {
                     "AlbumArtist": "New Artist", "Artists": ["New Artist"],
                     "RunTimeTicks": 1800000000u64,
                     "ImageTags": { "Primary": "img" }
+                },
+                // A non-Audio row the server slipped into the suggestions
+                // response. The client-side `kind == "Audio"` filter must drop
+                // it so a MusicAlbum never renders as a minute-long "track".
+                {
+                    "Id": "alb1", "Name": "Discover (Album)", "Type": "MusicAlbum",
+                    "ChildCount": 10
                 }
             ],
-            "TotalRecordCount": 1
+            "TotalRecordCount": 2
         })))
         .mount(&server)
         .await;
@@ -882,6 +942,9 @@ async fn suggestions_builds_query_and_parses() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let tracks = client.suggestions(12).await.unwrap();
+    // The MusicAlbum row is filtered out client-side — only the Audio track
+    // survives. This pins the response-side Audio filter (a regression that
+    // removes it would let the album through).
     assert_eq!(tracks.len(), 1);
     assert_eq!(tracks[0].name, "You Might Like");
 
@@ -1186,6 +1249,10 @@ async fn genres_builds_query_and_parses_counts() {
     assert!(
         include_types.split(',').any(|t| t == "MusicAlbum"),
         "IncludeItemTypes should include MusicAlbum, got: {include_types}"
+    );
+    assert!(
+        include_types.split(',').any(|t| t == "MusicArtist"),
+        "IncludeItemTypes should include MusicArtist (production sends all three), got: {include_types}"
     );
     let fields = get
         .url
@@ -1842,7 +1909,13 @@ async fn latest_albums_applies_offset_client_side() {
         .unwrap();
     let names: Vec<&str> = page.items.iter().map(|a| a.name.as_str()).collect();
     assert_eq!(names, vec!["Five", "Six", "Seven"]);
-    assert_eq!(page.total_count, 7);
+    // total_count mirrors the returned page size (post-slice), not the
+    // pre-slice fetch window — /Items/Latest has no server total, and the old
+    // window-length value falsely implied more pages existed.
+    assert_eq!(
+        page.total_count, 3,
+        "total_count must equal the returned page size, not offset+limit"
+    );
 }
 
 #[tokio::test]
@@ -1938,64 +2011,11 @@ async fn user_playlists_returns_every_playlist_in_library_view() {
     assert!(page.items[1].user_data.is_none());
 }
 
-#[tokio::test]
-async fn public_playlists_mirrors_user_playlists_until_split_lands() {
-    // Until a real user-vs-public discriminator (e.g. CanDelete / OwnerId)
-    // is wired, `public_playlists` intentionally returns the same set as
-    // `user_playlists` so neither method silently drops rows based on a
-    // broken `Path` heuristic.
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/Users/AuthenticateByName"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
-            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
-        })))
-        .mount(&server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path("/Items"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "Items": [
-                {
-                    "Id": "p1", "Name": "My Mix", "Type": "Playlist",
-                    "ChildCount": 12,
-                    "Path": "/config/data/users/u1/playlists/my-mix"
-                },
-                {
-                    "Id": "p2", "Name": "Community Top 40", "Type": "Playlist",
-                    "ChildCount": 40,
-                    "Path": "/media/playlists/community-top-40",
-                    "ImageTags": { "Primary": "tag-2" }
-                },
-                {
-                    "Id": "p3", "Name": "No Path Public", "Type": "Playlist",
-                    "ChildCount": 5
-                }
-            ],
-            "TotalRecordCount": 3
-        })))
-        .mount(&server)
-        .await;
-
-    let mut client = mock_client(&server.uri());
-    client.authenticate_by_name("n", "pw").await.unwrap();
-    let page = client
-        .public_playlists("lib-pl", Paging::new(0, 50))
-        .await
-        .unwrap();
-
-    assert_eq!(
-        page.items.len(),
-        3,
-        "public_playlists mirrors user_playlists today"
-    );
-    assert_eq!(page.total_count, 3);
-    let ids: Vec<&str> = page.items.iter().map(|p| p.id.as_str()).collect();
-    assert!(ids.contains(&"p1"));
-    assert!(ids.contains(&"p2"));
-    assert!(ids.contains(&"p3"));
-}
+// NOTE: `public_playlists` (a stub that delegated to `user_playlists` with no
+// real public-vs-private filtering) was removed in the audit pass — the name
+// promised behavior the body never implemented and no caller used it. Callers
+// use `user_playlists` explicitly so the "community playlists" gap is visible
+// rather than disguised as green coverage. See client.rs `user_playlists`.
 
 #[tokio::test]
 async fn user_playlists_empty_when_server_returns_no_items() {
@@ -2022,14 +2042,8 @@ async fn user_playlists_empty_when_server_returns_no_items() {
         .user_playlists("lib-pl", Paging::new(0, 50))
         .await
         .unwrap();
-    let public = client
-        .public_playlists("lib-pl", Paging::new(0, 50))
-        .await
-        .unwrap();
     assert!(user.items.is_empty());
     assert_eq!(user.total_count, 0);
-    assert!(public.items.is_empty());
-    assert_eq!(public.total_count, 0);
 }
 
 #[tokio::test]
@@ -2037,14 +2051,6 @@ async fn playlists_require_authenticated_session() {
     let client = JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
     let err = client
         .user_playlists("lib-pl", Paging::new(0, 20))
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
-        "expected NotAuthenticated, got {err:?}"
-    );
-    let err = client
-        .public_playlists("lib-pl", Paging::new(0, 20))
         .await
         .unwrap_err();
     assert!(
@@ -2097,28 +2103,33 @@ async fn playlist_tracks_preserves_order_and_builds_query() {
                 .to_str()
                 .unwrap();
             assert!(auth.contains("Token=\"t\""), "auth header: {auth}");
+            // Deliberately return items in an order that is NOT sorted by id
+            // (t3 < t1 < t2 is false) NOR by name (Charlie/Alpha/Bravo is not
+            // alphabetical). If `playlist_tracks` re-sorted by either key the
+            // assertion below would fail — so this proves it preserves the
+            // server's stored playlist order rather than re-deriving one.
             ResponseTemplate::new(200).set_body_json(json!({
                 "Items": [
                     {
-                        "Id": "t1", "Name": "First", "Type": "Audio",
+                        "Id": "t3", "Name": "Charlie", "Type": "Audio",
+                        "AlbumId": "a3", "Album": "Album Three",
+                        "AlbumArtist": "Artist C", "Artists": ["Artist C"],
+                        "RunTimeTicks": 2000000000u64,
+                        "ImageTags": { "Primary": "img-3" }
+                    },
+                    {
+                        "Id": "t1", "Name": "Alpha", "Type": "Audio",
                         "AlbumId": "a1", "Album": "Album One",
                         "AlbumArtist": "Artist A", "Artists": ["Artist A"],
                         "RunTimeTicks": 1800000000u64,
                         "ImageTags": { "Primary": "img-1" }
                     },
                     {
-                        "Id": "t2", "Name": "Second", "Type": "Audio",
+                        "Id": "t2", "Name": "Bravo", "Type": "Audio",
                         "AlbumId": "a2", "Album": "Album Two",
                         "AlbumArtist": "Artist B", "Artists": ["Artist B"],
                         "RunTimeTicks": 2220000000u64,
                         "ImageTags": { "Primary": "img-2" }
-                    },
-                    {
-                        "Id": "t3", "Name": "Third", "Type": "Audio",
-                        "AlbumId": "a3", "Album": "Album Three",
-                        "AlbumArtist": "Artist C", "Artists": ["Artist C"],
-                        "RunTimeTicks": 2000000000u64,
-                        "ImageTags": { "Primary": "img-3" }
                     }
                 ],
                 "TotalRecordCount": 3
@@ -2135,15 +2146,16 @@ async fn playlist_tracks_preserves_order_and_builds_query() {
         .unwrap();
     let tracks = page.items;
 
-    // Server order must be preserved exactly.
+    // Server order (t3, t1, t2) must be preserved exactly — neither
+    // id-ascending nor name-ascending would reproduce this.
     assert_eq!(tracks.len(), 3);
     assert_eq!(page.total_count, 3);
-    assert_eq!(tracks[0].id, "t1");
-    assert_eq!(tracks[0].name, "First");
-    assert_eq!(tracks[1].id, "t2");
-    assert_eq!(tracks[1].name, "Second");
-    assert_eq!(tracks[2].id, "t3");
-    assert_eq!(tracks[2].name, "Third");
+    assert_eq!(tracks[0].id, "t3");
+    assert_eq!(tracks[0].name, "Charlie");
+    assert_eq!(tracks[1].id, "t1");
+    assert_eq!(tracks[1].name, "Alpha");
+    assert_eq!(tracks[2].id, "t2");
+    assert_eq!(tracks[2].name, "Bravo");
 }
 
 #[tokio::test]
@@ -2603,6 +2615,15 @@ async fn search_paginates_and_exposes_total_record_count() {
         results.tracks[0].name,
         "The Best Ever Death Metal Band Out Of Denton"
     );
+    // The fixture deliberately populates ProductionYear / ChildCount /
+    // ImageTags / AlbumId; assert the parsed-into-model fields so a regression
+    // in the search result mapping (not just bucketing) is caught.
+    assert_eq!(results.albums[0].year, Some(2002));
+    assert_eq!(results.albums[0].track_count, 14);
+    assert_eq!(results.albums[0].image_tag.as_deref(), Some("b1"));
+    assert_eq!(results.artists[0].image_tag.as_deref(), Some("a1"));
+    assert_eq!(results.tracks[0].album_id.as_deref(), Some("album-1"));
+    assert_eq!(results.tracks[0].image_tag.as_deref(), Some("c1"));
 }
 
 #[tokio::test]
@@ -2826,19 +2847,23 @@ async fn set_favorite_falls_back_to_legacy_route_on_404() {
     assert!(state.is_favorite);
     assert_eq!(state.play_count, Some(5));
 
+    // Assert ORDER, not just presence: the preferred route must be hit
+    // *before* the legacy route, proving the legacy call is a fallback from
+    // the 404 rather than an unordered coincidence.
     let requests = server.received_requests().await.unwrap();
-    assert!(
-        requests
-            .iter()
-            .any(|r| r.method.as_str() == "POST" && r.url.path() == "/UserFavoriteItems/item-xyz"),
-        "expected preferred route to be tried first"
-    );
-    assert!(
-        requests
-            .iter()
-            .any(|r| r.method.as_str() == "POST"
-                && r.url.path() == "/Users/u1/FavoriteItems/item-xyz"),
-        "expected fallback to legacy route after 404"
+    let fav_paths: Vec<&str> = requests
+        .iter()
+        .filter(|r| r.method.as_str() == "POST")
+        .map(|r| r.url.path())
+        .filter(|p| *p == "/UserFavoriteItems/item-xyz" || *p == "/Users/u1/FavoriteItems/item-xyz")
+        .collect();
+    assert_eq!(
+        fav_paths,
+        vec![
+            "/UserFavoriteItems/item-xyz",
+            "/Users/u1/FavoriteItems/item-xyz",
+        ],
+        "preferred route must be tried first, then the legacy fallback"
     );
 }
 
@@ -2874,18 +2899,21 @@ async fn unset_favorite_falls_back_to_legacy_route_on_405() {
     assert!(!state.is_favorite);
     assert_eq!(state.play_count, Some(1));
 
+    // Assert ORDER, not just presence (see set_favorite test above).
     let requests = server.received_requests().await.unwrap();
-    assert!(
-        requests.iter().any(|r| r.method.as_str() == "DELETE"
-            && r.url.path() == "/UserFavoriteItems/item-xyz"),
-        "expected preferred route to be tried first"
-    );
-    assert!(
-        requests
-            .iter()
-            .any(|r| r.method.as_str() == "DELETE"
-                && r.url.path() == "/Users/u1/FavoriteItems/item-xyz"),
-        "expected fallback to legacy route after 405"
+    let fav_paths: Vec<&str> = requests
+        .iter()
+        .filter(|r| r.method.as_str() == "DELETE")
+        .map(|r| r.url.path())
+        .filter(|p| *p == "/UserFavoriteItems/item-xyz" || *p == "/Users/u1/FavoriteItems/item-xyz")
+        .collect();
+    assert_eq!(
+        fav_paths,
+        vec![
+            "/UserFavoriteItems/item-xyz",
+            "/Users/u1/FavoriteItems/item-xyz",
+        ],
+        "preferred route must be tried first, then the legacy fallback after 405"
     );
 }
 
@@ -3286,7 +3314,7 @@ async fn create_playlist_posts_pascal_case_body_and_returns_id() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let id = client
-        .create_playlist("Road Trip", &["t1", "t2", "t3"], None)
+        .create_playlist("Road Trip", &["t1", "t2", "t3"])
         .await
         .unwrap();
     assert_eq!(id, "new-playlist-id");
@@ -3372,10 +3400,7 @@ async fn create_playlist_with_empty_ids_sends_empty_array() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client
-        .create_playlist("Empty List", &[], None)
-        .await
-        .unwrap();
+    let id = client.create_playlist("Empty List", &[]).await.unwrap();
     assert_eq!(id, "empty-playlist-id");
 
     let requests = server.received_requests().await.unwrap();
@@ -3411,11 +3436,26 @@ async fn create_playlist_propagates_server_errors() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let err = client.create_playlist("x", &[], None).await.unwrap_err();
+    let err = client.create_playlist("x", &[]).await.unwrap_err();
     match err {
         crate::error::LyrebirdError::Server { status, .. } => assert_eq!(status, 500),
         other => panic!("expected Server 500, got {other:?}"),
     }
+
+    // create_playlist is a resource-creating POST: it must NOT auto-retry on
+    // 5xx (a duplicate playlist could be created if the first POST committed
+    // but its response was lost). Exactly one POST must have hit /Playlists.
+    let create_posts = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
+        .count();
+    assert_eq!(
+        create_posts, 1,
+        "non-idempotent create_playlist must not retry a 5xx, got {create_posts} POSTs"
+    );
 }
 
 #[tokio::test]
@@ -3426,7 +3466,7 @@ async fn create_playlist_requires_authenticated_session() {
     // a real host.
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
-    let err = client.create_playlist("x", &[], None).await.unwrap_err();
+    let err = client.create_playlist("x", &[]).await.unwrap_err();
     assert!(
         matches!(err, crate::error::LyrebirdError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
@@ -3559,6 +3599,11 @@ async fn playlist_tracks_includes_playlist_item_id_in_fields() {
     // via PlaylistItemId, which is now requested in Fields.
     assert_eq!(page.items.len(), 2);
     assert_eq!(page.total_count, 2);
+    // The two entries are byte-identical except for PlaylistItemId, so assert
+    // the values actually parsed onto the Track models — otherwise
+    // remove-by-entry / reorder can't tell the duplicates apart.
+    assert_eq!(page.items[0].playlist_item_id.as_deref(), Some("pi-1"));
+    assert_eq!(page.items[1].playlist_item_id.as_deref(), Some("pi-2"));
 }
 
 // ---------------------------------------------------------------------------
@@ -3641,49 +3686,15 @@ async fn add_to_playlist_without_position_omits_start_index() {
 }
 
 // ---------------------------------------------------------------------------
-// create_playlist — optional position param (#607)
+// create_playlist — never sends StartIndex (#607 removed: the param had no
+// server-side effect on POST /Playlists, so the misleading hint was dropped).
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn create_playlist_with_position_sends_start_index() {
-    // #607: when position is Some(n) the client must include StartIndex=n as a
-    // query param on POST /Playlists.
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/Users/AuthenticateByName"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
-            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
-        })))
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/Playlists"))
-        .and(query_param("StartIndex", "5"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "Id": "pos-pl-id" })))
-        .mount(&server)
-        .await;
-
-    let mut client = mock_client(&server.uri());
-    client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client
-        .create_playlist("Positioned", &["t1"], Some(5))
-        .await
-        .unwrap();
-    assert_eq!(id, "pos-pl-id");
-
-    let requests = server.received_requests().await.unwrap();
-    let post = requests
-        .iter()
-        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
-        .expect("expected POST to /Playlists");
-    let q = post.url.query().expect("expected a query string");
-    assert!(q.contains("StartIndex=5"), "query: {q}");
-}
-
-#[tokio::test]
-async fn create_playlist_without_position_omits_start_index() {
-    // #607: when position is None, StartIndex must NOT appear in the query.
+async fn create_playlist_never_sends_start_index() {
+    // `POST /Playlists` has no `StartIndex` semantics; the client must not
+    // append it. Pins the post-removal contract so a future reintroduction of
+    // a no-op position hint is caught.
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -3701,10 +3712,7 @@ async fn create_playlist_without_position_omits_start_index() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client
-        .create_playlist("Appended", &["t1"], None)
-        .await
-        .unwrap();
+    let id = client.create_playlist("Appended", &["t1"]).await.unwrap();
     assert_eq!(id, "no-pos-pl-id");
 
     let requests = server.received_requests().await.unwrap();
@@ -3715,7 +3723,7 @@ async fn create_playlist_without_position_omits_start_index() {
     let q = post.url.query().unwrap_or_default();
     assert!(
         !q.contains("StartIndex"),
-        "StartIndex must be absent when position is None, query: {q}"
+        "StartIndex must never be sent, query: {q}"
     );
 }
 
@@ -4233,16 +4241,29 @@ async fn set_session_invalidates_library_cache() {
     client.set_session("t2".into(), "u2".into());
     let _ = client.music_library_id().await.unwrap();
 
-    let get_count = server
-        .received_requests()
-        .await
-        .unwrap()
+    let requests = server.received_requests().await.unwrap();
+    let user_view_users: Vec<String> = requests
         .iter()
         .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/UserViews")
-        .count();
+        .map(|r| {
+            r.url
+                .query_pairs()
+                .find(|(k, _)| k == "userId")
+                .map(|(_, v)| v.into_owned())
+                .unwrap_or_default()
+        })
+        .collect();
     assert_eq!(
-        get_count, 2,
+        user_view_users.len(),
+        2,
         "set_session must invalidate cached library ids"
+    );
+    // The cache invalidation must propagate the NEW user id to the second
+    // lookup — not just re-fetch under the stale user.
+    assert_eq!(
+        user_view_users,
+        vec!["u1".to_string(), "u2".to_string()],
+        "second /UserViews must be issued for the new user (u2)"
     );
 }
 
@@ -4668,16 +4689,10 @@ fn database_roundtrips_settings() {
     assert_eq!(db.get_setting("missing").unwrap(), None);
 }
 
-#[test]
-fn play_history_counts() {
-    let db = Database::in_memory().unwrap();
-    db.record_play("track-1", 100).unwrap();
-    db.record_play("track-1", 200).unwrap();
-    db.record_play("track-2", 150).unwrap();
-    assert_eq!(db.play_count("track-1").unwrap(), 2);
-    assert_eq!(db.play_count("track-2").unwrap(), 1);
-    assert_eq!(db.play_count("unknown").unwrap(), 0);
-}
+// NOTE: `play_history_counts` was removed alongside `record_play` /
+// `play_count` / the `play_history` table in the audit pass — local play
+// history was write-only dead storage (the server owns PlayCount via
+// /Sessions/Playing*). See storage.rs and lib.rs `mark_track_started`.
 
 // ---------------------------------------------------------------------------
 // Session auto-restore (resume_session / login persistence)
@@ -5358,16 +5373,12 @@ fn shuffle_repeat_defaults_on_empty_db() {
 /// memory.
 #[test]
 fn shuffle_repeat_round_trips_all_variants() {
-    // Use a uniquely-named file in the OS temp directory so parallel test
-    // runs do not collide. Best-effort removal at the end — it is fine if
-    // the process exits before the remove; the OS will clean up temp files.
-    let tmp = std::env::temp_dir().join(format!(
-        "lyrebird_test_sr_{}.db",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
+    // RAII temp dir: cleanup runs unconditionally on drop even if an
+    // assertion below panics, so a failing case can't leak the db file
+    // (matches the rest of the suite). The TempDir gives a private directory,
+    // so parallel runs don't collide either.
+    let tmpdir = tempfile::TempDir::new().expect("temp dir");
+    let tmp = tmpdir.path().join("sr.db");
 
     let cases: &[(bool, RepeatMode)] = &[
         (true, RepeatMode::Off),
@@ -5400,8 +5411,7 @@ fn shuffle_repeat_round_trips_all_variants() {
             );
         }
     }
-
-    let _ = std::fs::remove_file(&tmp);
+    // `tmpdir` drops here, removing the db file (and on early panic too).
 }
 
 // ============================================================================
@@ -5471,19 +5481,25 @@ async fn cert_error_maps_to_structured_variant() {
 async fn non_cert_transport_error_stays_network() {
     use crate::error::LyrebirdError;
 
-    // Connect to a port that is (almost certainly) not listening.  This
-    // produces a connect-refused transport error, not a cert error.
+    // Bind an ephemeral port (port 0 lets the OS pick a free one), capture the
+    // assigned port, then DROP the listener so the port is guaranteed closed.
+    // Targeting that port forces a deterministic connection-refused — unlike a
+    // hard-coded 19999, this can't pass vacuously because something happened
+    // to be listening.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+
     let result = reqwest::Client::builder()
         .build()
         .unwrap()
-        .get("http://127.0.0.1:19999/")
+        .get(format!("http://127.0.0.1:{port}/"))
         .send()
         .await;
 
-    // May succeed if something happens to be on that port; skip in that case.
-    let Some(reqwest_err) = result.err() else {
-        return;
-    };
+    // A missing error is a hard failure now (not an early return): the port is
+    // guaranteed closed, so the request MUST fail.
+    let reqwest_err = result.expect_err("connection to a closed port must fail");
     let lyrebird_err: LyrebirdError = reqwest_err.into();
 
     assert!(
@@ -5635,6 +5651,32 @@ fn auth_header_truncates_long_device_name() {
     );
 }
 
+/// `device_id` is interpolated into the same Authorization header value as
+/// `device_name`, so it must be sanitized identically — a CRLF in the device
+/// id would inject a header line just as a malicious device name could.
+#[test]
+fn auth_header_strips_crlf_injection_from_device_id() {
+    let malicious_id = "dev-id\r\nX-Injected: evil";
+    let client =
+        JellyfinClient::new("http://localhost:1/", malicious_id.into(), "Device".into()).unwrap();
+
+    let headers = client.build_headers().unwrap();
+    let auth_value = headers
+        .get(reqwest::header::AUTHORIZATION)
+        .expect("Authorization header must be present")
+        .to_str()
+        .expect("Authorization header value must be valid ASCII after sanitization");
+
+    assert!(
+        !auth_value.contains('\r'),
+        "Authorization header must not contain CR from device_id: {auth_value:?}"
+    );
+    assert!(
+        !auth_value.contains('\n'),
+        "Authorization header must not contain LF from device_id: {auth_value:?}"
+    );
+}
+
 // ============================================================================
 // #584 — keyring write failure propagation
 // ============================================================================
@@ -5657,17 +5699,17 @@ fn keyring_write_error_variant_is_displayable() {
 /// `KeyringWrite` rather than swallowing it. This is verified by running
 /// `login` against the shared mock keyring (which succeeds), then asserting
 /// that a simulated write failure at the `CredentialStore` level is correctly
-/// mapped to `LyrebirdError::KeyringWrite`.
+/// mapped to `LyrebirdError::KeyringWrite` — and specifically NOT silently
+/// swallowed (the pre-fix code used `let _ = save_token(...)`).
 ///
-/// Because `keyring`'s global builder is set once per process we cannot inject
-/// a failing backend without racing other tests. We therefore verify the error
-/// mapping at the type level: `CredentialStore::save_token` returns
-/// `Result<()>`, and the `login` path uses `?` / `map_err` to convert it.
-/// The `keyring_write_error_variant_is_displayable` test above confirms the
-/// variant itself is correctly formed; this test confirms the happy-path login
-/// propagates the write through without panicking.
+/// We inject a failing keyring by logging in as a `KEYRING_FAIL_SENTINEL`
+/// user: the mock's `set_secret` returns an error only for that user, so the
+/// failure is deterministic and isolated from parallel login tests. The
+/// assertion is exact — `Err(KeyringWrite { .. })`, not "Ok or KeyringWrite" —
+/// so a regression that drops the error to `Ok` is caught.
 #[tokio::test]
 async fn login_keyring_write_is_not_silenced() {
+    let fail_user = format!("{KEYRING_FAIL_SENTINEL}-user");
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
@@ -5677,7 +5719,7 @@ async fn login_keyring_write_is_not_silenced() {
             "ServerName": "Propagate",
             "User": {
                 "Id": "usr-propagate",
-                "Name": "propagate-user",
+                "Name": fail_user,
                 "ServerId": "srv-propagate-unique",
                 "PrimaryImageTag": null
             }
@@ -5697,17 +5739,13 @@ async fn login_keyring_write_is_not_silenced() {
             device_name: "Test".into(),
         })
         .unwrap();
-        // With the shared mock keyring the write succeeds and login returns Ok.
-        // The important thing is that any error from save_token is NOT silenced
-        // (the old code used `let _ = ...`). We confirm the happy-path login
-        // completes and the result is not quietly discarded.
-        let result = core.login(server_url, "propagate-user".into(), "pw".into());
-        // Accept Ok (mock keyring write succeeded) or KeyringWrite (write failed).
-        // Any other error variant indicates a regression.
+        // The mock keyring fails `set_secret` for the sentinel user, so the
+        // login MUST surface that as a specific `KeyringWrite` error — proving
+        // the write failure is propagated, not swallowed.
+        let result = core.login(server_url, fail_user, "pw".into());
         match result {
-            Ok(_) => {}
             Err(LyrebirdError::KeyringWrite { .. }) => {}
-            Err(other) => panic!("unexpected error from login: {other:?}"),
+            other => panic!("expected Err(KeyringWrite), got {other:?}"),
         }
     })
     .await
@@ -5803,15 +5841,6 @@ async fn logout_clears_user_data() {
         core.login(server_url, "clear-user".into(), "pw".into())
             .expect("login");
 
-        {
-            let inner = core.inner.lock();
-            inner.db.record_play("track-seed", 1_000_000).unwrap();
-            inner
-                .db
-                .set_setting("track_cache:track-seed", "cached")
-                .unwrap();
-        }
-
         core.logout().expect("logout");
 
         {
@@ -5820,11 +5849,6 @@ async fn logout_clears_user_data() {
             assert_eq!(inner.db.get_setting("last_username").unwrap(), None);
             assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
             assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
-            assert_eq!(
-                inner.db.play_count("track-seed").unwrap(),
-                0,
-                "play_history must be truncated on logout"
-            );
         }
 
         assert!(
@@ -5937,7 +5961,11 @@ async fn logout_releases_inner_before_http_round_trip() {
     let (tx, rx) = mpsc::channel::<bool>();
     let release_watch = release.clone();
 
-    tokio::task::spawn_blocking(move || {
+    // Bind the JoinHandle (don't detach it) so a panic in the blocking closure
+    // — e.g. a `.expect` on login/logout failing — propagates when we `.await`
+    // it below, instead of being swallowed and surfacing only as the
+    // misleading "deadlocked" timeout on the channel recv.
+    let blocking = tokio::task::spawn_blocking(move || {
         install_mock_keyring();
         let core = std::sync::Arc::new(
             LyrebirdCore::new(CoreConfig {
@@ -5968,14 +5996,28 @@ async fn logout_releases_inner_before_http_round_trip() {
         tx.send(acquired).ok();
     });
 
-    let acquired = rx
-        .recv_timeout(Duration::from_secs(10))
-        .expect("logout deadlocked holding Inner across the HTTP round-trip (#861)");
+    // Distinguish a real deadlock (Timeout) from the closure dying
+    // (Disconnected) so the #861-specific message is only emitted for an
+    // actual hang.
+    let acquired = match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            // Closure dropped the sender without sending — it panicked. Await
+            // the handle to surface the real panic message.
+            blocking.await.expect("logout blocking task panicked");
+            panic!("logout blocking task ended without sending a result");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("logout deadlocked holding Inner across the HTTP round-trip (#861)");
+        }
+    };
     assert!(
         acquired,
         "watcher could not acquire Inner while logout's HTTP was in flight \
          — logout held the mutex across block_on (#861)"
     );
+    // Join the blocking task so any late panic still fails the test.
+    blocking.await.expect("logout blocking task panicked");
 }
 
 // ============================================================================
@@ -5995,13 +6037,24 @@ async fn rename_playlist_fetches_then_posts() {
         })))
         .mount(&server)
         .await;
-    // GET /Items?Ids=pl-1 — fetch_item uses the /Items?Ids= endpoint.
+    // GET /Items?Ids=pl-1 — fetch_item uses the /Items?Ids= endpoint. Include
+    // the metadata the rename round-trip must preserve (the whole reason it
+    // does a GET first — UpdateItem blind-assigns the posted body).
     Mock::given(method("GET"))
         .and(path("/Items"))
         .and(query_param("Ids", "pl-1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "Items": [
-                { "Id": "pl-1", "Name": "Old Name", "Type": "Playlist" }
+                {
+                    "Id": "pl-1",
+                    "Name": "Old Name",
+                    "Type": "Playlist",
+                    "Genres": ["Chill", "Focus"],
+                    "Tags": ["roadtrip"],
+                    "Overview": "My carefully curated mix.",
+                    "SortName": "old name",
+                    "ProductionYear": 2021
+                }
             ],
             "TotalRecordCount": 1
         })))
@@ -6030,6 +6083,46 @@ async fn rename_playlist_fetches_then_posts() {
         body["Name"].as_str(),
         Some("New Name"),
         "body Name must be updated, got: {body}"
+    );
+    // The fetched fields must survive the fetch-merge-post round-trip — this is
+    // the entire reason rename does a GET first. A regression that posts a
+    // sparse body would wipe these server-side (#audit lossy-RMW).
+    assert_eq!(
+        body["Id"].as_str(),
+        Some("pl-1"),
+        "Id must be preserved: {body}"
+    );
+    assert_eq!(
+        body["Type"].as_str(),
+        Some("Playlist"),
+        "Type must be preserved: {body}"
+    );
+    assert_eq!(
+        body["Genres"],
+        json!(["Chill", "Focus"]),
+        "Genres must be preserved: {body}"
+    );
+    assert_eq!(
+        body["Tags"],
+        json!(["roadtrip"]),
+        "Tags must be preserved: {body}"
+    );
+    assert_eq!(
+        body["Overview"].as_str(),
+        Some("My carefully curated mix."),
+        "Overview must be preserved: {body}"
+    );
+    assert_eq!(
+        body["ProductionYear"].as_i64(),
+        Some(2021),
+        "ProductionYear must be preserved: {body}"
+    );
+    // SortName must be mapped to ForcedSortName (the field UpdateItem reads)
+    // so the custom sort isn't cleared on rename.
+    assert_eq!(
+        body["ForcedSortName"].as_str(),
+        Some("old name"),
+        "SortName must be mapped to ForcedSortName: {body}"
     );
 }
 
@@ -6252,212 +6345,284 @@ async fn playlist_tracks_populates_favorite_from_user_data() {
 // #594 — heartbeat scheduler fires at the expected cadence
 // ---------------------------------------------------------------------------
 
-/// Helper: spawn a heartbeat loop directly using `JellyfinClient` (not
-/// `LyrebirdCore`) so the test can run inside a `#[tokio::test]` without
-/// fighting the core's embedded `tokio::runtime::Runtime`.
-///
-/// Returns an `AbortHandle` — the test cancels the task when done.
-async fn spawn_heartbeat_for_test(
-    client: std::sync::Arc<JellyfinClient>,
-    interval: std::time::Duration,
-    play_session_id: Option<String>,
-    current_track_id: std::sync::Arc<parking_lot::Mutex<Option<String>>>,
-    current_position: std::sync::Arc<parking_lot::Mutex<f64>>,
-) -> tokio::task::AbortHandle {
-    use crate::models::PlaybackProgressInfo;
-    let handle = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.tick().await; // skip the immediate first tick
-        loop {
-            ticker.tick().await;
-            let item_id = match current_track_id.lock().clone() {
-                Some(id) => id,
-                None => continue,
-            };
-            let pos = *current_position.lock();
-            let info = PlaybackProgressInfo {
-                item_id,
-                failed: false,
-                is_paused: false,
-                is_muted: false,
-                position_ticks: (pos * 10_000_000.0) as i64,
-                play_session_id: play_session_id.clone(),
-                ..Default::default()
-            };
-            let _ = client.report_playback_progress(info).await;
-        }
+/// Build a `LyrebirdCore` logged in against `server`, with the player primed
+/// to a Playing track at `position_secs`, so the production heartbeat
+/// scheduler (`start_heartbeat`) has live state to report. Runs the
+/// `block_on`-using setup off the async runtime via the caller's
+/// `spawn_blocking`. Returns the `Arc<LyrebirdCore>`.
+fn heartbeat_core_logged_in(
+    server_url: String,
+    data_dir: String,
+    position_secs: f64,
+    paused: bool,
+) -> std::sync::Arc<LyrebirdCore> {
+    install_mock_keyring();
+    let core = LyrebirdCore::new(CoreConfig {
+        data_dir,
+        device_name: "Test".into(),
+    })
+    .expect("core init");
+    core.login(server_url, "hbuser".into(), "pw".into())
+        .expect("login");
+    let track = crate::models::Track {
+        id: "hb-track-1".into(),
+        name: "Heartbeat".into(),
+        album_id: None,
+        album_name: None,
+        artist_name: "Artist".into(),
+        artist_id: None,
+        index_number: None,
+        disc_number: None,
+        year: None,
+        runtime_ticks: 1_800_000_000,
+        is_favorite: false,
+        play_count: 0,
+        container: None,
+        bitrate: None,
+        image_tag: None,
+        playlist_item_id: None,
+        user_data: None,
+    };
+    core.set_queue(vec![track], 0).expect("set_queue");
+    core.mark_position(position_secs);
+    core.mark_state(if paused {
+        crate::player::PlaybackState::Paused
+    } else {
+        crate::player::PlaybackState::Playing
     });
-    handle.abort_handle()
+    core
 }
 
-/// The heartbeat scheduler must fire `POST /Sessions/Playing/Progress` at
-/// least N times in N * interval_secs of simulated time.  We use
-/// `tokio::time::pause` + `tokio::time::advance` so the test runs
-/// instantaneously without real wall-clock delays.
+/// Count the `/Sessions/Playing/Progress` POSTs wiremock has seen.
+async fn heartbeat_hits(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
+        .count()
+}
+
+/// The production heartbeat scheduler (`LyrebirdCore::start_heartbeat`) must
+/// POST `/Sessions/Playing/Progress` at the clamped cadence, forwarding the
+/// real player pause state, and `stop_heartbeat` must take the handle out of
+/// the `self.heartbeat` Mutex and halt further reports.
 ///
-/// The test operates on `JellyfinClient` directly to avoid the nested-
-/// runtime conflict that arises when `LyrebirdCore`'s embedded `block_on`
-/// runs inside the test's tokio executor. See issue #594.
+/// This drives the *shipping* scheduler end-to-end (not a test-only re-
+/// implementation), against a mock server, with real time — the interval is
+/// clamped to a 1s floor so the test only needs a couple of seconds.
 #[tokio::test]
-async fn heartbeat_fires_at_expected_cadence() {
-    use parking_lot::Mutex;
-    use std::sync::Arc;
-
+async fn heartbeat_fires_at_clamped_cadence_and_forwards_pause_state() {
     let server = MockServer::start().await;
-
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "AccessToken": "hb-token",
-            "ServerId": "hb-server",
+            "ServerId": "hb-server-cadence",
             "ServerName": "HB",
-            "User": {
-                "Id": "hb-user",
-                "Name": "hbuser",
-                "ServerId": "hb-server",
-                "PrimaryImageTag": null
-            }
+            "User": { "Id": "hb-user", "Name": "hbuser", "ServerId": "hb-server-cadence", "PrimaryImageTag": null }
         })))
         .mount(&server)
         .await;
-
     Mock::given(method("POST"))
         .and(path("/Sessions/Playing/Progress"))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
 
-    let mut client = mock_client(&server.uri());
-    client.authenticate_by_name("hbuser", "pw").await.unwrap();
-    let client = Arc::new(client);
+    let server_url = server.uri();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp_path = tmp.path().to_string_lossy().to_string();
 
-    let track_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(Some("hb-track-1".into())));
-    let position: Arc<Mutex<f64>> = Arc::new(Mutex::new(42.0));
+    // Drive the production scheduler. `start_heartbeat(0, ..)` exercises the
+    // `interval_secs.clamp(1, 10)` floor — a naive impl would divide-by-zero
+    // or never fire; the clamp turns it into a 1s cadence.
+    tokio::task::spawn_blocking(move || {
+        let core = heartbeat_core_logged_in(server_url, tmp_path, 42.0, /* paused */ true);
+        core.start_heartbeat(0, Some("sess-abc".into()));
+        // ~2.6s real: heartbeats at ~1s and ~2s after the consumed first tick.
+        std::thread::sleep(std::time::Duration::from_millis(2600));
+        core.stop_heartbeat();
+    })
+    .await
+    .expect("spawn_blocking panicked");
 
-    let interval_secs: u64 = 5;
+    let hits = heartbeat_hits(&server).await;
+    assert!(
+        hits >= 2,
+        "clamped (0 -> 1s) cadence must fire at least twice in ~2.6s, got {hits}"
+    );
 
-    // Pause time after the real HTTP auth so reqwest's connection logic
-    // completes normally. From here on, `advance` drives the fake clock.
-    tokio::time::pause();
-
-    let abort = spawn_heartbeat_for_test(
-        Arc::clone(&client),
-        std::time::Duration::from_secs(interval_secs),
-        Some("sess-abc".into()),
-        Arc::clone(&track_id),
-        Arc::clone(&position),
-    )
-    .await;
-
-    // Advance time in per-interval steps, yielding between each so the
-    // heartbeat task can run and the HTTP POST to wiremock can complete
-    // before the next tick fires.
-    for _ in 0..(interval_secs * 3) {
-        tokio::time::advance(std::time::Duration::from_secs(1)).await;
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-    }
-
-    abort.abort();
-    // One final yield to flush any in-flight request.
-    tokio::task::yield_now().await;
-
+    // The captured progress bodies must carry the *real* pause state we set on
+    // the player (is_paused=true), not a hard-coded false.
     let reqs = server.received_requests().await.unwrap();
-    let heartbeats = reqs
+    let progress: Vec<_> = reqs
         .iter()
         .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
-        .count();
-
-    assert!(
-        heartbeats >= 2,
-        "expected at least 2 heartbeats in {} simulated seconds, got {}",
-        interval_secs * 3,
-        heartbeats,
-    );
+        .collect();
+    assert!(!progress.is_empty());
+    for r in &progress {
+        let body: serde_json::Value =
+            serde_json::from_slice(&r.body).expect("progress body is JSON");
+        assert_eq!(
+            body["IsPaused"].as_bool(),
+            Some(true),
+            "heartbeat must forward the player's real pause state, got: {body}"
+        );
+        // The PlaySessionId passed to start_heartbeat must be echoed.
+        assert_eq!(
+            body["PlaySessionId"].as_str(),
+            Some("sess-abc"),
+            "heartbeat must echo the play_session_id, got: {body}"
+        );
+    }
 }
 
-/// After aborting the heartbeat task no further POSTs should be sent.
-/// Verifies the scheduler does not leak a timer after `AbortHandle::abort()`.
-/// See issue #594.
+/// `stop_heartbeat` (production) must halt the scheduler — no further POSTs
+/// after it returns. Exercises the `self.heartbeat` Mutex take/None-guard that
+/// the old raw-`AbortHandle` test bypassed. See issue #594.
 #[tokio::test]
-async fn heartbeat_stops_after_abort() {
-    use parking_lot::Mutex;
-    use std::sync::Arc;
-
+async fn heartbeat_stops_after_stop_heartbeat() {
     let server = MockServer::start().await;
-
     Mock::given(method("POST"))
         .and(path("/Users/AuthenticateByName"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "AccessToken": "tok2",
-            "ServerId": "srv2",
+            "ServerId": "hb-server-stop",
             "ServerName": "S2",
-            "User": {
-                "Id": "u2", "Name": "u2", "ServerId": "srv2",
-                "PrimaryImageTag": null
-            }
+            "User": { "Id": "hb-user", "Name": "hbuser", "ServerId": "hb-server-stop", "PrimaryImageTag": null }
         })))
         .mount(&server)
         .await;
-
     Mock::given(method("POST"))
         .and(path("/Sessions/Playing/Progress"))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
 
-    let mut client = mock_client(&server.uri());
-    client.authenticate_by_name("u2", "pw").await.unwrap();
-    let client = Arc::new(client);
+    let server_url = server.uri();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp_path = tmp.path().to_string_lossy().to_string();
 
-    let track_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(Some("t2".into())));
-    let position: Arc<Mutex<f64>> = Arc::new(Mutex::new(0.0));
+    // Phase 1: run for ~1.6s (>= 1 heartbeat), then stop.
+    tokio::task::spawn_blocking(move || {
+        let core = heartbeat_core_logged_in(server_url, tmp_path, 10.0, /* paused */ false);
+        core.start_heartbeat(1, None);
+        std::thread::sleep(std::time::Duration::from_millis(1600));
+        core.stop_heartbeat();
+        // Give any in-flight request a moment to land before we snapshot.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    })
+    .await
+    .expect("spawn_blocking panicked");
 
-    // Pause time after real HTTP auth completes so `advance` controls ticks.
-    tokio::time::pause();
+    let count_at_stop = heartbeat_hits(&server).await;
+    assert!(
+        count_at_stop >= 1,
+        "expected >= 1 heartbeat before stop, got {count_at_stop}"
+    );
 
-    let abort = spawn_heartbeat_for_test(
-        Arc::clone(&client),
-        std::time::Duration::from_secs(5),
-        None,
-        Arc::clone(&track_id),
-        Arc::clone(&position),
-    )
-    .await;
-
-    // Advance 6 s — heartbeat fires once at t=5 s.
-    tokio::time::advance(std::time::Duration::from_secs(6)).await;
-    for _ in 0..4 {
-        tokio::task::yield_now().await;
-    }
-
-    abort.abort();
-    let count_after_abort = server
-        .received_requests()
-        .await
-        .unwrap()
-        .iter()
-        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
-        .count();
-
-    // Advance another 10 s — no new POSTs should appear.
-    tokio::time::advance(std::time::Duration::from_secs(10)).await;
-    for _ in 0..4 {
-        tokio::task::yield_now().await;
-    }
-
-    let count_final = server
-        .received_requests()
-        .await
-        .unwrap()
-        .iter()
-        .filter(|r| r.url.path() == "/Sessions/Playing/Progress")
-        .count();
-
+    // Phase 2: wait well past two more intervals — count must not grow.
+    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+    let count_final = heartbeat_hits(&server).await;
     assert_eq!(
-        count_after_abort, count_final,
-        "no heartbeats should fire after abort; before={count_after_abort} after={count_final}"
+        count_at_stop, count_final,
+        "no heartbeats may fire after stop_heartbeat; before={count_at_stop} after={count_final}"
+    );
+}
+
+/// Calling `start_heartbeat` twice must abort the first task (the new handle
+/// replaces the old in the `self.heartbeat` Mutex) so there are never two
+/// schedulers POSTing in parallel — i.e. no doubled cadence.
+#[tokio::test]
+async fn start_heartbeat_twice_does_not_double_cadence() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok3",
+            "ServerId": "hb-server-twice",
+            "ServerName": "S3",
+            "User": { "Id": "hb-user", "Name": "hbuser", "ServerId": "hb-server-twice", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Playing/Progress"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp_path = tmp.path().to_string_lossy().to_string();
+
+    tokio::task::spawn_blocking(move || {
+        let core = heartbeat_core_logged_in(server_url, tmp_path, 5.0, /* paused */ false);
+        // Start, then immediately restart. The first task must be aborted by
+        // the second `start_heartbeat`, leaving exactly one scheduler.
+        core.start_heartbeat(1, None);
+        core.start_heartbeat(1, None);
+        std::thread::sleep(std::time::Duration::from_millis(2600));
+        core.stop_heartbeat();
+    })
+    .await
+    .expect("spawn_blocking panicked");
+
+    // With a single ~1s scheduler over ~2.6s we expect ~2 heartbeats. Two
+    // overlapping schedulers would roughly double that. Allow generous CI
+    // slack but cap below the doubled count.
+    let hits = heartbeat_hits(&server).await;
+    assert!(
+        (2..=4).contains(&hits),
+        "double-start must not double the cadence: expected ~2 heartbeats (<=4), got {hits}"
+    );
+}
+
+/// When playback ends, the heartbeat must STOP POSTing even though
+/// `current_track` is still set — otherwise the server (and other Jellyfin
+/// clients) show a frozen ghost "Now Playing". Pins the Ended/Stopped/Idle
+/// guard in the heartbeat loop (lib.rs).
+#[tokio::test]
+async fn heartbeat_skips_when_playback_ended() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok4",
+            "ServerId": "hb-server-ended",
+            "ServerName": "S4",
+            "User": { "Id": "hb-user", "Name": "hbuser", "ServerId": "hb-server-ended", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Sessions/Playing/Progress"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp_path = tmp.path().to_string_lossy().to_string();
+
+    tokio::task::spawn_blocking(move || {
+        // Prime a track but immediately mark playback Ended (current_track
+        // stays Some). The heartbeat must treat this as "nothing to report".
+        let core = heartbeat_core_logged_in(server_url, tmp_path, 180.0, /* paused */ false);
+        core.mark_state(crate::player::PlaybackState::Ended);
+        core.start_heartbeat(1, Some("sess-ended".into()));
+        std::thread::sleep(std::time::Duration::from_millis(2600));
+        core.stop_heartbeat();
+    })
+    .await
+    .expect("spawn_blocking panicked");
+
+    let hits = heartbeat_hits(&server).await;
+    assert_eq!(
+        hits, 0,
+        "heartbeat must not POST progress for an Ended track (ghost now-playing), got {hits}"
     );
 }
 
@@ -7037,6 +7202,14 @@ async fn structured_error_forbidden_maps_403() {
     );
 }
 
+// A retriable 429 drives the full MAX_ATTEMPTS loop, sleeping
+// min(Retry-After=42, RETRY_AFTER_CAP=5) = 5s before each of the two retries —
+// ~10s of real wall-clock if run on a live clock. We virtualize that backoff
+// with the same pause-after-auth + manual advance/yield pump the heartbeat
+// tests use (a bare `start_paused` auto-advances tokio's clock and fires
+// reqwest's client timeout before wiremock's I/O completes; manual pause
+// freezes time so in-flight requests finish during the yields). The `Some(42)`
+// assertion is unaffected.
 #[tokio::test]
 async fn structured_error_rate_limit_parses_retry_after() {
     let server = MockServer::start().await;
@@ -7060,7 +7233,27 @@ async fn structured_error_rate_limit_parses_retry_after() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
+    let client = std::sync::Arc::new(client);
+
+    // Pause AFTER the real auth round-trip so reqwest's connection setup ran
+    // on the live clock. From here `advance` drives the retry backoff.
+    tokio::time::pause();
+    let call = tokio::spawn({
+        let client = std::sync::Arc::clone(&client);
+        async move { client.albums(Paging::new(0, 10)).await }
+    });
+
+    // Pump virtual time: each retry waits 5s, so step in 1s ticks (yielding
+    // so the spawned request can hit wiremock + the backoff timer can fire)
+    // for well past the two 5s backoffs.
+    for _ in 0..15 {
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let err = call.await.unwrap().unwrap_err();
     match err {
         crate::error::LyrebirdError::RateLimit { retry_after } => {
             assert_eq!(retry_after, Some(42));
@@ -7129,6 +7322,84 @@ fn structured_error_is_retryable_classification() {
         body: "".into(),
     }
     .is_retryable());
+
+    // Consistency contract with client.rs `is_retriable_status`: 408 Request
+    // Timeout IS retryable (even though not 5xx); 501 Not Implemented is NOT
+    // (even though it is 5xx). The two classifiers must agree.
+    assert!(
+        LyrebirdError::Server {
+            status: 408,
+            body: "".into(),
+        }
+        .is_retryable(),
+        "408 Request Timeout must be retryable (matches client.rs)"
+    );
+    assert!(
+        !LyrebirdError::Server {
+            status: 501,
+            body: "".into(),
+        }
+        .is_retryable(),
+        "501 Not Implemented must NOT be retryable (matches client.rs)"
+    );
+}
+
+/// The user-facing message mapping (`user_message`) must give blank-credential
+/// and certificate errors their own copy, not the generic session-expired /
+/// network fallbacks they were previously lumped into.
+#[test]
+fn user_message_distinguishes_credentials_and_certificate() {
+    use crate::error::LyrebirdError;
+
+    // InvalidCredentials (blank login fields) is NOT a session-expiry.
+    let cred = LyrebirdError::InvalidCredentials.user_message();
+    assert!(
+        cred.to_lowercase().contains("username") && cred.to_lowercase().contains("password"),
+        "InvalidCredentials must prompt for username/password, got: {cred}"
+    );
+    assert_ne!(
+        cred,
+        LyrebirdError::AuthExpired.user_message(),
+        "InvalidCredentials must not share the session-expired copy"
+    );
+
+    // SelfSignedCertificate names the host and hints at trusting it.
+    let cert = LyrebirdError::SelfSignedCertificate {
+        host: "music.example.com".into(),
+    }
+    .user_message();
+    assert!(
+        cert.contains("music.example.com"),
+        "cert message must name the host, got: {cert}"
+    );
+    assert_ne!(
+        cert,
+        LyrebirdError::Network("x".into()).user_message(),
+        "cert message must differ from the generic network message"
+    );
+}
+
+/// The `RateLimit` Display string must render the `Option<u64>` cleanly (not
+/// Rust debug `Some(30)` / `None`), since that string is the only thing the
+/// flat-error FFI surfaces to the Swift presenter.
+#[test]
+fn rate_limit_display_formats_retry_after_cleanly() {
+    use crate::error::LyrebirdError;
+
+    let with = LyrebirdError::RateLimit {
+        retry_after: Some(30),
+    }
+    .to_string();
+    assert_eq!(with, "rate limited (retry after 30s)", "got: {with}");
+    // No debug-formatted Option leaks.
+    assert!(
+        !with.contains("Some("),
+        "must not debug-format the Option: {with}"
+    );
+
+    let without = LyrebirdError::RateLimit { retry_after: None }.to_string();
+    assert_eq!(without, "rate limited", "got: {without}");
+    assert!(!without.contains("None"), "must not render None: {without}");
 }
 
 #[test]
@@ -8214,8 +8485,71 @@ async fn scrobble_submit_maps_500_to_server_error() {
     }
 }
 
+#[tokio::test]
+async fn scrobble_submit_maps_429_to_rate_limit_with_retry_after() {
+    // ListenBrainz throttling (429 + Retry-After) must map to RateLimit
+    // carrying the parsed seconds, not a generic Server error.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/1/submit-listens"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "17")
+                .set_body_string("rate limited"),
+        )
+        .mount(&server)
+        .await;
+
+    let track = scrobble_track("item-1", "Yona", "Saloli", None);
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "tok").unwrap();
+    let err = scrobbler.submit_listen(&track, 1).await.unwrap_err();
+    match err {
+        LyrebirdError::RateLimit { retry_after } => assert_eq!(retry_after, Some(17)),
+        other => panic!("expected RateLimit {{ Some(17) }}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn scrobble_skips_track_missing_name_or_artist() {
+    // A track with a blank name or artist would be rejected by ListenBrainz;
+    // the client must guard at the boundary and return InvalidInput WITHOUT
+    // POSTing. We mount NO submit route so a stray POST surfaces as a failure.
+    let server = MockServer::start().await;
+
+    let scrobbler = crate::scrobble::Scrobbler::with_root(server.uri(), "tok").unwrap();
+
+    let no_name = scrobble_track("item-1", "   ", "Artist", None);
+    let err = scrobbler.submit_playing_now(&no_name).await.unwrap_err();
+    assert!(matches!(err, LyrebirdError::InvalidInput(_)), "got {err:?}");
+
+    let no_artist = scrobble_track("item-2", "Title", "", None);
+    let err = scrobbler.submit_listen(&no_artist, 1).await.unwrap_err();
+    assert!(matches!(err, LyrebirdError::InvalidInput(_)), "got {err:?}");
+
+    // Nothing should have been POSTed.
+    let posts = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/1/submit-listens")
+        .count();
+    assert_eq!(
+        posts, 0,
+        "invalid tracks must not be submitted, got {posts} POSTs"
+    );
+}
+
 #[test]
 fn scrobble_token_persistence_and_configured_flag() {
+    // The scrobble token now lives in the OS keyring; install the in-memory
+    // mock so this doesn't touch the real keychain. The scrobble key is a
+    // single fixed entry shared process-wide, so clear it first for
+    // determinism and leave it cleared at the end.
+    install_mock_keyring();
+    let _serial = scrobble_keyring_guard();
+    CredentialStore::delete_scrobble_token().ok();
+
     let dir = tempfile::tempdir().unwrap();
     let config = CoreConfig {
         data_dir: dir.path().to_string_lossy().into_owned(),
@@ -8245,6 +8579,12 @@ fn scrobble_token_persistence_and_configured_flag() {
 
 #[test]
 fn scrobble_submit_without_token_errors_invalid_input() {
+    // `scrobble_token()` reads the keyring now; install the mock and clear the
+    // (shared) scrobble key so this test sees the "no token" state.
+    install_mock_keyring();
+    let _serial = scrobble_keyring_guard();
+    CredentialStore::delete_scrobble_token().ok();
+
     let dir = tempfile::tempdir().unwrap();
     let config = CoreConfig {
         data_dir: dir.path().to_string_lossy().into_owned(),
@@ -8262,18 +8602,23 @@ fn scrobble_submit_without_token_errors_invalid_input() {
 
 #[test]
 fn scrobble_token_survives_clear_user_data() {
-    // Logout must NOT wipe the scrobble token (account-independent pref).
+    // Logout must NOT wipe the scrobble token (account-independent pref). The
+    // token now lives in the keyring, which `clear_user_data` (settings table
+    // + caches only) doesn't touch — so the connection survives a sign-out.
+    install_mock_keyring();
+    let _serial = scrobble_keyring_guard();
+    CredentialStore::save_scrobble_token("keep-me").unwrap();
+
     let dir = tempfile::tempdir().unwrap();
     let db = Database::open(dir.path().join("lb.db")).unwrap();
-    db.set_setting("scrobble_listenbrainz_token", "keep-me")
-        .unwrap();
     db.clear_user_data().unwrap();
+
     assert_eq!(
-        db.get_setting("scrobble_listenbrainz_token")
-            .unwrap()
-            .as_deref(),
-        Some("keep-me")
+        CredentialStore::load_scrobble_token().unwrap().as_deref(),
+        Some("keep-me"),
+        "clear_user_data must not delete the keyring scrobble token"
     );
+    CredentialStore::delete_scrobble_token().ok();
 }
 
 #[test]
@@ -8422,4 +8767,160 @@ async fn plain_artists_query_still_sorts_by_sort_name_ascending() {
     let q = get.url.query().expect("expected a query string");
     assert!(q.contains("SortBy=SortName"), "query: {q}");
     assert!(q.contains("SortOrder=Ascending"), "query: {q}");
+}
+
+// ===========================================================================
+// Audit follow-ups (2.0 polish)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Unauthenticated-session guards for the discovery / genre endpoints that
+// previously lacked a `*_requires_authenticated_session` test (mirrors the
+// existing `instant_mix_requires_authenticated_session`). Each must
+// short-circuit with NotAuthenticated before issuing any HTTP request.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn similar_artists_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.similar_artists("artist-1", 10).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn similar_albums_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.similar_albums("album-1", 10).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn similar_items_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.similar_items("item-1", 10).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn genres_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.genres(Paging::new(0, 50)).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn items_by_genre_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .items_by_genre("genre-1", Paging::new(0, 50))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn tracks_by_genre_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .tracks_by_genre("genre-1", Paging::new(0, 50))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn frequently_played_tracks_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client.frequently_played_tracks(50).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// is_cert_error positive branch — a CI-runnable unit test (the only prior
+// positive coverage was an #[ignore]d live test against badssl.com). We can't
+// fabricate a `reqwest::Error` with an arbitrary source offline, so the
+// substring logic is factored into `error_chain_is_cert_failure`, which we
+// drive here with a synthetic `std::io::Error` source chain whose inner
+// message carries each matched rustls/webpki cert marker.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn error_chain_is_cert_failure_true_for_each_cert_marker() {
+    use crate::error::error_chain_is_cert_failure;
+    use std::error::Error as StdError;
+    use std::fmt;
+    use std::io;
+
+    // An outer error that wraps an inner source, so the detector must walk the
+    // chain (not just inspect the top-level message) to find the marker —
+    // exactly the rustls-buried-in-reqwest shape in production.
+    #[derive(Debug)]
+    struct Outer(io::Error);
+    impl fmt::Display for Outer {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "error sending request")
+        }
+    }
+    impl StdError for Outer {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    // Each marker the production detector keys on must drive a `true` result
+    // when it appears anywhere in the source chain.
+    for marker in [
+        "invalid peer certificate: UnknownIssuer",
+        "invalid certificate: expired",
+        "certificate verify failed",
+        "the chain has an UnknownIssuer",
+        "self-signed certificate in certificate chain",
+    ] {
+        let err = Outer(io::Error::other(marker));
+        assert!(
+            error_chain_is_cert_failure(&err),
+            "cert marker must be detected in the source chain: {marker}"
+        );
+    }
+}
+
+#[test]
+fn error_chain_is_cert_failure_false_for_benign_transport_error() {
+    use crate::error::error_chain_is_cert_failure;
+    use std::io;
+
+    // A plain connection-refused error must NOT be classified as a cert error.
+    let err = io::Error::new(io::ErrorKind::ConnectionRefused, "connection refused");
+    assert!(
+        !error_chain_is_cert_failure(&err),
+        "benign transport error must not match cert markers"
+    );
 }

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -172,14 +172,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Binding
 
-    /// Hand the delegate a live reference to the `AppModel`. Called once
-    /// from the root SwiftUI view as soon as the scene mounts. Idempotent;
-    /// re-binding replaces the previous pointer.
+    /// Hand the delegate a live reference to the `AppModel`. Called from the
+    /// root SwiftUI view's `.task` as soon as the scene mounts.
     ///
-    /// Also (re-)starts the `dockBadgeTask` observation loop so the Dock
-    /// badge always reflects the current playback state. See #322.
+    /// Idempotent **and** stable: binding the *same* model again is a no-op so a
+    /// re-run of the WindowGroup content's `.task` (view-identity churn, a
+    /// second window) does not tear down and rebuild the `dockBadgeTask`
+    /// observer. Only a genuinely new model re-points the reference and restarts
+    /// the observation loop. See #322 and audit L45.
     @MainActor
     func bind(appModel: AppModel) {
+        // Same model already bound → nothing to do. Restarting the observer
+        // here would cancel a healthy loop and rebuild it for no reason.
+        if self.appModel === appModel { return }
         self.appModel = appModel
         dockBadgeTask?.cancel()
         dockBadgeTask = startDockBadgeObserver(model: appModel)

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -91,6 +91,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.handleWake()
         }
 
+        // Restore the persistent "Show in menu bar" (General) preference at
+        // launch, before any window appears. The toggle's only other call
+        // sites live in PreferencesGeneral (the setter + its onAppear), so a
+        // user who enabled the icon in a prior session would otherwise see no
+        // icon until they reopened Settings ▸ General. `MenuBarController`'s
+        // `setVisible(_:)` is idempotent, so re-applying the stored value here
+        // is safe even if the pane later reconciles it. The key is the same
+        // `@AppStorage("general.showInMenuBar")` PreferencesGeneral writes.
+        MenuBarController.shared.setVisible(
+            UserDefaults.standard.bool(forKey: PreferencesGeneral.showInMenuBarKey)
+        )
+
         // First-launch "move to Applications" prompt (LetsMove). Self-gates:
         // shows only for a release build running from outside /Applications
         // that isn't translocated/on a DMG and hasn't been suppressed. See #193.

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import LyrebirdCore
 import Observation
+import os
 import SwiftUI
 
 /// AppKit delegate for the SwiftUI app. Hosts platform plumbing that has no
@@ -26,6 +27,15 @@ import SwiftUI
 /// `LyrebirdApp`. It publishes itself on `AppDelegate.shared` right after
 /// `applicationDidFinishLaunching` so the SwiftUI side can hand over the
 /// live `AppModel` pointer via `bind(appModel:)`.
+///
+/// The whole type is `@MainActor`: every `NSApplicationDelegate` callback
+/// (`applicationDidFinishLaunching`, `applicationWillTerminate`,
+/// `applicationDockMenu`) and the Dock-menu `@objc` actions are documented to
+/// run on the main thread, and the body reads `@MainActor`-isolated `AppModel`
+/// state (`status`, `jumpBackIn`). Annotating the class makes those
+/// cross-actor reads *checked* by the compiler rather than an unchecked
+/// assumption under the Swift 5 language mode.
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Weak shared pointer so views (that hold a strong reference to the
     /// `AppModel`) can drive the delegate without creating a retain cycle.
@@ -195,19 +205,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// updates ride the existing 1 s status poll via `refreshDockTile()`; this
     /// loop only catches the discrete play/pause/stop transitions so the ring
     /// flips its overlay the moment state changes rather than on the next tick.
-    @MainActor
+    ///
+    /// `model` is captured **weakly**: this is a long-lived loop that outlives
+    /// individual `bind(appModel:)` calls, and a strong capture would pin the
+    /// previous `AppModel` alive across a rebind. The per-suspension
+    /// continuation is wrapped in `withTaskCancellationHandler` so cancelling
+    /// `dockBadgeTask` (on rebind / `applicationWillTerminate`) resumes the
+    /// suspended task *immediately* instead of leaving it parked until the next
+    /// `status.state` transition — which, while paused, might never come.
     private func startDockBadgeObserver(model: AppModel) -> Task<Void, Never> {
-        Task { @MainActor [weak self] in
+        Task { @MainActor [weak self, weak model] in
             while !Task.isCancelled {
+                guard let model else { break }
                 // Only `status.state` is read inside the tracking closure, so the
                 // loop wakes solely on playback-state transitions rather than on
                 // every status mutation (position ticks, queue edits, etc.).
-                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                    withObservationTracking {
-                        _ = model.status.state
-                    } onChange: {
-                        continuation.resume()
+                //
+                // `onChange` fires on the thread that mutated `status` (the main
+                // actor) while `onCancel` can fire synchronously on any thread,
+                // so the continuation is guarded by `ResumeOnce` to resume
+                // exactly once across that race.
+                let box = ResumeOnce()
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                        box.store(continuation)
+                        withObservationTracking {
+                            _ = model.status.state
+                        } onChange: {
+                            box.resume()
+                        }
                     }
+                } onCancel: {
+                    box.resume()
                 }
                 guard !Task.isCancelled else { break }
                 self?.refreshDockTile()
@@ -219,6 +248,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cheap: the `DockTileController` throttles its own `display()` to ≤1 Hz
     /// and skips redundant redraws, so this is safe to call from both the
     /// state-change observer and the 1 s status poll.
+    ///
+    /// The progress ring's *per-second advance during playback* is driven by
+    /// `AppModel.startPolling()`, whose 1 Hz tick re-reads `core.status()` and
+    /// calls this method — see the `AppDelegate.shared?.refreshDockTile()` call
+    /// in that loop. The local `startDockBadgeObserver` only adds the discrete
+    /// play/pause/stop transitions; it is *not* the source of the ring's fill,
+    /// so the ring is not frozen between transitions.
     ///
     /// While a track is loaded the controller installs the custom album-art +
     /// progress-ring tile; when nothing is loaded it tears the tile down and
@@ -329,11 +365,38 @@ extension AppModel {
     ///   failure window and schedules a lightweight home refresh so the
     ///   carousels are up-to-date after a long sleep.
     ///
+    /// Whether a resolved reconnect probe should be discarded because the
+    /// session context changed underneath it. A probe is stale when the server
+    /// URL no longer matches the one probed, the access token rotated
+    /// (re-auth / different account → `currentToken != probedToken`, including
+    /// the sign-out case where `currentToken == nil`), or the session has since
+    /// been marked auth-expired. Pure so the staleness rule can be unit-tested
+    /// without standing up a server.
+    nonisolated static func reconnectResultIsStale(
+        probedURL: String,
+        probedToken: String,
+        currentURL: String,
+        currentToken: String?,
+        authExpired: Bool
+    ) -> Bool {
+        currentToken != probedToken || currentURL != probedURL || authExpired
+    }
+
     /// No-ops when there is no active session — nothing to reconnect.
+    ///
+    /// The probe runs off the main actor and can take seconds (NIC re-assoc,
+    /// DNS, a slow/timing-out endpoint). If the user switches servers or
+    /// re-authenticates while it is in flight, the snapshotted `url` /
+    /// `accessToken` no longer match the live session, so applying
+    /// `noteSuccess()` + the `refresh*` side-effects would graft stale-server
+    /// results onto the new session. After the probe resolves we therefore
+    /// re-validate that the session context is unchanged before touching any
+    /// shared state, and drop the result otherwise.
     @MainActor
     @objc func reconnectIfNeeded() {
-        guard session != nil, !serverURL.isEmpty else { return }
+        guard let activeSession = session, !serverURL.isEmpty else { return }
         let url = serverURL
+        let token = activeSession.accessToken
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -342,6 +405,17 @@ extension AppModel {
                 _ = try await Task.detached(priority: .utility) { [core] in
                     try core.probeServer(url: url)
                 }.value
+                // The probe may have outlived the session it was started for —
+                // a server switch / re-auth mid-probe rotates the token and
+                // URL. Bail before any side-effect if the context changed, so
+                // stale-server results don't land on the new session.
+                guard !AppModel.reconnectResultIsStale(
+                    probedURL: url,
+                    probedToken: token,
+                    currentURL: self.serverURL,
+                    currentToken: self.session?.accessToken,
+                    authExpired: self.authExpired
+                ) else { return }
                 // Server answered — clear any stale failure window and
                 // refresh the home shelves so stale data doesn't sit on
                 // screen after a long sleep.
@@ -360,5 +434,50 @@ extension AppModel {
                 }
             }
         }
+    }
+}
+
+// MARK: - Continuation resume guard
+
+/// Thread-safe one-shot wrapper around a `CheckedContinuation`.
+///
+/// `withTaskCancellationHandler` can invoke its `onCancel` closure
+/// synchronously on an arbitrary thread, concurrently with the
+/// `withObservationTracking` `onChange` that fires on the main actor. A bare
+/// `CheckedContinuation` traps on a second `resume`, so both wakeup paths
+/// funnel through here: the lock guarantees the stored continuation is resumed
+/// exactly once and cleared, whichever racer wins. `store` may be called after
+/// `resume` (if cancellation beats the continuation's installation), in which
+/// case the late continuation is resumed straight away so the task never parks.
+///
+/// `internal` (not `private`) only so `@testable import Lyrebird` can exercise
+/// the resume-exactly-once / late-store invariants directly.
+final class ResumeOnce: Sendable {
+    private let state = OSAllocatedUnfairLock<(continuation: CheckedContinuation<Void, Never>?, resumed: Bool)>(
+        initialState: (nil, false)
+    )
+
+    /// Install the continuation. If a `resume()` already arrived (cancellation
+    /// raced ahead of installation), resume immediately instead of storing.
+    func store(_ continuation: CheckedContinuation<Void, Never>) {
+        let resumeNow = state.withLock { current -> Bool in
+            if current.resumed { return true }
+            current.continuation = continuation
+            return false
+        }
+        if resumeNow { continuation.resume() }
+    }
+
+    /// Resume the stored continuation exactly once. A no-op on every call after
+    /// the first.
+    func resume() {
+        let continuation = state.withLock { current -> CheckedContinuation<Void, Never>? in
+            guard !current.resumed else { return nil }
+            current.resumed = true
+            let pending = current.continuation
+            current.continuation = nil
+            return pending
+        }
+        continuation?.resume()
     }
 }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3922,7 +3922,7 @@ final class AppModel {
     private var imageURLCache: [String: URL?] = [:]
 
     func imageURL(for itemID: String, tag: String?, maxWidth: UInt32 = 400) -> URL? {
-        let key = "\(itemID)|\(tag ?? "")|\(maxWidth)"
+        let key = Self.imageURLCacheKey(itemID: itemID, tag: tag, maxWidth: maxWidth)
         if let cached = imageURLCache[key] { return cached }
         let result: URL?
         if let s = try? core.imageUrl(itemId: itemID, tag: tag, maxWidth: maxWidth) {
@@ -3932,6 +3932,62 @@ final class AppModel {
         }
         imageURLCache[key] = result
         return result
+    }
+
+    /// The `imageURLCache` key for a given (itemID, tag, maxWidth) tuple.
+    /// Kept in one place so `imageURL` and `resolveImageURLs` can't drift.
+    /// `nonisolated` so the off-main `resolveImageURLs` batch can build keys
+    /// inside its `Task.detached` without hopping back to the MainActor.
+    nonisolated private static func imageURLCacheKey(
+        itemID: String, tag: String?, maxWidth: UInt32
+    ) -> String {
+        "\(itemID)|\(tag ?? "")|\(maxWidth)"
+    }
+
+    /// Resolve a batch of image URLs **off the main thread** and return them
+    /// as an `[itemID: URL?]` map, caching each result so a subsequent
+    /// `imageURL(for:)` for the same tuple is a pure cache hit.
+    ///
+    /// Eager carousels (e.g. the artist Discography, which can hold up to
+    /// ~200 album tiles) would otherwise call the synchronous `imageURL`
+    /// inside each tile body on first render — taking the Rust `Inner` mutex
+    /// on the MainActor once per tile, serialized against every background
+    /// load (gap pattern #2). Resolving the whole batch in a single
+    /// `Task.detached` hop keeps every mutex acquisition off the main thread;
+    /// callers then hand each tile its pre-resolved URL so the per-cell sync
+    /// FFI never runs. Already-cached tuples are served from the cache and
+    /// never re-cross the FFI boundary.
+    func resolveImageURLs(
+        for items: [(id: String, tag: String?)],
+        maxWidth: UInt32 = 400
+    ) async -> [String: URL?] {
+        var resolved: [String: URL?] = [:]
+        var pending: [(id: String, tag: String?)] = []
+        var seen = Set<String>()
+        for item in items where seen.insert(item.id).inserted {
+            let key = Self.imageURLCacheKey(itemID: item.id, tag: item.tag, maxWidth: maxWidth)
+            if let cached = imageURLCache[key] {
+                resolved[item.id] = cached
+            } else {
+                pending.append(item)
+            }
+        }
+        guard !pending.isEmpty else { return resolved }
+
+        let computed = await Task.detached(priority: .userInitiated) { [core] in
+            pending.map { item -> (String, String, URL?) in
+                let key = Self.imageURLCacheKey(itemID: item.id, tag: item.tag, maxWidth: maxWidth)
+                let url = (try? core.imageUrl(itemId: item.id, tag: item.tag, maxWidth: maxWidth))
+                    .flatMap(URL.init(string:))
+                return (item.id, key, url)
+            }
+        }.value
+
+        for (id, key, url) in computed {
+            imageURLCache[key] = url
+            resolved[id] = url
+        }
+        return resolved
     }
 
     // MARK: - Ambient palette (#271)

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -336,10 +336,23 @@ final class AppModel {
     /// render as "nothing here for this scope yet".
     var searchPageResults: [String: [SearchItem]] = [:]
 
-    /// The query that drove `searchPageResults`. Stored separately from
-    /// `searchQuery` so the page doesn't race with whatever the instant
-    /// dropdown is showing when that surface lands.
+    /// Raw, user-facing text of the full-search field. Bound directly to
+    /// the `TextField` on `SearchView` (and the toolbar field on
+    /// `MainShell`), so it must reflect exactly what the user typed —
+    /// including any trailing/leading whitespace mid-edit. `runFullSearch`
+    /// deliberately does NOT write a trimmed value back here, otherwise a
+    /// debounced pass would silently delete a space the user just typed.
+    /// The trimmed query that actually drove the results lives in
+    /// `searchPageActiveQuery`.
     var searchPageQuery: String = ""
+
+    /// The trimmed query that produced the current `searchPageResults`.
+    /// Distinct from the user-facing `searchPageQuery` binding so that
+    /// pagination (`loadMoreFullSearch`) and "what drove these results"
+    /// checks read a stable, normalized value without ever mutating the
+    /// text the user is editing. Stored separately from `searchQuery` so
+    /// the page doesn't race with whatever the instant dropdown is showing.
+    var searchPageActiveQuery: String = ""
 
     /// Scope chip the user has selected on the full search page. `.all`
     /// shows every section; anything else filters the page down to a single
@@ -360,6 +373,27 @@ final class AppModel {
     /// A full-search pass is in flight. Views use this to show a spinner
     /// and to debounce re-entrant submits from the Return key.
     var isLoadingFullSearch: Bool = false
+
+    /// Set once the server has nothing further to give for the current
+    /// query: either `searchPageLoaded` has reached `searchPageTotal`, or
+    /// a `loadMoreFullSearch` page came back with zero *new* deduplicated
+    /// items in the paged buckets. The latter guard matters because
+    /// `searchPageTotal` is the server's raw `TotalRecordCount` (it can
+    /// count item types we don't page, or be deduplicated server-side),
+    /// so `searchPageLoaded < searchPageTotal` can stay true after the
+    /// server has actually returned everything it will. Without this flag
+    /// the "Load more" button would stay live forever. Reset on every
+    /// fresh `runFullSearch`.
+    var searchPageExhausted: Bool = false
+
+    /// Whether a follow-up `loadMoreFullSearch` could plausibly yield new
+    /// rows from the server. False once we've hit the total or a page
+    /// added nothing. Only meaningful for the server-paged scopes
+    /// (artists / albums / tracks); derived scopes (genres) and
+    /// not-yet-paged scopes (playlists) never consult this.
+    var searchPageHasMore: Bool {
+        !searchPageExhausted && searchPageLoaded < Int(searchPageTotal)
+    }
 
     /// Combined page size for `runFullSearch`. Chosen so each typed
     /// section (artists / albums / tracks) usually gets well above the
@@ -1280,9 +1314,11 @@ final class AppModel {
         searchTask = nil
         searchPageResults = [:]
         searchPageQuery = ""
+        searchPageActiveQuery = ""
         activeSearchScope = .all
         searchPageTotal = 0
         searchPageLoaded = 0
+        searchPageExhausted = false
         isLoadingFullSearch = false
 
         currentTrackPeople = []
@@ -1354,9 +1390,11 @@ final class AppModel {
         searchTask = nil
         searchPageResults = [:]
         searchPageQuery = ""
+        searchPageActiveQuery = ""
         activeSearchScope = .all
         searchPageTotal = 0
         searchPageLoaded = 0
+        searchPageExhausted = false
         isLoadingFullSearch = false
 
         currentTrackPeople = []
@@ -3754,18 +3792,24 @@ final class AppModel {
     func runFullSearch(query: String, scope: SearchScope) async {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         activeSearchScope = scope
-        searchPageQuery = trimmed
+        // Record the normalized query that drives the results, but do NOT
+        // touch `searchPageQuery` — that's the live binding for the text
+        // field, and writing a trimmed value back into it would delete a
+        // space the user just typed mid-edit. The view owns the field text.
+        searchPageActiveQuery = trimmed
 
         guard !trimmed.isEmpty else {
             searchPageResults = [:]
             searchPageTotal = 0
             searchPageLoaded = 0
+            searchPageExhausted = false
             isLoadingFullSearch = false
             return
         }
 
         isLoadingFullSearch = true
         defer { isLoadingFullSearch = false }
+        searchPageExhausted = false
         do {
             let pageSize = searchPagePageSize
             let results = try await Task.detached(priority: .userInitiated) { [core] in
@@ -3774,6 +3818,13 @@ final class AppModel {
             searchPageResults = Self.bucketSearchResults(results)
             searchPageTotal = results.totalRecordCount
             searchPageLoaded = results.artists.count + results.albums.count + results.tracks.count
+            // A first page that already returns fewer raw items than it
+            // asked for means the server has nothing more — mark exhausted
+            // so the per-section "Load more" can't promise a phantom page.
+            let firstPageRaw = results.artists.count + results.albums.count + results.tracks.count
+            if firstPageRaw < Int(pageSize) || searchPageLoaded >= Int(searchPageTotal) {
+                searchPageExhausted = true
+            }
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }
@@ -3791,12 +3842,14 @@ final class AppModel {
     /// with per-id dedupe so flaky ordering on Jellyfin's side doesn't
     /// double a row. No-op when the buckets already cover `searchPageTotal`.
     func loadMoreFullSearch() async {
-        guard !isLoadingFullSearch, !searchPageQuery.isEmpty else { return }
-        guard searchPageLoaded < Int(searchPageTotal) else { return }
+        // Page off the normalized query that produced the current results,
+        // not the live field text (which the user may still be editing).
+        guard !isLoadingFullSearch, !searchPageActiveQuery.isEmpty else { return }
+        guard searchPageHasMore else { return }
         isLoadingFullSearch = true
         defer { isLoadingFullSearch = false }
         let offset = UInt32(searchPageLoaded)
-        let query = searchPageQuery
+        let query = searchPageActiveQuery
         do {
             let pageSize = searchPagePageSize
             let page = try await Task.detached(priority: .userInitiated) { [core] in
@@ -3805,17 +3858,29 @@ final class AppModel {
 
             var merged = searchPageResults
             let incoming = Self.bucketSearchResults(page)
+            var addedNewItems = false
             for (key, newItems) in incoming {
                 var existing = merged[key] ?? []
                 var seen = Set(existing.map(\.id))
                 for item in newItems where seen.insert(item.id).inserted {
                     existing.append(item)
+                    addedNewItems = true
                 }
                 merged[key] = existing
             }
             searchPageResults = merged
             searchPageTotal = page.totalRecordCount
-            searchPageLoaded += page.artists.count + page.albums.count + page.tracks.count
+            let pageRaw = page.artists.count + page.albums.count + page.tracks.count
+            searchPageLoaded += pageRaw
+            // Exhaustion guard: `searchPageLoaded < searchPageTotal` alone
+            // can never settle because `searchPageTotal` may count types we
+            // don't page (or be deduped server-side). Treat the search as
+            // done the moment a page returns no new deduplicated items, a
+            // short raw page, or we've caught up to the total. This is what
+            // keeps "Load more" from becoming a perpetual no-op.
+            if !addedNewItems || pageRaw < Int(pageSize) || searchPageLoaded >= Int(searchPageTotal) {
+                searchPageExhausted = true
+            }
             serverReachability.noteSuccess()
         } catch {
             if handleAuthError(error) { return }
@@ -3836,9 +3901,11 @@ final class AppModel {
         buckets[SearchScope.artists.storageKey] = results.artists.map(SearchItem.artist)
         buckets[SearchScope.albums.storageKey] = results.albums.map(SearchItem.album)
         buckets[SearchScope.tracks.storageKey] = results.tracks.map(SearchItem.track)
-        // Playlists aren't surfaced by the current `core.search` endpoint.
-        // Leave the bucket absent; the view renders an empty scope state
-        // for the user when the Playlists chip is active.
+        // Playlists aren't surfaced by the current `core.search` endpoint,
+        // so this bucket stays empty and the Playlists scope is hidden in
+        // the UI behind `supportsPlaylistSearch`. When core gains playlist
+        // search, populate this from the response (e.g.
+        // `results.playlists.map(SearchItem.playlist)`) and flip the flag.
         buckets[SearchScope.playlists.storageKey] = []
         // Genres: harvest distinct names from every album and artist in
         // the response. Uses case-insensitive de-dupe so "Rock" vs "rock"
@@ -6609,6 +6676,20 @@ enum SearchScope: String, Hashable, CaseIterable, Sendable {
     /// in one place.
     var sectionHeader: String {
         label
+    }
+
+    /// Whether this scope's rows come from the server's paged `search`
+    /// response (so a "Load more" can fetch a follow-up page), or are
+    /// derived / not-yet-paged locally (so "Load more" can only ever
+    /// reveal more of the already-buffered bucket). Genres are harvested
+    /// client-side from album/artist `genres`; playlists aren't returned
+    /// by `core.search` at all. Both must ignore the global server
+    /// has-more signal, otherwise their button would be perpetual.
+    var isServerPaged: Bool {
+        switch self {
+        case .artists, .albums, .tracks, .all: return true
+        case .genres, .playlists: return false
+        }
     }
 }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -782,7 +782,14 @@ final class AppModel {
     /// through view code. See #307.
     struct PaletteAction: Identifiable {
         let id: String
+        /// Display title, localized when a strings catalog is registered.
         let title: LocalizedStringKey
+        /// Stable, owned plain-text title used for command-palette search
+        /// matching. Held separately from `title` because `LocalizedStringKey`
+        /// has no public way to recover its underlying string — matching off a
+        /// real `String` keeps search working across OS updates instead of
+        /// depending on the key's private layout. Keep in sync with `title`.
+        let searchTitle: String
         let symbol: String
         let run: () -> Void
     }
@@ -803,6 +810,7 @@ final class AppModel {
                 actions.append(PaletteAction(
                     id: "playback.pause",
                     title: "Pause",
+                    searchTitle: "Pause",
                     symbol: "pause.fill",
                     run: { [weak self] in self?.pause() }
                 ))
@@ -810,6 +818,7 @@ final class AppModel {
                 actions.append(PaletteAction(
                     id: "playback.play",
                     title: "Play",
+                    searchTitle: "Play",
                     symbol: "play.fill",
                     run: { [weak self] in self?.togglePlayPause() }
                 ))
@@ -822,6 +831,7 @@ final class AppModel {
             actions.append(PaletteAction(
                 id: "playback.play",
                 title: "Play",
+                searchTitle: "Play",
                 symbol: "play.fill",
                 run: { [weak self] in self?.togglePlayPause() }
             ))
@@ -829,6 +839,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "playback.playNext",
             title: "Play Next",
+            searchTitle: "Play Next",
             symbol: "text.line.first.and.arrowtriangle.forward",
             run: { [weak self] in
                 guard let track = self?.status.currentTrack else { return }
@@ -838,6 +849,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "playback.addToQueue",
             title: "Add to Queue",
+            searchTitle: "Add to Queue",
             symbol: "text.badge.plus",
             run: { [weak self] in
                 guard let track = self?.status.currentTrack else { return }
@@ -849,24 +861,28 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "nav.library",
             title: "Go to Library",
+            searchTitle: "Go to Library",
             symbol: "music.note.list",
             run: { [weak self] in self?.selectTab(.library) }
         ))
         actions.append(PaletteAction(
             id: "nav.home",
             title: "Go to Home",
+            searchTitle: "Go to Home",
             symbol: "house",
             run: { [weak self] in self?.selectTab(.home) }
         ))
         actions.append(PaletteAction(
             id: "nav.discover",
             title: "Go to Discover",
+            searchTitle: "Go to Discover",
             symbol: "sparkles",
             run: { [weak self] in self?.goToDiscover() }
         ))
         actions.append(PaletteAction(
             id: "nav.favorites",
             title: "Go to Favorites",
+            searchTitle: "Go to Favorites",
             symbol: "heart",
             run: { [weak self] in self?.selectTab(.favorites) }
         ))
@@ -878,6 +894,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "app.openPreferences",
             title: "Open Preferences",
+            searchTitle: "Open Preferences",
             symbol: "gearshape",
             run: {
                 // `showSettingsWindow:` is the documented selector for
@@ -907,6 +924,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "playback.toggleShuffle",
             title: "Toggle Shuffle",
+            searchTitle: "Toggle Shuffle",
             symbol: "shuffle",
             run: { [weak self] in
                 guard let self else { return }
@@ -916,6 +934,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "playback.toggleRepeat",
             title: "Toggle Repeat",
+            searchTitle: "Toggle Repeat",
             symbol: "repeat",
             run: { [weak self] in
                 guard let self else { return }
@@ -937,6 +956,7 @@ final class AppModel {
         actions.append(PaletteAction(
             id: "queue.clear",
             title: "Clear Queue",
+            searchTitle: "Clear Queue",
             symbol: "trash",
             run: { [weak self] in
                 // #282: wipe the queue but keep the currently playing track
@@ -951,6 +971,7 @@ final class AppModel {
             actions.append(PaletteAction(
                 id: "download.current",
                 title: "Download Current",
+                searchTitle: "Download Current",
                 symbol: "arrow.down.circle",
                 run: { [weak self] in
                     guard self?.status.currentTrack != nil else { return }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4848,7 +4848,7 @@ final class AppModel {
         guard !trimmed.isEmpty else { return }
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: trimmed, itemIds: [], position: nil)
+                try core.createPlaylist(name: trimmed, itemIds: [])
             }.value
             // The core returns only the id; build a minimal `Playlist`
             // record client-side rather than refetching. An `imageTag` of
@@ -4928,7 +4928,7 @@ final class AppModel {
         let copyName = "\(source.name) Copy"
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: copyName, itemIds: trackIds, position: nil)
+                try core.createPlaylist(name: copyName, itemIds: trackIds)
             }.value
             // Core's `create_playlist` can accept seed items directly; the
             // `itemIds` path above covers the common case. We still build a
@@ -5880,7 +5880,15 @@ final class AppModel {
         // so it never short-circuits an explicit album-end — `skipNext`
         // walks those first and only returns nil when there's genuinely
         // nothing left.
-        guard autoplayWhenQueueEnds, let seed = status.currentTrack else { return }
+        guard autoplayWhenQueueEnds, let seed = status.currentTrack else {
+            // Playback is genuinely over and we're not autoplaying. Tear the
+            // session down so `reportPlaybackStopped` + `stopHeartbeat` run —
+            // otherwise the player keeps a stale `currentTrack` and the server
+            // shows a frozen "Now Playing" until the next user action (the
+            // companion to the core heartbeat Ended-state guard).
+            audio.stop()
+            return
+        }
         playInstantMix(seedId: seed.id)
     }
 
@@ -6273,7 +6281,7 @@ final class AppModel {
         guard !ids.isEmpty else { return }
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: trimmed, itemIds: ids, position: nil)
+                try core.createPlaylist(name: trimmed, itemIds: ids)
             }.value
             // Some older Jellyfin builds ignore the initial `ItemIds` on
             // `create_playlist` and return an empty playlist. Follow up

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3037,8 +3037,12 @@ final class AppModel {
     /// `core.playlistTracks(playlistId:)` for up to 500 entries — same cap as
     /// `loadPlaylistTracks(playlist:)`. Errors surface through the usual
     /// auth / reachability / error-banner path.
-    func loadPlaylistTracks(playlistId: String) async {
-        if let cached = playlistTracks[playlistId] {
+    ///
+    /// Pass `forceRefresh: true` to bypass the cache and re-fetch from the
+    /// server — required after a mutation (e.g. drop-to-add) that changed the
+    /// track list but couldn't reconstruct full `Track` rows locally.
+    func loadPlaylistTracks(playlistId: String, forceRefresh: Bool = false) async {
+        if !forceRefresh, let cached = playlistTracks[playlistId] {
             currentPlaylistTracks = cached
             return
         }
@@ -3225,9 +3229,21 @@ final class AppModel {
     /// `PlaylistDetailView` and any future "Add to playlist" affordance. See
     /// #236. Updates the in-memory caches optimistically and fires the core
     /// call in a detached task.
+    ///
+    /// We only know the bare track ids here, not full `Track` records, so the
+    /// visible list can't be appended to optimistically. Instead, on a
+    /// successful add we invalidate `playlistTracks[playlistId]` and — when
+    /// that playlist is the one currently on screen — re-fetch it so the new
+    /// rows actually appear. Without this the drop "succeeds" but the list
+    /// keeps showing the pre-drop tracks (the cache was never refreshed).
     func addToPlaylist(playlistId: String, trackIds: [String]) {
         guard !trackIds.isEmpty else { return }
         let ids = trackIds
+        // Is this the playlist currently on screen? `currentPlaylistTracks` is
+        // populated from `playlistTracks[playlistId]` whenever a playlist
+        // loads, so matching id sequences means the detail view is showing it
+        // and needs a re-fetch once the add lands.
+        let isShowingThisPlaylist = playlistTracks[playlistId]?.map(\.id) == currentPlaylistTracks.map(\.id)
         // Optimistically bump the count BEFORE the FFI call so the drop
         // visually lands without waiting for the round-trip. We don't know
         // the full `Track` records for ids that aren't already resident, so
@@ -3252,7 +3268,16 @@ final class AppModel {
                 try await Task.detached(priority: .userInitiated) { [core] in
                     try core.addToPlaylist(playlistId: playlistRef, itemIds: ids, position: nil)
                 }.value
-                self?.serverReachability.noteSuccess()
+                guard let self else { return }
+                self.serverReachability.noteSuccess()
+                // The add persisted but we only had bare ids, so the cached
+                // rows are now stale (missing the new tracks). Invalidate the
+                // cache and, if this playlist is on screen, re-fetch so the
+                // dropped tracks actually appear in the list.
+                self.playlistTracks[playlistRef] = nil
+                if isShowingThisPlaylist {
+                    await self.loadPlaylistTracks(playlistId: playlistRef, forceRefresh: true)
+                }
             } catch {
                 guard let self else { return }
                 if self.handleAuthError(error) { return }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -6175,35 +6175,52 @@ final class AppModel {
     /// contract as SwiftUI `List.onMove`, so the inspector can wire this up
     /// directly. See #80.
     ///
-    /// Today this only reorders the in-app overlay because the core has no
-    /// `reorder_queue` primitive. When that lands (TODO(core-#282)), this
-    /// should also push the new order down to `core.setQueue` so the
-    /// engine's view of "what plays next" matches the inspector.
+    /// Reorders the in-app overlay, then rebuilds and pushes the flat queue to
+    /// `core.setQueue` via `syncCoreQueueAfterReorder()` so the engine's view
+    /// of "what plays next" matches the inspector (#565).
     func moveUpNext(from source: IndexSet, to destination: Int) {
         upNextUserAdded.move(fromOffsets: source, toOffset: destination)
-        // Sync the reordered user-added list to the Rust core (#565).
-        // Rebuild a flat track array — current track at index 0, then the
-        // reordered Up Next overlay, then the auto-queue tail — and hand it
-        // back to `core.setQueue` with startIndex 0 so the engine keeps
-        // playing the current track while honouring the new order for
-        // everything that follows. The `try?` silences the throw so a core
-        // hiccup (e.g. session not ready) doesn't crash the UI.
+        syncCoreQueueAfterReorder()
+    }
+
+    /// Rebuild the flat core queue from the current inspector state and push
+    /// it down to `core.setQueue` so the engine's "what plays next" matches
+    /// the inspector's Up Next order (#565). Layout: current track at index 0,
+    /// then the (possibly reordered / shuffled / pruned) user-added overlay,
+    /// then the auto-queue tail. `startIndex: 0` keeps the current track
+    /// playing while honouring the new order for everything that follows.
+    ///
+    /// Shared by `moveUpNext`, `shuffleUpNext`, and `removeFromUpNext` so all
+    /// three actually re-sequence playback rather than only mutating the Swift
+    /// overlay. Errors surface on `errorMessage` (auth failures route through
+    /// `handleAuthError`) instead of being swallowed by `try?`, so a failed
+    /// sync is visible rather than silently leaving the engine on the old
+    /// order.
+    private func syncCoreQueueAfterReorder() {
         var allTracks: [Track] = []
         if let current = status.currentTrack { allTracks.append(current) }
         allTracks.append(contentsOf: upNextUserAdded.map(\.track))
         allTracks.append(contentsOf: upNextAutoQueue.map(\.track))
         guard !allTracks.isEmpty else { return }
-        try? core.setQueue(tracks: allTracks, startIndex: 0)
+        do {
+            _ = try core.setQueue(tracks: allTracks, startIndex: 0)
+        } catch {
+            if handleAuthError(error) { return }
+            errorMessage = LyrebirdErrorPresenter.message(for: error, context: .playback)
+        }
     }
 
     /// Remove one entry from the user-added "Up Next" list by its stable
     /// per-item `queueId`. Uses `queueId` rather than `track.id` so users
     /// can queue the same track twice and still remove a single instance.
     /// See #80.
+    ///
+    /// After pruning the overlay we rebuild and push the core queue so the
+    /// removed track actually drops out of playback — previously this mutated
+    /// only the Swift overlay and the engine still played the removed track.
     func removeFromUpNext(id: UUID) {
         upNextUserAdded.removeAll { $0.id == id }
-        // TODO(core-#282): drop the corresponding entry in the core queue
-        // once we have an addressable `remove_from_queue` primitive.
+        syncCoreQueueAfterReorder()
     }
 
     // MARK: - Queue actions (BATCH-07b, #284)
@@ -6306,9 +6323,44 @@ final class AppModel {
     func shuffleUpNext() {
         guard upNextUserAdded.count > 1 else { return }
         upNextUserAdded.shuffle()
-        // TODO(core-#282): when `reorder_queue` / `shuffle_queue` exists,
-        // push the new order down so the engine plays in the shuffled
-        // order rather than its original load order.
+        // Push the shuffled order down so the engine plays in the new order
+        // rather than its original load order — same rebuild contract as
+        // `moveUpNext`.
+        syncCoreQueueAfterReorder()
+    }
+
+    /// Jump playback to a specific queue entry (the Queue Inspector's
+    /// double-click on an Up Next / "Playing From" row). Rebuilds the flat
+    /// track list the inspector shows — current track, then the user-added
+    /// overlay, then the auto-queue tail — locates `entry` by its stable
+    /// per-instance `queueId`, and replays the whole list starting at that
+    /// index via `play(tracks:startIndex:)`. Routing through `play(...)`
+    /// means the core queue is re-seated and the engine auto-advances from
+    /// the jumped track onward, exactly like picking a track from a track
+    /// list. Matching by `queueId` (not `track.id`) means double-clicking the
+    /// second of two identical tracks jumps to that instance, not the first.
+    ///
+    /// No-ops if the entry isn't found in the current queue (e.g. it was
+    /// removed between render and tap).
+    func jumpToQueueEntry(_ entry: Queue) {
+        guard let plan = queueJumpPlan(for: entry.id) else { return }
+        play(tracks: plan.tracks, startIndex: plan.startIndex)
+    }
+
+    /// Pure helper for `jumpToQueueEntry`: flattens the inspector's three
+    /// sections into the play order (current track, then user-added overlay,
+    /// then auto-queue tail) and resolves `queueId` to a `(tracks,
+    /// startIndex)` pair for `play(tracks:startIndex:)`. Factored out so the
+    /// index arithmetic — which has to account for the current track
+    /// occupying slot 0 — is unit-testable without the playback FFI. Returns
+    /// `nil` when the id isn't present in any section.
+    func queueJumpPlan(for queueId: UUID) -> (tracks: [Track], startIndex: Int)? {
+        var entries: [Queue] = []
+        if let current = status.currentTrack { entries.append(Queue(track: current)) }
+        entries.append(contentsOf: upNextUserAdded)
+        entries.append(contentsOf: upNextAutoQueue)
+        guard let index = entries.firstIndex(where: { $0.id == queueId }) else { return nil }
+        return (entries.map(\.track), index)
     }
 
     /// Navigate to the source that started the current auto queue. Wired

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3419,6 +3419,15 @@ final class AppModel {
         playInstantMix(seedId: seedId)
     }
 
+    /// Start a radio station seeded from a pinned-station subject (#253). The
+    /// Home "Pinned Stations" row routes artist / mood / mix tiles here; the
+    /// stored id is a real Jellyfin item id (or a mood/mix seed), which
+    /// `core.instantMix` accepts polymorphically. Genre and playlist tiles
+    /// take their own routes (`browseGenre` / `navigate(to:.playlist)`).
+    func startStationRadio(seedId: String) {
+        playInstantMix(seedId: seedId)
+    }
+
     /// Re-seed the Instant Mix with a different track than the current one.
     /// Picks a random track from `recentlyPlayed` excluding the currently-
     /// playing track, so "Generate new mix" actually sounds different. Falls

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -489,8 +489,31 @@ final class AppModel {
     /// source (e.g. a single track picked from "All Tracks").
     var currentContext: QueueContext?
     /// Show / hide the right-side queue inspector panel. Toggled by the
-    /// Cmd+Opt+Q shortcut (#79).
+    /// Cmd+Opt+Q shortcut (#79) and the View ▸ "Show Queue" menu item.
+    /// `toggleQueueInspector()` lives in the Queue-inspector section below.
     var isQueueInspectorOpen: Bool = false
+
+    /// Mirror of `MainShell`'s `NavigationSplitView` column visibility, exposed
+    /// so the View ▸ "Show Sidebar" menu item can render a checkmark that
+    /// tracks the real rail state. `MainShell` is the source of truth — it owns
+    /// the `@State columnVisibility` plus the width-driven auto-hide reducer —
+    /// and writes this on every change (toolbar toggle, separator drag, restore).
+    /// `true` whenever the sidebar column is showing (`.all` / `.doubleColumn`).
+    var isSidebarVisible: Bool = true
+
+    /// One-shot, monotonic request to flip the sidebar. The menu can't write
+    /// `MainShell`'s private `columnVisibility` directly, and driving it through
+    /// a plain `Bool` would fight the auto-hide reducer's own writes, so the
+    /// menu bumps this counter and `MainShell` observes it and runs its
+    /// existing `toggleSidebarManually()` (which records the manual override so
+    /// width-driven auto-hide steps aside). Counter so a second request with the
+    /// rail already in the requested state still produces an observable change.
+    private(set) var sidebarToggleRequest: Int = 0
+
+    /// Ask `MainShell` to toggle the sidebar. See `sidebarToggleRequest`.
+    func requestSidebarToggle() {
+        sidebarToggleRequest += 1
+    }
 
     /// Tracks played earlier in *this app session*, most-recent first. The
     /// full-page Play Queue view (⌘U, #81) renders this above Now Playing as

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4687,8 +4687,14 @@ final class AppModel {
 
     /// Present a save panel and write the playlist to disk as an extended-M3U
     /// (`.m3u8`) file. Fetches the playlist's tracks via `playlist_tracks` FFI,
-    /// then delegates the string-building to `PlaylistExport.m3u8`. Stream URLs
-    /// are written without auth tokens so the file is safe to share (#76 / #237).
+    /// then delegates the string-building to `PlaylistExport.m3u8`.
+    ///
+    /// Stream URLs embed the server `api_key` so the exported file is actually
+    /// playable in an external player — a bare `/universal` path requires the
+    /// `Authorization` header and 401s for a generic M3U player (#76 / #237).
+    /// Because that bakes a credential into the file, the save panel warns the
+    /// user before they write it. If the token can't be resolved, the export
+    /// falls back to auth-free (prompt-on-play) URLs.
     func exportPlaylist(playlist: Playlist) {
         Task {
             // Fetch tracks before opening the panel so we know the export
@@ -4698,18 +4704,50 @@ final class AppModel {
                 errorMessage = "No tracks to export for \"\(playlist.name)\"."
                 return
             }
+            // Resolve the server token off the main actor (single FFI call,
+            // not per-track) so the M3U entries authenticate on their own.
+            let apiKey = await resolveExportApiKey(sampleTrackId: tracks.first?.id)
             let content = PlaylistExport.m3u8(
                 playlistName: playlist.name,
                 tracks: tracks,
-                serverURL: serverURL
+                serverURL: serverURL,
+                apiKey: apiKey
             )
             writeExport(
                 content,
                 suggestedName: "\(playlist.name).m3u8",
                 fileExtension: "m3u8",
-                panelTitle: "Export Playlist as .m3u8"
+                panelTitle: "Export Playlist as .m3u8",
+                warning: apiKey == nil
+                    ? nil
+                    : "This .m3u8 embeds your server access key so the tracks play in another app. Anyone you share the file with can stream your library with it — treat it like a password."
             )
         }
+    }
+
+    /// Extract the Jellyfin `api_key` the app authenticates with, for embedding
+    /// in an exported `.m3u8` so its entries are playable standalone. There's
+    /// no dedicated token FFI, so we read it out of `core.streamUrl(...)` —
+    /// which builds the same authenticated URL the audio engine streams from —
+    /// and pull the `api_key` query item. Runs off the main actor (the FFI
+    /// takes the Rust `Inner` mutex) and returns `nil` if the URL can't be
+    /// built or carries no key, in which case the caller emits auth-free URLs.
+    private func resolveExportApiKey(sampleTrackId: String?) async -> String? {
+        guard let sampleTrackId else { return nil }
+        let urlString: String?
+        do {
+            urlString = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.streamUrl(trackId: sampleTrackId, mediaSourceId: nil, playSessionId: nil)
+            }.value
+        } catch {
+            return nil
+        }
+        guard let urlString,
+              let components = URLComponents(string: urlString),
+              let key = components.queryItems?.first(where: { $0.name == "api_key" })?.value,
+              !key.isEmpty
+        else { return nil }
+        return key
     }
 
     /// Present a save panel and write the playlist to disk as a JSON manifest
@@ -4747,17 +4785,25 @@ final class AppModel {
     /// Shared `NSSavePanel` IO for the playlist export formats. Presents the
     /// panel on the main actor and writes `content` to the chosen URL, routing
     /// any failure to `errorMessage`. A user cancel is a silent no-op.
+    ///
+    /// `warning`, when non-nil, is shown in the panel's message area before the
+    /// user commits — used by the M3U export to disclose that the file embeds a
+    /// server credential.
     private func writeExport(
         _ content: String,
         suggestedName: String,
         fileExtension: String,
-        panelTitle: String
+        panelTitle: String,
+        warning: String? = nil
     ) {
         let panel = NSSavePanel()
         panel.title = panelTitle
         panel.nameFieldStringValue = suggestedName
         panel.allowedContentTypes = [.init(filenameExtension: fileExtension) ?? .plainText]
         panel.canCreateDirectories = true
+        if let warning {
+            panel.message = warning
+        }
 
         let response = panel.runModal()
         guard response == .OK, let url = panel.url else { return }
@@ -4995,6 +5041,21 @@ final class AppModel {
     func applyPlaylistDrop(playlistId: String, trackId: String, destinationIndex: Int) {
         guard let tracks = playlistTracks[playlistId] else { return }
         guard let sourceIndex = tracks.firstIndex(where: { $0.id == trackId }) else { return }
+        moveTrackInPlaylist(playlistId: playlistId, from: sourceIndex, to: destinationIndex)
+    }
+
+    /// Index-addressed variant of `applyPlaylistDrop`. The drag payload carries
+    /// the source row's index (see `PlaylistReorderPayload`), which is the only
+    /// thing that disambiguates a duplicated track: when the same track id
+    /// appears more than once in a playlist, resolving by id alone always moves
+    /// the first copy. Routing by index moves the exact copy the user grabbed.
+    ///
+    /// The index is validated against the *current* cached order before the
+    /// move, so a stale index from a list that mutated mid-drag is dropped
+    /// rather than moving the wrong row.
+    func applyPlaylistDrop(playlistId: String, sourceIndex: Int, destinationIndex: Int) {
+        guard let tracks = playlistTracks[playlistId] else { return }
+        guard sourceIndex >= 0, sourceIndex < tracks.count else { return }
         moveTrackInPlaylist(playlistId: playlistId, from: sourceIndex, to: destinationIndex)
     }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -3986,6 +3986,10 @@ final class AppModel {
     // MARK: - Playback
 
     func play(tracks: [Track], startIndex: Int = 0) {
+        // Starting a fresh queue disarms any leftover "Stop after current
+        // track" one-shot — "Resets to off the next time you start
+        // playback" (#116).
+        AppModel.resetStopAfterCurrent()
         do {
             _ = try core.setQueue(tracks: tracks, startIndex: UInt32(startIndex))
             guard let first = tracks[safe: startIndex] else { return }
@@ -5769,9 +5773,61 @@ final class AppModel {
     /// track. A no-op when the queue holds nothing further (end of queue), in
     /// which case the engine simply has no item to splice ahead. Single source
     /// of truth shared by the normal advance and stall recovery (#931).
+    ///
+    /// Gated on the user's "Gapless playback" preference (#116): when off, the
+    /// engine is never handed a queued-ahead item, so each track ends cleanly
+    /// before `handleTrackEnded` rebuilds the next via `play(track:)` — the
+    /// gap-prone path becomes the *intended* behaviour rather than a fallback.
     private func armNextTrackPreload() {
+        guard AppModel.gaplessEnabled else { return }
         guard let next = nextTrackForPreload else { return }
         audio.preloadNextTrack(next)
+    }
+
+    // MARK: - Playback behaviour preferences (#116)
+
+    /// UserDefaults key for the "Gapless playback" toggle in the Playback
+    /// pane. Kept in sync with `PreferencesPlayback`'s `@AppStorage`.
+    private static let gaplessEnabledKey = "playback.gaplessEnabled"
+
+    /// UserDefaults key for the "Stop after current track" toggle in the
+    /// Playback pane. Kept in sync with `PreferencesPlayback`'s `@AppStorage`.
+    private static let stopAfterCurrentKey = "playback.stopAfterCurrent"
+
+    /// Resolve the persisted gapless flag, defaulting to `true` when the key
+    /// has never been written. `UserDefaults.bool(forKey:)` returns `false`
+    /// for a missing key, which would silently invert this feature's
+    /// "default on" contract (the toggle ships on), so probe for the object
+    /// first — same pattern as `autoplayWhenQueueEndsDefault`.
+    static var gaplessEnabled: Bool {
+        guard UserDefaults.standard.object(forKey: gaplessEnabledKey) != nil else {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: gaplessEnabledKey)
+    }
+
+    /// Read **and clear** the "Stop after current track" one-shot. Returns
+    /// `true` exactly once per arming: `handleTrackEnded` calls this, and a
+    /// `true` result both halts the advance and disarms the toggle so the
+    /// next end-of-track transition behaves normally. Defaults to `false`
+    /// for an unset key (the toggle ships off), which `bool(forKey:)` already
+    /// returns, so no object-probe is needed here.
+    static func consumeStopAfterCurrent() -> Bool {
+        let armed = UserDefaults.standard.bool(forKey: stopAfterCurrentKey)
+        if armed {
+            UserDefaults.standard.set(false, forKey: stopAfterCurrentKey)
+        }
+        return armed
+    }
+
+    /// Disarm "Stop after current track" when a fresh playback session
+    /// begins. Honours the toggle's documented contract — "Resets to off the
+    /// next time you start playback" — so an arming left over from a previous
+    /// session can never silently stop the user one track into a new queue.
+    private static func resetStopAfterCurrent() {
+        if UserDefaults.standard.bool(forKey: stopAfterCurrentKey) {
+            UserDefaults.standard.set(false, forKey: stopAfterCurrentKey)
+        }
     }
 
     #if DEBUG
@@ -5860,6 +5916,14 @@ final class AppModel {
     }
 
     private func handleTrackEnded() {
+        // "Stop after current track" (#116): when armed, halt at this
+        // track's end instead of advancing, and disarm the one-shot so the
+        // queue resumes normally afterwards. Checked before `skipNext()` so
+        // the playhead never moves past the track the user wanted to stop on.
+        if AppModel.consumeStopAfterCurrent() {
+            stop()
+            return
+        }
         // Advance to the next track in the queue if there is one. Arm the
         // gapless pre-load for the track *after* this new one so the next
         // end-of-track transition is seamless — without this the freshly

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -4479,12 +4479,17 @@ final class AppModel {
         isFavorite(artist: artist)
     }
 
-    /// Insert a handful of the artist's top tracks immediately after the
-    /// currently-playing track. Uses the `core.playNext` primitive wired
-    /// in for #282. Falls back silently when there are no top tracks to load.
+    /// Insert the artist's full catalog immediately after the currently-playing
+    /// track. Loads the same track set as `playAll(artist:)` / `shuffle(artist:)`
+    /// (via `loadTracks(forArtist:)`, the 500-track soft cap) so "Play Next"
+    /// queues the whole artist — matching `playNext(album:)` — rather than just
+    /// the top-tracks teaser. Uses the `core.playNext` primitive wired in for
+    /// #282; falls back to `play` when nothing is currently playing so the menu
+    /// item never queues into an empty player. Silent no-op when the artist has
+    /// no loadable tracks.
     func playNextArtist(artist: Artist) {
         Task {
-            let tracks = await loadArtistTopTracks(artistId: artist.id)
+            let tracks = await loadTracks(forArtist: artist.id)
             guard !tracks.isEmpty else { return }
             if status.currentTrack == nil {
                 play(tracks: tracks, startIndex: 0)

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -42,4 +42,14 @@ extension AppModel {
     /// `supportsMarkPlayed` / `supportsArtistPlayShuffle` for the same
     /// pattern.
     var supportsGenreActions: Bool { true }
+
+    /// Playlist search results. The current `core.search` endpoint does
+    /// not return playlists, so `bucketSearchResults` leaves that bucket
+    /// empty. Gating the Playlists scope chip + section behind this flag
+    /// keeps the full-search page from exposing a permanently-empty scope
+    /// whose section can only ever say "No playlists matched this query."
+    /// Flip to `true` — and populate the bucket in `bucketSearchResults`
+    /// — once the core surfaces playlists through `search`. Same pattern
+    /// as `supportsGenreActions`.
+    var supportsPlaylistSearch: Bool { false }
 }

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -42,4 +42,22 @@ extension AppModel {
     /// `supportsMarkPlayed` / `supportsArtistPlayShuffle` for the same
     /// pattern.
     var supportsGenreActions: Bool { true }
+
+    /// In-app UI localization (#345). Gates the General ▸ Language picker.
+    /// The picker only persists `general.language` today — nothing reads it
+    /// back to set `AppleLanguages`, override the bundle locale, or otherwise
+    /// re-render the UI in another language, and `AppLanguage` only offers
+    /// System / English (both no-ops). Flag stays `false` so the inert control
+    /// isn't presented as a working setting; flips to `true` once the strings
+    /// catalog ships real locales and the runtime override is wired.
+    var supportsLanguageSelection: Bool { false }
+
+    /// Theme selection (#405). Gates the Appearance ▸ Theme picker. Choosing a
+    /// swatch persists `appearance.theme`, but no live surface reads it back —
+    /// `Theme.primary` / `Theme.accent` are still fixed brand constants, so the
+    /// selection can't recolour the UI yet (the theme engine wiring is #405).
+    /// Flag stays `false` so the picker renders as a disabled "coming soon"
+    /// preview rather than masquerading as a working selector; flips to `true`
+    /// once `Theme` resolves its accent/primary from the persisted preset.
+    var supportsThemeSelection: Bool { false }
 }

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -42,4 +42,23 @@ extension AppModel {
     /// `supportsMarkPlayed` / `supportsArtistPlayShuffle` for the same
     /// pattern.
     var supportsGenreActions: Bool { true }
+
+    /// Streaming / download quality + preferred-codec selection (#260).
+    /// Gates the quality and codec pickers in the Audio pane. These need
+    /// the core to thread `MaxStreamingBitrate` + a `DeviceProfile`
+    /// (audio codec / container) into the Jellyfin `PlaybackInfo`
+    /// request; `core/src/client.rs` has no such parameter yet, so the
+    /// pickers would write a preference nothing reads. Disabled until the
+    /// core FFI lands rather than presenting controls that don't affect
+    /// playback.
+    var supportsStreamQualitySelection: Bool { false }
+
+    /// Crossfade between tracks (#116). Gates the crossfade slider in the
+    /// Playback pane. Overlapping the tail of one track with the head of
+    /// the next needs a second player / mixer in `AudioEngine`; the
+    /// engine has no crossfade path today, so the slider would persist a
+    /// value nothing honours. Disabled until the engine supports
+    /// overlapping playback. Gapless (no-overlap joins) is a separate,
+    /// already-wired feature — see `armNextTrackPreload`.
+    var supportsCrossfade: Bool { false }
 }

--- a/macos/Sources/Lyrebird/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/ArtistContextMenu.swift
@@ -31,8 +31,8 @@ struct ArtistContextMenu: View {
             Button("Play All", systemImage: "play.fill") { model.playAll(artist: artist) }
             Button("Shuffle All", systemImage: "shuffle") { model.shuffle(artist: artist) }
         }
-        // Play Next falls through to top-tracks playback today, so it works
-        // without the artist-tracks FFI.
+        // Play Next inserts the artist's full catalog after the current track,
+        // matching album/track "Play Next" rather than only the top-tracks teaser.
         Button("Play Next", systemImage: "text.insert") { model.playNextArtist(artist: artist) }
 
         Divider()

--- a/macos/Sources/Lyrebird/Components/CommandPalette.swift
+++ b/macos/Sources/Lyrebird/Components/CommandPalette.swift
@@ -50,6 +50,13 @@ struct CommandPalette: View {
     /// last-known `libraryResults` underneath.
     @State private var isSearching: Bool = false
 
+    /// Set when the most recent library search threw (network / auth /
+    /// transient). Drives an inline error row distinct from the "No matches"
+    /// empty state so a failed round-trip isn't silently indistinguishable
+    /// from a genuinely empty result. Cleared on the next keystroke and on a
+    /// successful search. See audit CommandPalette.swift:427.
+    @State private var searchError: String?
+
     @FocusState private var searchFocused: Bool
 
     /// Debounce window before a library search fires. 80ms is snappy enough
@@ -120,6 +127,7 @@ struct CommandPalette: View {
                 debouncedQuery = ""
                 libraryResults = nil
                 isSearching = false
+                searchError = nil
                 selectedIndex = 0
                 return
             }
@@ -221,20 +229,32 @@ struct CommandPalette: View {
     @ViewBuilder
     private var resultsScroll: some View {
         if visibleRows.isEmpty {
-            VStack(spacing: 6) {
-                Text("No matches")
-                    .font(Theme.font(13, weight: .semibold))
-                    .foregroundStyle(Theme.ink2)
-                Text("Try a different query or ⌘1..5 to filter by category.")
-                    .font(Theme.font(11, weight: .medium))
-                    .foregroundStyle(Theme.ink3)
+            if let searchError {
+                // Distinct from "No matches": a thrown search means we don't
+                // actually know whether results exist, so don't claim "none".
+                searchErrorView(searchError)
+            } else {
+                VStack(spacing: 6) {
+                    Text("No matches")
+                        .font(Theme.font(13, weight: .semibold))
+                        .foregroundStyle(Theme.ink2)
+                    Text("Try a different query or ⌘1..5 to filter by category.")
+                        .font(Theme.font(11, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 48)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 48)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: 0) {
+                        if searchError != nil {
+                            // Non-fatal badge above retained rows: the rows may
+                            // be stale (kept from a prior keystroke), so flag
+                            // that the latest search didn't land.
+                            searchErrorBanner
+                        }
                         ForEach(Array(visibleRows.enumerated()), id: \.offset) { idx, row in
                             PaletteRow(
                                 row: row,
@@ -265,11 +285,50 @@ struct CommandPalette: View {
         }
     }
 
+    /// Full-height error state shown when a search threw and there are no
+    /// rows to fall back on. Visually distinct from the "No matches" empty
+    /// state so the user can tell a failure from a genuinely empty result.
+    private func searchErrorView(_ message: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+            Text("Search failed")
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+            Text(message)
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 48)
+        .padding(.horizontal, 24)
+        .accessibilityElement(children: .combine)
+    }
+
+    /// Slim inline badge drawn above retained (possibly stale) rows when the
+    /// latest search threw but earlier results are still on screen.
+    private var searchErrorBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 11, weight: .semibold))
+            Text("Search couldn’t refresh — showing earlier results.")
+                .font(Theme.font(11, weight: .medium))
+                .lineLimit(1)
+            Spacer()
+        }
+        .foregroundStyle(Theme.ink3)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+    }
+
     private var hintsRow: some View {
         HStack(spacing: 18) {
             hint("\u{2191}\u{2193}", "navigate")
             hint("\u{21A9}", "select")
-            hint("\u{2318}\u{21A9}", "new window")
             hint("Esc", "close")
             Spacer()
         }
@@ -297,14 +356,25 @@ struct CommandPalette: View {
         case artist(Artist)
         case album(Album)
         case track(Track)
-        case action(String) // PaletteAction.id
+        // Carries the resolved `PaletteAction` so the row renders its
+        // (localized) title + authoritative symbol straight off the model —
+        // no parallel id→title/symbol tables to drift. Identity is the
+        // action's `id`, so `PaletteAction` need not itself be `Hashable`.
+        case action(AppModel.PaletteAction)
+
+        /// The action id for a `.action` row, else `nil`. Used by the pin
+        /// affordances and the commit dispatcher.
+        var actionId: String? {
+            if case .action(let a) = self { return a.id }
+            return nil
+        }
 
         func hash(into hasher: inout Hasher) {
             switch self {
             case .artist(let a): hasher.combine(0); hasher.combine(a.id)
             case .album(let a): hasher.combine(1); hasher.combine(a.id)
             case .track(let t): hasher.combine(2); hasher.combine(t.id)
-            case .action(let id): hasher.combine(3); hasher.combine(id)
+            case .action(let a): hasher.combine(3); hasher.combine(a.id)
             }
         }
 
@@ -313,7 +383,7 @@ struct CommandPalette: View {
             case (.artist(let a), .artist(let b)): return a.id == b.id
             case (.album(let a), .album(let b)): return a.id == b.id
             case (.track(let a), .track(let b)): return a.id == b.id
-            case (.action(let a), .action(let b)): return a == b
+            case (.action(let a), .action(let b)): return a.id == b.id
             default: return false
             }
         }
@@ -344,7 +414,7 @@ struct CommandPalette: View {
         }
 
         if actionsVisible {
-            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty {
                 // #308: empty query surfaces Pinned first, then Recent, then
                 // the remaining roster — each action exactly once. Both the
@@ -354,17 +424,32 @@ struct CommandPalette: View {
                 // the live ids drops those stale entries silently.
                 rows.append(contentsOf: orderedActionRows())
             } else {
-                for action in model.paletteActions {
-                    // Action matching is intentionally prefix-only so typing
-                    // "play" shows "Play" / "Play Next" but not unrelated
-                    // verbs.
-                    if actionTitleString(action).lowercased().hasPrefix(trimmed) {
-                        rows.append(.action(action.id))
-                    }
+                for action in model.paletteActions
+                where CommandPalette.actionMatches(action.searchTitle, query: trimmed) {
+                    rows.append(.action(action))
                 }
             }
         }
         return rows
+    }
+
+    /// Whether a palette action whose title is `title` should surface for the
+    /// user's `query`. Matching is substring-first (so "preferences",
+    /// "shuffle", "queue", "favorites", "library" all hit), with a
+    /// whitespace-token prefix pass so a query like "fav" also matches the
+    /// "Favorites" token inside "Go to Favorites". Both sides are lowercased
+    /// for case-insensitivity. Pure + static so the contract is unit-testable
+    /// without constructing the view.
+    static func actionMatches(_ title: String, query: String) -> Bool {
+        let needle = query
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !needle.isEmpty else { return true }
+        let haystack = title.lowercased()
+        if haystack.contains(needle) { return true }
+        return haystack
+            .split(whereSeparator: { $0.isWhitespace })
+            .contains { $0.hasPrefix(needle) }
     }
 
     /// Empty-query action ordering: Pinned → Recent → the rest, deduped, in
@@ -373,27 +458,32 @@ struct CommandPalette: View {
     /// `paletteActions`) never appears even if its id lingers in a persisted
     /// pinned/recent list. See #308.
     private func orderedActionRows() -> [Row] {
-        let rosterIds = model.paletteActions.map(\.id)
-        let rosterSet = Set(rosterIds)
+        let roster = model.paletteActions
+        let rosterIds = roster.map(\.id)
+        // Resolve ids back to live actions so the row carries the model
+        // (title + symbol) rather than just an id. A persisted pinned/recent
+        // id with no live action (capability flag off) resolves to nil and is
+        // dropped — same silent-skip contract as before.
+        let byId = Dictionary(uniqueKeysWithValues: roster.map { ($0.id, $0) })
 
-        var ordered: [String] = []
+        var ordered: [Row] = []
         var seen = Set<String>()
         func push(_ ids: [String]) {
-            for id in ids where rosterSet.contains(id) && seen.insert(id).inserted {
-                ordered.append(id)
+            for id in ids where seen.insert(id).inserted {
+                if let action = byId[id] { ordered.append(.action(action)) }
             }
         }
         push(model.palettePinnedActionIds)
         push(model.paletteRecentActionIds)
         push(rosterIds) // the remainder, in the roster's own order
-        return ordered.map(Row.action)
+        return ordered
     }
 
     /// Whether `row` is a currently-pinned action. Library rows can't be
     /// pinned (pin/unpin is an action-only affordance for #308), so they
     /// always report `false`.
     private func isPinned(_ row: Row) -> Bool {
-        guard case .action(let id) = row else { return false }
+        guard let id = row.actionId else { return false }
         return model.isPaletteActionPinned(id: id)
     }
 
@@ -403,7 +493,7 @@ struct CommandPalette: View {
     /// See #308.
     @ViewBuilder
     private func pinContextMenu(for row: Row) -> some View {
-        if case .action(let id) = row {
+        if let id = row.actionId {
             let pinned = model.isPaletteActionPinned(id: id)
             Button {
                 model.togglePaletteActionPin(id: id)
@@ -424,12 +514,16 @@ struct CommandPalette: View {
             }.value
             guard runId == searchRunId else { return }
             libraryResults = results
+            searchError = nil
         } catch {
-            // Silent on error — the palette stays on the last-known results
-            // (or empty state) rather than surfacing an error banner over
-            // what is already an ephemeral overlay.
+            // Surface the failure: a thrown search (network / auth / transient)
+            // must be distinguishable from a genuinely empty result, so we
+            // log it and badge an inline error row (see `searchError`). Keep
+            // the last-known `libraryResults` rather than clearing to nil so a
+            // single flaky round-trip mid-typing doesn't wipe good rows.
             guard runId == searchRunId else { return }
-            libraryResults = nil
+            Log.app.error("CommandPalette search failed query=\(query, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            searchError = error.localizedDescription
         }
     }
 
@@ -458,8 +552,8 @@ struct CommandPalette: View {
         case .track(let track):
             model.play(tracks: [track], startIndex: 0)
             close()
-        case .action(let id):
-            model.executePaletteAction(id: id)
+        case .action(let action):
+            model.executePaletteAction(id: action.id)
             // executePaletteAction flips isCommandPaletteOpen itself, but
             // belt-and-suspenders: ensure close fires so the transition
             // animation kicks off even if the action closure errors out.
@@ -471,27 +565,12 @@ struct CommandPalette: View {
         model.isCommandPaletteOpen = false
     }
 
-    private func actionTitleString(_ action: AppModel.PaletteAction) -> String {
-        // `LocalizedStringKey` doesn't expose its raw string directly. The
-        // titles we ship are fixed English literals (no localization tables
-        // registered yet), so bridging via `String(describing:)` retrieves
-        // the underlying key string which is also the display string.
-        // Swap for proper localization once a strings catalog lands.
-        let mirror = Mirror(reflecting: action.title)
-        for child in mirror.children {
-            if child.label == "key", let key = child.value as? String {
-                return key
-            }
-        }
-        return ""
-    }
-
     // MARK: - Keyboard
 
     /// Invisible button overlay that binds the palette's non-text shortcuts.
     /// Return is handled by the TextField's `.onSubmit`, and Esc is handled
     /// by the scrim button's `.cancelAction`; both are intentionally absent
-    /// from this block so ⌘-Return and Esc reach one handler apiece rather
+    /// from this block so Return and Esc reach one handler apiece rather
     /// than racing with the TextField. Arrow keys need this channel because
     /// SwiftUI's `onKeyPress` doesn't reach through a focused TextField on
     /// macOS 14 reliably. `.opacity(0)` + `.allowsHitTesting(false)` keep
@@ -503,8 +582,6 @@ struct CommandPalette: View {
                 .keyboardShortcut(.downArrow, modifiers: [])
             Button("Up", action: { moveSelection(by: -1) })
                 .keyboardShortcut(.upArrow, modifiers: [])
-            Button("New Window", action: commitInNewWindow)
-                .keyboardShortcut(.return, modifiers: .command)
             Button("All", action: { category = .all })
                 .keyboardShortcut("1", modifiers: .command)
             Button("Artists", action: { category = .artists })
@@ -538,15 +615,6 @@ struct CommandPalette: View {
             selectedIndex = next
         }
     }
-
-    /// ⌘↩ placeholder — issue #309 calls out "open in new window" as a
-    /// future affordance. For now it falls through to the standard commit
-    /// so the keybinding lands on something and the user isn't stuck. Swap
-    /// to the real per-row new-window dispatcher when that ships.
-    private func commitInNewWindow() {
-        // TODO(#309): wire a real "open in new window" path.
-        commitSelection()
-    }
 }
 
 // MARK: - Row
@@ -568,7 +636,7 @@ struct PaletteRow: View {
                 .foregroundStyle(Theme.ink2)
                 .frame(width: 22, height: 22, alignment: .center)
             VStack(alignment: .leading, spacing: 1) {
-                Text(primaryText)
+                primaryTextView
                     .font(Theme.font(13, weight: .semibold))
                     .foregroundStyle(Theme.ink)
                     .lineLimit(1)
@@ -610,21 +678,23 @@ struct PaletteRow: View {
         case .artist: return "person"
         case .album: return "square.stack"
         case .track: return "music.note"
-        case .action(let id):
-            // Pulling the symbol off `paletteActions` in the parent and
-            // passing it in would mean threading an extra parameter — the
-            // id → symbol map below stays in one place so the row doesn't
-            // need to reach back into AppModel.
-            return PaletteRow.actionSymbolById[id] ?? "bolt"
+        // Symbol comes straight off the resolved `PaletteAction` so it can't
+        // drift from the model and isn't gated on a parallel lookup table.
+        case .action(let a): return a.symbol
         }
     }
 
-    private var primaryText: String {
+    /// Primary label. Library rows render plain (server-provided) names;
+    /// action rows render the model's `LocalizedStringKey` `title` so the
+    /// label localizes once a strings catalog is registered — no hardcoded
+    /// English mirror that bypasses localization or falls back to a raw id.
+    @ViewBuilder
+    private var primaryTextView: some View {
         switch row {
-        case .artist(let a): return a.name
-        case .album(let a): return a.name
-        case .track(let t): return t.name
-        case .action(let id): return PaletteRow.actionTitleById[id] ?? id
+        case .artist(let a): Text(a.name)
+        case .album(let a): Text(a.name)
+        case .track(let t): Text(t.name)
+        case .action(let a): Text(a.title)
         }
     }
 
@@ -654,40 +724,4 @@ struct PaletteRow: View {
         case .action: return "Run"
         }
     }
-
-    // Static maps so the row can label/icon itself without needing a
-    // reference to `AppModel`. Kept in sync with `AppModel.paletteActions`
-    // by hand — the set is small and stable. When the registry grows
-    // faster, fold this back into a computed lookup off AppModel.
-    static let actionTitleById: [String: String] = [
-        "playback.play": "Play",
-        "playback.pause": "Pause",
-        "playback.playNext": "Play Next",
-        "playback.addToQueue": "Add to Queue",
-        "nav.library": "Go to Library",
-        "nav.home": "Go to Home",
-        "nav.discover": "Go to Discover",
-        "nav.favorites": "Go to Favorites",
-        "app.openPreferences": "Open Preferences",
-        "playback.toggleShuffle": "Toggle Shuffle",
-        "playback.toggleRepeat": "Toggle Repeat",
-        "queue.clear": "Clear Queue",
-        "download.current": "Download Current",
-    ]
-
-    static let actionSymbolById: [String: String] = [
-        "playback.play": "play.fill",
-        "playback.pause": "pause.fill",
-        "playback.playNext": "text.line.first.and.arrowtriangle.forward",
-        "playback.addToQueue": "text.badge.plus",
-        "nav.library": "music.note.list",
-        "nav.home": "house",
-        "nav.discover": "sparkles",
-        "nav.favorites": "heart",
-        "app.openPreferences": "gearshape",
-        "playback.toggleShuffle": "shuffle",
-        "playback.toggleRepeat": "repeat",
-        "queue.clear": "trash",
-        "download.current": "arrow.down.circle",
-    ]
 }

--- a/macos/Sources/Lyrebird/Components/EmptyLibraryState.swift
+++ b/macos/Sources/Lyrebird/Components/EmptyLibraryState.swift
@@ -11,12 +11,6 @@ import AppKit
 struct EmptyLibraryState: View {
     let serverUrl: URL?
 
-    /// Resolved copy for the a11y-combine label. We pull the catalog values
-    /// once here so the composite `Text` uses the same phrasing the rest of
-    /// the view renders.
-    private var headline: String { String(localized: "empty.library.title", bundle: .main) }
-    private var subtitle: String { String(localized: "empty.library.subtitle", bundle: .main) }
-
     var body: some View {
         VStack(spacing: 18) {
             Image(systemName: "music.note.list")
@@ -67,8 +61,13 @@ struct EmptyLibraryState: View {
         }
         .padding(.vertical, 56)
         .frame(maxWidth: .infinity)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(headline). \(subtitle)")
+        // `.contain` (not `.combine`): the subtree holds the interactive
+        // "Open Jellyfin web" button, and `.combine` would flatten it into a
+        // single static element — stripping its `.isButton` trait and action
+        // so VoiceOver couldn't reach or activate it. With `.contain` the
+        // headline, subtitle, and button each stay individually focusable,
+        // and each already exposes its own localized label.
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/EmptyStateView.swift
+++ b/macos/Sources/Lyrebird/Components/EmptyStateView.swift
@@ -160,6 +160,21 @@ extension EmptyStateView {
         )
     }
 
+    /// Library "no matches" state shown when an active filter excludes every
+    /// loaded item — distinct from the first-run "no library" state, which
+    /// stays gated on the raw count. The primary CTA clears the filter so the
+    /// user isn't stranded on a blank content area. See audit L494.
+    static func noFilterMatches(
+        onClearFilter: @escaping () -> Void
+    ) -> EmptyStateView {
+        EmptyStateView(
+            symbol: "line.3.horizontal.decrease.circle",
+            headline: "No matches",
+            body: "No items in your library match the current filter.",
+            primaryCTA: ("Clear Filter", onClearFilter)
+        )
+    }
+
     /// Empty playlist state. Issue #299. Caller provides the "Add tracks"
     /// handler when a playlist supports edits; pass `nil` to render the
     /// read-only variant (e.g. for a smart playlist).

--- a/macos/Sources/Lyrebird/Components/EmptyStateView.swift
+++ b/macos/Sources/Lyrebird/Components/EmptyStateView.swift
@@ -112,7 +112,19 @@ struct EmptyStateView: View {
         }
         .padding(.vertical, 56)
         .frame(maxWidth: .infinity)
-        .accessibilityElement(children: .combine)
+        // When CTAs are present the subtree contains interactive buttons, so
+        // we must `.contain` (not `.combine`) — `.combine` flattens the
+        // buttons into a single static element, stripping their `.isButton`
+        // trait and tap action so VoiceOver can't reach or activate them.
+        // With no CTA the subtree is text-only, so `.combine` reads the
+        // headline + body as one element, which is the nicer announcement.
+        .accessibilityElement(children: hasCTA ? .contain : .combine)
+    }
+
+    /// Whether the view renders at least one interactive CTA button. Drives
+    /// the accessibility-container strategy (see `body`).
+    private var hasCTA: Bool {
+        primaryCTA != nil || secondaryCTA != nil
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
@@ -1,29 +1,48 @@
 import SwiftUI
 @preconcurrency import LyrebirdCore
 
-/// Audio container formats the filter offers. Matching is done against the
-/// track's (lower/upper-mixed) `container` string, normalised to upper case.
-/// `ALAC` is shipped by Jellyfin in an `m4a`/`mp4` container, so its match set
-/// covers the common container spellings as well as the codec name itself.
+/// Audio formats the filter offers. Matching is done against the track's
+/// (case-insensitive) `container` string only — the loaded `Track` payload
+/// carries no codec field, so matching is *container-level*, not codec-level.
+///
+/// FLAC and MP3 each map to a dedicated container, so those are exact. ALAC
+/// and AAC, however, both ship inside the same `m4a`/`mp4` container, and the
+/// container alone can't tell them apart. Rather than claim a codec-level
+/// distinction we can't honour (the prior code mapped M4A/MP4 to ALAC, which
+/// silently kept lossy AAC files too), both ALAC and AAC match the shared
+/// `m4a`/`mp4` containers. Selecting either therefore keeps every m4a/mp4
+/// track; tightening this to true codec granularity needs a codec/profile
+/// signal on the `Track` model (see #819-adjacent work).
 enum TrackFormat: String, CaseIterable, Identifiable, Hashable {
 	case flac = "FLAC"
 	case alac = "ALAC"
+	case aac = "AAC"
 	case mp3 = "MP3"
 
 	var id: String { rawValue }
 
-	var label: String { rawValue }
+	var label: String {
+		switch self {
+		// Make the shared-container caveat visible in the UI so a user who
+		// selects ALAC isn't surprised that AAC m4a/mp4 files come along.
+		case .alac: return "ALAC (m4a)"
+		case .aac: return "AAC (m4a)"
+		default: return rawValue
+		}
+	}
 
-	/// Upper-cased container tokens that count as this format.
+	/// Upper-cased container tokens that count as this format. M4A/MP4 is
+	/// shared by ALAC and AAC because the container is the only signal we have.
 	private var containerTokens: Set<String> {
 		switch self {
 		case .flac: return ["FLAC"]
-		case .alac: return ["ALAC", "M4A", "MP4"]
+		case .alac, .aac: return ["M4A", "MP4", "M4B", "ALAC", "AAC"]
 		case .mp3: return ["MP3", "MPEG"]
 		}
 	}
 
-	/// Whether a track's `container` string matches this format.
+	/// Whether a track's `container` string matches this format. Container-level
+	/// only — see the type doc for why ALAC/AAC can't be told apart here.
 	func matches(container raw: String?) -> Bool {
 		guard let token = raw?.trimmingCharacters(in: .whitespaces).uppercased(),
 			!token.isEmpty
@@ -72,7 +91,6 @@ struct LibraryFilter: Equatable {
 	/// Stored separately from the slider's full range so a filter that spans
 	/// the whole catalogue reads as "inactive".
 	var yearRange: ClosedRange<Int>?
-	var onlyDownloaded = false
 	var onlyFavorited = false
 	/// Selected formats. Empty = no format constraint.
 	var formats: Set<TrackFormat> = []
@@ -86,7 +104,6 @@ struct LibraryFilter: Equatable {
 		var n = 0
 		if !genres.isEmpty { n += 1 }
 		if yearRange != nil { n += 1 }
-		if onlyDownloaded { n += 1 }
 		if onlyFavorited { n += 1 }
 		if !formats.isEmpty { n += 1 }
 		if !durations.isEmpty { n += 1 }
@@ -94,6 +111,28 @@ struct LibraryFilter: Equatable {
 	}
 
 	var isActive: Bool { activeGroupCount > 0 }
+
+	// MARK: - Per-tab applicability
+
+	/// Which filter dimensions the given `LibraryTab` actually consults in its
+	/// `passesFilter` predicate. The popover renders only the matching groups
+	/// so a control can never appear active on a tab that ignores it (#214
+	/// follow-up). Mirrors `LibraryView.passesFilter(_:)`:
+	/// - genre → albums, artists
+	/// - year → albums, tracks
+	/// - format / duration → tracks only
+	/// - favorited → every tab (always rendered)
+	static func appliesGenre(on tab: LibraryTab) -> Bool {
+		tab == .albums || tab == .artists
+	}
+
+	static func appliesYear(on tab: LibraryTab) -> Bool {
+		tab == .albums || tab == .tracks
+	}
+
+	static func appliesTrackFields(on tab: LibraryTab) -> Bool {
+		tab == .tracks
+	}
 }
 
 /// 280pt popover anchored to the Library filter icon. Edits a working copy of
@@ -109,10 +148,11 @@ struct LibraryFilterPopover: View {
 	/// Release-year bounds discovered across the loaded library. Drives the
 	/// year slider's track. `nil` when no item carries a year.
 	let yearBounds: ClosedRange<Int>?
-	/// Whether the "Only downloaded" toggle should be shown. Gated on the
-	/// download engine (`AppModel.supportsDownloads`, #819) so the control
-	/// doesn't appear dead while downloads are unwired.
-	let showDownloaded: Bool
+	/// The Library tab the popover is filtering. Only the dimensions the
+	/// active tab's `passesFilter` actually consults are rendered, so a
+	/// Format/Duration/Year group never appears "active" on a tab that
+	/// ignores it (#214 follow-up). See `appliesYear` / `appliesTrackFields`.
+	let tab: LibraryTab
 	/// Dismiss handler — the host owns the `isPresented` binding.
 	let onClose: () -> Void
 
@@ -127,13 +167,13 @@ struct LibraryFilterPopover: View {
 		filter: Binding<LibraryFilter>,
 		availableGenres: [String],
 		yearBounds: ClosedRange<Int>?,
-		showDownloaded: Bool,
+		tab: LibraryTab,
 		onClose: @escaping () -> Void
 	) {
 		self._filter = filter
 		self.availableGenres = availableGenres
 		self.yearBounds = yearBounds
-		self.showDownloaded = showDownloaded
+		self.tab = tab
 		self.onClose = onClose
 		let initial = filter.wrappedValue
 		self._draft = State(initialValue: initial)
@@ -147,12 +187,13 @@ struct LibraryFilterPopover: View {
 		VStack(spacing: 0) {
 			ScrollView {
 				VStack(alignment: .leading, spacing: 18) {
-					if !availableGenres.isEmpty { genreGroup }
-					if yearBounds != nil { yearGroup }
-					if showDownloaded { downloadedGroup }
+					if appliesGenre, !availableGenres.isEmpty { genreGroup }
+					if appliesYear, yearBounds != nil { yearGroup }
 					favoritedGroup
-					formatGroup
-					durationGroup
+					if appliesTrackFields {
+						formatGroup
+						durationGroup
+					}
 				}
 				.padding(16)
 			}
@@ -163,6 +204,12 @@ struct LibraryFilterPopover: View {
 		.frame(maxHeight: 460)
 		.background(Theme.bgAlt)
 	}
+
+	// MARK: - Tab applicability
+
+	private var appliesGenre: Bool { LibraryFilter.appliesGenre(on: tab) }
+	private var appliesYear: Bool { LibraryFilter.appliesYear(on: tab) }
+	private var appliesTrackFields: Bool { LibraryFilter.appliesTrackFields(on: tab) }
 
 	// MARK: - Groups
 
@@ -206,10 +253,6 @@ struct LibraryFilterPopover: View {
 				)
 			}
 		}
-	}
-
-	private var downloadedGroup: some View {
-		toggleRow("Only downloaded", isOn: $draft.onlyDownloaded)
 	}
 
 	private var favoritedGroup: some View {
@@ -369,6 +412,11 @@ struct RangeSlider: View {
 	private let thumbSize: CGFloat = 16
 	private let trackHeight: CGFloat = 4
 
+	/// Name for the container coordinate space the drag is measured in, so
+	/// `value.location.x` reads against the track instead of the thumb's own
+	/// (offset) coordinate space.
+	private let coordinateSpace = "rangeSlider"
+
 	var body: some View {
 		GeometryReader { geo in
 			let span = max(bounds.upperBound - bounds.lowerBound, 1)
@@ -390,18 +438,25 @@ struct RangeSlider: View {
 
 				thumb
 					.offset(x: lowX)
-					.gesture(drag(usable: usable, span: span, isLow: true))
+					.gesture(drag(usable: usable, isLow: true))
 					.accessibilityLabel("Minimum year")
 					.accessibilityValue("\(Int(low))")
+					.accessibilityAdjustableAction { direction in
+						adjust(isLow: true, direction: direction)
+					}
 
 				thumb
 					.offset(x: highX)
-					.gesture(drag(usable: usable, span: span, isLow: false))
+					.gesture(drag(usable: usable, isLow: false))
 					.accessibilityLabel("Maximum year")
 					.accessibilityValue("\(Int(high))")
+					.accessibilityAdjustableAction { direction in
+						adjust(isLow: false, direction: direction)
+					}
 			}
 			.frame(height: thumbSize)
 			.frame(maxHeight: .infinity)
+			.coordinateSpace(name: coordinateSpace)
 		}
 		.frame(height: 24)
 	}
@@ -413,17 +468,57 @@ struct RangeSlider: View {
 			.shadow(color: .black.opacity(0.3), radius: 2, y: 1)
 	}
 
-	private func drag(usable: CGFloat, span: Double, isLow: Bool) -> some Gesture {
-		DragGesture()
+	private func drag(usable: CGFloat, isLow: Bool) -> some Gesture {
+		// Measured in the ZStack's coordinate space (see `coordinateSpace`), so
+		// `value.location.x` is the cursor's position along the track, not an
+		// offset relative to the dragged thumb.
+		DragGesture(coordinateSpace: .named(coordinateSpace))
 			.onChanged { value in
-				let fraction = max(0, min(1, value.location.x / usable))
-				let raw = bounds.lowerBound + Double(fraction) * span
-				let clamped = max(bounds.lowerBound, min(bounds.upperBound, raw)).rounded()
+				let clamped = Self.value(
+					forCursorX: value.location.x,
+					usable: usable,
+					thumbSize: thumbSize,
+					bounds: bounds)
 				if isLow {
 					low = min(clamped, high)
 				} else {
 					high = max(clamped, low)
 				}
 			}
+	}
+
+	/// Convert a cursor x-position (in the track's coordinate space) to a
+	/// rounded value in `bounds`. The thumb is `thumbSize` wide and drawn
+	/// leading-aligned, so its centre sits half a thumb in from the track
+	/// origin; subtracting `thumbSize / 2` maps the cursor to the thumb-centre
+	/// travel that `usable` (= width − thumbSize) describes. Factored out so the
+	/// drag math is unit-testable (it was the source of the year-slider snapping
+	/// bug, #214). `internal` rather than `private` for `@testable` access.
+	static func value(
+		forCursorX cursorX: CGFloat,
+		usable: CGFloat,
+		thumbSize: CGFloat,
+		bounds: ClosedRange<Double>
+	) -> Double {
+		let span = max(bounds.upperBound - bounds.lowerBound, 1)
+		let centred = cursorX - thumbSize / 2
+		let fraction = max(0, min(1, centred / max(usable, 1)))
+		let raw = bounds.lowerBound + Double(fraction) * span
+		return max(bounds.lowerBound, min(bounds.upperBound, raw)).rounded()
+	}
+
+	/// VoiceOver / keyboard adjustable action: nudge the given thumb by one
+	/// year per increment, clamped to the bounds and to the other thumb so the
+	/// low thumb can't cross above the high (or vice versa). Keeps the control
+	/// operable without a pointer drag (#214 a11y follow-up).
+	private func adjust(isLow: Bool, direction: AccessibilityAdjustmentDirection) {
+		let delta: Double = direction == .increment ? 1 : -1
+		if isLow {
+			let next = (low + delta).rounded()
+			low = max(bounds.lowerBound, min(next, high))
+		} else {
+			let next = (high + delta).rounded()
+			high = min(bounds.upperBound, max(next, low))
+		}
 	}
 }

--- a/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
@@ -82,11 +82,18 @@ struct LibraryFilter: Equatable {
 	/// Number of active filter groups — drives the pink dot / count badge on
 	/// the filter icon. A group counts once regardless of how many options
 	/// inside it are selected.
+	///
+	/// `onlyDownloaded` is deliberately excluded: no `passesFilter` overload
+	/// can honor it until a download-state query exists, and the toggle is
+	/// itself UI-gated off (`showDownloaded: model.supportsDownloads`, false
+	/// today). Counting it would mark the filter "active" — lighting the dot
+	/// badge and triggering the no-results path — while filtering nothing.
+	/// Fold it back in here the moment a `model.isDownloaded(...)` lands and
+	/// the `passesFilter` overloads consult it. See audit L724.
 	var activeGroupCount: Int {
 		var n = 0
 		if !genres.isEmpty { n += 1 }
 		if yearRange != nil { n += 1 }
-		if onlyDownloaded { n += 1 }
 		if onlyFavorited { n += 1 }
 		if !formats.isEmpty { n += 1 }
 		if !durations.isEmpty { n += 1 }

--- a/macos/Sources/Lyrebird/Components/PinnedStationTile.swift
+++ b/macos/Sources/Lyrebird/Components/PinnedStationTile.swift
@@ -31,9 +31,9 @@ struct PinnedStation: Codable, Hashable, Identifiable {
 
 /// Horizontal tile for the Pinned Stations row on Home (#253). Displays a
 /// pulsing "on air" dot, the station name in italic 20pt, and a short
-/// subtitle ("42 tracks · updated today"-style). Tapping the tile just logs
-/// today — the actual "start this station" routing waits on the Instant Mix
-/// FFI (#144) and the typed pin infrastructure.
+/// subtitle ("42 tracks · updated today"-style). Tapping the tile runs the
+/// row's `action`, which `HomeView.handleStationTap` routes to the station's
+/// subject (browse the genre, open the playlist, or start a seeded radio).
 struct PinnedStationTile: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let station: PinnedStation
@@ -129,105 +129,6 @@ struct PinnedStationTile: View {
         case .genre: return "GENRE"
         case .mix: return "MIX"
         }
-    }
-}
-
-/// End-cap for the Pinned Stations row — a ghost "+ Add station" pill. Today
-/// it's inert (TODO below); once the pin UI lands it opens the picker.
-struct PinnedStationAddPill: View {
-    let action: () -> Void
-    @State private var isHovering = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                Image(systemName: "plus")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(Theme.ink2)
-                Text("Add station")
-                    .font(Theme.font(13, weight: .semibold))
-                    .foregroundStyle(Theme.ink2)
-            }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 14)
-            .frame(height: 140)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Theme.surface.opacity(isHovering ? 0.8 : 0.4))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(
-                        Theme.borderStrong.opacity(isHovering ? 0.9 : 0.5),
-                        style: StrokeStyle(lineWidth: 1.5, dash: [5, 4])
-                    )
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
-        .help("Pin a station")
-        .accessibilityLabel("Add station")
-    }
-}
-
-/// Larger, prominent empty-state CTA shown when no stations are pinned. Shares
-/// its action with the end-of-row `PinnedStationAddPill` so both routes land
-/// in the (future) pin picker.
-struct PinnedStationsEmptyState: View {
-    let action: () -> Void
-    @State private var isHovering = false
-
-    var body: some View {
-        HStack(spacing: 16) {
-            ZStack {
-                Circle()
-                    .fill(Theme.surface2)
-                    .frame(width: 56, height: 56)
-                Image(systemName: "pin.fill")
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(Theme.primary)
-                    .rotationEffect(.degrees(-15))
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text("No pinned stations yet")
-                    .font(Theme.font(15, weight: .bold))
-                    .foregroundStyle(Theme.ink)
-                Text("Pin your favorite radios, playlists, and moods for quick access here.")
-                    .font(Theme.font(12, weight: .medium))
-                    .foregroundStyle(Theme.ink2)
-                    .lineLimit(2)
-            }
-            Spacer(minLength: 12)
-            Button(action: action) {
-                HStack(spacing: 8) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .bold))
-                    Text("Pin a station")
-                        .font(Theme.font(13, weight: .bold))
-                }
-                .foregroundStyle(.white)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .background(Capsule().fill(Theme.accent))
-                .shadow(color: Theme.accent.opacity(0.35), radius: 10, y: 4)
-            }
-            .buttonStyle(.plain)
-            .onHover { isHovering = $0 }
-            .scaleEffect(isHovering ? 1.03 : 1.0)
-            .animation(.easeOut(duration: 0.12), value: isHovering)
-            .help("Pin a station — coming soon")
-            .accessibilityLabel("Pin a station")
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Theme.surface.opacity(0.6))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Theme.border, lineWidth: 1)
-        )
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/PlayPauseSpaceMonitor.swift
+++ b/macos/Sources/Lyrebird/Components/PlayPauseSpaceMonitor.swift
@@ -1,0 +1,160 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Bare-Space Play/Pause (audit L383)
+//
+// The Play/Pause transport used to be bound to the bare Space key as a
+// `CommandMenu` shortcut. SwiftUI registers `CommandMenu` shortcuts as
+// `NSMenuItem` key equivalents, and `NSMenu.performKeyEquivalent` runs *before*
+// the event reaches the first responder — so the global Play/Pause fired even
+// while the user was typing a space into a `TextField` / `TextEditor`. SwiftUI
+// does not auto-suppress a bare-key command while a text field is focused, and
+// the per-view `spaceKeyGuardForTextField()` patch only covered the handful of
+// screens it was applied to.
+//
+// The fix moves the bare-Space binding off the menu entirely and onto a single
+// process-level `NSEvent` local monitor installed for the app's lifetime. The
+// monitor reads the current first responder at key-press time (so there is no
+// stale-state problem) and:
+//   • lets the event through untouched when a text editor is focused, so Space
+//     types a space exactly as it should; and
+//   • otherwise consumes it and toggles playback.
+//
+// Because the shortcut is no longer an `NSMenuItem` key equivalent, NSMenu no
+// longer swallows it ahead of text fields, which is the root cause the older
+// guard was working around.
+
+/// Pure decision for the bare-Space monitor, split out so it can be unit-tested
+/// without constructing real AppKit responders. Given whether a track is
+/// loaded and whether a text editor currently owns focus, decide what the
+/// Space key should do.
+enum SpaceKeyAction: Equatable {
+    /// Toggle play/pause and swallow the event.
+    case togglePlayback
+    /// Let the event continue normal dispatch (e.g. type a literal space).
+    case passThrough
+}
+
+enum PlayPauseSpaceDecision {
+    /// - Parameters:
+    ///   - hasModifiers: whether any of ⌘/⌥/⌃/⇧ were held (a deliberate combo,
+    ///     never a transport toggle).
+    ///   - isTextEditing: whether a text field / text view currently has focus.
+    ///   - hasCurrentTrack: whether a track is loaded (nothing to toggle when not).
+    static func decide(
+        hasModifiers: Bool,
+        isTextEditing: Bool,
+        hasCurrentTrack: Bool
+    ) -> SpaceKeyAction {
+        // A modified Space (e.g. ⌥Space) is never a transport toggle — leave it
+        // for whatever owns that combo.
+        if hasModifiers { return .passThrough }
+        // While editing text, Space must always type a space.
+        if isTextEditing { return .passThrough }
+        // Nothing loaded → nothing to toggle; don't eat the key.
+        if !hasCurrentTrack { return .passThrough }
+        return .togglePlayback
+    }
+}
+
+extension View {
+    /// Installs the app-wide bare-Space Play/Pause monitor for this view's
+    /// lifetime. Mount once on a long-lived ancestor (`RootView`). The toggle
+    /// fires only when a track is loaded and no text editor is focused.
+    func playPauseSpaceMonitor(_ toggle: @escaping () -> Void,
+                               hasCurrentTrack: @escaping () -> Bool) -> some View {
+        self.background(
+            PlayPauseSpaceMonitorHost(toggle: toggle, hasCurrentTrack: hasCurrentTrack)
+        )
+    }
+}
+
+/// Zero-size `NSViewRepresentable` that installs / removes the bare-Space
+/// `NSEvent` local monitor for its parent view's lifetime. Mirrors the
+/// representable-not-onAppear approach used by `SpaceKeyGuardHost` so the
+/// monitor token is owned by the coordinator and torn down deterministically.
+private struct PlayPauseSpaceMonitorHost: NSViewRepresentable {
+    let toggle: () -> Void
+    let hasCurrentTrack: () -> Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.install()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Keep the closures fresh so the monitor always sees current state.
+        context.coordinator.toggle = toggle
+        context.coordinator.hasCurrentTrack = hasCurrentTrack
+    }
+
+    func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.remove()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(toggle: toggle, hasCurrentTrack: hasCurrentTrack)
+    }
+
+    final class Coordinator {
+        var toggle: () -> Void
+        var hasCurrentTrack: () -> Bool
+        private var monitor: Any?
+
+        init(toggle: @escaping () -> Void, hasCurrentTrack: @escaping () -> Bool) {
+            self.toggle = toggle
+            self.hasCurrentTrack = hasCurrentTrack
+        }
+
+        func install() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                self?.handle(event: event) ?? event
+            }
+        }
+
+        func remove() {
+            if let m = monitor {
+                NSEvent.removeMonitor(m)
+                monitor = nil
+            }
+        }
+
+        /// Returns `nil` when the Space was consumed (playback toggled), or the
+        /// original event when it should continue normal dispatch.
+        private func handle(event: NSEvent) -> NSEvent? {
+            guard event.keyCode == 49 else { return event } // kVK_Space
+            let hasModifiers = !event.modifierFlags
+                .intersection([.command, .option, .control, .shift])
+                .isEmpty
+            let action = PlayPauseSpaceDecision.decide(
+                hasModifiers: hasModifiers,
+                isTextEditing: Self.isTextEditing(),
+                hasCurrentTrack: hasCurrentTrack()
+            )
+            switch action {
+            case .passThrough:
+                return event
+            case .togglePlayback:
+                toggle()
+                return nil
+            }
+        }
+
+        /// Whether the key window's first responder is an editable text surface.
+        /// SwiftUI `TextField` renders as `NSTextField`; once focused the field
+        /// editor (`NSTextView`) becomes first responder. `TextEditor` is a
+        /// standalone editable `NSTextView`. Treat any editable text view as
+        /// "editing" so Space types rather than toggling.
+        private static func isTextEditing() -> Bool {
+            guard
+                let window = NSApp.keyWindow,
+                let responder = window.firstResponder
+            else { return false }
+            if responder is NSTextField { return true }
+            if let tv = responder as? NSTextView { return tv.isEditable }
+            return false
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Components/PlaylistExport.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistExport.swift
@@ -9,7 +9,10 @@ import Foundation
 ///
 /// Two export formats plus a sharable deep link:
 ///   - **M3U** (`#EXTM3U` + `#EXTINF`) — the de-facto playlist interchange
-///     format every desktop player understands.
+///     format every desktop player understands. Entries use the static-
+///     download stream form with an embedded `api_key` so the file is actually
+///     playable in an external player (a bare `/universal` path 401s); see
+///     `streamURL` for the credential caveat.
 ///   - **JSON** — a stable, machine-readable manifest of the playlist for
 ///     re-import / backup / scripting.
 ///   - **Deep link** — the Jellyfin web `details` route, with any embedded
@@ -22,14 +25,70 @@ enum PlaylistExport {
 
     // MARK: - Stream URL
 
-    /// The auth-free universal-stream path for a track, e.g.
-    /// `https://server.example.com/Audio/<id>/universal`. No query parameters
-    /// and no `api_key`, so the resulting M3U is safe to share even though it
-    /// references the origin server. Servers that allow unauthenticated
-    /// download (common on LAN setups) can play it directly; others will
-    /// prompt for auth, which is the correct behaviour for a shared file.
-    static func streamURL(forTrackId trackId: String, base: String) -> String {
-        "\(base)/Audio/\(trackId)/universal"
+    /// Default file extension for the static-download stream URL when a track's
+    /// source container is unknown. `Static=true` returns the original bytes
+    /// regardless of the extension, so this is only a content-type hint for the
+    /// receiving player; `mp3` is the safest universally-recognised default.
+    private static let defaultStreamExtension = "mp3"
+
+    /// Characters left un-escaped when percent-encoding the `api_key` query
+    /// value. `.urlQueryAllowed` permits the query *delimiters* (`&`, `=`, `+`,
+    /// `?`, `;`) which would corrupt the query string if a token contained
+    /// them — real Jellyfin tokens are hex, but we encode defensively so a
+    /// future token format can't split the URL.
+    private static let apiKeyAllowed: CharacterSet = {
+        var set = CharacterSet.urlQueryAllowed
+        set.remove(charactersIn: "&=+?;")
+        return set
+    }()
+
+    /// A playable stream URL for a track.
+    ///
+    /// **Contract (#237).** An exported `.m3u8` is only useful if its entries
+    /// actually play in the external player it's handed to. A bare
+    /// `/Audio/<id>/universal` path is *not* playable: that route requires the
+    /// `Authorization` header (it rejects a query-string `api_key`), which no
+    /// generic M3U player sends, so every entry 401s. We therefore emit the
+    /// static-download form
+    /// `\(base)/Audio/<id>/stream.<ext>?api_key=<token>&Static=true`, which
+    /// authenticates off the query string and streams the original file — the
+    /// shape a desktop player (VLC, etc.) can fetch from a URL alone.
+    ///
+    /// This means the exported file embeds a credential. Callers must surface
+    /// that to the user (see `AppModel.exportPlaylist`'s save-panel warning).
+    /// When `apiKey` is `nil`/empty we fall back to the bare universal path so
+    /// the file is still well-formed; such a file references the origin server
+    /// but will prompt for auth in the player.
+    ///
+    /// `container` is the track's source container (e.g. `flac`, `mp3`); it
+    /// only shapes the URL's extension hint.
+    static func streamURL(
+        forTrackId trackId: String,
+        base: String,
+        apiKey: String? = nil,
+        container: String? = nil
+    ) -> String {
+        guard let apiKey, !apiKey.isEmpty else {
+            // No token to embed — keep the file well-formed with the bare path.
+            return "\(base)/Audio/\(trackId)/universal"
+        }
+        let ext = streamExtension(for: container)
+        let encodedKey = apiKey.addingPercentEncoding(
+            withAllowedCharacters: Self.apiKeyAllowed
+        ) ?? apiKey
+        return "\(base)/Audio/\(trackId)/stream.\(ext)?api_key=\(encodedKey)&Static=true"
+    }
+
+    /// Normalize a source container into a lower-cased, dot-free extension for
+    /// the stream URL, falling back to `defaultStreamExtension` when the
+    /// container is missing or blank.
+    private static func streamExtension(for container: String?) -> String {
+        guard let container else { return defaultStreamExtension }
+        let trimmed = container
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        return trimmed.isEmpty ? defaultStreamExtension : trimmed
     }
 
     // MARK: - M3U
@@ -44,7 +103,16 @@ enum PlaylistExport {
     ///
     /// The document always ends with a trailing newline so appending to it /
     /// concatenating files behaves.
-    static func m3u8(playlistName: String, tracks: [Track], serverURL: String) -> String {
+    ///
+    /// `apiKey` is embedded in each entry's stream URL so the file is playable
+    /// in an external player (see `streamURL` for the contract + the embedded-
+    /// credential caveat). Pass `nil` to emit auth-free (prompt-on-play) URLs.
+    static func m3u8(
+        playlistName: String,
+        tracks: [Track],
+        serverURL: String,
+        apiKey: String? = nil
+    ) -> String {
         let base = normalizedBase(serverURL)
         var lines: [String] = ["#EXTM3U"]
         // A comment header naming the playlist — ignored by players, but makes
@@ -54,7 +122,14 @@ enum PlaylistExport {
             let seconds = track.runtimeTicks > 0 ? Int(track.runtimeTicks / 10_000_000) : -1
             let title = displayTitle(for: track)
             lines.append("#EXTINF:\(seconds),\(sanitizedLine(title))")
-            lines.append(streamURL(forTrackId: track.id, base: base))
+            lines.append(
+                streamURL(
+                    forTrackId: track.id,
+                    base: base,
+                    apiKey: apiKey,
+                    container: track.container
+                )
+            )
         }
         return lines.joined(separator: "\n") + "\n"
     }

--- a/macos/Sources/Lyrebird/Components/PlaylistReorderHandle.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistReorderHandle.swift
@@ -102,10 +102,14 @@ private struct PlaylistReorderModifier: ViewModifier {
             }
             .onHover { isHovering = $0 }
             .onDrag {
-                // Payload is the track id. Consumers key off the registered
-                // UTI so drops from other drag sources are rejected.
+                // Payload encodes the source *index* alongside the track id as
+                // "<index>|<trackId>". The index is what disambiguates a
+                // duplicated track: a playlist can contain the same track id
+                // more than once, so resolving the moved row by id alone would
+                // always grab the first copy. Carrying the index lets the drop
+                // move the exact copy the user grabbed.
                 NSItemProvider(
-                    object: NSString(string: trackId)
+                    object: NSString(string: PlaylistReorderPayload.encode(index: index, trackId: trackId))
                 )
             }
             .onDrop(
@@ -117,6 +121,34 @@ private struct PlaylistReorderModifier: ViewModifier {
                     model: model
                 )
             )
+    }
+}
+
+/// Wire format for the drag payload: `"<sourceIndex>|<trackId>"`. The source
+/// index disambiguates duplicated tracks (same id appearing more than once in
+/// a playlist) so the dropped copy is moved by position, not re-derived from
+/// the id. The track id is retained for the legacy id-based fallback when a
+/// payload arrives without an index (e.g. a stale drag source).
+enum PlaylistReorderPayload {
+    /// Build the `"<index>|<trackId>"` wire string.
+    static func encode(index: Int, trackId: String) -> String {
+        "\(index)|\(trackId)"
+    }
+
+    /// Parse a payload string into its `(sourceIndex, trackId)` parts.
+    ///
+    /// Splits on the *first* `|` only, so a track id that itself contains a
+    /// pipe round-trips intact. Returns `sourceIndex == nil` when the leading
+    /// segment isn't an integer — the caller then falls back to resolving the
+    /// move by track id.
+    static func decode(_ payload: String) -> (sourceIndex: Int?, trackId: String) {
+        guard let sep = payload.firstIndex(of: "|") else {
+            // No separator: treat the whole string as a bare track id.
+            return (nil, payload)
+        }
+        let indexPart = String(payload[payload.startIndex..<sep])
+        let trackId = String(payload[payload.index(after: sep)...])
+        return (Int(indexPart), trackId)
     }
 }
 
@@ -157,13 +189,25 @@ private struct PlaylistReorderDropDelegate: DropDelegate {
         let destinationIndex = self.destinationIndex
         let model = self.model
         provider.loadObject(ofClass: NSString.self) { object, _ in
-            guard let trackId = object as? String else { return }
+            guard let payload = object as? String else { return }
+            let parsed = PlaylistReorderPayload.decode(payload)
             Task { @MainActor in
-                model.applyPlaylistDrop(
-                    playlistId: playlistId,
-                    trackId: trackId,
-                    destinationIndex: destinationIndex
-                )
+                if let sourceIndex = parsed.sourceIndex {
+                    // Preferred path: move the exact copy the user grabbed by
+                    // its source index, so duplicated tracks move independently.
+                    model.applyPlaylistDrop(
+                        playlistId: playlistId,
+                        sourceIndex: sourceIndex,
+                        destinationIndex: destinationIndex
+                    )
+                } else {
+                    // Legacy fallback: no index in the payload, resolve by id.
+                    model.applyPlaylistDrop(
+                        playlistId: playlistId,
+                        trackId: parsed.trackId,
+                        destinationIndex: destinationIndex
+                    )
+                }
             }
         }
         return true

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -54,42 +54,21 @@ struct QueueInspector: View {
     @State private var dragCancelMonitor: Any?
     @State private var dragEscapeMonitor: Any?
 
-    /// Transient toast shown when the user double-clicks an auto-queue row.
-    /// The underlying `seek_to_queue_index` primitive (#282) does not exist
-    /// yet; rather than silently doing nothing we surface a brief message so
-    /// the interaction feels acknowledged. Auto-dismisses after 3 s.
-    @State private var showJumpToast = false
-    /// Work item backing the 3 s auto-dismiss. Held so a second double-click
-    /// within the window resets the timer instead of racing two dismissals.
-    @State private var jumpToastDismissWork: DispatchWorkItem?
-
     var body: some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                header
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
-                        actionRow
-                        nowPlayingCard
-                        lyricsSnippet
-                        upNextSection
-                        playingFromSection
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 16)
+        VStack(spacing: 0) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    actionRow
+                    nowPlayingCard
+                    lyricsSnippet
+                    upNextSection
+                    playingFromSection
                 }
-            }
-            .frame(maxHeight: .infinity)
-            .background(Theme.bgAlt)
-
-            if showJumpToast {
-                JumpToTrackToast(onDismiss: dismissJumpToast)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 12)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 16)
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: showJumpToast)
         .frame(maxHeight: .infinity)
         .background(Theme.bgAlt)
         // Clear-queue confirmation dialog (#284). Count interpolated into
@@ -466,40 +445,44 @@ struct QueueInspector: View {
     /// `List.onMove` semantics are preserved through
     /// `AppModel.moveUpNext(from:to:)` so the model continues to see the
     /// same `IndexSet → Int` contract it had before.
+    ///
+    /// Rendered as a `LazyVStack` directly in the inspector's outer
+    /// `ScrollView` (#79). It used to nest its own `ScrollView` clamped to 8
+    /// rows / 352pt, which trapped two-finger scroll inside the Up Next
+    /// region for longer queues and hid items 9+ behind a competing inner
+    /// scrollbar. Letting the page scroll keeps the whole list reachable, and
+    /// `LazyVStack` still defers off-screen row construction.
     @ViewBuilder
     private var upNextList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                dropIndicator(at: 0)
-                ForEach(Array(model.upNextUserAdded.enumerated()), id: \.element.id) { index, entry in
-                    QueueInspectorRow(
-                        entry: entry,
-                        removable: true,
-                        onRemove: { model.removeFromUpNext(id: entry.id) },
-                        onMoveUp: { moveEntry(entry, by: -1) },
-                        onMoveDown: { moveEntry(entry, by: 1) }
-                    )
-                    .focused($focusedQueueId, equals: entry.id)
-                    .opacity(draggingId == entry.id ? 0.4 : 1.0)
-                    .onDrag {
-                        draggingId = entry.id
-                        return NSItemProvider(object: entry.id.uuidString as NSString)
-                    }
-                    .onDrop(
-                        of: [.text],
-                        delegate: QueueRowDropDelegate(
-                            targetIndex: index,
-                            draggingId: $draggingId,
-                            dropTargetIndex: $dropTargetIndex,
-                            model: model
-                        )
-                    )
-
-                    dropIndicator(at: index + 1)
+        LazyVStack(spacing: 0) {
+            dropIndicator(at: 0)
+            ForEach(Array(model.upNextUserAdded.enumerated()), id: \.element.id) { index, entry in
+                QueueInspectorRow(
+                    entry: entry,
+                    removable: true,
+                    onRemove: { model.removeFromUpNext(id: entry.id) },
+                    onMoveUp: { moveEntry(entry, by: -1) },
+                    onMoveDown: { moveEntry(entry, by: 1) }
+                )
+                .focused($focusedQueueId, equals: entry.id)
+                .opacity(draggingId == entry.id ? 0.4 : 1.0)
+                .onDrag {
+                    draggingId = entry.id
+                    return NSItemProvider(object: entry.id.uuidString as NSString)
                 }
+                .onDrop(
+                    of: [.text],
+                    delegate: QueueRowDropDelegate(
+                        targetIndex: index,
+                        draggingId: $draggingId,
+                        dropTargetIndex: $dropTargetIndex,
+                        model: model
+                    )
+                )
+
+                dropIndicator(at: index + 1)
             }
         }
-        .frame(height: boundedListHeight(for: model.upNextUserAdded.count))
     }
 
     /// 2pt accent-tinted line rendered between rows while a drag is in
@@ -529,10 +512,12 @@ struct QueueInspector: View {
                 if model.upNextAutoQueue.isEmpty {
                     emptyRow("Nothing else queued from this source.")
                 } else {
-                    // Simple `ForEach` here — no drag-reorder on the auto
-                    // tail (it's the source's natural order; reordering
-                    // would be #282's next step, post-core primitive).
-                    VStack(spacing: 0) {
+                    // `LazyVStack` (not a plain `VStack`) so a large source
+                    // context — a full album/playlist tail — doesn't
+                    // instantiate every row up front; off-screen rows
+                    // materialize as the outer page scrolls. No drag-reorder
+                    // here: the auto tail is the source's natural order.
+                    LazyVStack(spacing: 0) {
                         ForEach(model.upNextAutoQueue) { entry in
                             QueueInspectorRow(
                                 entry: entry,
@@ -575,30 +560,13 @@ struct QueueInspector: View {
         model.moveUpNext(from: IndexSet(integer: idx), to: offset)
     }
 
-    /// Jump playback to an auto-queue entry. The underlying
-    /// `seek_to_queue_index` primitive (TODO(core-#282)) does not exist yet.
-    /// Rather than silently doing nothing, we surface a transient toast so
-    /// the user knows the gesture was recognized and that the feature is
-    /// coming. When #282 lands, replace the toast call with the real seek.
+    /// Jump playback to an auto-queue entry. Routes through
+    /// `AppModel.jumpToQueueEntry(_:)`, which rebuilds the flat track list
+    /// (current → user-added → auto tail), locates this entry, and replays
+    /// from its index so the engine actually repositions and auto-advances
+    /// from there. See #282.
     private func jumpTo(entry: Queue) {
-        // TODO(core-#282): replace with `try core.seek_to_queue_index(...)`.
-        showJumpToastMessage()
-    }
-
-    /// Show the "Jump to track coming soon" toast and arm a 3 s auto-dismiss.
-    /// A second double-click within the window resets the timer cleanly.
-    private func showJumpToastMessage() {
-        jumpToastDismissWork?.cancel()
-        withAnimation { showJumpToast = true }
-        let work = DispatchWorkItem { dismissJumpToast() }
-        jumpToastDismissWork = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: work)
-    }
-
-    private func dismissJumpToast() {
-        jumpToastDismissWork?.cancel()
-        jumpToastDismissWork = nil
-        withAnimation { showJumpToast = false }
+        model.jumpToQueueEntry(entry)
     }
 
     // MARK: - Helpers
@@ -628,15 +596,6 @@ struct QueueInspector: View {
         let m = total / 60
         let s = total % 60
         return String(format: "%d:%02d", m, s)
-    }
-
-    /// Cap the reorder list height so a 200-track user queue can't push
-    /// the rest of the inspector off-screen. Each row is ~44pt tall; we
-    /// ceiling at 8 rows, past which the list scrolls internally.
-    private func boundedListHeight(for rows: Int) -> CGFloat {
-        let rowHeight: CGFloat = 44
-        let visible = min(max(rows, 1), 8)
-        return CGFloat(visible) * rowHeight
     }
 }
 
@@ -710,7 +669,18 @@ private struct QueueInspectorRow: View {
         .focusable(removable)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(entry.track.name) by \(entry.track.artistName)")
-        .accessibilityAddTraits(removable ? .isButton : [])
+        // Expose Remove as a VoiceOver / Full Keyboard Access rotor action so
+        // it's reachable without hovering — the visible X button is gated on
+        // mouse hover, which keyboard and assistive-tech users can't trigger
+        // (#588). The `.isButton` trait is deliberately *not* added: the row
+        // has no single primary activation (its actions are reorder via
+        // Opt+↑/↓ and this Remove action), so advertising a button trait
+        // would promise a tap-to-activate that doesn't exist.
+        .accessibilityActions {
+            if removable {
+                Button("Remove") { onRemove() }
+            }
+        }
         // Opt+↑ / Opt+↓ reorders the focused row. Only match when the
         // Option modifier is held so plain arrow keys fall through to
         // the surrounding list's focus traversal.
@@ -852,59 +822,5 @@ private struct SaveQueueSheet: View {
     private var totalCount: Int {
         let currentCount = model.status.currentTrack == nil ? 0 : 1
         return currentCount + model.upNextUserAdded.count + model.upNextAutoQueue.count
-    }
-}
-
-// MARK: - Jump-to-track toast
-
-/// Transient informational toast shown when the user double-clicks an
-/// auto-queue row. The seek-to-index primitive (#282) isn't wired yet;
-/// this prevents the gesture from feeling broken by giving explicit
-/// feedback that it was recognized. Dismisses automatically after 3 s
-/// or via the close button.
-private struct JumpToTrackToast: View {
-    let onDismiss: () -> Void
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Theme.ink2)
-                .accessibilityHidden(true)
-
-            Text("Jump to track coming soon")
-                .font(Theme.font(12, weight: .semibold))
-                .foregroundStyle(Theme.ink)
-                .lineLimit(1)
-
-            Spacer(minLength: 8)
-
-            Button(action: onDismiss) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Theme.ink3)
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Dismiss")
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 9)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.surface)
-        .overlay(alignment: .leading) {
-            Rectangle()
-                .fill(Theme.ink2)
-                .frame(width: 3)
-        }
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Theme.border, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .shadow(color: Color.black.opacity(0.25), radius: 8, y: 3)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Jump to track coming soon")
-        .accessibilityAddTraits(.isStaticText)
     }
 }

--- a/macos/Sources/Lyrebird/Components/ServerUnreachableBanner.swift
+++ b/macos/Sources/Lyrebird/Components/ServerUnreachableBanner.swift
@@ -12,14 +12,19 @@ import SwiftUI
 /// `AppModel`. Hides automatically when a subsequent fetch succeeds
 /// (`ServerReachability.noteSuccess`).
 ///
+/// All user-facing copy is localized through `Localizable.xcstrings` (the
+/// `banner.server_unreachable.*` keys + the shared `common.retry`), matching
+/// the rest of the UI and the sibling `OfflineBanner`.
+///
 /// ## Variants
 ///
 /// - **Default** — `ServerUnreachableBanner(onRetry:)` renders the generic
-///   copy ("Can't reach your server.") for backwards compatibility with the
-///   existing call site in `MainShell`.
-/// - **Named server** — `ServerUnreachableBanner(host:onRetry:)` threads
-///   the configured host (optionally `host:port`) into the copy, matching
-///   issue #101's "Can't reach {server}. Trying again…" design.
+///   copy from `banner.server_unreachable.generic` for backwards compatibility
+///   with the existing call site in `MainShell`.
+/// - **Named server** — `ServerUnreachableBanner(host:onRetry:)` threads the
+///   configured host (optionally `host:port`) into the
+///   `banner.server_unreachable.named %@` format, matching issue #101's
+///   "Can't reach {server}. Trying again…" design.
 struct ServerUnreachableBanner: View {
     /// Host (or `host:port`) displayed in the copy. `nil` falls back to the
     /// generic "your server" wording.
@@ -31,11 +36,17 @@ struct ServerUnreachableBanner: View {
         self.onRetry = onRetry
     }
 
-    private var message: String {
+    /// Resolved banner copy as a `LocalizedStringKey`. The named-server variant
+    /// interpolates the user-supplied host — it's user data, not a translatable
+    /// phrase, so only the surrounding scaffolding comes from the catalog
+    /// (`banner.server_unreachable.named %@`). The generic fallback goes through
+    /// `banner.server_unreachable.generic`. Matches the sibling `OfflineBanner`,
+    /// which routes its strings through the catalog the same way.
+    private var message: LocalizedStringKey {
         if let host, !host.isEmpty {
-            return "Can't reach \(host). Trying again\u{2026}"
+            return "banner.server_unreachable.named \(host)"
         }
-        return "Can't reach your server."
+        return "banner.server_unreachable.generic"
     }
 
     var body: some View {
@@ -54,7 +65,7 @@ struct ServerUnreachableBanner: View {
             Spacer(minLength: 12)
 
             Button(action: onRetry) {
-                Text("Retry")
+                Text("common.retry")
                     .font(Theme.font(12, weight: .bold))
                     .foregroundStyle(Theme.ink)
                     .padding(.horizontal, 12)
@@ -69,7 +80,7 @@ struct ServerUnreachableBanner: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Retry server connection")
+            .accessibilityLabel("banner.server_unreachable.retry.a11y")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -80,9 +91,13 @@ struct ServerUnreachableBanner: View {
                 .fill(Theme.warning)
                 .frame(width: 3)
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(message)
-        .accessibilityAddTraits(.isStaticText)
+        // `children: .contain` keeps the banner as a single VoiceOver container
+        // while preserving its descendants as individually focusable elements —
+        // critically the Retry Button, which a `.combine` flatten would fold into
+        // one inert static-text element and make unreachable. The icon is already
+        // `accessibilityHidden`, so VoiceOver lands on the message Text and then
+        // the actionable Retry button.
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -137,16 +137,38 @@ struct Sidebar: View {
 
             // Server footer
             HStack(spacing: 10) {
-                Circle().fill(Theme.teal).frame(width: 8, height: 8)
-                    .shadow(color: Theme.teal.opacity(0.7), radius: 4)
+                // Status dot + status line reflect *actual* reachability, not
+                // a hard-coded "Connected". A live session whose server has
+                // gone dark (5xx / refused / timeout, per `ServerReachability`)
+                // or a torn-down session reads as disconnected with a muted
+                // dot, so the footer can't claim a healthy link during an
+                // outage. The album count uses `albumsTotal` (the real library
+                // size) rather than `albums.count` (only the pages loaded so
+                // far). See `SidebarServerStatus`.
+                let status = SidebarServerStatus.decide(
+                    hasSession: model.session != nil,
+                    isReachable: model.serverReachability.isServerReachable
+                )
+                let connected = status == .connected
+                Circle()
+                    .fill(connected ? Theme.teal : Theme.ink3)
+                    .frame(width: 8, height: 8)
+                    .shadow(color: connected ? Theme.teal.opacity(0.7) : .clear, radius: 4)
+                    .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(model.session?.server.name ?? "—")
                         .font(Theme.font(11, weight: .bold))
                         .foregroundStyle(Theme.ink)
                         .lineLimit(1)
-                    Text("Connected · \(model.albums.count) albums")
-                        .font(Theme.font(10, weight: .medium))
-                        .foregroundStyle(Theme.ink3)
+                    Group {
+                        if connected {
+                            Text("sidebar.server.connected \(Int(model.albumsTotal))")
+                        } else {
+                            Text("sidebar.server.disconnected")
+                        }
+                    }
+                    .font(Theme.font(10, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
                 }
                 Spacer()
                 Button { model.logout() } label: {
@@ -423,28 +445,48 @@ struct Sidebar: View {
     /// the Library with a tab pre-selected.
     @ViewBuilder
     private var favoritesRow: some View {
+        // Favorites is its own root tab (`.favorites`), so it's "active" under
+        // the same rule every `navItem` uses: the tab is selected and we're at
+        // the tab root (no drill pushed). Without this the row was the only nav
+        // entry that gave no selected-state feedback — no accent, no selection
+        // background/bar, and no `.isSelected` VoiceOver trait. Mirrors
+        // `navItem`'s active treatment so the two read identically.
+        let active = model.screen == .favorites && model.navPath.isEmpty
         Button {
             model.selectTab(.favorites)
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: "heart")
-                    .foregroundStyle(Theme.ink2)
+                    .foregroundStyle(active ? a11yTheme.accent : Theme.ink2)
                     .frame(width: 18)
                     .accessibilityHidden(true)
                 Text("sidebar.stats.favorites")
-                    .font(Theme.font(13, weight: .semibold))
-                    .foregroundStyle(Theme.ink2)
+                    .font(Theme.font(13, weight: active ? .bold : .semibold))
+                    .foregroundStyle(active ? Theme.ink : Theme.ink2)
                     .lineLimit(labelLineLimit)
                 Spacer()
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(active ? Theme.surface2 : .clear)
+            )
+            .overlay(alignment: .leading) {
+                if active {
+                    Rectangle()
+                        .fill(Theme.accent)
+                        .frame(width: 3)
+                        .clipShape(RoundedRectangle(cornerRadius: 1))
+                        .padding(.vertical, 6)
+                }
+            }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("sidebar.stats.favorites")
-        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(active ? [.isSelected, .isButton] : .isButton)
     }
 
     @ViewBuilder
@@ -547,6 +589,16 @@ private struct SidebarInlineEditField: View {
 
     @FocusState private var isFocused: Bool
 
+    /// Set the instant `onSubmit` (Return) fires so the focus-loss that Return
+    /// triggers can't run the blur branch as a *second* commit. Without this,
+    /// pressing Return launched `commitSidebarPlaylistEdit()` and then the
+    /// resign-first-responder flipped `isFocused` to `false` synchronously —
+    /// before that first (async) commit Task had cleared
+    /// `sidebarEditingPlaylistId` — so the `onChange` branch saw a still-live
+    /// edit session and committed again. For a new playlist that meant two
+    /// `createPlaylist` round-trips and two server rows. See #71 / #75 / #590.
+    @State private var committed = false
+
     var body: some View {
         @Bindable var model = model
         TextField("Playlist name", text: $model.sidebarEditingDraft)
@@ -565,6 +617,7 @@ private struct SidebarInlineEditField: View {
                 DispatchQueue.main.async { isFocused = true }
             }
             .onSubmit {
+                committed = true
                 Task { await model.commitSidebarPlaylistEdit() }
             }
             .onExitCommand {
@@ -572,10 +625,12 @@ private struct SidebarInlineEditField: View {
             }
             .onChange(of: isFocused) { _, focused in
                 // #590: Only act on a genuine user-driven focus loss.
-                // If `sidebarEditingPlaylistId` was already cleared (by
-                // Escape, commit, or a concurrent model update), skip the
-                // commit/cancel path so we don't double-act.
+                // Skip when Return already committed this edit (the resulting
+                // focus loss must not commit a second time), and when
+                // `sidebarEditingPlaylistId` was already cleared by Escape,
+                // commit, or a concurrent model update.
                 guard !focused else { return }
+                guard !committed else { return }
                 guard model.sidebarEditingPlaylistId != nil else { return }
                 let trimmed = model.sidebarEditingDraft
                     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/macos/Sources/Lyrebird/Components/SidebarAutoHide.swift
+++ b/macos/Sources/Lyrebird/Components/SidebarAutoHide.swift
@@ -104,6 +104,23 @@ enum SidebarAutoHide {
     static func registeringManualToggle(_ state: State) -> State {
         State(didAutoCollapse: false, userDidOverride: true)
     }
+
+    /// Whether width-driven auto-hide should run for a given Appearance
+    /// `Sidebar` preference. Only `.autoHide` opts in — that's the whole point
+    /// of the preference, and it's what makes the three picker options
+    /// behaviourally distinct (#318 / sidebar audit):
+    ///
+    ///   * `.autoHide` — the rail collapses on narrow windows and restores when
+    ///     they widen (this reducer drives it).
+    ///   * `.visible` — the rail stays put; width never collapses it.
+    ///   * `.hidden` — starts collapsed (handled by `WindowStateStore`); the
+    ///     width reducer doesn't force it open.
+    ///
+    /// Returning `false` means the view should skip the reducer entirely and
+    /// leave `columnVisibility` to the user / restored state.
+    static func isEnabled(for preference: AppearanceSidebar) -> Bool {
+        preference == .autoHide
+    }
 }
 
 /// Stable `@AppStorage` key for the sidebar auto-hide override (#318).

--- a/macos/Sources/Lyrebird/Components/SidebarServerStatus.swift
+++ b/macos/Sources/Lyrebird/Components/SidebarServerStatus.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Pure decision logic for the `Sidebar` server-footer status indicator.
+///
+/// The footer previously hard-coded a green dot and the literal word
+/// "Connected" regardless of whether the server was actually answering, and
+/// showed `model.albums.count` (the number of albums loaded into the paged
+/// cache so far) instead of the real library total. That made the footer lie
+/// in two ways: it stayed "Connected" through a full server outage, and the
+/// album count read low until the user had scrolled the whole library in.
+///
+/// This type captures the "connected vs disconnected, and which dot tint"
+/// contract as a single pure, side-effect-free reducer so it's unit-testable
+/// without booting a SwiftUI scene. The view owns the reads of
+/// `model.session` / `model.serverReachability.isServerReachable` and the
+/// `model.albumsTotal` count; everything visual downstream branches on the
+/// returned `State`. Mirrors the `DynamicTypeReflow` / `PlaylistSidebarOrder`
+/// pure-helper pattern used elsewhere in the sidebar.
+enum SidebarServerStatus {
+    /// Resolved footer state.
+    enum State: Equatable {
+        /// A session exists and the server is answering. The footer shows the
+        /// teal "live" dot and the localized "Connected · N albums" copy.
+        case connected
+        /// Either there is no active session or reachability has flipped to
+        /// failing. The footer shows a muted dot and "Disconnected" so the
+        /// indicator can't claim a healthy connection during an outage.
+        case disconnected
+    }
+
+    /// Pure reducer. `hasSession` is `model.session != nil`; `isReachable` is
+    /// `model.serverReachability.isServerReachable`. We require *both* — a
+    /// signed-in user whose server has gone dark is still "disconnected" for
+    /// the purpose of this indicator, and a torn-down session (sign-out) is
+    /// disconnected even though reachability starts optimistic.
+    static func decide(hasSession: Bool, isReachable: Bool) -> State {
+        (hasSession && isReachable) ? .connected : .disconnected
+    }
+}

--- a/macos/Sources/Lyrebird/Components/StreamErrorToast.swift
+++ b/macos/Sources/Lyrebird/Components/StreamErrorToast.swift
@@ -42,22 +42,32 @@ struct StreamErrorToast: View {
         self.onDismiss = onDismiss
     }
 
-    private var message: String {
-        "\u{201C}\(trackName)\u{201D} couldn't play. Skipping."
+    /// The toast body copy. Resolves through `Localizable.xcstrings` via the
+    /// `stream.error.skipping %@` key so the phrasing is translatable; the
+    /// `trackName` is user data interpolated into the localized format string
+    /// (matching the `tour.a11y.shortcut %@` pattern used elsewhere).
+    private var message: LocalizedStringKey {
+        "stream.error.skipping \(trackName)"
     }
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "exclamationmark.octagon.fill")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Theme.danger)
-                .accessibilityHidden(true)
+            // Icon + message read as one combined VoiceOver element so the
+            // failure is announced as a single phrase, while the action
+            // buttons below remain independently focusable siblings.
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.octagon.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Theme.danger)
+                    .accessibilityHidden(true)
 
-            Text(message)
-                .font(Theme.font(12, weight: .semibold))
-                .foregroundStyle(Theme.ink)
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
+                Text(message)
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .accessibilityElement(children: .combine)
 
             Spacer(minLength: 12)
 
@@ -77,7 +87,7 @@ struct StreamErrorToast: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("stream.error.retry.a11y")
+            .accessibilityLabel(Text("stream.error.retry.a11y"))
 
             Button(action: onGoToTrack) {
                 Text("stream.error.go_to_track")
@@ -97,7 +107,7 @@ struct StreamErrorToast: View {
                         .frame(width: 20, height: 20)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("common.dismiss.a11y")
+                .accessibilityLabel(Text("common.dismiss.a11y"))
             }
         }
         .padding(.horizontal, 16)
@@ -115,9 +125,11 @@ struct StreamErrorToast: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: Color.black.opacity(0.35), radius: 12, y: 4)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(message)
-        .accessibilityAddTraits(.isStaticText)
+        // No container-level `.accessibilityElement(children: .combine)` here:
+        // collapsing the whole toast into one static-text element hid the
+        // Retry / Go to track / Dismiss buttons from VoiceOver. The icon +
+        // message are combined in their own inner element above; the buttons
+        // stay independently focusable siblings.
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/TextFieldSpaceGuard.swift
+++ b/macos/Sources/Lyrebird/Components/TextFieldSpaceGuard.swift
@@ -6,35 +6,53 @@ import SwiftUI
 // SwiftUI's `CommandMenu` registers shortcuts as NSMenuItem key equivalents,
 // which `NSMenu.performKeyEquivalent` processes *before* forwarding unhandled
 // events to the first responder. This means the global Play/Pause ⎵ shortcut
-// fires even when the user is typing in a TextField.
+// (LyrebirdApp's Playback menu, `.keyboardShortcut(.space, modifiers: [])`)
+// fires even when the user is typing in a TextField, eating the space.
 //
-// The fix: install a process-level `NSEvent` local monitor. When a Space key-
-// down arrives and the first responder is an `NSTextField` (or its cell
-// subclass), we let the event reach the text field directly by posting it
-// through `NSApp.sendEvent` after the command handler has already consumed
-// the original. We do this by detecting the situation in the monitor and
-// inserting a literal space via the text field's text-input API so the
-// character lands without a second `sendEvent` round-trip that might loop.
+// The fix: a single process-level `NSEvent` local monitor. The monitor runs
+// during event dispatch *before* `NSApp.sendEvent` hands the key equivalent
+// to `NSMenu`, so when a bare Space arrives while an editable text control
+// owns the first responder we:
+//
+//   1. route the event through the field editor's `interpretKeyEvents(_:)`,
+//      which is AppKit's real text-input entry point — it preserves IME /
+//      marked-text composition, undo coalescing, and selection-replacement
+//      semantics (unlike a raw `insertText(" ")`), and
+//   2. return `nil` so the event never reaches the menu and the Play/Pause
+//      equivalent doesn't also fire.
+//
+// When the first responder is *not* an editable text control the event is
+// returned unchanged so normal dispatch (including the Play/Pause shortcut)
+// proceeds.
+//
+// Only one monitor exists no matter how many guarded views are mounted: each
+// `.spaceKeyGuardForTextField()` host retains the shared monitor on appear
+// and releases it on disappear (see `SpaceGuardMonitor`). Earlier revisions
+// installed one app-global monitor *per host*, so every guarded field
+// multiplied the keyDown handlers firing across the whole app.
 //
 // Applied via `.spaceKeyGuardForTextField()` on any view that hosts a
-// focused TextField (Sidebar, SearchView, CommandPalette).
+// focused TextField (Sidebar, SearchView, CommandPalette, InstantMixSheet).
 
 extension View {
     /// Installs the space-key guard for the lifetime of this view.
     ///
     /// Use this on the nearest common ancestor of any `TextField` that should
     /// receive space-bar input even when the global Play/Pause ⎵ shortcut is
-    /// registered. The guard is a no-op when no text field has first-responder
-    /// status.
+    /// registered. The guard is a no-op when no editable text control has
+    /// first-responder status. The underlying monitor is shared and
+    /// ref-counted, so applying this on several views installs exactly one
+    /// process-level monitor.
     func spaceKeyGuardForTextField() -> some View {
         self.background(SpaceKeyGuardHost())
     }
 }
 
-/// Zero-size `NSViewRepresentable` that installs / removes the `NSEvent`
-/// local monitor for its parent view's lifetime. Using a representable
-/// rather than an `onAppear`/`onDisappear` pair avoids retain-cycle risks
-/// that come with capturing a monitor token in a SwiftUI closure.
+/// Zero-size `NSViewRepresentable` that retains / releases the shared
+/// `NSEvent` local monitor for its parent view's lifetime. Using a
+/// representable rather than an `onAppear`/`onDisappear` pair avoids
+/// retain-cycle risks that come with capturing a monitor token in a SwiftUI
+/// closure.
 private struct SpaceKeyGuardHost: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
@@ -51,68 +69,134 @@ private struct SpaceKeyGuardHost: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
+    /// Holds a single retain on the shared monitor. Balancing
+    /// `install()` / `remove()` keeps the ref count correct even if SwiftUI
+    /// re-creates the representable. Main-actor isolated because the shared
+    /// monitor is, and representable lifecycle runs on the main thread.
+    @MainActor
     final class Coordinator {
-        private var monitor: Any?
+        private var retained = false
 
         func install() {
-            guard monitor == nil else { return }
-            // `.keyDown` at the default priority (0) fires after the main
-            // NSApplication `sendEvent` has already given `NSMenu` a first
-            // crack at the event. We need to catch it *before* that, so we
-            // use a window-level event monitor via addLocalMonitorForEvents
-            // which intercepts events before they reach NSApp.sendEvent.
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                self?.handle(event: event) ?? event
-            }
+            guard !retained else { return }
+            retained = true
+            SpaceGuardMonitor.shared.retain()
         }
 
         func remove() {
-            if let m = monitor {
-                NSEvent.removeMonitor(m)
-                monitor = nil
-            }
+            guard retained else { return }
+            retained = false
+            SpaceGuardMonitor.shared.release()
+        }
+    }
+}
+
+/// Process-wide, ref-counted owner of the single `.keyDown` local monitor.
+///
+/// The first guarded host to mount installs the monitor; the last to unmount
+/// removes it. All access is funnelled through the main actor (guarded hosts
+/// appear/disappear on the main thread, and the monitor closure runs on the
+/// main thread), so a plain counter is sufficient — no extra locking.
+@MainActor
+final class SpaceGuardMonitor {
+    static let shared = SpaceGuardMonitor()
+
+    private var monitor: Any?
+    private var refCount = 0
+
+    private init() {}
+
+    /// Number of live retains. Exposed for tests.
+    var activeRetainCount: Int { refCount }
+
+    /// Whether the underlying `NSEvent` monitor is currently installed.
+    /// Exposed for tests.
+    var isInstalled: Bool { monitor != nil }
+
+    func retain() {
+        refCount += 1
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            SpaceGuardMonitor.handle(event: event)
+        }
+    }
+
+    func release() {
+        guard refCount > 0 else { return }
+        refCount -= 1
+        guard refCount == 0, let m = monitor else { return }
+        NSEvent.removeMonitor(m)
+        monitor = nil
+    }
+
+    /// Returns `nil` if the event was consumed (space routed straight to the
+    /// active text control's field editor), or the original event if it
+    /// should continue normal dispatch.
+    static func handle(event: NSEvent) -> NSEvent? {
+        guard SpaceGuardDetection.isBareSpace(keyCode: event.keyCode, modifierFlags: event.modifierFlags) else {
+            return event
+        }
+        guard let window = NSApp.keyWindow,
+              let responder = window.firstResponder else { return event }
+
+        // Resolve the editable text view (the field editor for NSTextField &
+        // its subclasses — search / combo / secure fields — or a standalone
+        // editable NSTextView) that should receive the space.
+        guard let textView = SpaceGuardDetection.editableTextView(for: responder, in: window) else {
+            return event
         }
 
-        /// Returns `nil` if the event was consumed (space delivered directly
-        /// to the active text field), or the original event if it should
-        /// continue normal dispatch.
-        private func handle(event: NSEvent) -> NSEvent? {
-            // Only intercept bare space (no modifier flags that would
-            // indicate a deliberate key combo).
-            guard
-                event.keyCode == 49, // kVK_Space
-                event.modifierFlags
-                    .intersection([.command, .option, .control, .shift])
-                    .isEmpty
-            else {
-                return event
-            }
+        // Route through AppKit's text-input pipeline so IME composition,
+        // undo coalescing, and selection-replacement all behave exactly as
+        // they would for a key that reached the field editor normally. Then
+        // swallow the event so the menu's Play/Pause equivalent can't fire.
+        textView.interpretKeyEvents([event])
+        return nil
+    }
+}
 
-            // Check whether the first responder is an NSTextField or one of
-            // its editor variants. SwiftUI TextField renders as NSTextField;
-            // when focused, the field editor (NSTextView) becomes first
-            // responder with the NSTextField as the field editor's delegate.
-            guard let window = NSApp.keyWindow,
-                  let responder = window.firstResponder else { return event }
+/// Pure detection logic for the space guard, factored out so the
+/// "is this a bare space?" and "is the first responder an editable text
+/// control?" decisions can be unit-tested without a live window server.
+enum SpaceGuardDetection {
+    /// `kVK_Space`.
+    static let spaceKeyCode: UInt16 = 49
 
-            let isTextField: Bool
-            if responder is NSTextField {
-                isTextField = true
-            } else if let tv = responder as? NSTextView, tv.delegate is NSTextField {
-                isTextField = true
-            } else {
-                isTextField = false
-            }
+    /// True for an unmodified Space (any of Command/Option/Control/Shift set
+    /// means a deliberate combo we shouldn't intercept).
+    static func isBareSpace(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) -> Bool {
+        keyCode == spaceKeyCode
+            && modifierFlags
+                .intersection([.command, .option, .control, .shift])
+                .isEmpty
+    }
 
-            guard isTextField else { return event }
-
-            // Deliver the space directly via the responder chain text-input
-            // API so the character is inserted at the current insertion
-            // point without a second sendEvent round-trip. Returning nil
-            // prevents the event from reaching NSApp.sendEvent, which would
-            // otherwise hand it to NSMenu again.
-            responder.insertText(" ")
-            return nil
+    /// The editable `NSTextView` that should receive a guarded space when
+    /// `responder` owns the first responder, or `nil` when the responder
+    /// isn't an editable text control.
+    ///
+    /// While editing, the first responder is the field editor (an
+    /// `NSTextView`) shared by the focused `NSTextField` / `NSSearchField` /
+    /// `NSComboBox` / `NSSecureTextField`; a standalone editable text area is
+    /// itself an `NSTextView`. We therefore accept any editable `NSTextView`
+    /// directly, and fall back to the window's field editor when the control
+    /// itself is first responder (e.g. just before its editor is installed).
+    /// Detection is by `isEditable`, not by hard-coding a delegate class, so
+    /// search / combo / secure fields and bare text views are all covered.
+    static func editableTextView(for responder: NSResponder, in window: NSWindow) -> NSTextView? {
+        if let textView = responder as? NSTextView {
+            return textView.isEditable ? textView : nil
         }
+        // NSSearchField / NSComboBox / NSSecureTextField are all NSTextField
+        // subclasses, so this single cast covers every editable field-style
+        // control when the control itself (not its field editor) is the
+        // first responder.
+        if let field = responder as? NSTextField, field.isEditable {
+            if let editor = window.fieldEditor(false, for: field) as? NSTextView,
+               editor.isEditable {
+                return editor
+            }
+        }
+        return nil
     }
 }

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -374,9 +374,9 @@ private struct SelectionClickModifier: ViewModifier {
                 // `.highPriorityGesture` and stop it bubbling to selection.
                 // A `.simultaneousGesture` here would always co-fire and
                 // re-introduce the heart-tap-clears-selection regression
-                // (#217 review). The reference `SelectableTrackRow` can use
-                // `.simultaneousGesture` only because it has no interactive
-                // subviews.
+                // (#217 review). `SelectableTrackRow` uses the same `.gesture`
+                // pattern so Cmd/Shift taps aren't co-fired by the bare-tap
+                // recognizer (which would defeat multiselect).
                 .gesture(
                     TapGesture().onEnded { onSelect([]) }
                 )

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -8,11 +8,12 @@ import SwiftUI
 ///
 /// Keyboard navigation (#105): rows are `.focusable()`, expose their id via
 /// `model.focusedTrackId`, and handle Up / Down / Return / Space exactly like
-/// `TrackListRow`. Callers that want arrow navigation between siblings must
-/// pass a `siblings` array so the row can compute the previous / next id;
-/// callers that don't (e.g. a one-off row) can leave it empty and only
-/// Return / Space will work. See also the TODO on type-ahead in
-/// `TrackListRow`.
+/// `TrackListRow`. Callers thread the full ordered `tracks` array plus this
+/// row's `index` so Up / Down can move the shared focus cursor to the
+/// previous / next row; when a move isn't possible (list bounds, or a
+/// caller that left `tracks` empty) the arrow key is declined so the OS
+/// default focus-ring traversal still works. See also the TODO on
+/// type-ahead in `TrackListRow`.
 struct TrackRow: View {
     @Environment(AppModel.self) private var model
     // Contrast-adaptive accent for foreground text/icons (active-track title,
@@ -24,16 +25,16 @@ struct TrackRow: View {
     let track: Track
     let number: Int
     var onPlay: (() -> Void)? = nil
-    /// Ordered list of sibling tracks this row belongs to, used to compute
-    /// the previous / next focus target on arrow keys. Empty means "no
-    /// siblings for nav" — the row will still be focusable and will still
-    /// handle Return / Space, but Up / Down become no-ops.
-    var siblings: [Track] = []
-    /// Position of this row inside `siblings`. When `siblings` is empty
-    /// this is ignored. Kept as an explicit argument so callers that
-    /// already have `idx` from a `ForEach(enumerated)` don't have to pay
-    /// for a linear scan through `siblings`.
-    var siblingIndex: Int = 0
+    /// Ordered list of tracks this row belongs to, used to compute the
+    /// previous / next focus target on arrow keys. Mirrors
+    /// `TrackListRow.tracks`. Empty means "no siblings for nav" — the row
+    /// stays focusable and still handles Return / Space, but Up / Down are
+    /// declined (`.ignored`) so default focus traversal takes over.
+    var tracks: [Track] = []
+    /// Position of this row inside `tracks`. When `tracks` is empty this is
+    /// ignored. Kept as an explicit argument so callers that already have
+    /// `idx` from a `ForEach(enumerated)` don't pay for a linear scan.
+    var index: Int = 0
     /// When non-nil, the row is being rendered inside a playlist detail
     /// view; forwarded to `TrackContextMenu` so the right-click menu can
     /// surface a "Remove from Playlist" entry (#789).
@@ -177,18 +178,25 @@ struct TrackRow: View {
             }
         }
         .onKeyPress(.upArrow) {
-            moveFocus(by: -1)
-            return .handled
+            // Only claim the key if we actually moved focus; otherwise
+            // decline so SwiftUI's default focus-ring traversal runs.
+            moveFocus(by: -1) ? .handled : .ignored
         }
         .onKeyPress(.downArrow) {
-            moveFocus(by: 1)
-            return .handled
+            moveFocus(by: 1) ? .handled : .ignored
         }
         .onKeyPress(.return) {
             onPlay?()
             return .handled
         }
         .onKeyPress(.space) {
+            // Space toggles global transport, but only from the row that is
+            // the current player target. From any other row we decline so
+            // the event isn't trapped and default Space behaviour (e.g.
+            // scrolling, button activation) still works.
+            guard TrackRowKeyboard.spaceTogglesTransport(isActive: isActive) else {
+                return .ignored
+            }
             model.togglePlayPause()
             return .handled
         }
@@ -210,14 +218,40 @@ struct TrackRow: View {
         track.playCount == 1 ? "1 play" : "\(track.playCount) plays"
     }
 
-    /// Move focus by `delta` within `siblings`. No-op when siblings wasn't
-    /// provided — the row just stops responding to arrow keys, which is
-    /// the same behaviour as any non-list focusable control.
-    private func moveFocus(by delta: Int) {
-        guard !siblings.isEmpty else { return }
-        let target = siblingIndex + delta
-        guard target >= 0, target < siblings.count else { return }
-        model.focusedTrackId = siblings[target].id
+    /// Move the shared focus cursor by `delta` within `tracks`. Returns
+    /// `true` when focus actually moved (the caller marks the key handled),
+    /// `false` when there's nowhere to go — no siblings, or already at a
+    /// list edge — so the caller can decline the key and let the OS take
+    /// over default focus traversal.
+    private func moveFocus(by delta: Int) -> Bool {
+        guard let targetId = TrackRowKeyboard.focusTarget(tracks: tracks, index: index, delta: delta) else {
+            return false
+        }
+        model.focusedTrackId = targetId
+        return true
+    }
+}
+
+/// Pure decision logic for `TrackRow`'s keyboard handling, extracted so the
+/// focus-traversal bounds and the Space-transport scoping can be unit-tested
+/// without realizing a SwiftUI view or a live window server. Mirrors the
+/// extract-the-decision pattern used by `MenuBarNowPlaying`.
+enum TrackRowKeyboard {
+    /// The id of the track `delta` positions away from `index` inside
+    /// `tracks`, or `nil` when that lands outside the list (or `tracks` is
+    /// empty). A `nil` result means the arrow key should be declined.
+    static func focusTarget(tracks: [Track], index: Int, delta: Int) -> String? {
+        guard !tracks.isEmpty else { return nil }
+        let target = index + delta
+        guard target >= 0, target < tracks.count else { return nil }
+        return tracks[target].id
+    }
+
+    /// Whether a Space press on this row should toggle global transport.
+    /// Only the active (currently-playing-target) row claims Space; every
+    /// other row declines it so the event isn't trapped.
+    static func spaceTogglesTransport(isActive: Bool) -> Bool {
+        isActive
     }
 }
 

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -4,7 +4,13 @@ import UniformTypeIdentifiers
 
 @main
 struct LyrebirdApp: App {
-    @State private var model: AppModel
+    /// The live view model, or the error that prevented its construction.
+    /// `AppModel()` boots the Rust core, which can fail on a corrupt local
+    /// database. Rather than `fatalError` (which bricks the app on a
+    /// recoverable problem), we hold the failure and render a dedicated
+    /// recovery scene with "Reset Local Data" / "Export Diagnostics"
+    /// affordances. See `CoreInitFailureView` (audit L31).
+    @State private var modelResult: Result<AppModel, Error>
 
     /// Sparkle 2 auto-update handle. Owned here so the controller's
     /// scheduled-update timer starts at launch and the "Check for Updates…"
@@ -25,19 +31,136 @@ struct LyrebirdApp: App {
 
     init() {
         FontRegistration.register()
-        do {
-            _model = State(wrappedValue: try AppModel())
-        } catch {
-            fatalError("Failed to initialize Lyrebird core: \(error)")
-        }
+        // Capture success or failure instead of crashing. A failed core init
+        // (e.g. a corrupt on-disk DB) is recoverable, so the body renders
+        // `CoreInitFailureView` rather than calling `fatalError`.
+        _modelResult = State(wrappedValue: Result { try AppModel() })
     }
 
     private var preferredColorScheme: ColorScheme? {
         (AppearanceMode(rawValue: modeRaw) ?? .dark).preferredColorScheme
     }
 
+    /// The successfully-constructed model, or `nil` if core init failed.
+    /// `SceneBuilder` can't branch (no `buildEither`), so rather than swap whole
+    /// scene trees we keep one flat tree: the primary window branches *in its
+    /// View body* between the app shell and the recovery screen, and the
+    /// model-backed secondary windows / commands guard on this optional. See
+    /// audit L31.
+    private var model: AppModel? {
+        if case .success(let m) = modelResult { return m }
+        return nil
+    }
+
+    /// The error from a failed `AppModel()` / core construction, if any.
+    private var initError: Error? {
+        if case .failure(let e) = modelResult { return e }
+        return nil
+    }
+
     var body: some Scene {
+        // Primary window. The scene is always declared; only its *content*
+        // branches — the full shell when the core came up, or the recovery
+        // screen (reset / diagnostics) when it didn't, replacing the old
+        // `fatalError`. Keeping the scenes unconditional (and guarding inside
+        // their View/Commands closures, which can branch) sidesteps
+        // `SceneBuilder`'s lack of conditional support. See `CoreInitFailureView`
+        // (audit L31).
         WindowGroup("Lyrebird") {
+            primaryWindowContent
+        }
+        .defaultSize(width: 1280, height: 820)
+        // Hide the system title bar so the sidebar runs edge-to-edge under the
+        // traffic lights. `.hiddenTitleBar` flips `titlebarAppearsTransparent`
+        // and adds `.fullSizeContentView`, letting content flow into the
+        // title-bar strip; the unified toolbar style keeps `.toolbar {}` content
+        // in the right strip.
+        .windowStyle(.hiddenTitleBar)
+        .windowToolbarStyle(.unifiedCompact)
+        .commands {
+            // The app menus only make sense with a live model; on the failure
+            // path they're omitted and the recovery window keeps the standard
+            // system menus. `CommandsBuilder` supports this `if let`.
+            if let model {
+                LyrebirdCommands(model: model, updater: updater)
+            }
+        }
+
+        // Native Preferences scene. macOS wires up ⌘, and the menu item for
+        // free. On macOS 14+ `WindowGroup` + `Settings` handle size/position
+        // persistence, so we don't persist a frame manually. See #17.
+        Settings {
+            if let model {
+                PreferencesView()
+                    .environment(model)
+                    .preferredColorScheme(preferredColorScheme)
+            }
+        }
+        .windowResizability(.contentSize)
+
+        // Detached Mini Player. A single-instance `Window` (not a `WindowGroup`)
+        // so ⌘⌥P toggles exactly one mini player rather than spawning
+        // duplicates. The borderless / vibrancy / rounded / always-on-top chrome
+        // is applied by `MiniPlayerView`'s embedded
+        // `MiniPlayerWindowConfigurator` since `Scene` modifiers can't reach
+        // those `NSWindow` knobs. `.contentSize` honours the 280–480pt band.
+        Window("mini_player.window.title", id: MiniPlayerScene.id) {
+            if let model {
+                MiniPlayerView()
+                    .environment(model)
+                    .preferredColorScheme(preferredColorScheme)
+            }
+        }
+        .windowResizability(.contentSize)
+        .defaultSize(width: 320, height: 120)
+        .windowStyle(.hiddenTitleBar)
+        .defaultPosition(.topTrailing)
+
+        // Keyboard Shortcuts help window. A single-instance `Window` so Help >
+        // Keyboard Shortcuts / ⌘? toggles exactly one panel. It renders the
+        // static `AppShortcuts.all` catalog, so it stays useful even signed out
+        // and on the core-init failure path (no `AppModel` needed).
+        Window("shortcuts.window.title", id: AppShortcuts.windowID) {
+            KeyboardShortcutsView()
+                .preferredColorScheme(preferredColorScheme)
+        }
+        .defaultSize(width: 480, height: 560)
+        .windowResizability(.contentSize)
+
+        // Dedicated About window (#25). `AboutView` reads version / credits from
+        // `AboutInfo` and the connected-server host from the live `AppModel`, so
+        // it needs the model in its environment.
+        Window("about.window.title", id: AboutView.windowID) {
+            if let model {
+                AboutView()
+                    .environment(model)
+                    .preferredColorScheme(preferredColorScheme)
+            }
+        }
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
+
+        // Status-bar "Now Playing" extra. Stays reachable even when every
+        // Lyrebird window is closed or the app is hidden. The `.window` style
+        // renders artwork + a rich transport cluster; the label reflects play
+        // state. "Open Lyrebird" routes through `returnToFullWindow`, which
+        // activates the app and raises the main window.
+        MenuBarExtra {
+            if let model {
+                MenuBarNowPlaying()
+                    .environment(model)
+                    .preferredColorScheme(preferredColorScheme)
+            }
+        } label: {
+            menuBarExtraLabel
+        }
+        .menuBarExtraStyle(.window)
+    }
+
+    /// The primary window's content, branching on whether the core constructed.
+    @ViewBuilder
+    private var primaryWindowContent: some View {
+        if let model {
             RootView()
                 .environment(model)
                 .frame(minWidth: 960, minHeight: 640)
@@ -47,100 +170,29 @@ struct LyrebirdApp: App {
                 // already opted in, so track-change banners work without
                 // re-toggling. No-ops when the preference is off.
                 .task { NotificationManager.shared.requestAuthorizationIfNeeded() }
-                // Publish the current window's `AppModel` as a focused
-                // scene value so `@FocusedValue(\.appModel)` readers
-                // (e.g. future menu commands that live outside the
-                // WindowGroup body) can resolve against whichever window
-                // is key. Single-window apps only need this to be ready
-                // for a multi-window future. See `FocusedValueKey+AppModel`.
+                // Publish the current window's `AppModel` as a focused scene
+                // value so `@FocusedValue(\.appModel)` readers resolve against
+                // whichever window is key. See `FocusedValueKey+AppModel`.
                 .focusedSceneValue(\.appModel, model)
-        }
-        .defaultSize(width: 1280, height: 820)
-        // Hide the system title bar so the sidebar runs edge-to-edge
-        // under the traffic lights (Apple Music / Music for Classical /
-        // Reeder / Spark layout). `.hiddenTitleBar` flips
-        // `titlebarAppearsTransparent` and adds `.fullSizeContentView`
-        // to the window's `styleMask`, letting our content flow into
-        // the title-bar strip. The unified toolbar style stays in place
-        // so any `.toolbar {}` content still lands in the right strip.
-        .windowStyle(.hiddenTitleBar)
-        .windowToolbarStyle(.unifiedCompact)
-        .commands {
-            LyrebirdCommands(model: model, updater: updater)
-        }
-
-        // Native Preferences scene. macOS wires up ⌘, and menu item for free.
-        // Window restoration: on macOS 14+ `WindowGroup` + `Settings`
-        // handle size/position persistence for us, so we intentionally do
-        // not register a `SceneStorage` or persist a frame manually. See #17.
-        Settings {
-            PreferencesView()
-                .environment(model)
+        } else if let initError {
+            // Recoverable core-init failure: show the reset / diagnostics
+            // recovery screen instead of crashing (audit L31).
+            CoreInitFailureView(error: initError)
+                .frame(minWidth: 480, minHeight: 420)
                 .preferredColorScheme(preferredColorScheme)
         }
-        .windowResizability(.contentSize)
+    }
 
-        // Detached Mini Player. A dedicated single-instance `Window`
-        // (not a `WindowGroup`) so ⌘⌥P toggles exactly one mini player rather
-        // than spawning duplicates. The window's borderless / vibrancy /
-        // rounded / always-on-top chrome is applied by `MiniPlayerView`'s
-        // embedded `MiniPlayerWindowConfigurator` since `Scene` modifiers
-        // can't reach those `NSWindow` knobs. `.contentSize` resizability
-        // honours the view's 280–480pt width band.
-        Window("mini_player.window.title", id: MiniPlayerScene.id) {
-            MiniPlayerView()
-                .environment(model)
-                .preferredColorScheme(preferredColorScheme)
-        }
-        .windowResizability(.contentSize)
-        .defaultSize(width: 320, height: 120)
-        .windowStyle(.hiddenTitleBar)
-        .defaultPosition(.topTrailing)
-
-        // Keyboard Shortcuts help window. A dedicated single-instance
-        // `Window` (not a `WindowGroup`) so Help > Keyboard Shortcuts / ⌘?
-        // toggles exactly one panel rather than spawning duplicates. It renders
-        // the `AppShortcuts.all` catalog — the same map the menu bar mirrors —
-        // as a searchable two-column list. No `AppModel` needed: the catalog is
-        // static data, so the window stays open and useful even signed out.
-        Window("shortcuts.window.title", id: AppShortcuts.windowID) {
-            KeyboardShortcutsView()
-                .preferredColorScheme(preferredColorScheme)
-        }
-        .defaultSize(width: 480, height: 560)
-        .windowResizability(.contentSize)
-
-        // Dedicated About window (#25). A single-instance `Window` (not a
-        // `WindowGroup`) so the app-menu "About Lyrebird" item — rebound via
-        // `CommandGroup(replacing: .appInfo)` above — summons exactly one
-        // panel. `AboutView` reads version / credits from the shared
-        // `AboutInfo` and the connected-server host from the live `AppModel`,
-        // so it needs the model in its environment. `.contentSize` lets the
-        // fixed-width column size itself to its content.
-        Window("about.window.title", id: AboutView.windowID) {
-            AboutView()
-                .environment(model)
-                .preferredColorScheme(preferredColorScheme)
-        }
-        .windowResizability(.contentSize)
-        .defaultPosition(.center)
-
-        // Status-bar "Now Playing" extra. A `MenuBarExtra` lives in the system
-        // menu bar, so this transport surface stays reachable even when every
-        // Lyrebird window is closed or the app is hidden. The `.window`
-        // style lets the panel render artwork + a rich transport cluster rather
-        // than a flat text menu; the label reflects play state at a glance.
-        // Clicking "Open Lyrebird" routes through `returnToFullWindow`, which
-        // activates the app and raises the main window.
-        MenuBarExtra {
-            MenuBarNowPlaying()
-                .environment(model)
-                .preferredColorScheme(preferredColorScheme)
-        } label: {
+    /// Label for the status-bar extra. Falls back to the plain "playing" glyph
+    /// on the failure path so the menu-bar item still has a sensible label.
+    @ViewBuilder
+    private var menuBarExtraLabel: some View {
+        if let model {
             MenuBarNowPlayingLabel()
                 .environment(model)
+        } else {
+            Image(systemName: "music.note")
         }
-        .menuBarExtraStyle(.window)
     }
 }
 
@@ -248,21 +300,30 @@ struct LyrebirdCommands: Commands {
         CommandGroup(after: .sidebar) {
             Divider()
 
-            Button("menu.view.show_sidebar") {
-                // TODO(#5): bind to a published `isSidebarVisible` flag on
-                // AppModel and have `MainShell` conditionally mount `Sidebar()`.
-                // The menu item is reserved now so the shortcut exists.
-            }
+            // Show Sidebar (⌘⌥S). A `Toggle` so AppKit draws a checkmark
+            // tracking the real rail state. `MainShell` owns the
+            // `NavigationSplitView` column visibility (and the width-driven
+            // auto-hide reducer), so the menu mirrors its state via
+            // `model.isSidebarVisible` and drives changes through
+            // `requestSidebarToggle()`, which `MainShell` observes and routes to
+            // its existing `toggleSidebarManually()`. See audit L251.
+            Toggle("menu.view.show_sidebar", isOn: Binding(
+                get: { model.isSidebarVisible },
+                set: { _ in model.requestSidebarToggle() }
+            ))
             .keyboardShortcut("s", modifiers: [.command, .option])
-            .disabled(true)
+            .disabled(model.session == nil)
 
-            Button("menu.view.show_queue") {
-                // TODO(#272): the queue drawer lands with BATCH-07's rich
-                // inspector. Menu item reserved so ⌘⌥Q resolves to something
-                // discoverable once the panel exists.
-            }
+            // Show Queue (⌘⌥Q). Toggles the right-side Queue Inspector (#79),
+            // checkmark tracking `isQueueInspectorOpen`. This menu item owns the
+            // ⌘⌥Q shortcut; `MainShell` no longer needs its hidden duplicate.
+            // See audit L251.
+            Toggle("menu.view.show_queue", isOn: Binding(
+                get: { model.isQueueInspectorOpen },
+                set: { _ in model.toggleQueueInspector() }
+            ))
             .keyboardShortcut("q", modifiers: [.command, .option])
-            .disabled(true)
+            .disabled(model.session == nil)
 
             Divider()
 
@@ -364,7 +425,12 @@ struct LyrebirdCommands: Commands {
             // window's `willCloseNotification` observer (see `RootView`).
             Toggle("menu.view.mini_player", isOn: Binding(
                 get: { model.isMiniPlayerVisible },
-                set: { _ in model.toggleMiniPlayer() }
+                // Drive to the value SwiftUI requests rather than blindly
+                // toggling, so the action can't desync from the checkbox state
+                // (audit L365). `RootView.onChange(of: isMiniPlayerVisible)`
+                // opens / closes the window from the flag, so setting it is
+                // sufficient.
+                set: { model.isMiniPlayerVisible = $0 }
             ))
             .keyboardShortcut("p", modifiers: [.command, .option])
             .disabled(model.session == nil)
@@ -377,10 +443,18 @@ struct LyrebirdCommands: Commands {
         // Bluetooth AVRCP events hit the same `AppModel` methods via
         // `MediaSession` — see file header for why they aren't re-registered.
         CommandMenu("menu.playback") {
+            // Play / Pause. The bare-Space shortcut is intentionally NOT bound
+            // as a menu key equivalent: SwiftUI registers `CommandMenu`
+            // shortcuts as `NSMenuItem` key equivalents, which fire ahead of the
+            // first responder and so swallowed Space even while a text field was
+            // focused (audit L383). The ⎵ binding now lives on an app-wide
+            // `NSEvent` monitor (`RootView.playPauseSpaceMonitor`) that passes
+            // the event through to focused text editors. The menu item itself
+            // stays (clickable, and showing the Play/Pause state) — the label
+            // notes ⎵ so the shortcut is still discoverable.
             Button(playPauseLabelKey) {
                 model.togglePlayPause()
             }
-            .keyboardShortcut(.space, modifiers: [])
             .disabled(model.status.currentTrack == nil)
 
             Divider()
@@ -445,18 +519,21 @@ struct LyrebirdCommands: Commands {
         // Bring All to Front, and (on macOS 14+) the tiling entries. We add
         // an explicit Tile Window action so the command is discoverable
         // even when the system hasn't surfaced the OS-level tiling item.
+        // `NSApp.keyWindow` is not an `@Observable` value, so gating
+        // `.disabled` on it left the items' enabled state stale — SwiftUI never
+        // re-evaluated the body on `didBecomeKey` / `didResignKey` (audit L453).
+        // `tileCurrentWindow` already guards on `NSApp.keyWindow` and is a safe
+        // no-op when there is none, so the gate is dropped entirely.
         CommandGroup(after: .windowArrangement) {
             Button("menu.window.tile_left") {
                 tileCurrentWindow(edge: .left)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.control, .option, .command])
-            .disabled(NSApp.keyWindow == nil)
 
             Button("menu.window.tile_right") {
                 tileCurrentWindow(edge: .right)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.control, .option, .command])
-            .disabled(NSApp.keyWindow == nil)
         }
 
         // MARK: - Help menu (replace default "Lyrebird Help" placeholder)
@@ -657,6 +734,14 @@ struct RootView: View {
             // re-entry, so a `.task` firing on every scene rebuild is safe.
             await model.attemptRestoreSession()
         }
+        // App-wide bare-Space Play/Pause (audit L383). Installed here on the
+        // always-mounted root so it covers every screen, and routed through a
+        // first-responder check so Space still types into focused text fields
+        // instead of toggling playback. Replaces the old menu-level ⎵ shortcut.
+        .playPauseSpaceMonitor(
+            { model.togglePlayPause() },
+            hasCurrentTrack: { model.status.currentTrack != nil }
+        )
         // Bridge the Mini Player flag to the actual scene. Driving the
         // window from a single `@Observable` flag keeps the ⌘⌥P checkmark,
         // the settings-menu "return", and the open window from ever drifting

--- a/macos/Sources/Lyrebird/LyrebirdErrorPresenter.swift
+++ b/macos/Sources/Lyrebird/LyrebirdErrorPresenter.swift
@@ -69,6 +69,22 @@ enum LyrebirdErrorPresenter {
             return "error.auth.expired"
         }
 
+        // `LyrebirdError::RateLimit` renders as "rate limited (retry after
+        // …)" — it does NOT carry the "server returned an error:" prefix,
+        // so it must be matched at the top level. (A 429 that came back as
+        // `LyrebirdError::Server` is handled inside the block below.)
+        if description.contains("rate limited") || description.contains("rate limit") {
+            return "error.rate_limit"
+        }
+
+        // `LyrebirdError::SelfSignedCertificate` renders as "the server at
+        // '<host>' uses a certificate that could not be verified …". Route
+        // it to a cert-specific banner so the UI can offer a trust action
+        // rather than treating it as a generic network failure.
+        if description.contains("certificate") {
+            return "error.certificate"
+        }
+
         // `LyrebirdError::Server` renders as "server returned an error:
         // {status} {message}". Pattern-match the status digits embedded
         // in the Display so 403/404/429 get specialised banners even

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -2053,6 +2053,126 @@
           }
         }
       }
+    },
+    "core_failure.body" : {
+      "comment" : "Explanation on the core-init failure recovery screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrebird’s local data couldn’t be opened. This is usually fixable: reset the local data to start fresh, or export a diagnostics bundle to share with a bug report."
+          }
+        }
+      }
+    },
+    "core_failure.export" : {
+      "comment" : "Button on the failure screen that writes a sanitized diagnostics bundle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Diagnostics…"
+          }
+        }
+      }
+    },
+    "core_failure.export.done" : {
+      "comment" : "Confirmation after a diagnostics bundle was written from the failure screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diagnostics exported."
+          }
+        }
+      }
+    },
+    "core_failure.export.failed" : {
+      "comment" : "Shown when exporting diagnostics failed; %@ is the error.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t export diagnostics: %@"
+          }
+        }
+      }
+    },
+    "core_failure.quit" : {
+      "comment" : "Button that quits the app from the failure screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quit"
+          }
+        }
+      }
+    },
+    "core_failure.reset" : {
+      "comment" : "Button that moves the corrupt local data aside so the next launch starts clean.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Local Data"
+          }
+        }
+      }
+    },
+    "core_failure.reset.done" : {
+      "comment" : "Confirmation after the local data was moved aside; %@ is the backup path.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local data was moved to:\n%@\nPlease quit and reopen Lyrebird."
+          }
+        }
+      }
+    },
+    "core_failure.reset.failed" : {
+      "comment" : "Shown when resetting the local data failed; %@ is the error.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t reset local data: %@"
+          }
+        }
+      }
+    },
+    "core_failure.reset.nothing" : {
+      "comment" : "Shown when there was no local data directory to reset.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No local data was found to reset. Try exporting diagnostics instead."
+          }
+        }
+      }
+    },
+    "core_failure.title" : {
+      "comment" : "Title of the recovery screen shown when the core fails to start.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrebird couldn’t start"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -373,6 +373,18 @@
         }
       }
     },
+    "error.certificate" : {
+      "comment" : "Banner copy for LyrebirdError.SelfSignedCertificate — the server's TLS certificate couldn't be verified (e.g. self-signed). The user may need to trust the server.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server's certificate couldn't be verified. You may need to trust this server."
+          }
+        }
+      }
+    },
     "error.invalid_input" : {
       "comment" : "Banner copy for LyrebirdError.InvalidInput — user-supplied value was rejected.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -673,6 +673,258 @@
         }
       }
     },
+    "onboarding.back" : {
+      "comment" : "Back button on the onboarding connect step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.title" : {
+      "comment" : "Hero headline on the first onboarding screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome to Lyrebird"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.subtitle" : {
+      "comment" : "Tagline under the welcome headline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your music, your server, your rules."
+          }
+        }
+      }
+    },
+    "onboarding.welcome.get_started" : {
+      "comment" : "Primary CTA on the welcome screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get started"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.existing_account" : {
+      "comment" : "Secondary link on the welcome screen for returning users.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I already have an account →"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.existing_account.a11y" : {
+      "comment" : "Accessibility label for the returning-user link on the welcome screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I already have an account"
+          }
+        }
+      }
+    },
+    "onboarding.connect.title" : {
+      "comment" : "Heading on the onboarding connect-server step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect your server"
+          }
+        }
+      }
+    },
+    "onboarding.connect.subtitle" : {
+      "comment" : "Helper copy under the connect-server heading.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Jellyfin URL is the address you use to reach it from a browser."
+          }
+        }
+      }
+    },
+    "onboarding.connect.continue" : {
+      "comment" : "Primary submit button on the connect step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        }
+      }
+    },
+    "onboarding.connect.connecting" : {
+      "comment" : "Submit button label while a sign-in request is in flight.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecting…"
+          }
+        }
+      }
+    },
+    "onboarding.connect.skip_offline" : {
+      "comment" : "Link that skips sign-in and lets the user explore offline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip, explore offline →"
+          }
+        }
+      }
+    },
+    "onboarding.sync.title" : {
+      "comment" : "Heading on the first-sync step that shows library loading progress.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading your library"
+          }
+        }
+      }
+    },
+    "onboarding.sync.phase.artists" : {
+      "comment" : "Progress line while artists are loading on the first-sync step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading artists…"
+          }
+        }
+      }
+    },
+    "onboarding.sync.phase.albums" : {
+      "comment" : "Progress line while albums are loading on the first-sync step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading albums…"
+          }
+        }
+      }
+    },
+    "onboarding.sync.phase.tracks" : {
+      "comment" : "Progress line while tracks are loading on the first-sync step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading tracks…"
+          }
+        }
+      }
+    },
+    "onboarding.sync.phase.artwork" : {
+      "comment" : "Progress line while artwork is loading on the first-sync step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching artwork…"
+          }
+        }
+      }
+    },
+    "onboarding.sync.counter" : {
+      "comment" : "Library totals counter on the first-sync step. %1$@ is the track count, %2$@ the artist count, %3$@ the album count, each pre-formatted with grouping separators.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ tracks · %2$@ artists · %3$@ albums"
+          }
+        }
+      }
+    },
+    "onboarding.sync.continue" : {
+      "comment" : "CTA that leaves onboarding for the Home screen once the library has loaded.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue to Home"
+          }
+        }
+      }
+    },
+    "onboarding.sync.syncing" : {
+      "comment" : "Disabled CTA label shown while the library is still loading.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing…"
+          }
+        }
+      }
+    },
+    "onboarding.sync.error" : {
+      "comment" : "Status line on the first-sync step when the library failed to load; offers a retry.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t load your library."
+          }
+        }
+      }
+    },
+    "onboarding.sync.retry" : {
+      "comment" : "Button that re-attempts the library load after a failure on the first-sync step.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        }
+      }
+    },
     "menu.app.about" : {
       "comment" : "App menu \u201cAbout Lyrebird\u201d item that opens the dedicated About window (#25).",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1069,6 +1069,42 @@
         }
       }
     },
+    "sidebar.server.connected %lld" : {
+      "comment" : "Sidebar footer status line when the server is reachable; %lld is the total album count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Connected · %lld album"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Connected · %lld albums"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "sidebar.server.disconnected" : {
+      "comment" : "Sidebar footer status line when there is no session or the server is unreachable.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnected"
+          }
+        }
+      }
+    },
     "sidebar.stats.favorites" : {
       "comment" : "Sidebar stats row: Favorites.",
       "extractionState" : "manual",
@@ -1137,6 +1173,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Go to track"
+          }
+        }
+      }
+    },
+    "stream.error.skipping %@" : {
+      "comment" : "StreamErrorToast body copy; %@ is the failed track name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” couldn’t play. Skipping."
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -97,6 +97,42 @@
         }
       }
     },
+    "banner.server_unreachable.generic" : {
+      "comment" : "ServerUnreachableBanner message when the configured server is failing to answer and no host is available to name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't reach your server."
+          }
+        }
+      }
+    },
+    "banner.server_unreachable.named %@" : {
+      "comment" : "ServerUnreachableBanner message naming the configured host. %@ is the user's server host (or host:port) and is interpolated verbatim as user data.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't reach %@. Trying again\u2026"
+          }
+        }
+      }
+    },
+    "banner.server_unreachable.retry.a11y" : {
+      "comment" : "VoiceOver label for the Retry button on the server-unreachable banner.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry server connection"
+          }
+        }
+      }
+    },
     "breadcrumb.album.fallback" : {
       "comment" : "Breadcrumb segment when the current album hasn't resolved its name yet.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -33,6 +33,17 @@ struct AlbumDetailView: View {
     /// Whether the full editorial blurb popover is open (#68). Mirrors the
     /// artist About section's "Read more" affordance.
     @State private var isAboutExpanded = false
+    /// Whether the editorial overview actually overflows its 4-line clamp
+    /// (#475). Driven by comparing the clamped vs. full rendered height; the
+    /// "Read more" button is shown only when this is true so a short overview
+    /// that already fits doesn't get a no-op "Read more".
+    @State private var isOverviewTruncated = false
+    /// Rendered height of the visible 4-line-clamped overview, captured via a
+    /// background `GeometryReader`. Compared against `fullOverviewHeight`.
+    @State private var clampedOverviewHeight: CGFloat = 0
+    /// Rendered height of an off-screen, unclamped copy of the same overview.
+    /// When it exceeds the clamped height the visible text is truncated (#475).
+    @State private var fullOverviewHeight: CGFloat = 0
     /// Whether the right-side liner-notes drawer is presented (#221). The
     /// liner-note fields + credits also live inline at the bottom of the page
     /// (#65); the drawer surfaces the same structured data without a scroll to
@@ -66,6 +77,16 @@ struct AlbumDetailView: View {
         .overlay(alignment: .trailing) { linerNotesDrawer }
         .task(id: albumID) {
             isLoading = true
+            // Reset every album-scoped @State before the awaits so a prior
+            // album's data can't paint during this album's reload window
+            // (#67). Without this the stat strip, liner notes, and "More by
+            // artist" shelf flash the previous album until each fetch
+            // resolves — and a new album with no artist would inherit the old
+            // album's `moreByArtist` entirely (#83).
+            tracks = []
+            detail = AlbumDetail(label: nil, releaseDate: nil, people: [], overview: nil)
+            moreByArtist = []
+            fetchedAlbum = nil
             // Reset the editorial-blurb popover so a prior album's expanded
             // "About this album" never bleeds into this page (#68).
             isAboutExpanded = false
@@ -79,7 +100,9 @@ struct AlbumDetailView: View {
             isLoading = false
             detail = await model.loadAlbumDetail(albumId: albumID)
             // Load "More by Artist" in parallel with detail — non-blocking for
-            // the tracklist which is already visible at this point.
+            // the tracklist which is already visible at this point. When the
+            // album has no resolvable artist, clear the shelf so a prior
+            // album's "More by artist" can't persist under the new header (#83).
             if let artistId = album?.artistId, !artistId.isEmpty {
                 let all = await model.loadArtistAlbums(artistId: artistId)
                 moreByArtist = Array(
@@ -88,6 +111,8 @@ struct AlbumDetailView: View {
                         .sorted { ($0.year ?? 0) > ($1.year ?? 0) }
                         .prefix(10)
                 )
+            } else {
+                moreByArtist = []
             }
         }
     }
@@ -173,7 +198,7 @@ struct AlbumDetailView: View {
     private func statStrip(album: Album) -> some View {
         HStack(spacing: 28) {
             stat(value: "\(album.trackCount)", label: "Tracks")
-            stat(value: formatMinutes(album.runtimeTicks), label: "Minutes")
+            stat(value: formatMinutes(totalRuntimeTicks(album: album)), label: "Minutes")
             stat(value: detail.label ?? "—", label: "Label")
             stat(value: formatSummary(tracks: tracks), label: "Format")
         }
@@ -463,29 +488,80 @@ struct AlbumDetailView: View {
     /// button that opens the full text in a popover. The popover is driven by
     /// a plain SwiftUI `Button`, so it's focusable and Return-activatable for
     /// free — the same affordance as the artist About section.
+    ///
+    /// "Read more" is shown only when the overview actually overflows the
+    /// 4-line clamp (#475): the clamped `Text` measures its rendered height
+    /// via a background `GeometryReader`, while an off-screen copy of the same
+    /// text with no line limit measures the full height. When the clamp is
+    /// shorter than the full text the overview is truncated and the button
+    /// appears; for a short overview that fits in ≤4 lines the heights match
+    /// and the no-op button is omitted.
     @ViewBuilder
     private func aboutBody(overview: String) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(overview)
-                .font(Theme.font(14, weight: .regular))
-                .foregroundStyle(Theme.ink2)
-                .lineLimit(4)
-                .fixedSize(horizontal: false, vertical: true)
-                .textSelection(.enabled)
-            Button {
-                isAboutExpanded = true
-            } label: {
-                Text("Read more")
-                    .font(Theme.font(12, weight: .semibold))
-                    .foregroundStyle(Theme.accent)
+            // The visible text and an off-screen unclamped copy are overlaid in
+            // a ZStack so they share the same proposed width; each reports its
+            // rendered height through a preference key. The full copy is
+            // `.hidden()` + non-interactive so it never paints or hit-tests —
+            // it exists only to measure the un-truncated height.
+            ZStack(alignment: .topLeading) {
+                Text(overview)
+                    .font(Theme.font(14, weight: .regular))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .hidden()
+                    .accessibilityHidden(true)
+                    .allowsHitTesting(false)
+                    .background {
+                        GeometryReader { proxy in
+                            Color.clear.preference(
+                                key: FullOverviewHeightKey.self,
+                                value: proxy.size.height)
+                        }
+                    }
+
+                Text(overview)
+                    .font(Theme.font(14, weight: .regular))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(4)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .background {
+                        GeometryReader { proxy in
+                            Color.clear.preference(
+                                key: ClampedOverviewHeightKey.self,
+                                value: proxy.size.height)
+                        }
+                    }
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Read full description for \(album?.name ?? "this album")")
-            .accessibilityHint("Opens the complete album description in a popover")
-            .popover(isPresented: $isAboutExpanded, arrowEdge: .top) {
-                aboutPopover(overview: overview)
+            if isOverviewTruncated {
+                Button {
+                    isAboutExpanded = true
+                } label: {
+                    Text("Read more")
+                        .font(Theme.font(12, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Read full description for \(album?.name ?? "this album")")
+                .accessibilityHint("Opens the complete album description in a popover")
+                .popover(isPresented: $isAboutExpanded, arrowEdge: .top) {
+                    aboutPopover(overview: overview)
+                }
             }
         }
+        .onPreferenceChange(ClampedOverviewHeightKey.self) { clampedOverviewHeight = $0 }
+        .onPreferenceChange(FullOverviewHeightKey.self) { fullOverviewHeight = $0 }
+        .onChange(of: clampedOverviewHeight) { _, _ in recomputeOverviewTruncation() }
+        .onChange(of: fullOverviewHeight) { _, _ in recomputeOverviewTruncation() }
+    }
+
+    /// Re-derive the truncation flag from the latest clamped / full heights.
+    /// Called whenever either measurement changes so "Read more" appears only
+    /// once the overview is confirmed to overflow its 4-line clamp (#475).
+    private func recomputeOverviewTruncation() {
+        isOverviewTruncated = AboutOverviewTruncation.isTruncated(
+            clamped: clampedOverviewHeight,
+            full: fullOverviewHeight)
     }
 
     /// Full-description popover. Scrolls when the text is long so the popover
@@ -756,6 +832,18 @@ struct AlbumDetailView: View {
 
     // MARK: - Formatting helpers
 
+    /// Authoritative album runtime in ticks, shared by the hero "Minutes"
+    /// stat and the liner-note "Runtime" row so the two can never disagree
+    /// (#176). Sums the cached track runtimes when they're loaded — which
+    /// also keeps the hero from reading "0" when the server reports no
+    /// album-level runtime — and falls back to the album's `runtime_ticks`
+    /// only before the tracks resolve.
+    private func totalRuntimeTicks(album: Album) -> UInt64 {
+        tracks.isEmpty
+            ? album.runtimeTicks
+            : tracks.reduce(0) { $0 + $1.runtimeTicks }
+    }
+
     /// Minutes-only duration string for the hero stat. The older
     /// implementation returned an integer minute count; we keep the same
     /// shape so the "Minutes" stat reads as a clean number.
@@ -769,9 +857,7 @@ struct AlbumDetailView: View {
     /// so re-ripped albums with trimmed tails stay accurate; falls back to
     /// the album's `runtime_ticks` otherwise.
     private func runtimeSummary(album: Album) -> String {
-        let ticks: UInt64 = tracks.isEmpty
-            ? album.runtimeTicks
-            : tracks.reduce(0) { $0 + $1.runtimeTicks }
+        let ticks = totalRuntimeTicks(album: album)
         let totalSeconds = Int(Double(ticks) / 10_000_000.0)
         if totalSeconds >= 3600 {
             let h = totalSeconds / 3600
@@ -839,6 +925,49 @@ struct AlbumDetailView: View {
             }
         }
         return ordered.joined(separator: " · ")
+    }
+}
+
+// MARK: - About overview truncation (#475)
+
+/// Pure decision for whether the editorial "About this album" overview
+/// overflows its 4-line clamp and therefore warrants a "Read more" button
+/// (#475). Hoisted out of the view — mirroring `LinerNotesDrawerPresentation`
+/// — so the height comparison can be unit-tested without booting a scene.
+///
+/// SwiftUI measures both the clamped and the full (unclamped) rendered height
+/// of the same text; this type owns the comparison so the view only flips a
+/// boolean. A small epsilon absorbs sub-point rounding so a text that exactly
+/// fills four lines doesn't grow a phantom "Read more".
+enum AboutOverviewTruncation {
+    /// Sub-point slack so float rounding between the two measurements can't
+    /// register a fits-exactly overview as truncated.
+    static let epsilon: CGFloat = 1.0
+
+    /// `true` when the full text is meaningfully taller than the clamped text,
+    /// i.e. the visible overview is cut off. Returns `false` until both heights
+    /// have been measured (non-zero) so the button never flashes in during the
+    /// first layout pass before measurement settles.
+    static func isTruncated(clamped: CGFloat, full: CGFloat) -> Bool {
+        guard clamped > 0, full > 0 else { return false }
+        return full > clamped + epsilon
+    }
+}
+
+/// Rendered height of the visible, 4-line-clamped overview text (#475).
+private struct ClampedOverviewHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Rendered height of the off-screen, unclamped copy of the overview text,
+/// used to detect truncation against the clamped height (#475).
+private struct FullOverviewHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -381,14 +381,19 @@ struct AlbumDetailView: View {
                         discHeader(number: group.disc)
                     }
                     ForEach(Array(group.tracks.enumerated()), id: \.element.id) { localIdx, track in
+                        // Arrow-key focus navigation walks the full (disc-
+                        // flattened) `tracks` list, so resolve this row's
+                        // absolute index once and reuse it for both nav and
+                        // tap-to-play.
+                        let absoluteIdx = tracks.firstIndex(where: { $0.id == track.id }) ?? 0
                         TrackRow(
                             track: track,
                             number: discLocalNumber(fallback: localIdx + 1, track: track),
                             onPlay: {
-                                if let absoluteIdx = tracks.firstIndex(where: { $0.id == track.id }) {
-                                    model.play(tracks: tracks, startIndex: absoluteIdx)
-                                }
-                            }
+                                model.play(tracks: tracks, startIndex: absoluteIdx)
+                            },
+                            tracks: tracks,
+                            index: absoluteIdx
                         )
                     }
                 }

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -499,40 +499,47 @@ struct AlbumDetailView: View {
     @ViewBuilder
     private func aboutBody(overview: String) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            // The visible text and an off-screen unclamped copy are overlaid in
-            // a ZStack so they share the same proposed width; each reports its
-            // rendered height through a preference key. The full copy is
-            // `.hidden()` + non-interactive so it never paints or hit-tests —
-            // it exists only to measure the un-truncated height.
-            ZStack(alignment: .topLeading) {
-                Text(overview)
-                    .font(Theme.font(14, weight: .regular))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .hidden()
-                    .accessibilityHidden(true)
-                    .allowsHitTesting(false)
-                    .background {
-                        GeometryReader { proxy in
-                            Color.clear.preference(
-                                key: FullOverviewHeightKey.self,
-                                value: proxy.size.height)
-                        }
+            // The visible 4-line-clamped text drives layout; an off-screen
+            // unclamped copy of the same text is attached as a `.background`
+            // so it measures the full height *without* expanding the visible
+            // text's footprint. A ZStack sibling would size the stack to the
+            // max of both children — the full height — leaving a large blank
+            // gap above "Read more" exactly when the overview is truncated
+            // (#475). Background/overlay content is proposed the host's size
+            // but never grows it, so the clamped text keeps its 4-line height
+            // while the hidden copy overflows freely to report the full height.
+            Text(overview)
+                .font(Theme.font(14, weight: .regular))
+                .foregroundStyle(Theme.ink2)
+                .lineLimit(4)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+                .background(alignment: .topLeading) {
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: ClampedOverviewHeightKey.self,
+                            value: proxy.size.height)
                     }
-
-                Text(overview)
-                    .font(Theme.font(14, weight: .regular))
-                    .foregroundStyle(Theme.ink2)
-                    .lineLimit(4)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
-                    .background {
-                        GeometryReader { proxy in
-                            Color.clear.preference(
-                                key: ClampedOverviewHeightKey.self,
-                                value: proxy.size.height)
+                }
+                .background(alignment: .topLeading) {
+                    // Unclamped measuring copy. `.hidden()` + non-interactive
+                    // so it never paints or hit-tests; `fixedSize` vertical so
+                    // it reports its full multi-line height at the host's
+                    // proposed width.
+                    Text(overview)
+                        .font(Theme.font(14, weight: .regular))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .hidden()
+                        .accessibilityHidden(true)
+                        .allowsHitTesting(false)
+                        .background {
+                            GeometryReader { proxy in
+                                Color.clear.preference(
+                                    key: FullOverviewHeightKey.self,
+                                    value: proxy.size.height)
+                            }
                         }
-                    }
-            }
+                }
             if isOverviewTruncated {
                 Button {
                     isAboutExpanded = true

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// Layout (top-to-bottom):
 /// 1. **Hero band** (360pt) — blurred backdrop art, 200pt circular portrait,
 ///    eyebrow "ARTIST", 72pt italic-black title, genre line, stats strip.
-/// 2. **Transport row** — 54pt Play All, Shuffle, Follow / Following pill,
-///    Artist Radio, Instant Mix. Mirrors the album detail transport for
+/// 2. **Transport row** — 54pt Play, Shuffle, Follow / Following pill,
+///    Artist Radio. Mirrors the album detail transport for
 ///    consistency. Following an artist favorites the artist entity on the
 ///    server (Jellyfin has no separate follow primitive) so it can seed a
 ///    future "New from artists you follow" home section.
@@ -52,6 +52,14 @@ struct ArtistDetailView: View {
     /// collapse to `nil` so the About section hides entirely.
     @State private var bioOverview: String?
 
+    /// Pre-resolved discography artwork URLs, keyed by album id. Populated
+    /// off the main thread in the `.task` block (see `model.resolveImageURLs`)
+    /// so the eager discography `HStack` hands each tile a ready URL instead of
+    /// taking the Rust `Inner` mutex on the MainActor inside every tile body
+    /// (gap pattern #2). A missing key means "not resolved yet"; the tile
+    /// shows its gradient placeholder until the warm pass lands.
+    @State private var discographyArtwork: [String: URL] = [:]
+
     /// Scoped (⌘F) search query that filters the Top Songs list in-place.
     /// Cleared on navigation away and on artist change so it never bleeds
     /// across pages.
@@ -77,6 +85,24 @@ struct ArtistDetailView: View {
         }
     }
 
+    /// Help-tooltip text for the primary play button. The button plays the
+    /// loaded Top Songs when there is play history, and only falls back to the
+    /// full catalog when there is none — so the label must reflect which of the
+    /// two it will actually do, rather than always promising "all tracks".
+    /// Factored out (with `primaryPlayAccessibilityLabel`) so the label/behavior
+    /// contract is unit-testable without instantiating the view.
+    static func primaryPlayHelp(hasTopTracks: Bool) -> String {
+        hasTopTracks ? "Play top songs" : "Play all tracks"
+    }
+
+    /// VoiceOver label for the primary play button. Mirrors `primaryPlayHelp`
+    /// but names the artist, matching the resting album-detail transport voice.
+    static func primaryPlayAccessibilityLabel(hasTopTracks: Bool, artistName: String) -> String {
+        hasTopTracks
+            ? "Play top songs by \(artistName)"
+            : "Play all tracks by \(artistName)"
+    }
+
     /// Resolve the artist: cached library page first, then whichever
     /// record the `.task` block fetched on demand. Missing (server
     /// unreachable or truly deleted) falls through to the gentle
@@ -86,16 +112,23 @@ struct ArtistDetailView: View {
     }
 
     var body: some View {
-        ScrollView {
+        // Resolve the artist exactly once per render. `artist` is an O(n) scan
+        // over `model.artists` (potentially thousands of entries), and `body`
+        // invalidates on every keystroke in the scoped filter — so resolving
+        // it per sub-view would run the scan five-plus times per keystroke.
+        // One `let` here, threaded into each section, collapses that to one
+        // scan per render.
+        let artist = self.artist
+        return ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                hero
-                transportBar
+                hero(artist)
+                transportBar(artist)
                 topSongsSection
                 discographySection
-                featuringPlaylistsSection
+                featuringPlaylistsSection(artist)
                 similarArtistsSection
-                aboutSection
-                footer
+                aboutSection(artist)
+                footer(artist)
             }
         }
         .background(Theme.bg)
@@ -118,6 +151,7 @@ struct ArtistDetailView: View {
             isBioExpanded = false
             scopedQuery = ""
             featuringPlaylists = []
+            discographyArtwork = [:]
             isLoadingTopTracks = true
             if model.artists.first(where: { $0.id == artistID }) == nil {
                 fetchedArtist = await model.resolveArtist(id: artistID)
@@ -127,6 +161,17 @@ struct ArtistDetailView: View {
             // first page of 100 library-wide albums, so Discography
             // rendered empty for most artists on a large library.
             artistAlbums = await model.loadArtistAlbums(artistId: artistID)
+            // Warm the discography artwork URLs off the main thread before the
+            // eager tiles render, so the per-tile `imageURL` calls are pure
+            // cache hits instead of ~200 serialized mutex-guarded FFI calls on
+            // the MainActor (gap pattern #2). Each tile gets a pre-resolved URL.
+            let resolved = await model.resolveImageURLs(
+                for: artistAlbums.map { (id: $0.id, tag: $0.imageTag) },
+                maxWidth: 400
+            )
+            discographyArtwork = resolved.reduce(into: [:]) { acc, pair in
+                if let url = pair.value { acc[pair.key] = url }
+            }
             topTracks = await model.loadArtistTopTracks(artistId: artistID)
             isLoadingTopTracks = false
             similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
@@ -150,7 +195,7 @@ struct ArtistDetailView: View {
     /// has no image we fall back to a deterministic gradient placeholder and
     /// `person.circle.fill` so the band doesn't read as broken.
     @ViewBuilder
-    private var hero: some View {
+    private func hero(_ artist: Artist?) -> some View {
         if let artist = artist {
             ZStack(alignment: .bottomLeading) {
                 backdrop(for: artist)
@@ -346,20 +391,21 @@ struct ArtistDetailView: View {
 
     // MARK: - Transport (#228)
 
-    /// Play All / Shuffle / Follow / Radio / Mix row. Matches the album
-    /// detail transport so the two detail screens share a transport mental
-    /// model. Most actions delegate to stubs on `AppModel` pending core
-    /// work — the UI is live, the wiring lights up when each FFI lands.
+    /// Play / Shuffle / Follow / Radio row. Matches the album detail transport
+    /// so the two detail screens share a transport mental model. Most actions
+    /// delegate to stubs on `AppModel` pending core work — the UI is live, the
+    /// wiring lights up when each FFI lands.
     @ViewBuilder
-    private var transportBar: some View {
+    private func transportBar(_ artist: Artist?) -> some View {
         if let artist = artist {
             HStack(spacing: 14) {
                 Button {
-                    // Play All delegates to `playAll` on AppModel. That path
-                    // falls back to "play the top 5" today (see #156 / #465)
-                    // because the artist-tracks FFI isn't wired yet — so for
-                    // the primary CTA we use the top-tracks list when Play
-                    // All would no-op, which matches user expectation.
+                    // Primary CTA. With play history we play the loaded Top
+                    // Songs; the rank/queue UI is already built around that
+                    // list. Only when there's no play history do we fall
+                    // through to `playAll(artist:)` (the full catalog). The
+                    // button is labeled to match this — "Play top songs" — so
+                    // it doesn't promise a full-catalog play it rarely does.
                     if topTracks.isEmpty {
                         model.playAll(artist: artist)
                     } else {
@@ -374,8 +420,13 @@ struct ArtistDetailView: View {
                         .shadow(color: Theme.accent.opacity(0.35), radius: 12, y: 8)
                 }
                 .buttonStyle(.plain)
-                .help("Play all tracks")
-                .accessibilityLabel("Play all tracks by \(artist.name)")
+                .help(Self.primaryPlayHelp(hasTopTracks: !topTracks.isEmpty))
+                .accessibilityLabel(
+                    Self.primaryPlayAccessibilityLabel(
+                        hasTopTracks: !topTracks.isEmpty,
+                        artistName: artist.name
+                    )
+                )
 
                 if model.supportsArtistPlayShuffle {
                     transportSecondary(
@@ -386,18 +437,14 @@ struct ArtistDetailView: View {
 
                 followButton(for: artist)
 
+                // Artist radio = Instant Mix seeded by this artist. The core
+                // exposes a single polymorphic `instantMix` primitive, so a
+                // separate "Instant Mix" button would call the exact same path
+                // — one button, one honest affordance, rather than two
+                // identically-behaving controls under different labels.
                 transportSecondary(
                     icon: "dot.radiowaves.left.and.right",
                     help: "Start artist radio"
-                ) { model.startArtistRadio(artist: artist) }
-
-                // Instant Mix from the artist — same stub as the above radio
-                // today, but they're separate affordances per the brief so
-                // when #144 lands we can split them (radio = artist-seeded
-                // station; mix = polymorphic Instant Mix).
-                transportSecondary(
-                    icon: "waveform.path.ecg",
-                    help: "Start instant mix"
                 ) { model.startArtistRadio(artist: artist) }
 
                 Spacer()
@@ -564,7 +611,15 @@ struct ArtistDetailView: View {
                 // the lazy-recycle buffer churn that triggers the UAF.
                 HStack(alignment: .top, spacing: 16) {
                     ForEach(group.albums, id: \.id) { album in
-                        ArtistDiscographyTile(album: album)
+                        // Hand the tile its artwork URL pre-resolved off the
+                        // main thread (see `.task` → `resolveImageURLs`) so the
+                        // eager HStack never calls the sync `imageURL` FFI on
+                        // the MainActor inside a tile body. `nil` until the warm
+                        // pass lands; the tile shows its placeholder meanwhile.
+                        ArtistDiscographyTile(
+                            album: album,
+                            artworkURL: discographyArtwork[album.id]
+                        )
                     }
                 }
                 .padding(.vertical, 4)
@@ -660,7 +715,7 @@ struct ArtistDetailView: View {
     /// section never reads as a broken empty shelf. Data comes from
     /// `featuringPlaylists`, populated by the `.task(id:)` block.
     @ViewBuilder
-    private var featuringPlaylistsSection: some View {
+    private func featuringPlaylistsSection(_ artist: Artist?) -> some View {
         if !featuringPlaylists.isEmpty, let artist = artist {
             VStack(alignment: .leading, spacing: 12) {
                 sectionHeader(eyebrow: "APPEARS ON", title: "Featuring \(artist.name)")
@@ -731,7 +786,7 @@ struct ArtistDetailView: View {
     /// doesn't grow a dead About region. Genres already surface in the hero
     /// and catalog depth in the footer, so nothing useful is lost.
     @ViewBuilder
-    private var aboutSection: some View {
+    private func aboutSection(_ artist: Artist?) -> some View {
         if let artist = artist, let overview = bioOverview, !overview.isEmpty {
             VStack(alignment: .leading, spacing: 12) {
                 sectionHeader(eyebrow: "ABOUT", title: "About \(artist.name)")
@@ -906,7 +961,7 @@ struct ArtistDetailView: View {
     // MARK: - Footer
 
     @ViewBuilder
-    private var footer: some View {
+    private func footer(_ artist: Artist?) -> some View {
         if let artist = artist {
             Text("\(artist.name) · \(artistAlbums.count) \(artistAlbums.count == 1 ? "album" : "albums") in your library")
                 .font(Theme.font(11, weight: .medium))
@@ -927,6 +982,10 @@ private struct ArtistDiscographyTile: View {
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let album: Album
+    /// Artwork URL resolved off the main thread by the parent's `.task` block.
+    /// `nil` while the warm pass is in flight — `Artwork` then renders its
+    /// deterministic gradient placeholder, never a sync FFI from this body.
+    let artworkURL: URL?
     @State private var isHovering = false
 
     var body: some View {
@@ -936,7 +995,7 @@ private struct ArtistDiscographyTile: View {
             VStack(alignment: .leading, spacing: 8) {
                 ZStack(alignment: .bottomTrailing) {
                     Artwork(
-                        url: model.imageURL(for: album.id, tag: album.imageTag, maxWidth: 400),
+                        url: artworkURL,
                         seed: album.name,
                         size: 160,
                         radius: 6

--- a/macos/Sources/Lyrebird/Screens/CoreInitFailureView.swift
+++ b/macos/Sources/Lyrebird/Screens/CoreInitFailureView.swift
@@ -1,0 +1,125 @@
+import AppKit
+import SwiftUI
+
+/// Recoverable failure scene shown when the Rust core fails to construct at
+/// launch (audit L31). Previously this path called `fatalError`, which bricked
+/// the app on a recoverable problem (e.g. a corrupt local database). Instead we
+/// render the error text plus two recovery affordances — "Reset Local Data"
+/// (quarantines the core's data directory so the next launch starts clean) and
+/// "Export Diagnostics" (writes a sanitized bundle for a bug report) — and a
+/// Quit button.
+///
+/// No `AppModel` is available here (its construction is exactly what failed), so
+/// this view is fully self-contained: it reads version/build from the bundle and
+/// uses `CoreDataLocation` / `DiagnosticBundle` directly.
+struct CoreInitFailureView: View {
+    /// The error thrown by `AppModel()` / `LyrebirdCore` construction.
+    let error: Error
+
+    @State private var statusMessage: String?
+    @State private var didReset = false
+
+    var body: some View {
+        ZStack {
+            Theme.bg.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: 16) {
+                Text("core_failure.title")
+                    .font(Theme.font(28, weight: .black, italic: true))
+                    .foregroundStyle(Theme.ink)
+
+                Text("core_failure.body")
+                    .font(Theme.font(14))
+                    .foregroundStyle(Theme.ink3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // The raw error text, selectable so it can be pasted into a bug
+                // report. Monospaced + scrollable so a long underlying error
+                // doesn't blow out the window.
+                ScrollView {
+                    Text(verbatim: errorDescription)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(Theme.ink)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(maxHeight: 120)
+                .background(Theme.bgAlt)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                if let statusMessage {
+                    Text(verbatim: statusMessage)
+                        .font(Theme.font(12))
+                        .foregroundStyle(didReset ? Theme.accent : Theme.ink3)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 12) {
+                    Button("core_failure.reset") { resetLocalData() }
+                        .disabled(didReset)
+                    Button("core_failure.export") { exportDiagnostics() }
+                    Spacer()
+                    Button("core_failure.quit") { NSApp.terminate(nil) }
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 520)
+        }
+    }
+
+    private var errorDescription: String {
+        let localized = (error as NSError).localizedDescription
+        return localized.isEmpty ? "\(error)" : localized
+    }
+
+    /// Quarantine the core's data directory so a corrupt database is moved aside
+    /// and the next launch starts clean. We don't try to re-create the
+    /// `AppModel` in place (the SwiftUI tree is already wedged on the failure
+    /// scene); instead we confirm success and prompt the user to relaunch.
+    private func resetLocalData() {
+        do {
+            let backup = try CoreDataLocation.quarantineDataDirectory()
+            didReset = true
+            if let backup {
+                statusMessage = String(
+                    format: NSLocalizedString("core_failure.reset.done", comment: ""),
+                    backup.path
+                )
+            } else {
+                statusMessage = NSLocalizedString("core_failure.reset.nothing", comment: "")
+            }
+        } catch {
+            statusMessage = String(
+                format: NSLocalizedString("core_failure.reset.failed", comment: ""),
+                (error as NSError).localizedDescription
+            )
+        }
+    }
+
+    /// Write a sanitized diagnostic bundle. No live `AppModel`, so the server
+    /// URL is empty — correct for a pre-login crash; `DiagnosticBundle` redacts
+    /// hosts regardless. Mirrors the save-panel hop in `LyrebirdCommands`.
+    private func exportDiagnostics() {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0 (dev)"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "—"
+
+        let panel = NSSavePanel()
+        panel.title = "Export Diagnostic Bundle"
+        panel.nameFieldStringValue = "Lyrebird-Diagnostics-\(DiagnosticBundle.filenameStamp(Date())).zip"
+        panel.allowedContentTypes = [.zip]
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try DiagnosticBundle.export(to: url, version: version, build: build, serverURL: "")
+            statusMessage = NSLocalizedString("core_failure.export.done", comment: "")
+        } catch {
+            statusMessage = String(
+                format: NSLocalizedString("core_failure.export.failed", comment: ""),
+                (error as NSError).localizedDescription
+            )
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -40,10 +40,7 @@ struct HomeView: View {
                 quickPicksSection
                 suggestionsSection
                 favoritesSection
-                // pinnedStationsRow — hidden for v1.0: section is backed by
-                // @AppStorage mock data only; tapping tiles or the + button
-                // does nothing. Re-enable once the real pin infrastructure
-                // lands (#144, #253).
+                pinnedStationsRow
                 artistRadioRow
                 Spacer(minLength: 24)
             }
@@ -273,31 +270,30 @@ struct HomeView: View {
         }
     }
 
-    /// Pinned Stations row (#253). A user-curated shelf of station "presets"
-    /// — artist radios, playlists, moods. The real pin infrastructure (server
-    /// or core-backed) doesn't exist yet, so we back the row with a local
-    /// `@AppStorage` array of `PinnedStation` triples. When empty we show an
-    /// empty-state card with a "Pin a station" CTA; the CTA and the end-of-row
-    /// "+ Add station" pill are both inert pending the pin UI.
+    /// Pinned Stations row (#253). A user-curated shelf of station "presets".
+    /// Today the only pin source is the genre Pin button / context menu
+    /// (`AppModel.pinGenreToHome`), which persists into `PinnedStationsStore`;
+    /// this row is its reader, so a pinned genre shows up here one click away.
+    /// Like every other Home shelf it hides itself when empty (no pins yet)
+    /// rather than render a permanent empty band — the user pins from a genre
+    /// page, so there is no in-row "add" affordance to show.
     @ViewBuilder
     private var pinnedStationsRow: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Image(systemName: "pin.fill")
-                    .foregroundStyle(Theme.primary)
-                    .font(.system(size: 14, weight: .bold))
-                    .rotationEffect(.degrees(-15))
-                Text("Pinned Stations")
-                    .font(Theme.font(18, weight: .bold))
-                    .foregroundStyle(Theme.ink)
-                Text("Your radio presets — always one click away")
-                    .font(Theme.font(12, weight: .medium))
-                    .foregroundStyle(Theme.ink3)
-            }
+        if !pinnedStations.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "pin.fill")
+                        .foregroundStyle(Theme.primary)
+                        .font(.system(size: 14, weight: .bold))
+                        .rotationEffect(.degrees(-15))
+                    Text("Pinned Stations")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                    Text("Your radio presets — always one click away")
+                        .font(Theme.font(12, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
 
-            if pinnedStations.isEmpty {
-                PinnedStationsEmptyState(action: handlePinAction)
-            } else {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(alignment: .top, spacing: 14) {
                         ForEach(pinnedStations) { station in
@@ -307,7 +303,6 @@ struct HomeView: View {
                                 action: { handleStationTap(station) }
                             )
                         }
-                        PinnedStationAddPill(action: handlePinAction)
                     }
                     .padding(.vertical, 4)
                 }
@@ -339,18 +334,9 @@ struct HomeView: View {
         }
     }
 
-    /// Inert handler for the "Pin a station" / "+ Add station" CTAs. The pin
-    /// picker UI hasn't been built yet (see #253 follow-up) — log and bail.
-    private func handlePinAction() {
-        // TODO: #253 follow-up — open the pin picker / station library
-        // modal. For now, just log so we can see the hit rate in console.
-        print("[HomeView] Pin a station tapped — pin picker UI not yet built (#253).")
-    }
-
-    /// Handler for a tapped pinned station. Dispatches on `station.type`.
-    /// Genre routing browses the genre detail screen (#823 Wave 2).
-    /// Artist / playlist / mood / mix routing still waits on the Instant
-    /// Mix FFI (#144) and the typed pin model.
+    /// Handler for a tapped pinned station. Dispatches on `station.type` to
+    /// the same destinations the rest of the app uses for each kind, so a
+    /// pinned tile behaves exactly like opening that subject elsewhere.
     private func handleStationTap(_ station: PinnedStation) {
         switch station.type {
         case .genre:
@@ -359,10 +345,14 @@ struct HomeView: View {
             // Construct a name-only Genre and let browseGenre resolve the
             // real Jellyfin UUID via the /MusicGenres cache before pushing.
             model.browseGenre(genre: Genre(name: station.title))
-        case .artist, .playlist, .mood, .mix:
-            // TODO: #144 / #253 — route to start the corresponding station
-            // once the typed pin model + Instant Mix FFI land.
-            Log.app.notice("PinnedStation tap (type=\(station.type.rawValue, privacy: .public) id=\(station.id, privacy: .public)) — routing not yet wired")
+        case .playlist:
+            // The id is a real Jellyfin playlist UUID — drill into it.
+            model.navigate(to: .playlist(station.id))
+        case .artist, .mood, .mix:
+            // Start a radio seeded from the station's subject. Artist radio,
+            // mood, and auto-mix all reduce to an Instant Mix off the stored
+            // id (an artist UUID or a mood/mix seed).
+            model.startStationRadio(seedId: station.id)
         }
     }
 
@@ -523,10 +513,12 @@ struct HomeView: View {
         }
     }
 
-    /// Track-level Recently Played (#52) — compact rows with a 48pt
-    /// thumbnail. Distinct from the existing tile-based `recentlyPlayed`
-    /// row above: this variant is denser and prioritises "tap to replay"
-    /// over "browse art". Hidden when there's no history.
+    /// Track-level "Recent Tracks" (#52) — compact rows with a 48pt
+    /// thumbnail. Distinct from the tile-based `recentlyPlayedSection` above:
+    /// both read `model.recentlyPlayed`, so this variant carries a different
+    /// title/subtitle to avoid two "Recently Played" headers stacked on one
+    /// screen. It is denser and prioritises "tap to replay" over "browse art".
+    /// Hidden when there's no history.
     ///
     /// Jellyfin tracks `DatePlayed` via its playback-reporting pipeline,
     /// which is always on for the stock server install. If a user has
@@ -539,8 +531,8 @@ struct HomeView: View {
             carouselSection(
                 icon: "clock.arrow.circlepath",
                 iconColor: Theme.accent,
-                title: "Recently Played",
-                subtitle: "Your latest listens, one click away",
+                title: "Recent Tracks",
+                subtitle: "Jump back into a recent track",
                 onSeeAll: nil
             ) {
                 HStack(alignment: .top, spacing: 12) {
@@ -804,8 +796,7 @@ struct HomeView: View {
     }
 
     /// Empty-state card shown when the user hasn't favorited any albums
-    /// yet. Mirrors the shape of `PinnedStationsEmptyState` so the Home
-    /// layout has a consistent "tap this to fill the shelf" vocabulary.
+    /// yet, giving the Home layout a "tap this to fill the shelf" affordance.
     private var favoritesEmptyState: some View {
         HStack(spacing: 16) {
             ZStack {

--- a/macos/Sources/Lyrebird/Screens/LibrarySortLogic.swift
+++ b/macos/Sources/Lyrebird/Screens/LibrarySortLogic.swift
@@ -1,0 +1,162 @@
+import Foundation
+@preconcurrency import LyrebirdCore
+
+/// Pure, View-free sort/filter/pagination logic for the Library grid.
+///
+/// Extracted out of `LibraryView` for the same reason `TrackSelectionResolver`
+/// was: the arithmetic that decides display order, which rows survive a filter,
+/// when a stable random order reshuffles, and when a near-end scroll should
+/// page the server can all be exercised by unit tests without standing up a
+/// SwiftUI scene graph or an `AppModel`. The View layer keeps only the
+/// `@State` it memoizes the results into plus the side effects (`loadMore*`).
+enum LibrarySortLogic {
+
+    // MARK: - Sort
+
+    /// Deterministic shuffle keyed on a per-session seed. Returns the same
+    /// order for the same `(items, seed)` pair, so the `.random` sort stays
+    /// stable across re-renders (it only changes when the seed is regenerated
+    /// — i.e. when the user re-picks Random — or when the source array
+    /// changes). Replaces the old `Array.shuffled()` that re-rolled on every
+    /// access and made the grid visibly reorder on hover. See audit L871.
+    ///
+    /// The key is `SipHash` over `(id, seed)` via `Hasher`; ties (astronomically
+    /// unlikely across UUID-shaped ids) fall back to the id itself so the order
+    /// is total and reproducible.
+    static func seededShuffle<T>(_ items: [T], seed: UUID, id: (T) -> String) -> [T] {
+        items.sorted { lhs, rhs in
+            let lid = id(lhs)
+            let rid = id(rhs)
+            let lh = shuffleKey(lid, seed: seed)
+            let rh = shuffleKey(rid, seed: seed)
+            if lh == rh { return lid < rid }
+            return lh < rh
+        }
+    }
+
+    private static func shuffleKey(_ id: String, seed: UUID) -> UInt64 {
+        var hasher = Hasher()
+        hasher.combine(seed)
+        hasher.combine(id)
+        return UInt64(bitPattern: Int64(hasher.finalize()))
+    }
+
+    // MARK: - Pagination
+
+    /// Whether a near-end scroll to `index` in the *displayed* (filtered +
+    /// sorted) list should fire a follow-up page.
+    ///
+    /// The pre-fix code compared `index` (a position in the filtered list)
+    /// against `loaded - distance` (a count of *raw* loaded items). An active
+    /// filter shrinks the displayed list below `loaded`, so that threshold was
+    /// never reached and pagination silently stalled (audit L578). The fix
+    /// computes the threshold against `displayedCount` — the length of the list
+    /// the user is actually scrolling — while the caller still gates on
+    /// "more raw items remain on the server" (`loaded < total`) and "no page
+    /// already in flight".
+    static func shouldLoadMore(
+        index: Int,
+        displayedCount: Int,
+        triggerDistance: Int
+    ) -> Bool {
+        guard displayedCount > 0 else { return false }
+        let threshold = max(displayedCount - triggerDistance, 0)
+        return index >= threshold
+    }
+
+    /// Whether to *eagerly* fetch the next page while a filter is active even
+    /// though the visible window hasn't been scrolled to its end.
+    ///
+    /// Client-side filtering only sees the rows already paged in, so a filter
+    /// that matches sparsely can leave the displayed list far shorter than the
+    /// viewport — with no `.onAppear` near the end to drive `shouldLoadMore`,
+    /// pagination would wedge and the result would be silently truncated
+    /// (audit L783). When a filter is active, more raw items remain on the
+    /// server (`loaded < total`), and the filtered list is still thin enough to
+    /// risk under-filling the viewport, keep pulling pages until either the
+    /// dataset is exhausted or enough matches accumulate.
+    ///
+    /// `prefetchTarget` is the number of filtered matches we try to have on
+    /// hand before backing off; tuned to comfortably cover a tall window so the
+    /// list doesn't visibly dribble in one page at a time.
+    static func shouldEagerlyPageForFilter(
+        filterActive: Bool,
+        displayedCount: Int,
+        loadedCount: Int,
+        total: Int,
+        prefetchTarget: Int
+    ) -> Bool {
+        guard filterActive else { return false }
+        guard loadedCount < total else { return false }
+        return displayedCount < prefetchTarget
+    }
+}
+
+/// Which `LibrarySortOrder`s a given `LibraryTab` can actually honor, so the
+/// header menu only offers orders the tab applies and the menu label never
+/// misrepresents the real ordering (audit L196).
+///
+/// Artists carry no year/runtime and "Artist" is a no-op on the artist list,
+/// so those collapse to alphabetical; playlists likewise lack year and
+/// play-count. Rather than silently falling back (which made the menu lie),
+/// the unsupported orders are removed from the menu for that tab, and a tab
+/// switch that lands on an unsupported order snaps to a supported fallback.
+extension LibrarySortOrder {
+    /// The orders a tab offers, in canonical menu order.
+    static func supportedOrders(for tab: LibraryTab) -> [LibrarySortOrder] {
+        switch tab {
+        case .albums, .tracks:
+            // Albums and tracks carry every dimension the menu sorts on.
+            return allCases
+        case .artists:
+            // No year/runtime; "Artist" is meaningless on the artist list.
+            return [
+                .nameAscending, .nameDescending,
+                .recentlyPlayed, .mostPlayed, .random,
+            ]
+        case .playlists:
+            // Playlists carry name + runtime only on the loaded shape.
+            return [
+                .nameAscending, .nameDescending,
+                .longest, .shortest, .random,
+            ]
+        case .downloaded:
+            // No backing list; sort is moot but keep name orders for symmetry.
+            return [.nameAscending, .nameDescending]
+        }
+    }
+
+    /// Whether `tab` can honor this order.
+    func isSupported(by tab: LibraryTab) -> Bool {
+        LibrarySortOrder.supportedOrders(for: tab).contains(self)
+    }
+
+    /// The order to fall back to when a tab can't honor the active one. Always
+    /// the first supported order for the tab (alphabetical A–Z in every case),
+    /// so the menu label stays truthful after a tab switch.
+    static func fallback(for tab: LibraryTab) -> LibrarySortOrder {
+        supportedOrders(for: tab).first ?? .nameAscending
+    }
+}
+
+/// Memoized snapshot of the active tab's filter→sort result, held in
+/// `LibraryView` `@State` and recomputed only when an input actually changes
+/// (sort order, filter, tab, shuffle seed, or the source array). Holding the
+/// already-sorted arrays here means the grid body, the A–Z rail's name/id maps,
+/// and the count subline all read one precomputed list instead of each
+/// re-deriving a full locale-aware sort per render. See audit L234 / L852.
+///
+/// Only the active tab's slice is populated; the others stay empty so a switch
+/// doesn't sort four collections at once. Names and ids are precomputed
+/// alongside the model arrays so the A–Z rail can't drift from what's rendered.
+struct LibraryDisplayItems: Equatable {
+    var albums: [Album] = []
+    var artists: [Artist] = []
+    var tracks: [Track] = []
+    var playlists: [Playlist] = []
+
+    /// Display-order names for the active tab (A–Z rail buckets read this).
+    var names: [String] = []
+    /// Display-order ids for the active tab, paired positionally with `names`.
+    var ids: [String] = []
+}

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -397,7 +397,7 @@ struct LibraryView: View {
                 filter: $filter,
                 availableGenres: availableGenres,
                 yearBounds: yearBounds,
-                showDownloaded: model.supportsDownloads,
+                tab: selectedTab,
                 onClose: { showFilter = false }
             )
         }

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -105,6 +105,18 @@ struct LibraryView: View {
     /// default changes in Preferences mid-session, so the new default re-applies
     /// on next entry (and immediately, if that tab is on screen).
     @State private var appliedDefaultTabs: Set<LibraryTab> = []
+    /// Seed for the `.random` sort's deterministic shuffle. Regenerated only
+    /// when the user (re-)selects Random or the source collection's identity
+    /// changes — never on a plain re-render — so hovering a card no longer
+    /// reorders the grid. See audit L871 and `LibrarySortLogic.seededShuffle`.
+    @State private var shuffleSeed = UUID()
+    /// Memoized filter→sort result for the active tab. Recomputed in
+    /// `.onChange` of `sortOrder`, `filter`, `selectedTab`, the shuffle seed,
+    /// and the relevant `model.X` source array — *not* on every render. The old
+    /// code re-ran a full locale-aware sort over the whole loaded library up to
+    /// 3× per render (and on every hover, which mutates `hoverID`), which was
+    /// heavy MainActor work on a ~20k-item library. See audit L234 / L852.
+    @State private var displayedItems = LibraryDisplayItems()
 
     private var density: AppearanceDensity {
         AppearanceDensity(rawValue: densityRaw) ?? .roomy
@@ -180,12 +192,13 @@ struct LibraryView: View {
         // is entered fresh; `.onChange` covers the case where the user
         // is already on the library and the sidebar flips the tab.
         .onAppear {
-            selectedTab = model.libraryTab
+            selectedTab = resolvedTab(model.libraryTab)
             applyDefaultSort(for: selectedTab)
             applyPendingDecadeFilter()
+            recomputeDisplayedItems()
         }
         .onChange(of: model.libraryTab) { _, newValue in
-            selectedTab = newValue
+            selectedTab = resolvedTab(newValue)
         }
         // A decade tile tapped while the Library is already on screen flips
         // `pendingLibraryYearRange` without re-running `.onAppear`; pick it up
@@ -202,13 +215,35 @@ struct LibraryView: View {
             // it referenced are no longer on screen. See #217.
             clearSelection()
             applyDefaultSort(for: newValue)
+            // If the active sort isn't one the new tab can honor, snap to a
+            // supported order so the menu label stays truthful. See audit L196.
+            normalizeSortForTab(newValue)
+            recomputeDisplayedItems()
         }
         // `anchorIndex` is a positional cursor into the displayed list; a sort
         // or filter change reorders that list, so a stale anchor would extend a
         // Shift+Click range from the wrong row. The ID-based `selectedTrackIds`
         // survives the reorder, so only the anchor needs clearing. See #217.
-        .onChange(of: sortOrder) { _, _ in anchorIndex = nil }
-        .onChange(of: filter) { _, _ in anchorIndex = nil }
+        .onChange(of: sortOrder) { _, newValue in
+            anchorIndex = nil
+            // Re-rolling the shuffle each time Random is (re-)picked is the
+            // explicit "reshuffle" gesture; a stable seed otherwise. See L871.
+            if newValue == .random { shuffleSeed = UUID() }
+            recomputeDisplayedItems()
+        }
+        .onChange(of: filter) { _, _ in
+            anchorIndex = nil
+            recomputeDisplayedItems()
+        }
+        // The source arrays grow as pages stream in; re-derive the displayed
+        // snapshot so new rows appear in the right sorted/filtered position.
+        // Under Random the seed is left untouched here, so already-visible rows
+        // keep their slot and newly-paged ids fold in deterministically rather
+        // than the whole grid reshuffling on each page. See audit L852 / L871.
+        .onChange(of: model.albums) { _, _ in recomputeDisplayedItems() }
+        .onChange(of: model.artists) { _, _ in recomputeDisplayedItems() }
+        .onChange(of: model.tracks) { _, _ in recomputeDisplayedItems() }
+        .onChange(of: model.playlists) { _, _ in recomputeDisplayedItems() }
         // A change to a persisted default while this view is alive means the
         // user just edited Preferences → Library. Re-apply so the criterion
         // "changes reflect in list views" holds without a relaunch.
@@ -228,17 +263,12 @@ struct LibraryView: View {
     private let alphabetRailMinItems = 200
 
     /// The `name` of every row in the active tab, in the exact order it's
-    /// displayed. Reuses the same `sorted*` arrays the grid/list render so the
-    /// rail's letter → index mapping can't drift from what's on screen.
-    /// Downloaded has no backing list yet, so it contributes nothing.
+    /// displayed. Reads the memoized snapshot the grid/list also render from so
+    /// the rail's letter → index mapping can't drift from what's on screen and
+    /// the sort isn't re-run for the rail. Downloaded has no backing list yet,
+    /// so it contributes nothing.
     private var displayedSortNames: [String] {
-        switch selectedTab {
-        case .albums: return sortedAlbums.map(\.name)
-        case .artists: return sortedArtists.map(\.name)
-        case .tracks: return sortedTracks.map(\.name)
-        case .playlists: return sortedPlaylists.map(\.name)
-        case .downloaded: return []
-        }
+        displayedItems.names
     }
 
     /// The `id` of every row in the active tab, in display order. Paired
@@ -246,13 +276,7 @@ struct LibraryView: View {
     /// straight to a `scrollTo` target — `ForEach(_, id: \.element.id)` registers
     /// these ids as scroll anchors.
     private var displayedItemIds: [String] {
-        switch selectedTab {
-        case .albums: return sortedAlbums.map(\.id)
-        case .artists: return sortedArtists.map(\.id)
-        case .tracks: return sortedTracks.map(\.id)
-        case .playlists: return sortedPlaylists.map(\.id)
-        case .downloaded: return []
-        }
+        displayedItems.ids
     }
 
     /// Whether to show the rail for the current tab + sort. Gated on a large
@@ -282,10 +306,11 @@ struct LibraryView: View {
 
     /// The selected tracks resolved against the currently-sorted list, in
     /// display order. Used by the selection banner so its batch actions run
-    /// on the same ordering the user sees.
+    /// on the same ordering the user sees. Reads the memoized snapshot rather
+    /// than re-sorting. See audit L852.
     private var selectedTracks: [Track] {
         guard !selectedTrackIds.isEmpty else { return [] }
-        return sortedTracks.filter { selectedTrackIds.contains($0.id) }
+        return displayedItems.tracks.filter { selectedTrackIds.contains($0.id) }
     }
 
     private func clearSelection() {
@@ -351,7 +376,12 @@ struct LibraryView: View {
             Spacer()
             HStack(spacing: 8) {
                 filterButton
-                LibrarySortMenu(selection: $sortOrder)
+                // Offer only the orders the active tab can honor so the menu
+                // label can't misrepresent the real ordering. See audit L196.
+                LibrarySortMenu(
+                    selection: $sortOrder,
+                    options: LibrarySortOrder.supportedOrders(for: selectedTab)
+                )
                 LibraryViewToggle(mode: $viewMode)
             }
         }
@@ -403,9 +433,18 @@ struct LibraryView: View {
         }
     }
 
+    /// Tabs offered in the chip row. The Downloaded tab is hidden until the
+    /// download engine lands (`model.supportsDownloads`, false today) — it has
+    /// no backing list and would only ever render the generic empty state,
+    /// mirroring how the filter popover already gates its downloaded group.
+    /// See audit L552.
+    private var visibleTabs: [LibraryTab] {
+        LibraryTab.allCases.filter { $0 != .downloaded || model.supportsDownloads }
+    }
+
     private var chipRow: some View {
         ChipRow(
-            options: LibraryTab.allCases.map { (label: $0.label, tag: $0) },
+            options: visibleTabs.map { (label: $0.label, tag: $0) },
             selection: $selectedTab
         )
     }
@@ -427,8 +466,14 @@ struct LibraryView: View {
         case .albums:
             if model.albums.isEmpty {
                 EmptyLibraryState(serverUrl: serverWebURL)
+            } else if displayedItems.albums.isEmpty {
+                emptyFilteredState(
+                    loadedCount: model.albums.count,
+                    total: Int(model.albumsTotal),
+                    isLoadingMore: model.isLoadingMoreAlbums
+                )
             } else {
-                let items = sortedAlbums
+                let items = displayedItems.albums
                 VStack(alignment: .leading, spacing: 18) {
                     switch viewMode {
                     case .grid:
@@ -458,8 +503,14 @@ struct LibraryView: View {
         case .artists:
             if model.artists.isEmpty {
                 EmptyLibraryState(serverUrl: serverWebURL)
+            } else if displayedItems.artists.isEmpty {
+                emptyFilteredState(
+                    loadedCount: model.artists.count,
+                    total: Int(model.artistsTotal),
+                    isLoadingMore: model.isLoadingMoreArtists
+                )
             } else {
-                let items = sortedArtists
+                let items = displayedItems.artists
                 VStack(alignment: .leading, spacing: 18) {
                     switch viewMode {
                     case .grid:
@@ -493,8 +544,14 @@ struct LibraryView: View {
             // albums branch.
             if model.tracks.isEmpty {
                 EmptyLibraryState(serverUrl: serverWebURL)
+            } else if displayedItems.tracks.isEmpty {
+                emptyFilteredState(
+                    loadedCount: model.tracks.count,
+                    total: Int(model.tracksTotal),
+                    isLoadingMore: model.isLoadingMoreTracks
+                )
             } else {
-                let items = sortedTracks
+                let items = displayedItems.tracks
                 VStack(alignment: .leading, spacing: 18) {
                     LazyVStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(items.enumerated()), id: \.element.id) { idx, track in
@@ -521,8 +578,14 @@ struct LibraryView: View {
         case .playlists:
             if model.playlists.isEmpty {
                 EmptyLibraryState(serverUrl: serverWebURL)
+            } else if displayedItems.playlists.isEmpty {
+                emptyFilteredState(
+                    loadedCount: model.playlists.count,
+                    total: Int(model.playlistsTotal),
+                    isLoadingMore: model.isLoadingMorePlaylists
+                )
             } else {
-                let items = sortedPlaylists
+                let items = displayedItems.playlists
                 VStack(alignment: .leading, spacing: 18) {
                     switch viewMode {
                     case .grid:
@@ -550,10 +613,36 @@ struct LibraryView: View {
                 }
             }
         case .downloaded:
-            // Placeholder until the per-tab surface lands. The chip row, header,
-            // and count subline remain live so navigation feels responsive.
+            // Reachable only if downloads are enabled (the chip is otherwise
+            // hidden and `resolvedTab` redirects a stale persisted selection).
+            // Until a downloads-specific surface lands, the generic empty state
+            // stands in. See audit L552.
             EmptyLibraryState(serverUrl: serverWebURL)
         }
+    }
+
+    /// The view shown when the active tab's filtered list is empty while the
+    /// raw collection isn't: either the "no matches" state, or — if a filter is
+    /// active and more pages might still yield matches (eager paging in flight
+    /// or the dataset not yet exhausted) — a spinner, so we don't flash "No
+    /// matches" before the eager fetch has had a chance to find any. See audit
+    /// L494 / L783.
+    @ViewBuilder
+    private func emptyFilteredState(loadedCount: Int, total: Int, isLoadingMore: Bool) -> some View {
+        if filter.isActive && (isLoadingMore || loadedCount < total) {
+            paginationSpinner
+        } else {
+            noFilterMatchesState
+        }
+    }
+
+    /// Shown when an active filter excludes every loaded item in the current
+    /// tab (the raw collection is non-empty but the filtered one is empty).
+    /// Distinct from `EmptyLibraryState`, which stays gated on the raw count.
+    /// The CTA clears the filter so the user isn't stranded on a blank area.
+    /// See audit L494.
+    private var noFilterMatchesState: some View {
+        EmptyStateView.noFilterMatches { filter = LibraryFilter() }
     }
 
     /// Bottom spinner shown while a follow-up page is in flight. Stays under
@@ -570,9 +659,18 @@ struct LibraryView: View {
         .accessibilityLabel("Loading more")
     }
 
+    /// Number of filtered matches we try to have paged in before backing off
+    /// the eager filter-driven fetch. Comfortably covers a tall window so a
+    /// sparse filter doesn't dribble one page at a time. See audit L783.
+    private let paginationPrefetchTarget = 60
+
     /// Fire `loadMoreAlbums` when the user scrolls into the last
-    /// `paginationTriggerDistance` cells and there are more albums on the
-    /// server than currently loaded. The view-level guard (and the matching
+    /// `paginationTriggerDistance` cells *of the displayed list* and there are
+    /// more albums on the server than currently loaded. Comparing against the
+    /// displayed (filtered) count rather than the raw loaded count is the fix
+    /// for pagination stalling whenever a filter is active (audit L578): a
+    /// filter shrinks the rendered list below `loaded`, so a raw-count
+    /// threshold was never reached. The view-level guard (and the matching
     /// guard in `AppModel.loadMoreAlbums`) together prevent concurrent Tasks
     /// from queuing up and re-firing once the flag clears. Fixes #589.
     private func triggerLoadMoreAlbumsIfNeeded(atIndex idx: Int) {
@@ -580,8 +678,11 @@ struct LibraryView: View {
         let total = Int(model.albumsTotal)
         guard total > loaded else { return }
         guard !model.isLoadingMoreAlbums else { return }
-        let threshold = max(loaded - paginationTriggerDistance, 0)
-        guard idx >= threshold else { return }
+        guard LibrarySortLogic.shouldLoadMore(
+            index: idx,
+            displayedCount: displayedItems.albums.count,
+            triggerDistance: paginationTriggerDistance
+        ) else { return }
         Task { await model.loadMoreAlbums() }
     }
 
@@ -593,36 +694,46 @@ struct LibraryView: View {
         let total = Int(model.artistsTotal)
         guard total > loaded else { return }
         guard !model.isLoadingMoreArtists else { return }
-        let threshold = max(loaded - paginationTriggerDistance, 0)
-        guard idx >= threshold else { return }
+        guard LibrarySortLogic.shouldLoadMore(
+            index: idx,
+            displayedCount: displayedItems.artists.count,
+            triggerDistance: paginationTriggerDistance
+        ) else { return }
         Task { await model.loadMoreArtists() }
     }
 
     /// Fire `loadMoreTracks` when the user scrolls into the last
-    /// `paginationTriggerDistance` cells and there are more tracks on the
-    /// server than currently loaded. Mirror of `triggerLoadMoreAlbumsIfNeeded`;
-    /// see that function's docs for the concurrency guard rationale (#589).
+    /// `paginationTriggerDistance` cells of the displayed list and there are
+    /// more tracks on the server than currently loaded. Mirror of
+    /// `triggerLoadMoreAlbumsIfNeeded`; see that function's docs for the
+    /// displayed-count rationale (audit L578) and concurrency guard (#589).
     private func triggerLoadMoreTracksIfNeeded(atIndex idx: Int) {
         let loaded = model.tracks.count
         let total = Int(model.tracksTotal)
         guard total > loaded else { return }
         guard !model.isLoadingMoreTracks else { return }
-        let threshold = max(loaded - paginationTriggerDistance, 0)
-        guard idx >= threshold else { return }
+        guard LibrarySortLogic.shouldLoadMore(
+            index: idx,
+            displayedCount: displayedItems.tracks.count,
+            triggerDistance: paginationTriggerDistance
+        ) else { return }
         Task { await model.loadMoreTracks() }
     }
 
     /// Mirror of `triggerLoadMoreAlbumsIfNeeded` for the Playlists grid.
     /// Separate function rather than a parameterised helper so the guard
-    /// arithmetic stays obvious at the call site. See #589 for the
-    /// concurrency guard rationale.
+    /// arithmetic stays obvious at the call site. See audit L578 for the
+    /// displayed-count threshold and #589 for the concurrency guard.
     private func triggerLoadMorePlaylistsIfNeeded(atIndex idx: Int) {
         let loaded = model.playlists.count
         let total = Int(model.playlistsTotal)
         guard total > loaded else { return }
         guard !model.isLoadingMorePlaylists else { return }
-        let threshold = max(loaded - paginationTriggerDistance, 0)
-        guard idx >= threshold else { return }
+        guard LibrarySortLogic.shouldLoadMore(
+            index: idx,
+            displayedCount: displayedItems.playlists.count,
+            triggerDistance: paginationTriggerDistance
+        ) else { return }
         Task { await model.loadMorePlaylists() }
     }
 
@@ -651,30 +762,53 @@ struct LibraryView: View {
         }
     }
 
-    /// 11pt uppercase count subline. Renders as `N of M` when the server
-    /// total is known AND more items remain to load; otherwise falls back
-    /// to plain `N`. Mirrors the spec's "{n} tracks · Sorted by {sort}" —
-    /// sort hasn't been wired yet (#216), so for now the subline is just
-    /// the count. Issue #429 / #212.
+    /// Number of rows actually rendered in the active tab — the memoized
+    /// filtered + sorted count. Drives the subline so the displayed number
+    /// can't contradict what's on screen when a filter is active. See L659.
+    private var displayedCount: Int {
+        switch selectedTab {
+        case .albums: return displayedItems.albums.count
+        case .artists: return displayedItems.artists.count
+        case .tracks: return displayedItems.tracks.count
+        case .playlists: return displayedItems.playlists.count
+        case .downloaded: return 0
+        }
+    }
+
+    /// 11pt uppercase count subline. With an active filter it reports the
+    /// rendered count against the loaded total ("N FILTERED OF M") so the
+    /// number always matches what's shown (audit L659). Without a filter it
+    /// renders `N of M` while more pages remain on the server, otherwise plain
+    /// `N`. Issue #429 / #212.
     private var countSubline: String {
+        let noun = selectedTab.countNoun
+        if filter.isActive {
+            let loaded = tabCount(for: selectedTab)
+            return "\(displayedCount) FILTERED OF \(loaded) \(noun.uppercased())"
+        }
         let count = tabCount(for: selectedTab)
         let total = tabTotal(for: selectedTab)
         if total > count {
-            return "\(count) OF \(total) \(selectedTab.countNoun.uppercased())"
+            return "\(count) OF \(total) \(noun.uppercased())"
         }
-        return "\(count) \(selectedTab.countNoun)".uppercased()
+        return "\(count) \(noun)".uppercased()
     }
 
     /// VoiceOver-friendly version of the count subline. Reads naturally
     /// as "42 of 5000 albums" rather than the uppercased + tracking-spaced
     /// display string.
     private var countAccessibilityLabel: String {
+        let noun = selectedTab.countNoun
+        if filter.isActive {
+            let loaded = tabCount(for: selectedTab)
+            return "\(displayedCount) filtered of \(loaded) \(noun)"
+        }
         let count = tabCount(for: selectedTab)
         let total = tabTotal(for: selectedTab)
         if total > count {
-            return "\(count) of \(total) \(selectedTab.countNoun)"
+            return "\(count) of \(total) \(noun)"
         }
-        return "\(count) \(selectedTab.countNoun)"
+        return "\(count) \(noun)"
     }
 
     private var backgroundWash: some View {
@@ -868,7 +1002,7 @@ struct LibraryView: View {
                 return cmp == .orderedAscending
             }
         case .random:
-            return filteredAlbums.shuffled()
+            return LibrarySortLogic.seededShuffle(filteredAlbums, seed: shuffleSeed, id: \.id)
         case .recentlyAdded:
             // `Album` does not carry `DateCreated` on the paginated shape, so
             // preserve the server's load order (which is `SortName` asc by
@@ -959,7 +1093,7 @@ struct LibraryView: View {
             // No per-item date on the artist payload — keep server order.
             return filteredArtists
         case .random:
-            return filteredArtists.shuffled()
+            return LibrarySortLogic.seededShuffle(filteredArtists, seed: shuffleSeed, id: \.id)
         case .nameAscending, .artist, .longest, .shortest, .yearAscending, .yearDescending:
             // Year and runtime aren't carried for artists, and "Artist" is a
             // no-op on the artist list itself; treat all as alpha asc.
@@ -991,7 +1125,7 @@ struct LibraryView: View {
                 return cmp == .orderedAscending
             }
         case .random:
-            return filteredTracks.shuffled()
+            return LibrarySortLogic.seededShuffle(filteredTracks, seed: shuffleSeed, id: \.id)
         case .recentlyAdded:
             return filteredTracks
         case .recentlyPlayed:
@@ -1071,12 +1205,121 @@ struct LibraryView: View {
         case .recentlyAdded:
             return filteredPlaylists
         case .random:
-            return filteredPlaylists.shuffled()
+            return LibrarySortLogic.seededShuffle(filteredPlaylists, seed: shuffleSeed, id: \.id)
         case .nameAscending, .artist, .recentlyPlayed, .mostPlayed, .yearAscending, .yearDescending:
             return filteredPlaylists.sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
         }
+    }
+
+    // MARK: - Memoization
+
+    /// Recompute the active tab's filter→sort snapshot into `displayedItems`.
+    /// Called from the `.onChange`/`.onAppear` hooks that observe every input
+    /// (sort order, filter, tab, shuffle seed, source arrays) — never from
+    /// `body` — so the expensive locale-aware sort runs once per real change
+    /// instead of up to 3× per render (and on every hover). See audit L234 /
+    /// L852. Only the active tab's slice is populated; the rest stay empty.
+    private func recomputeDisplayedItems() {
+        var next = LibraryDisplayItems()
+        switch selectedTab {
+        case .albums:
+            next.albums = sortedAlbums
+            next.names = next.albums.map(\.name)
+            next.ids = next.albums.map(\.id)
+        case .artists:
+            next.artists = sortedArtists
+            next.names = next.artists.map(\.name)
+            next.ids = next.artists.map(\.id)
+        case .tracks:
+            next.tracks = sortedTracks
+            next.names = next.tracks.map(\.name)
+            next.ids = next.tracks.map(\.id)
+        case .playlists:
+            next.playlists = sortedPlaylists
+            next.names = next.playlists.map(\.name)
+            next.ids = next.playlists.map(\.id)
+        case .downloaded:
+            break
+        }
+        displayedItems = next
+        // A filter that matches sparsely can leave the displayed list shorter
+        // than the viewport with no near-end `.onAppear` to drive pagination;
+        // keep pulling pages so filtered results aren't silently truncated.
+        // See audit L783.
+        eagerlyPageForActiveFilterIfNeeded()
+    }
+
+    /// When a filter is active and the displayed list is still thin while more
+    /// raw items remain on the server, fetch the next page proactively. Drives
+    /// off the same async `loadMore*` the scroll trigger uses (and the model's
+    /// in-flight guard), so it can't fan out into duplicate fetches. The page
+    /// landing mutates the source array, which re-enters `recomputeDisplayedItems`
+    /// via `.onChange`, so this self-terminates once enough matches accumulate
+    /// or the dataset is exhausted. See audit L783.
+    private func eagerlyPageForActiveFilterIfNeeded() {
+        guard filter.isActive else { return }
+        switch selectedTab {
+        case .albums:
+            guard !model.isLoadingMoreAlbums,
+                LibrarySortLogic.shouldEagerlyPageForFilter(
+                    filterActive: true,
+                    displayedCount: displayedItems.albums.count,
+                    loadedCount: model.albums.count,
+                    total: Int(model.albumsTotal),
+                    prefetchTarget: paginationPrefetchTarget
+                ) else { return }
+            Task { await model.loadMoreAlbums() }
+        case .artists:
+            guard !model.isLoadingMoreArtists,
+                LibrarySortLogic.shouldEagerlyPageForFilter(
+                    filterActive: true,
+                    displayedCount: displayedItems.artists.count,
+                    loadedCount: model.artists.count,
+                    total: Int(model.artistsTotal),
+                    prefetchTarget: paginationPrefetchTarget
+                ) else { return }
+            Task { await model.loadMoreArtists() }
+        case .tracks:
+            guard !model.isLoadingMoreTracks,
+                LibrarySortLogic.shouldEagerlyPageForFilter(
+                    filterActive: true,
+                    displayedCount: displayedItems.tracks.count,
+                    loadedCount: model.tracks.count,
+                    total: Int(model.tracksTotal),
+                    prefetchTarget: paginationPrefetchTarget
+                ) else { return }
+            Task { await model.loadMoreTracks() }
+        case .playlists:
+            guard !model.isLoadingMorePlaylists,
+                LibrarySortLogic.shouldEagerlyPageForFilter(
+                    filterActive: true,
+                    displayedCount: displayedItems.playlists.count,
+                    loadedCount: model.playlists.count,
+                    total: Int(model.playlistsTotal),
+                    prefetchTarget: paginationPrefetchTarget
+                ) else { return }
+            Task { await model.loadMorePlaylists() }
+        case .downloaded:
+            break
+        }
+    }
+
+    /// Redirect a tab the UI can't currently show (Downloaded while downloads
+    /// are unwired) to a live tab, so a stale persisted `model.libraryTab`
+    /// never lands on a hidden chip. See audit L552.
+    private func resolvedTab(_ tab: LibraryTab) -> LibraryTab {
+        if tab == .downloaded && !model.supportsDownloads { return .albums }
+        return tab
+    }
+
+    /// If the active `sortOrder` isn't one `tab` can honor, snap to the tab's
+    /// supported fallback so the header menu label reflects the order actually
+    /// applied rather than silently degrading to alphabetical. See audit L196.
+    private func normalizeSortForTab(_ tab: LibraryTab) {
+        guard !sortOrder.isSupported(by: tab) else { return }
+        sortOrder = LibrarySortOrder.fallback(for: tab)
     }
 }
 
@@ -1237,10 +1480,15 @@ struct AlbumCard: View {
                     .opacity(isHovering ? 1 : 0)
                     .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
                     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
-                    // Hover overlay isn't discoverable without a mouse, so
-                    // name the play button explicitly for VoiceOver. See
-                    // #331.
-                    .accessibilityLabel("Play \(album.name)")
+                    // The overlay is opacity-hidden until hover; without these
+                    // it stays in the a11y tree and hit-testable while invisible
+                    // (a phantom target a click could land on). Gate both on
+                    // hover, and since it's a Button nested inside the card's
+                    // navigation Button label, hide it from VoiceOver — play is
+                    // instead exposed as an accessibility action on the card
+                    // itself (below) and via the context menu. See audit L1227.
+                    .allowsHitTesting(isHovering)
+                    .accessibilityHidden(true)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -1281,10 +1529,16 @@ struct AlbumCard: View {
         }
         .contextMenu { AlbumContextMenu(album: album) }
         // Outer "navigate to album" tap target. Reads as
-        // "<album> by <artist>. Opens album detail." The inner play
-        // button exposes itself separately for "play this album".
+        // "<album> by <artist>. Opens album detail." Because the hover play
+        // button is hidden from VoiceOver (it's a Button nested in this
+        // Button's label and only visible on hover), expose play as a rotor
+        // accessibility action here so it stays reachable without a mouse.
+        // See audit L1227 / #331.
         .accessibilityLabel(albumAccessibilityLabel)
         .accessibilityHint("Opens album detail")
+        .accessibilityAction(named: "Play \(album.name)") {
+            model.play(album: album)
+        }
     }
 
     private var albumAccessibilityLabel: String {
@@ -1344,10 +1598,14 @@ enum LibrarySortOrder: String, Hashable, CaseIterable, Identifiable {
 /// `LibraryViewToggle` so the two header controls read as a pair.
 struct LibrarySortMenu: View {
     @Binding var selection: LibrarySortOrder
+    /// Orders to offer. The Library passes the active tab's supported set so
+    /// the menu never lists an order the tab silently ignores. Defaults to the
+    /// full set for any host that doesn't scope it. See audit L196.
+    var options: [LibrarySortOrder] = LibrarySortOrder.allCases
 
     var body: some View {
         Menu {
-            ForEach(LibrarySortOrder.allCases, id: \.self) { option in
+            ForEach(options, id: \.self) { option in
                 Button {
                     selection = option
                 } label: {

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -229,9 +229,19 @@ struct MainShell: View {
         }
         // Persist the sidebar column visibility on every change — the toolbar
         // toggle, the native separator drag/collapse, and ⌘⌃S all write
-        // `columnVisibility`, so observing it here captures every path.
+        // `columnVisibility`, so observing it here captures every path. Also
+        // mirror the showing/hidden state into `AppModel` so the View ▸ "Show
+        // Sidebar" menu item renders an accurate checkmark (audit L251).
         .onChange(of: columnVisibility) { _, newValue in
             persistedSidebarRaw = newValue.persistedRawValue
+            model.isSidebarVisible = (newValue != .detailOnly)
+        }
+        // View ▸ "Show Sidebar" (⌘⌥S) routes through `AppModel` because the menu
+        // can't reach this view's private `columnVisibility`. Each request bumps
+        // a counter; run the same manual-toggle path the toolbar button uses so
+        // the auto-hide override bookkeeping stays consistent (audit L251).
+        .onChange(of: model.sidebarToggleRequest) { _, _ in
+            toggleSidebarManually()
         }
         // Persist the queue inspector visibility (#79 surface) so it reopens
         // with the window if the user left it open.
@@ -248,19 +258,10 @@ struct MainShell: View {
             guard newId != nil, let track = model.status.currentTrack else { return }
             model.announceTrackChange(to: track)
         }
-        // Cmd+Opt+Q toggles the queue inspector (#79). Hung off a zero-sized
-        // hidden button so the shortcut is global to `MainShell` without
-        // requiring a visible chrome affordance — the visible toggle will
-        // land in PlayerBar in BATCH-07b. `.hidden()` alone is not enough
-        // (SwiftUI elides hidden buttons from the responder chain), so the
-        // button has a 1×1 clear frame that stays non-interactive.
-        .background(
-            Button("menu.view.toggle_queue") { model.toggleQueueInspector() }
-                .keyboardShortcut("q", modifiers: [.command, .option])
-                .frame(width: 0, height: 0)
-                .opacity(0)
-                .accessibilityHidden(true)
-        )
+        // Cmd+Opt+Q toggles the queue inspector (#79). The shortcut now lives
+        // on the View ▸ "Show Queue" menu `Toggle` (audit L251), so the former
+        // hidden 1×1 button that also bound ⌘⌥Q has been removed to avoid a
+        // duplicate key-equivalent registration racing the menu item.
         // First-run feature tour (coach marks) — see #113. Auto-appears once
         // on the first launch after connect (`!hasSeenFeatureTour`) and can be
         // replayed any time via Help ▸ "Show Tour"
@@ -395,6 +396,9 @@ struct MainShell: View {
             persistedRaw: persistedSidebarRaw,
             preferenceRaw: sidebarPreferenceRaw
         )
+        // Seed the menu mirror so View ▸ "Show Sidebar" shows the right
+        // checkmark from the first frame (audit L251).
+        model.isSidebarVisible = (columnVisibility != .detailOnly)
 
         let restoredInspector = WindowStateStore.restoredInspectorVisible(persistedRaw: persistedInspectorRaw)
         if model.isQueueInspectorOpen != restoredInspector {

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -360,7 +360,16 @@ struct MainShell: View {
     /// launch is honoured. Only assigns `columnVisibility` when the reducer
     /// asks for a transition, so a redundant write never stomps an in-flight
     /// collapse / reveal animation.
+    ///
+    /// Gated on the Appearance `Sidebar` preference: width-driven auto-hide is
+    /// the behaviour `.autoHide` opts into, so `.visible` / `.hidden` skip it
+    /// entirely (the rail stays where the user / restored state put it). That
+    /// gating is what makes the three picker options behaviourally distinct —
+    /// without it, `.autoHide` was a no-op alias for `.visible`.
     private func applySidebarAutoHide(width: CGFloat) {
+        let preference = AppearanceSidebar(rawValue: sidebarPreferenceRaw) ?? .visible
+        guard SidebarAutoHide.isEnabled(for: preference) else { return }
+
         var state = sidebarAutoHide
         state.userDidOverride = userDidOverrideAutoHide
         let decision = SidebarAutoHide.decide(

--- a/macos/Sources/Lyrebird/Screens/OnboardingView.swift
+++ b/macos/Sources/Lyrebird/Screens/OnboardingView.swift
@@ -7,12 +7,13 @@ import SwiftUI
 /// 2. **Connect Server** (#292) — same fields as login with extended helper
 ///    copy and a "Skip, explore offline" escape link.
 /// 3. **First Sync** (#293) — animated progress through artists → albums →
-///    tracks → artwork with a live counter; "Continue to Home" unlocks when
-///    the library crosses an 80% threshold.
+///    tracks → artwork with a live counter; "Continue to Home" unlocks only
+///    once the library has *actually* loaded (see `FirstSyncGate`), not when
+///    the cosmetic timer finishes.
 ///
 /// The flow exits by either completing a successful login (the last step
-/// flips `hasCompletedOnboarding` once the initial library sync crosses
-/// threshold and bounces the user into `MainShell`) or by tapping the
+/// flips `hasCompletedOnboarding` once the initial library sync has produced
+/// real data and bounces the user into `MainShell`) or by tapping the
 /// "Skip, explore offline" link on the connect step (same flag flip, lands
 /// on `LoginView` which becomes the signed-out surface).
 struct OnboardingView: View {
@@ -117,19 +118,19 @@ private struct WelcomeStep: View {
             JellyfishMark(size: 120)
                 .padding(.bottom, 8)
 
-            Text("Welcome to Lyrebird")
+            Text("onboarding.welcome.title")
                 .font(Theme.font(48, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
                 .multilineTextAlignment(.center)
 
-            Text("Your music, your server, your rules.")
+            Text("onboarding.welcome.subtitle")
                 .font(Theme.font(16, weight: .medium))
                 .foregroundStyle(Theme.ink2)
                 .multilineTextAlignment(.center)
 
             VStack(spacing: 14) {
                 Button(action: onGetStarted) {
-                    Text("Get started")
+                    Text("onboarding.welcome.get_started")
                         .font(Theme.font(14, weight: .bold))
                         .frame(width: 280, height: 44)
                         .foregroundStyle(Theme.ink)
@@ -139,15 +140,15 @@ private struct WelcomeStep: View {
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(.defaultAction)
-                .accessibilityLabel("Get started")
+                .accessibilityLabel("onboarding.welcome.get_started")
 
                 Button(action: onExistingAccount) {
-                    Text("I already have an account →")
+                    Text("onboarding.welcome.existing_account")
                         .font(Theme.font(13, weight: .semibold))
                         .foregroundStyle(Theme.primary)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("I already have an account")
+                .accessibilityLabel("onboarding.welcome.existing_account.a11y")
             }
             .padding(.top, 16)
         }
@@ -184,10 +185,10 @@ private struct ConnectStep: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Connect your server")
+                Text("onboarding.connect.title")
                     .font(Theme.font(28, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
-                Text("Your Jellyfin URL is the address you use to reach it from a browser.")
+                Text("onboarding.connect.subtitle")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink2)
                     .fixedSize(horizontal: false, vertical: true)
@@ -206,8 +207,10 @@ private struct ConnectStep: View {
 
             VStack(alignment: .leading, spacing: 14) {
                 labeledField(
-                    label: "SERVER URL",
-                    placeholder: "https://jellyfin.example.com",
+                    label: "login.field.url",
+                    a11yLabel: "login.a11y.server_url",
+                    // URL placeholder is a sample host, not a translatable phrase.
+                    placeholder: String("https://jellyfin.example.com"),
                     text: $url,
                     focus: .url,
                     onSubmit: { focusedField = .username }
@@ -215,16 +218,19 @@ private struct ConnectStep: View {
                 ProbeResultRow(state: probe.state)
 
                 labeledField(
-                    label: "USERNAME",
-                    placeholder: "you",
+                    label: "login.field.username",
+                    a11yLabel: "login.a11y.username",
+                    placeholder: String(localized: "login.username.placeholder"),
                     text: $username,
                     focus: .username,
                     onSubmit: { focusedField = .password }
                 )
 
                 labeledSecureField(
-                    label: "PASSWORD",
-                    placeholder: "••••••••",
+                    label: "login.field.password",
+                    a11yLabel: "login.a11y.password",
+                    // Bullet glyphs are the masked-input affordance; not a phrase.
+                    placeholder: String("••••••••"),
                     text: $password,
                     shake: shakeAttempts,
                     onSubmit: submit
@@ -242,7 +248,7 @@ private struct ConnectStep: View {
                     if model.isLoggingIn {
                         ProgressView().scaleEffect(0.7).tint(Theme.ink)
                     }
-                    Text(model.isLoggingIn ? "Connecting…" : "Continue")
+                    Text(model.isLoggingIn ? LocalizedStringKey("onboarding.connect.connecting") : LocalizedStringKey("onboarding.connect.continue"))
                         .font(Theme.font(14, weight: .bold))
                 }
                 .frame(maxWidth: .infinity)
@@ -258,7 +264,7 @@ private struct ConnectStep: View {
             .keyboardShortcut(.defaultAction)
 
             Button(action: onSkipOffline) {
-                Text("Skip, explore offline →")
+                Text("onboarding.connect.skip_offline")
                     .font(Theme.font(12, weight: .semibold))
                     .foregroundStyle(Theme.ink3)
             }
@@ -269,6 +275,13 @@ private struct ConnectStep: View {
         .onAppear {
             discovery.start()
             focusedField = url.isEmpty ? .url : .username
+            // Re-onboarding while already authenticated (e.g. a returning
+            // user who reset onboarding but kept a live session): advance
+            // straight to the sync step instead of stranding them on a
+            // Connect form they've already satisfied. The `onChange` below
+            // can't catch this case because the session is non-nil from the
+            // first render, so the value never *changes*.
+            if model.session != nil { onContinue() }
         }
         .onDisappear {
             discovery.stop()
@@ -280,8 +293,13 @@ private struct ConnectStep: View {
                 probe.schedule(url: newValue)
             }
         }
-        .onChange(of: model.session != nil) { _, signedIn in
-            if signedIn { onContinue() }
+        // Observe the session *identity* rather than a nil-ness Bool: a fresh
+        // login that replaces an already-non-nil session leaves the Bool
+        // unchanged, so the auto-advance would never fire. The user id flips
+        // on any sign-in (including signing in as a different account), which
+        // is the real signal we want to advance on.
+        .onChange(of: model.session?.user.id) { _, userId in
+            if userId != nil { onContinue() }
         }
     }
 
@@ -321,7 +339,8 @@ private struct ConnectStep: View {
 
     @ViewBuilder
     private func labeledField(
-        label: String,
+        label: LocalizedStringKey,
+        a11yLabel: LocalizedStringKey,
         placeholder: String,
         text: Binding<String>,
         focus: Field,
@@ -347,12 +366,14 @@ private struct ConnectStep: View {
                 .focused($focusedField, equals: focus)
                 .submitLabel(.next)
                 .onSubmit(onSubmit)
+                .accessibilityLabel(a11yLabel)
         }
     }
 
     @ViewBuilder
     private func labeledSecureField(
-        label: String,
+        label: LocalizedStringKey,
+        a11yLabel: LocalizedStringKey,
         placeholder: String,
         text: Binding<String>,
         shake: Int,
@@ -380,49 +401,119 @@ private struct ConnectStep: View {
                 .onSubmit(onSubmit)
                 .modifier(ShakeEffect(animatableData: CGFloat(shake)))
                 .animation(.interpolatingSpring(stiffness: 800, damping: 10), value: shake)
+                .accessibilityLabel(a11yLabel)
         }
     }
 }
 
 // MARK: - First sync step
 
+/// Pure decision logic for when the "Continue to Home" CTA may unlock.
+///
+/// Split out from the view so it can be unit-tested without rendering: the
+/// regression we're guarding against is the CTA opening on a *cosmetic*
+/// timer regardless of whether any real data loaded (#293). The gate is now
+/// driven exclusively by `AppModel` signals.
+enum FirstSyncGate {
+    /// `true` only when the initial library load has actually finished
+    /// successfully *and* there's something to show (or the server genuinely
+    /// has an empty library, in which case there's nothing to wait for).
+    ///
+    /// - Parameters:
+    ///   - finishedLoading: the initial `refreshLibrary` round-trip completed
+    ///     (whether it succeeded or failed). Until this latches, the gate is
+    ///     closed no matter what the cosmetic progress bar shows.
+    ///   - hasError: `model.errorMessage` is non-nil — the load failed, so we
+    ///     must not strand the user in an empty library.
+    ///   - hasAnyData: at least one album / artist / track landed locally.
+    ///   - librarySyncRatio: fraction of the server-reported totals we hold
+    ///     locally. Crosses the 0.8 threshold only for libraries that fit in
+    ///     the initial page; large libraries unlock via `hasAnyData` instead
+    ///     (Home is paginated and loads more on scroll).
+    ///   - serverReportsEmptyLibrary: the server's totals are all zero, so a
+    ///     completed-but-empty load is a legitimate "nothing to sync" state.
+    static func isReady(
+        finishedLoading: Bool,
+        hasError: Bool,
+        hasAnyData: Bool,
+        librarySyncRatio: Double,
+        serverReportsEmptyLibrary: Bool
+    ) -> Bool {
+        guard finishedLoading, !hasError else { return false }
+        return librarySyncRatio >= readyThreshold || hasAnyData || serverReportsEmptyLibrary
+    }
+
+    /// Spec threshold: "Continue to Home activates when sync crosses 80%."
+    /// Only reachable for single-page libraries; see `isReady`.
+    static let readyThreshold: Double = 0.8
+}
+
 private struct FirstSyncStep: View {
     @Environment(AppModel.self) private var model
     let onContinue: () -> Void
 
-    /// Nominal 0…1 progress derived from which library lists have started
-    /// populating. `refreshLibrary` fans out artist / album / track calls in
-    /// parallel, so this animates through the phases in order even when the
-    /// server answers fast.
+    /// Nominal 0…1 progress used purely to animate the bar so it doesn't sit
+    /// still on a slow network. This is *cosmetic only* — it never gates the
+    /// CTA (see `FirstSyncGate`). The real fraction (`librarySyncRatio`) is
+    /// blended in so a fast server visibly fills the bar.
     @State private var animatedProgress: Double = 0.0
 
     /// Current animated phase. Drives the "Loading artists… / albums… /
     /// tracks… / artwork…" copy line.
     @State private var phase: SyncPhase = .artists
 
+    /// Latches `true` once the initial library load has finished (success or
+    /// failure). The CTA stays disabled until this flips, regardless of the
+    /// cosmetic progress bar. Guarded so the pre-load render (when no fetch
+    /// has started yet) can't open the gate.
+    @State private var didFinishInitialLoad = false
+
     enum SyncPhase: Int, CaseIterable {
         case artists, albums, tracks, artwork
 
-        var label: String {
+        var labelKey: LocalizedStringKey {
             switch self {
-            case .artists: return "Loading artists…"
-            case .albums: return "Loading albums…"
-            case .tracks: return "Loading tracks…"
-            case .artwork: return "Fetching artwork…"
+            case .artists: return "onboarding.sync.phase.artists"
+            case .albums: return "onboarding.sync.phase.albums"
+            case .tracks: return "onboarding.sync.phase.tracks"
+            case .artwork: return "onboarding.sync.phase.artwork"
             }
         }
     }
 
-    /// Progress crosses 0.8 = CTA unlocks. Matches the spec: "Continue to
-    /// Home button activates when sync crosses 80%." Once activated, the
-    /// computed library-percent or the animation whichever is further keeps
-    /// the bar in sync while the user is deciding.
-    private var isReady: Bool {
-        displayProgress >= 0.8
+    /// Whether the load failed — drives the error row + retry affordance.
+    private var hasError: Bool {
+        model.errorMessage != nil
     }
 
+    /// At least one album / artist / track has landed locally.
+    private var hasAnyData: Bool {
+        !model.albums.isEmpty || !model.artists.isEmpty || !model.tracks.isEmpty
+    }
+
+    /// The server reports a genuinely empty library (all totals zero). Only
+    /// meaningful once `didFinishInitialLoad` is set — before that the totals
+    /// are simply unresolved.
+    private var serverReportsEmptyLibrary: Bool {
+        model.albumsTotal == 0 && model.artistsTotal == 0 && model.tracksTotal == 0
+    }
+
+    /// CTA readiness, driven entirely by real load signals.
+    private var isReady: Bool {
+        FirstSyncGate.isReady(
+            finishedLoading: didFinishInitialLoad,
+            hasError: hasError,
+            hasAnyData: hasAnyData,
+            librarySyncRatio: librarySyncRatio,
+            serverReportsEmptyLibrary: serverReportsEmptyLibrary
+        )
+    }
+
+    /// Cosmetic bar fill: the further of the animation and the real fraction
+    /// while loading; pinned full once the data is actually ready.
     private var displayProgress: Double {
-        max(animatedProgress, librarySyncRatio)
+        if isReady { return 1.0 }
+        return max(animatedProgress, librarySyncRatio)
     }
 
     /// Fraction of the library we actually have locally so far. This grows
@@ -446,7 +537,7 @@ private struct FirstSyncStep: View {
 
             VStack(spacing: 8) {
                 JellyfishMark(size: 72)
-                Text("Loading your library")
+                Text("onboarding.sync.title")
                     .font(Theme.font(28, weight: .black, italic: true))
                     .foregroundStyle(Theme.ink)
             }
@@ -470,10 +561,26 @@ private struct FirstSyncStep: View {
                 .frame(height: 6)
 
                 HStack(spacing: 6) {
-                    ProgressView().controlSize(.mini)
-                    Text(phase.label)
-                        .font(Theme.font(12, weight: .semibold))
-                        .foregroundStyle(Theme.teal)
+                    if hasError {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(Theme.accentHot)
+                        Text("onboarding.sync.error")
+                            .font(Theme.font(12, weight: .semibold))
+                            .foregroundStyle(Theme.accentHot)
+                        Button(action: retry) {
+                            Text("onboarding.sync.retry")
+                                .font(Theme.font(12, weight: .bold))
+                                .foregroundStyle(Theme.primary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("onboarding.sync.retry")
+                    } else {
+                        ProgressView().controlSize(.mini)
+                        Text(phase.labelKey)
+                            .font(Theme.font(12, weight: .semibold))
+                            .foregroundStyle(Theme.teal)
+                    }
                     Spacer()
                     Text(counterLabel)
                         .font(Theme.font(12, weight: .medium))
@@ -483,7 +590,7 @@ private struct FirstSyncStep: View {
             }
 
             Button(action: onContinue) {
-                Text(isReady ? "Continue to Home" : "Syncing…")
+                Text(isReady ? LocalizedStringKey("onboarding.sync.continue") : LocalizedStringKey("onboarding.sync.syncing"))
                     .font(Theme.font(14, weight: .bold))
                     .frame(width: 280, height: 44)
                     .foregroundStyle(Theme.ink)
@@ -497,17 +604,52 @@ private struct FirstSyncStep: View {
             .buttonStyle(.plain)
             .disabled(!isReady)
             .keyboardShortcut(.defaultAction)
-            .accessibilityLabel("Continue to Home")
+            .accessibilityLabel("onboarding.sync.continue")
         }
         .padding(.vertical, 40)
         .onAppear {
             startProgressAnimation()
-            // `ConnectStep.submit` calls `model.login`, which already kicks
-            // off `refreshLibrary`. If we got here via `onChange` of
-            // `model.session`, the library fetch is likely already in
-            // flight. No extra call needed — `librarySyncRatio` will tick
-            // up as the arrays populate.
+            ensureLibraryLoad()
         }
+        .onChange(of: model.isLoadingLibrary) { _, loading in
+            // The initial fetch kicked off by `model.login` (or by
+            // `ensureLibraryLoad` below) completes when this flips back to
+            // false. That's the real "sync finished" edge that unlocks the
+            // CTA — never the cosmetic timer.
+            if !loading { didFinishInitialLoad = true }
+        }
+    }
+
+    /// Make sure a library load actually runs. `ConnectStep.submit` →
+    /// `model.login` already kicks off `refreshLibrary`, so in the common
+    /// path a fetch is in flight (or finished) by the time we get here and we
+    /// just observe its completion via `onChange(of: isLoadingLibrary)`. The
+    /// fallbacks cover paths that reach the sync step without a fetch having
+    /// been triggered (so the CTA can't hang forever).
+    private func ensureLibraryLoad() {
+        if model.isLoadingLibrary {
+            // A fetch (login's) is in flight; the onChange handler latches
+            // completion. Nothing to do.
+            return
+        }
+        if hasAnyData || hasError {
+            // The fetch already finished before this view appeared (data
+            // present) or failed (error surfaced). Either way it's done.
+            didFinishInitialLoad = true
+            return
+        }
+        // No fetch in flight and nothing loaded — drive one ourselves so the
+        // CTA can eventually unlock. `onChange(of: isLoadingLibrary)` latches
+        // completion once `refreshLibrary` finishes.
+        Task { await model.refreshLibrary() }
+    }
+
+    /// Retry a failed initial load. Clears the error so the progress row
+    /// returns to its loading state, then re-fetches.
+    private func retry() {
+        didFinishInitialLoad = false
+        model.errorMessage = nil
+        Task { await model.refreshLibrary() }
     }
 
     /// Server-reported total across the three lists we care about. Same
@@ -526,7 +668,13 @@ private struct FirstSyncStep: View {
         let t = formatter.string(from: NSNumber(value: tracks)) ?? "\(tracks)"
         let a = formatter.string(from: NSNumber(value: artists)) ?? "\(artists)"
         let al = formatter.string(from: NSNumber(value: albums)) ?? "\(albums)"
-        return "\(t) tracks · \(a) artists · \(al) albums"
+        // Look up the positional template ("%1$@ tracks · %2$@ artists ·
+        // %3$@ albums") by key and fill in the pre-formatted, grouping-
+        // separated counts. Using the format-string form (rather than
+        // interpolating into the key) keeps the catalog key stable and lets
+        // translators reorder the clauses.
+        let template = String(localized: "onboarding.sync.counter")
+        return String(format: template, t, a, al)
     }
 
     /// Drives `animatedProgress` and `phase` forward on a 250ms tick so
@@ -584,13 +732,13 @@ private struct BackButton: View {
             HStack(spacing: 6) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 12, weight: .bold))
-                Text("Back")
+                Text("onboarding.back")
                     .font(Theme.font(12, weight: .semibold))
             }
             .foregroundStyle(Theme.ink3)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Back")
+        .accessibilityLabel("onboarding.back")
     }
 }
 
@@ -604,7 +752,7 @@ private struct ProbeResultRow: View {
             case .checking:
                 HStack(spacing: 6) {
                     ProgressView().controlSize(.mini)
-                    Text("Checking…")
+                    Text("login.probe.checking")
                         .font(Theme.font(12, weight: .medium))
                         .foregroundStyle(Theme.teal)
                 }
@@ -640,7 +788,7 @@ private struct DiscoveredServersChipRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("FOUND ON THIS NETWORK")
+            Text("login.discovered_servers")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
@@ -664,6 +812,7 @@ private struct DiscoveredServersChipRow: View {
                         .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Use discovered server \(server.name)")
                 }
             }
         }

--- a/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
@@ -234,9 +234,9 @@ struct PlaylistDetailView: View {
             Menu {
                 if let playlist = playlist {
                     Button("Play Next") { model.playNext(playlist: playlist) }
-                        .disabled(true)
+                        .disabled(tracks.isEmpty)
                     Button("Add to Queue") { model.addToQueue(playlist: playlist) }
-                        .disabled(true)
+                        .disabled(tracks.isEmpty)
                     Divider()
                     Button("Export as M3U…") { model.exportPlaylist(playlist: playlist) }
                         .disabled(tracks.isEmpty)
@@ -333,29 +333,25 @@ struct PlaylistDetailView: View {
     /// Resolve a click on `index` given the current modifier state into a
     /// new selection set. Cmd toggles the hit row. Shift extends the range
     /// from `anchorIndex` to the hit row. Bare click plays the row.
+    ///
+    /// `index` is captured at render time and can be stale (e.g. the track
+    /// array shrank after a remove). The pure arithmetic lives in
+    /// `TrackSelectionResolver.resolve`, which returns `nil` for an
+    /// out-of-bounds index, so a stale click is a no-op instead of a crash.
+    /// This is the same glue `LibraryView.handleTrackClick` uses.
     private func handleRowClick(index: Int, modifiers: NSEvent.ModifierFlags) {
-        let track = tracks[index]
-        if modifiers.contains(.command) {
-            if selectedTrackIds.contains(track.id) {
-                selectedTrackIds.remove(track.id)
-            } else {
-                selectedTrackIds.insert(track.id)
-            }
-            anchorIndex = index
-        } else if modifiers.contains(.shift) {
-            let from = anchorIndex ?? index
-            let range = from <= index ? from...index : index...from
-            var next = selectedTrackIds
-            for i in range where tracks.indices.contains(i) {
-                next.insert(tracks[i].id)
-            }
-            selectedTrackIds = next
-            anchorIndex = index
-        } else {
-            // Bare click → play the track and reset any selection.
-            selectedTrackIds = []
-            anchorIndex = index
-            model.play(tracks: tracks, startIndex: index)
+        let snapshot = tracks
+        guard let outcome = TrackSelectionResolver.resolve(
+            clickedIndex: index,
+            trackIds: snapshot.map(\.id),
+            currentSelection: selectedTrackIds,
+            anchorIndex: anchorIndex,
+            modifiers: modifiers
+        ) else { return }
+        selectedTrackIds = outcome.selection
+        anchorIndex = outcome.anchorIndex
+        if outcome.shouldPlay {
+            model.play(tracks: snapshot, startIndex: index)
         }
     }
 
@@ -449,50 +445,65 @@ struct PlaylistDetailView: View {
     ///   from external sources (e.g. a text file of ids, or a hand-rolled
     ///   `.plainText` Transferable implementation).
     ///
-    /// Returns `true` as long as at least one provider is in flight so
-    /// SwiftUI's drop affordance confirms the drop visually. The actual
-    /// add happens asynchronously after the provider resolves.
+    /// Returns `true` only when at least one provider advertises a type we can
+    /// read (data or plain text) — i.e. the drop has a chance of yielding ids,
+    /// so SwiftUI's affordance confirms it. A drop of solely unreadable
+    /// providers is rejected so the OS plays the "no" animation.
+    ///
+    /// The actual add happens asynchronously once the provider resolves. The
+    /// list refresh is owned by `AppModel.addToPlaylist` (it re-fetches on
+    /// success), so there's no follow-up `loadPlaylistTracks` here. Failures
+    /// inside the async callbacks — a nil payload, a provider error, or bytes
+    /// that yield no ids — surface on `model.errorMessage` rather than
+    /// vanishing silently.
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
         guard !providers.isEmpty else { return false }
         let playlistId = playlistID
+        var accepted = false
         // Best-effort: try data first, then fall back to plain-text.
         for provider in providers {
             if provider.hasItemConformingToTypeIdentifier(UTType.data.identifier) {
-                provider.loadDataRepresentation(forTypeIdentifier: UTType.data.identifier) { data, _ in
-                    guard let data else { return }
-                    let ids = parseTrackIds(from: data)
-                    guard !ids.isEmpty else { return }
-                    Task { @MainActor in
-                        model.addToPlaylist(playlistId: playlistId, trackIds: ids)
-                        await model.loadPlaylistTracks(playlistId: playlistId)
-                    }
+                accepted = true
+                provider.loadDataRepresentation(forTypeIdentifier: UTType.data.identifier) { data, error in
+                    handleDroppedPayload(data, error: error, into: playlistId)
                 }
             } else if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
-                provider.loadDataRepresentation(forTypeIdentifier: UTType.plainText.identifier) { data, _ in
-                    guard let data else { return }
-                    let ids = parseTrackIds(from: data)
-                    guard !ids.isEmpty else { return }
-                    Task { @MainActor in
-                        model.addToPlaylist(playlistId: playlistId, trackIds: ids)
-                        await model.loadPlaylistTracks(playlistId: playlistId)
-                    }
+                accepted = true
+                provider.loadDataRepresentation(forTypeIdentifier: UTType.plainText.identifier) { data, error in
+                    handleDroppedPayload(data, error: error, into: playlistId)
                 }
             }
         }
-        return true
+        return accepted
     }
 
-    /// Pull a list of track ids out of arbitrary dropped bytes. Tries JSON
-    /// first, then newline-separated text; ignores blanks and whitespace.
-    private func parseTrackIds(from data: Data) -> [String] {
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String] {
-            return json.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    /// Resolve one provider's loaded bytes into track ids and forward to
+    /// `AppModel.addToPlaylist`, surfacing any failure on `model.errorMessage`.
+    /// Runs on the provider's callback queue, so it hops to the main actor
+    /// before touching the model.
+    private func handleDroppedPayload(_ data: Data?, error: Error?, into playlistId: String) {
+        if let error {
+            Task { @MainActor in
+                model.errorMessage = "Couldn't read the dropped item: \(error.localizedDescription)"
+            }
+            return
         }
-        guard let text = String(data: data, encoding: .utf8) else { return [] }
-        return text
-            .split(whereSeparator: { $0.isNewline })
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
+        guard let data else {
+            Task { @MainActor in
+                model.errorMessage = "Couldn't read the dropped item."
+            }
+            return
+        }
+        let ids = PlaylistDropPayload.parseTrackIds(from: data)
+        guard !ids.isEmpty else {
+            Task { @MainActor in
+                model.errorMessage = "That drop didn't contain any tracks to add."
+            }
+            return
+        }
+        Task { @MainActor in
+            model.addToPlaylist(playlistId: playlistId, trackIds: ids)
+        }
     }
 }
 
@@ -600,7 +611,13 @@ private struct SelectableTrackRow: View {
         .gesture(
             TapGesture().modifiers(.shift).onEnded { onClick(.shift) }
         )
-        .simultaneousGesture(
+        // Plain tap must use `.gesture` (not `.simultaneousGesture`): with a
+        // simultaneous gesture the bare-tap recognizer fires *alongside* the
+        // Cmd/Shift recognizers when a modifier is held, so a Cmd+Click both
+        // toggled selection AND played+cleared it, defeating multiselect.
+        // `.gesture` lets the modifier-qualified gestures take precedence.
+        // Matches `TrackListRow`'s working pattern.
+        .gesture(
             TapGesture().onEnded { onClick([]) }
         )
         .accessibilityLabel("\(track.name) by \(track.artistName)")
@@ -625,6 +642,26 @@ private struct SelectableTrackRow: View {
 
 /// Direction enum used by `handleKeyboardReorder` to avoid raw booleans.
 private enum VerticalDirection { case up, down }
+
+/// Pure parsing for drop-to-add payloads. Extracted out of the view so the
+/// "what counts as a droppable track-id list" contract — which `handleDrop`
+/// leans on to decide acceptance and error surfacing (#236) — can be
+/// unit-tested without an `NSItemProvider` or a SwiftUI scene.
+enum PlaylistDropPayload {
+    /// Pull a list of track ids out of arbitrary dropped bytes. Tries JSON
+    /// first (a `["id-1","id-2"]` array of strings), then newline-separated
+    /// text; ignores blanks and surrounding whitespace.
+    static func parseTrackIds(from data: Data) -> [String] {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String] {
+            return json.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        }
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        return text
+            .split(whereSeparator: { $0.isNewline })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+}
 
 // MARK: - Undo toast
 

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -358,6 +358,8 @@ struct PlaylistView: View {
                         track: track,
                         number: idx + 1,
                         onPlay: { model.play(tracks: tracks, startIndex: idx) },
+                        tracks: tracks,
+                        index: idx,
                         playlistScope: playlist
                     )
                     // BATCH-06b (#73 / #235): drag-to-reorder. The modifier

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAdvanced.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAdvanced.swift
@@ -1,9 +1,10 @@
 import AppKit
+import Nuke
 import SwiftUI
 
 /// Advanced / Developer / Debug preferences pane. Closes #267.
 ///
-/// Surfaces three sections of developer-oriented controls:
+/// Surfaces two sections of developer-oriented controls:
 ///
 /// 1. **Diagnostic logs** — toggle to enable verbose tracing. The flag is
 ///    stored in `@AppStorage("advanced.verboseLogging")` so it survives
@@ -19,14 +20,11 @@ import SwiftUI
 ///    - *Reset onboarding* writes `false` to `hasCompletedOnboarding`
 ///      (same key used by `OnboardingView`) so the welcome / server-setup
 ///      flow re-runs on the next launch.
-///    - *Clear caches* removes the `~/Library/Caches/<bundle-id>/` tree —
-///      artwork tiles and other ephemeral data. Does not touch stored
-///      credentials or user preferences.
-///
-/// 3. **Show internal IDs** — toggle stored in
-///    `@AppStorage("advanced.showInternalIds")`. When enabled, detail views
-///    can surface the raw Jellyfin UUID alongside the display name so
-///    engineers can copy item IDs for API calls without leaving the app.
+///    - *Clear caches* evicts **only** the artwork cache (the same Nuke
+///      pipeline cache the Library pane clears) and its on-disk directory.
+///      It deliberately does **not** touch the caches root, so offline
+///      downloads (`Caches/Downloads`, see `PreferencesDownloads`), stored
+///      credentials, and user preferences all survive.
 ///
 /// All controls use `@AppStorage` — no AppModel mutations, no core FFI.
 /// Destructive buttons are guarded by `confirmationDialog` alerts so
@@ -38,8 +36,11 @@ struct PreferencesAdvanced: View {
     // MARK: - Stored preferences
 
     @AppStorage("advanced.verboseLogging") private var verboseLogging: Bool = false
-    @AppStorage("advanced.showInternalIds") private var showInternalIds: Bool = false
-    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = true
+    // Default must match the other two declarations (LyrebirdApp.swift,
+    // OnboardingView.swift) so the absent-key state agrees app-wide: a
+    // never-written key reads `false` everywhere, which means onboarding
+    // runs on a fresh install.
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
 
     // MARK: - Ephemeral UI state
 
@@ -47,6 +48,8 @@ struct PreferencesAdvanced: View {
     @State private var showClearCachesConfirm = false
     @State private var onboardingResetDone = false
     @State private var cachesClearedDone = false
+    @State private var cachesClearInProgress = false
+    @State private var cachesClearError: String?
     @State private var copyCommandDone = false
     @State private var consoleHintShown = false
 
@@ -58,7 +61,6 @@ struct PreferencesAdvanced: View {
 
             diagnosticLogsSection
             resetStateSection
-            internalIDsSection
 
             Spacer(minLength: 0)
         }
@@ -82,11 +84,21 @@ struct PreferencesAdvanced: View {
         ) {
             Button("Clear Caches", role: .destructive) {
                 clearCaches()
-                cachesClearedDone = true
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Artwork tiles and other temporary data will be removed. Your music library and settings are not affected.")
+            Text("Cached artwork will be removed. Your music library, offline downloads, and settings are not affected.")
+        }
+        .alert(
+            "Couldn't Clear Caches",
+            isPresented: Binding(
+                get: { cachesClearError != nil },
+                set: { if !$0 { cachesClearError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { cachesClearError = nil }
+        } message: {
+            Text(cachesClearError ?? "")
         }
     }
 
@@ -176,8 +188,8 @@ struct PreferencesAdvanced: View {
             PreferenceRow(
                 label: "Caches",
                 help: cachesClearedDone
-                    ? "Cleared — artwork and temporary files have been removed."
-                    : "Removes artwork tiles and other temporary files. Credentials and preferences are preserved."
+                    ? "Cleared — cached artwork has been removed."
+                    : "Removes cached artwork. Offline downloads, credentials, and preferences are preserved."
             ) {
                 Button {
                     showClearCachesConfirm = true
@@ -199,26 +211,7 @@ struct PreferencesAdvanced: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear caches")
-                .accessibilityHint("Deletes temporary files including artwork. Your library and settings are untouched.")
-            }
-        }
-    }
-
-    private var internalIDsSection: some View {
-        PreferenceSection(
-            title: "Show Internal IDs",
-            footnote: "Useful when filing issues or testing API calls. IDs appear alongside display names in track, album, and artist detail views."
-        ) {
-            PreferenceRow(
-                label: "Show UUIDs in detail views",
-                help: showInternalIds
-                    ? "On — Jellyfin item IDs are displayed beside names in detail views."
-                    : "Off — detail views show display names only."
-            ) {
-                Toggle("", isOn: $showInternalIds)
-                    .labelsHidden()
-                    .toggleStyle(.switch)
-                    .accessibilityLabel("Show internal item IDs")
+                .accessibilityHint("Removes cached artwork. Your library, offline downloads, and settings are untouched.")
             }
         }
     }
@@ -340,17 +333,124 @@ struct PreferencesAdvanced: View {
         .accessibilityLabel(accessibilityLabel)
     }
 
-    /// Removes the app's `Caches` sandbox directory subtree. This clears
-    /// artwork tiles and any other ephemeral blobs the app has written.
-    /// Credentials (Keychain), preferences (UserDefaults / AppStorage),
-    /// and downloaded offline tracks are stored elsewhere and are not
-    /// affected.
+    /// Clears the artwork cache only — the same Nuke pipeline cache the
+    /// Library pane evicts (`Artwork.pipeline.cache.removeAll()`), plus the
+    /// pipeline's on-disk `DataCache` directory.
+    ///
+    /// It deliberately does **not** delete the caches root. Offline
+    /// downloads live at `Caches/Downloads` (see `PreferencesDownloads`);
+    /// nuking the whole caches tree would destroy them, contradicting the
+    /// dialog's promise that the library isn't affected. Credentials
+    /// (Keychain) and preferences (UserDefaults) live outside Caches and
+    /// are untouched either way.
+    ///
+    /// The in-memory eviction and the artwork directory's URL are read on
+    /// the MainActor (Nuke's `ImagePipeline` / `DataCache` are main-actor
+    /// isolated in this module); the filesystem delete + verify runs off
+    /// the main thread so the recursive walk doesn't block the UI, and the
+    /// success / failure result is marshalled back to the MainActor.
     private func clearCaches() {
+        guard !cachesClearInProgress else { return }
+        cachesClearInProgress = true
+        cachesClearError = nil
+
+        // Memory cache eviction is cheap and main-actor isolated.
+        Artwork.pipeline.cache.removeAll()
+
+        // Resolve the on-disk artwork directory on main, then hand only that
+        // URL (Sendable) to the background task — never the caches root.
+        let artworkDir = (Artwork.pipeline.configuration.dataCache as? DataCache)?.path
+
+        Task {
+            // Do the recursive delete + recreate off the main thread so the
+            // filesystem walk never blocks the UI.
+            let result = await Task.detached(priority: .utility) {
+                Self.clearArtworkCacheDirectory(at: artworkDir)
+            }.value
+
+            // Marshal the outcome back to the MainActor for the @State writes.
+            await MainActor.run {
+                cachesClearInProgress = false
+                switch result {
+                case .success:
+                    cachesClearedDone = true
+                    // Auto-reset the row's "Cleared" affordance so it doesn't
+                    // stay stuck on the success copy forever.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                        cachesClearedDone = false
+                    }
+                case .failure(let error):
+                    cachesClearedDone = false
+                    cachesClearError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    /// Pure filesystem step: delete the artwork `DataCache` directory and
+    /// recreate it empty, returning the outcome instead of swallowing it.
+    ///
+    /// Safety: refuses to operate on the caches root or on a `Downloads`
+    /// directory, so a future config change can never turn this into the
+    /// download-destroying recursive nuke this used to be. A `nil` URL
+    /// (no on-disk cache configured) is a no-op success — the in-memory
+    /// eviction in `clearCaches()` already did the meaningful work.
+    ///
+    /// `nonisolated static` so it carries no `self`/MainActor capture and
+    /// can run on a background executor; unit-testable in isolation.
+    nonisolated static func clearArtworkCacheDirectory(
+        at directory: URL?
+    ) -> Result<Void, Error> {
+        guard let directory else { return .success(()) }
+
+        guard isSafeArtworkCacheDirectory(directory) else {
+            return .failure(CacheClearError.refusedUnsafePath(directory.path))
+        }
+
         let fm = FileManager.default
-        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else { return }
-        try? fm.removeItem(at: caches)
-        // Recreate the directory so subsequent writes don't fail.
-        try? fm.createDirectory(at: caches, withIntermediateDirectories: true)
+        do {
+            if fm.fileExists(atPath: directory.path) {
+                try fm.removeItem(at: directory)
+            }
+            // Recreate so the next artwork write doesn't fail on a missing dir,
+            // then verify it actually exists before reporting success.
+            try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+            guard fm.fileExists(atPath: directory.path) else {
+                return .failure(CacheClearError.recreateFailed(directory.path))
+            }
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Guards against ever deleting the caches root itself or a downloads
+    /// store. The artwork cache is always a named subdirectory (Nuke uses
+    /// `com.lyrebird.macos.artwork`), so a target whose last path component
+    /// is `Caches` or `Downloads` is rejected.
+    nonisolated static func isSafeArtworkCacheDirectory(_ directory: URL) -> Bool {
+        let last = directory.lastPathComponent
+        if last == "Downloads" || last == "Caches" || last.isEmpty || last == "/" {
+            return false
+        }
+        return true
+    }
+
+    /// Errors surfaced to the user when the artwork-cache clear can't
+    /// complete, so a failed or partial clear is visible instead of being
+    /// silently reported as success.
+    enum CacheClearError: LocalizedError {
+        case refusedUnsafePath(String)
+        case recreateFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .refusedUnsafePath(let path):
+                return "The cache location looked unsafe to delete (\(path)), so nothing was removed."
+            case .recreateFailed(let path):
+                return "The cache was cleared but the folder couldn't be recreated at \(path)."
+            }
+        }
     }
 }
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
@@ -2,12 +2,17 @@ import SwiftUI
 
 // MARK: - Persisted enums
 
-/// Theme preset. Matches the five presets from the design prototype's
-/// `THEMES` table (Purple / Ocean / Forest / Sunset / Peanut). Only `purple`
-/// is fully wired today — selecting another preset persists the choice so the
-/// Tweaks palette and theme engine (#313 / #405) pick it up when they land.
+/// Theme preset. The picker offers only the presets the theme engine can
+/// actually render: Purple (the shipping default) plus the two colour-blind-
+/// verified alternatives, Ocean and Forest, each backed by a real
+/// `ThemePreset` primary/accent pair. The design prototype's `THEMES` table
+/// also listed Sunset and Peanut, but those never had a backing `ThemePreset`
+/// case — `ThemePreset(appearanceTheme:)` silently folded them into Purple, so
+/// offering them would promise a palette the engine can't produce. They're
+/// dropped here until a verified pair is designed for each (the getter's
+/// `?? .purple` fallback keeps any user who persisted "sunset"/"peanut" valid).
 enum AppearanceTheme: String, CaseIterable, Identifiable {
-    case purple, ocean, forest, sunset, peanut
+    case purple, ocean, forest
 
     var id: String { rawValue }
 
@@ -16,25 +21,15 @@ enum AppearanceTheme: String, CaseIterable, Identifiable {
         case .purple: return "Purple"
         case .ocean: return "Ocean"
         case .forest: return "Forest"
-        case .sunset: return "Sunset"
-        case .peanut: return "Peanut"
         }
     }
 
-    /// Representative swatch color used in the theme picker. For presets that
-    /// ship a colour-blind-verified pair (Ocean / Forest), the swatch is
-    /// derived from `ThemePreset.primaryHex` so the picker preview always
-    /// matches the WCAG-verified accent the preset applies — the two can never
-    /// drift apart. Other presets are sampled from the design's `primary`
-    /// token in `design/project/src/tokens.jsx`.
+    /// Representative swatch color used in the theme picker. Every case ships a
+    /// colour-blind-verified `ThemePreset`, so the swatch is derived from
+    /// `ThemePreset.primaryHex` — the picker preview always matches the
+    /// WCAG-verified accent the preset applies and the two can never drift apart.
     var swatch: Color {
-        switch self {
-        case .purple: return Color(hex: 0x887BFF)
-        case .ocean: return Color(hex: ThemePreset.ocean.primaryHex)
-        case .forest: return Color(hex: ThemePreset.forest.primaryHex)
-        case .sunset: return Color(hex: 0xFF6625)
-        case .peanut: return Color(hex: 0xD4A360)
-        }
+        Color(hex: ThemePreset(appearanceTheme: self).primaryHex)
     }
 }
 
@@ -135,11 +130,16 @@ enum AppearanceKeys {
 
 /// Appearance pane — theme, mode, density, sidebar visibility.
 ///
-/// Only the color-scheme mode is wired end-to-end today (via
-/// `LyrebirdApp.preferredColorScheme`). The other controls persist the user's
-/// choice so the theme engine (#405) and sidebar chrome (#162) pick them up
-/// when that work lands. Source: `research/06-screen-specs.md` Issue 64.
+/// The color-scheme mode (via `LyrebirdApp.preferredColorScheme`), density
+/// (via the track-list density work), and sidebar visibility are wired
+/// end-to-end. The Theme picker is gated behind `AppModel.supportsThemeSelection`
+/// and rendered as a disabled "coming soon" preview: choosing a swatch would
+/// only persist `appearance.theme`, which no live surface reads yet — the
+/// theme engine that resolves `Theme.primary` / `Theme.accent` from the
+/// preset is #405. Source: `research/06-screen-specs.md` Issue 64.
 struct AppearancePane: View {
+    @Environment(AppModel.self) private var model
+
     @AppStorage(AppearanceKeys.theme) private var themeRaw: String = AppearanceTheme.purple.rawValue
     @AppStorage(AppearanceKeys.mode) private var modeRaw: String = AppearanceMode.dark.rawValue
     @AppStorage(AppearanceKeys.density) private var densityRaw: String = AppearanceDensity.roomy.rawValue
@@ -189,17 +189,23 @@ struct AppearancePane: View {
         )
     }
 
-    /// Theme-section helper text. When the system asks apps to convey meaning
-    /// without relying on colour alone (System Settings → Accessibility →
-    /// Display → "Differentiate without color"), steer toward the Ocean preset
-    /// whose primary/accent pair stays distinguishable for every colour-blind
-    /// type. Otherwise show the default copy.
+    /// Theme-section helper text. While theme selection is gated off
+    /// (`!supportsThemeSelection`) the picker is a disabled preview, so the copy
+    /// says so plainly rather than implying the swatch is actionable. Once the
+    /// theme engine (#405) lands and the picker is live, the copy steers users
+    /// who have asked the system to convey meaning without relying on colour
+    /// alone (System Settings → Accessibility → Display → "Differentiate without
+    /// color") toward the Ocean preset, whose primary/accent pair stays
+    /// distinguishable for every colour-blind type.
     private var themeHint: String {
+        guard model.supportsThemeSelection else {
+            return "Theme colours are coming soon — the picker previews the palettes; the rest of the app still uses the Purple theme for now."
+        }
         if ThemePreset.suggestedForAccessibility() == .ocean,
            (AppearanceTheme(rawValue: themeRaw) ?? .purple) != .ocean {
             return "Your system prefers colour-independent contrast — the Ocean theme keeps the accent distinguishable for every colour-blind type."
         }
-        return "Purple is the shipping default. Other presets persist today and render once the theme engine lands."
+        return "Purple is the shipping default. Pick Ocean or Forest for a colour-blind-verified accent pair."
     }
 
     var body: some View {
@@ -210,7 +216,7 @@ struct AppearancePane: View {
                 title: "Theme",
                 hint: themeHint
             ) {
-                ThemePicker(selection: theme)
+                ThemePicker(selection: theme, isEnabled: model.supportsThemeSelection)
             }
 
             AppearanceSection(
@@ -242,7 +248,7 @@ struct AppearancePane: View {
 
             AppearanceSection(
                 title: "Sidebar",
-                hint: "Auto-hide wires up alongside the sidebar chrome work."
+                hint: "Auto-hide collapses the sidebar on narrow windows and restores it when they widen. Visible keeps it pinned; Hidden starts collapsed."
             ) {
                 SegmentedPicker(
                     options: AppearanceSidebar.allCases,
@@ -300,21 +306,54 @@ private struct AppearanceSection<Content: View>: View {
 
 // MARK: - Theme picker
 
-/// Horizontal row of five colored swatches. The active swatch draws a ring
-/// in `Theme.accent` and inks the label. Tapping a swatch updates the
-/// binding. Purely visual today — the theme engine itself lands in #405.
+/// Horizontal row of colored swatches. The active swatch draws a ring in
+/// `Theme.accent` and inks the label.
+///
+/// When `isEnabled` is false the row is a disabled "coming soon" preview: the
+/// swatches still show the palettes (and the ring marks the persisted choice),
+/// but taps are inert and the row dims, so the picker never masquerades as a
+/// working selector while the theme engine (#405) that would consume the
+/// selection is still unwired. Once `isEnabled` flips true, tapping a swatch
+/// updates the binding.
 private struct ThemePicker: View {
     @Binding var selection: AppearanceTheme
+    var isEnabled: Bool = true
 
     var body: some View {
-        HStack(spacing: 14) {
+        HStack(alignment: .top, spacing: 14) {
             ForEach(AppearanceTheme.allCases) { theme in
                 swatch(theme)
             }
+            if !isEnabled {
+                comingSoonBadge
+            }
             Spacer(minLength: 0)
         }
+        .opacity(isEnabled ? 1 : 0.55)
+        .disabled(!isEnabled)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Theme")
+        // Surface the disabled state to assistive tech so VoiceOver announces
+        // the picker as unavailable rather than reading the swatches as
+        // tappable selectors.
+        .accessibilityValue(isEnabled ? "" : "Coming soon")
+    }
+
+    private var comingSoonBadge: some View {
+        Text("SOON")
+            .font(Theme.font(9, weight: .bold))
+            .tracking(1)
+            .foregroundStyle(Theme.ink3)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill(Theme.surface)
+            )
+            .overlay(
+                Capsule().stroke(Theme.border, lineWidth: 1)
+            )
+            .padding(.top, 12)
+            .accessibilityHidden(true)
     }
 
     private func swatch(_ target: AppearanceTheme) -> some View {
@@ -405,6 +444,10 @@ private struct SegmentedPicker<Option: Identifiable & Hashable>: View {
 }
 
 #Preview {
+    // Real rendering requires an `AppModel` in the environment; the Settings
+    // scene in `LyrebirdApp` injects one. Previews without a model will crash
+    // on `@Environment(AppModel.self)` — this preview is kept as documentation
+    // for where the view lives.
     AppearancePane()
         .padding(32)
         .frame(width: 560, height: 520)

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
@@ -3,11 +3,14 @@ import SwiftUI
 
 /// Audio quality preferences pane.
 ///
-/// Deliberately overlaps with the Playback pane's quality pickers — both read
-/// from `playback.streamingQuality` and `playback.downloadQuality` so changes
-/// in one surface show up in the other. Audio is the "proper" home per the
-/// System Settings-style layout (#114); Playback keeps its copy because a
-/// user hunting for "streaming quality" will look under Playback first.
+/// Canonical home for **Streaming Quality**, **Download Quality**, and the
+/// **Preferred Codec** (#117). These used to be duplicated in the Playback
+/// pane against the same `@AppStorage` keys; the duplicates were removed so
+/// each setting has exactly one editing surface here. The quality/codec
+/// pickers are gated behind `model.supportsStreamQualitySelection` and shown
+/// disabled until the core threads `MaxStreamingBitrate` + a `DeviceProfile`
+/// into the Jellyfin `PlaybackInfo` request (#260) — until then they would
+/// persist a preference nothing reads.
 ///
 /// Also houses the **Transcoding preference** — a two-option toggle between
 /// Direct Play (the server decides, prefers passthrough) and Always Transcode
@@ -15,10 +18,11 @@ import SwiftUI
 /// escape hatch for users hitting compatibility issues with a specific codec
 /// or container on their output device.
 ///
-/// Preference keys (user-facing `@AppStorage`, shared with Playback):
+/// Preference keys (user-facing `@AppStorage`):
 /// - `playback.streamingQuality`     — `PlaybackQuality`
 /// - `playback.downloadQuality`      — `PlaybackQuality`
-/// - `audio.transcodingPreference`   — `TranscodingPreference` (new)
+/// - `playback.preferredCodec`       — `PreferredAudioCodec`
+/// - `audio.transcodingPreference`   — `TranscodingPreference`
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 69 and GitHub issue #117.
 struct PreferencesAudio: View {
@@ -26,6 +30,7 @@ struct PreferencesAudio: View {
 
     @AppStorage("playback.streamingQuality") private var streamingQuality: PlaybackQuality = .automatic
     @AppStorage("playback.downloadQuality") private var downloadQuality: PlaybackQuality = .lossless
+    @AppStorage("playback.preferredCodec") private var preferredCodec: PreferredAudioCodec = .automatic
     @AppStorage("audio.transcodingPreference") private var transcodingRaw: String = TranscodingPreference.directPlay.rawValue
     @AppStorage(AudioOutputDevices.preferenceKey) private var outputDeviceUID: String = ""
     @AppStorage(AudioOutputDevices.exclusiveModePreferenceKey) private var exclusiveMode: Bool = false
@@ -73,6 +78,13 @@ struct PreferencesAudio: View {
         !outputDeviceUID.isEmpty && !devices.contains { $0.uid == outputDeviceUID }
     }
 
+    /// Whether the quality / codec pickers are wired into playback. Gated on
+    /// the capability flag (#260) — the core has no `MaxStreamingBitrate` /
+    /// `DeviceProfile` parameter on its `PlaybackInfo` request yet, so until it
+    /// does the pickers are shown disabled rather than persisting a preference
+    /// nothing reads.
+    private var qualityAvailable: Bool { model.supportsStreamQualitySelection }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             header
@@ -115,16 +127,20 @@ struct PreferencesAudio: View {
 
             PreferenceSection(
                 title: "Streaming Quality",
-                footnote: "Applied when playing over the network. Higher tiers use more bandwidth; Lossless and Original require your server (and your connection) to sustain them."
+                footnote: qualityAvailable
+                    ? "Applied when playing over the network. Higher tiers use more bandwidth; Lossless and Original require your server (and your connection) to sustain them."
+                    : "Quality and codec selection is planned. It needs server-side transcoding support that isn't available in this build yet."
             ) {
                 PreferenceRow(
                     label: "Quality",
-                    help: streamingQuality.subtitle
+                    help: qualityAvailable ? streamingQuality.subtitle : "Coming soon."
                 ) {
                     ExplicitQualityPicker(selection: $streamingQuality)
+                        .disabled(!qualityAvailable)
                         .accessibilityLabel("Streaming quality")
                 }
             }
+            .opacity(qualityAvailable ? 1 : 0.55)
 
             PreferenceSection(
                 title: "Download Quality",
@@ -132,12 +148,36 @@ struct PreferencesAudio: View {
             ) {
                 PreferenceRow(
                     label: "Quality",
-                    help: downloadQuality.subtitle
+                    help: qualityAvailable ? downloadQuality.subtitle : "Coming soon."
                 ) {
                     ExplicitQualityPicker(selection: $downloadQuality)
+                        .disabled(!qualityAvailable)
                         .accessibilityLabel("Download quality")
                 }
             }
+            .opacity(qualityAvailable ? 1 : 0.55)
+
+            PreferenceSection(
+                title: "Preferred Codec",
+                footnote: "Codec the server transcodes to when a direct stream isn't possible. \"Automatic\" trusts the server's default."
+            ) {
+                PreferenceRow(
+                    label: "Codec",
+                    help: qualityAvailable ? preferredCodec.subtitle : "Coming soon."
+                ) {
+                    Picker("", selection: $preferredCodec) {
+                        ForEach(PreferredAudioCodec.allCases) { codec in
+                            Text(codec.label).tag(codec)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 140)
+                    .disabled(!qualityAvailable)
+                    .accessibilityLabel("Preferred audio codec")
+                }
+            }
+            .opacity(qualityAvailable ? 1 : 0.55)
 
             PreferenceSection(
                 title: "Transcoding",
@@ -212,9 +252,9 @@ enum TranscodingPreference: String, CaseIterable, Identifiable {
 }
 
 /// Segmented quality picker that shows all five explicit tiers (no Auto).
-/// Matches the #117 spec exactly — the Playback pane's `QualityPicker` also
-/// shows `automatic` because historically that pane's copy read "Let Lyrebird
-/// pick." A separate picker here avoids touching that surface.
+/// Matches the #117 spec exactly. `.automatic` is intentionally absent — the
+/// spec asks for explicit choices — so a legacy on-disk `.automatic` simply
+/// shows nothing selected until the first tap.
 private struct ExplicitQualityPicker: View {
     @Binding var selection: PlaybackQuality
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesGeneral.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesGeneral.swift
@@ -4,20 +4,32 @@ import SwiftUI
 ///
 /// Launch-at-login, menu-bar presence, and language.
 ///
-/// - **Language**: only English ships; the picker is present so the setting
-///   is visible and the user can see i18n is on the roadmap. Real wiring is
-///   tracked in `TODO(i18n-#345)`.
+/// - **Language**: in-app localization isn't wired yet (#345) — nothing reads
+///   `general.language` back to re-render the UI, and `AppLanguage` only offers
+///   System / English (both no-ops). The picker is therefore gated behind
+///   `AppModel.supportsLanguageSelection` so it isn't presented as a working
+///   setting while inert; it reappears once the strings catalog ships real
+///   locales and a runtime override is wired.
 /// - **Auto-start on login**: wired to `SMAppService.mainApp` via
 ///   `LaunchAtLogin`. The stored `@AppStorage` value shadows the system
 ///   registration so the toggle reflects the true state on every launch.
 /// - **Show in menu bar**: wired to `MenuBarController.shared`. The
-///   `NSStatusItem` is created on enable and released on disable.
+///   `NSStatusItem` is created on enable and released on disable. The persisted
+///   value is re-applied at app launch from `AppDelegate` so the icon survives
+///   relaunch without the user reopening this pane.
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 66 top-level General bullet.
 struct PreferencesGeneral: View {
+    /// Stable `@AppStorage` key for the persistent "Show in menu bar" toggle.
+    /// Shared with `AppDelegate`, which re-applies the stored value at launch
+    /// so the icon survives relaunch without the pane being opened.
+    static let showInMenuBarKey = "general.showInMenuBar"
+
+    @Environment(AppModel.self) private var model
+
     @AppStorage("general.language") private var languageRaw: String = AppLanguage.system.rawValue
     @AppStorage("general.autoStartOnLogin") private var autoStartOnLogin: Bool = false
-    @AppStorage("general.showInMenuBar") private var showInMenuBar: Bool = false
+    @AppStorage(PreferencesGeneral.showInMenuBarKey) private var showInMenuBar: Bool = false
 
     private var language: Binding<AppLanguage> {
         Binding(
@@ -58,23 +70,29 @@ struct PreferencesGeneral: View {
         VStack(alignment: .leading, spacing: 24) {
             header
 
-            PreferenceSection(
-                title: "Language",
-                footnote: "Only English ships today — additional languages will appear as translations land."
-            ) {
-                PreferenceRow(
-                    label: "Language",
-                    help: language.wrappedValue.subtitle
+            // Language picker is gated behind `supportsLanguageSelection`
+            // (#345). The control is inert today — nothing consumes
+            // `general.language` — so we hide it rather than present a dead
+            // setting. It returns once localization is wired.
+            if model.supportsLanguageSelection {
+                PreferenceSection(
+                    title: "Language",
+                    footnote: "Only English ships today — additional languages will appear as translations land."
                 ) {
-                    Picker("", selection: language) {
-                        ForEach(AppLanguage.allCases) { option in
-                            Text(option.label).tag(option)
+                    PreferenceRow(
+                        label: "Language",
+                        help: language.wrappedValue.subtitle
+                    ) {
+                        Picker("", selection: language) {
+                            ForEach(AppLanguage.allCases) { option in
+                                Text(option.label).tag(option)
+                            }
                         }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 180)
+                        .accessibilityLabel("Application language")
                     }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    .frame(width: 180)
-                    .accessibilityLabel("Application language")
                 }
             }
 
@@ -130,7 +148,9 @@ struct PreferencesGeneral: View {
             Text("General")
                 .font(Theme.font(28, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("Language, startup, and menu-bar presence.")
+            Text(model.supportsLanguageSelection
+                ? "Language, startup, and menu-bar presence."
+                : "Startup and menu-bar presence.")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }
@@ -163,6 +183,10 @@ enum AppLanguage: String, CaseIterable, Identifiable {
 }
 
 #Preview {
+    // Real rendering requires an `AppModel` in the environment; the Settings
+    // scene in `LyrebirdApp` injects one. Previews without a model will crash
+    // on `@Environment(AppModel.self)` — this preview is kept as documentation
+    // for where the view lives.
     PreferencesGeneral()
         .frame(width: 560, height: 520)
         .padding(32)

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
@@ -271,33 +271,55 @@ struct PreferencesLibrary: View {
     }
 
     /// Evict the shared Nuke pipeline's memory + disk caches.
+    ///
+    /// `cache.removeAll()` clears memory synchronously but the disk
+    /// `DataCache.removeAll()` only *stages* the deletion and returns instantly
+    /// (its files are removed on a background queue). Reading `totalSize` right
+    /// away — or after a fixed delay — can therefore still report the old bytes
+    /// while the button says "Cleared ✓". So we hop to a detached task,
+    /// `flush()` the cache (a synchronous wait for the staged deletion to land),
+    /// then read the now-accurate size from that same off-main context.
     private func clearCache() {
-        Artwork.pipeline.cache.removeAll()
         justCleared = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-            refreshCacheSize()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
-                justCleared = false
-            }
+        Task {
+            let label = await Task.detached(priority: .utility) { () -> String in
+                Artwork.pipeline.cache.removeAll()
+                let dataCache = Artwork.pipeline.configuration.dataCache as? DataCache
+                dataCache?.flush()
+                return Self.formatCacheSize(dataCache)
+            }.value
+            cacheSizeLabel = label
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            justCleared = false
         }
     }
 
     /// Read the artwork cache's current on-disk size and render it as
-    /// `4.3 MB` / `1.7 GB`. Wrapped in a Task so the index walk doesn't
-    /// block first paint. Stays on the main actor because `Artwork.pipeline`
-    /// and `DataCache` are both main-actor isolated in this module.
+    /// `4.3 MB` / `1.7 GB`.
+    ///
+    /// `DataCache.totalSize` enumerates and `stat`s every file on disk — Nuke
+    /// documents it as "Requires disk IO, avoid using from the main thread" —
+    /// so the walk runs in a detached task and only the resulting label hops
+    /// back to the main actor. `DataCache` is `Sendable`, so reading it off the
+    /// main thread is safe.
     private func refreshCacheSize() {
-        Task { @MainActor in
-            let cache = Artwork.pipeline.configuration.dataCache as? DataCache
-            let label: String = {
-                guard let cache else { return "—" }
-                let formatter = ByteCountFormatter()
-                formatter.allowedUnits = [.useKB, .useMB, .useGB]
-                formatter.countStyle = .file
-                return formatter.string(fromByteCount: Int64(cache.totalSize))
-            }()
+        Task {
+            let label = await Task.detached(priority: .utility) { () -> String in
+                Self.formatCacheSize(Artwork.pipeline.configuration.dataCache as? DataCache)
+            }.value
             cacheSizeLabel = label
         }
+    }
+
+    /// Format a `DataCache`'s on-disk footprint as a human-readable byte count.
+    /// `nil` (no disk cache configured) renders as an em dash. Reads
+    /// `totalSize`, so this must run off the main thread.
+    nonisolated private static func formatCacheSize(_ cache: DataCache?) -> String {
+        guard let cache else { return "—" }
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB, .useGB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(cache.totalSize))
     }
 }
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -2,18 +2,22 @@ import SwiftUI
 
 /// Playback preferences pane.
 ///
-/// Exposes streaming quality, download quality, preferred audio codec, and
-/// the behavioural knobs covered by issue #116 — crossfade, gapless, replay-
-/// gain normalization, pre-gain, and "stop after current track". Quality and
-/// codec live here historically; the Audio pane (#117) also surfaces quality
-/// pickers, so the two sections overlap intentionally — the values are the
-/// same `@AppStorage` keys behind the scenes.
+/// Exposes the behavioural knobs covered by issue #116 — gapless joins,
+/// crossfade, ReplayGain normalization, pre-gain, and "stop after current
+/// track". Streaming/download quality and preferred codec used to live here
+/// too, but they share their `@AppStorage` keys with the Audio pane (#117),
+/// which is their canonical home; the duplicates were removed here so each
+/// setting has exactly one editing surface.
 ///
-/// These are UI-only knobs today — wiring into the AVPlayer source URL,
-/// Jellyfin transcoding profile, and the audio engine's crossfade/replay-gain
-/// paths lives in follow-up work (see TODOs below). Persisting the selection
-/// now means the eventual implementation can read the current choice on day
-/// one without a migration.
+/// What's live vs. coming soon:
+/// - **Gapless** and **Stop after current track** are wired into the engine /
+///   queue (`AppModel.armNextTrackPreload` reads `gaplessEnabled`;
+///   `handleTrackEnded` consumes `stopAfterCurrent`).
+/// - **Normalization** and **Pre-gain** route through `AppModel.setNormalization`
+///   onto the live ReplayGain path (#42).
+/// - **Crossfade** has no engine support yet (no overlapping-playback path in
+///   `AudioEngine`), so its slider is gated behind `supportsCrossfade` and
+///   shown disabled rather than persisting a value nothing honours.
 ///
 /// Design: matches the native Preferences aesthetic inside the Lyrebird shell.
 /// Sections sit on `Theme.surface` with `Theme.border` outlines; labels use
@@ -22,9 +26,6 @@ import SwiftUI
 /// the display labels.
 ///
 /// Preference keys (user-facing `@AppStorage`):
-/// - `playback.streamingQuality`     — `PlaybackQuality`
-/// - `playback.downloadQuality`      — `PlaybackQuality`
-/// - `playback.preferredCodec`       — `PreferredAudioCodec`
 /// - `playback.crossfadeSeconds`     — `Double` (0 = off, 1…12)
 /// - `playback.gaplessEnabled`       — `Bool` (default true)
 /// - `playback.normalization`        — `NormalizationMode`
@@ -35,14 +36,12 @@ import SwiftUI
 struct PreferencesPlayback: View {
     @Environment(AppModel.self) private var model
 
-    @AppStorage("playback.streamingQuality") private var streamingQuality: PlaybackQuality = .automatic
-    @AppStorage("playback.downloadQuality") private var downloadQuality: PlaybackQuality = .lossless
-    @AppStorage("playback.preferredCodec") private var preferredCodec: PreferredAudioCodec = .automatic
-
-    // #116 gap-fill knobs. All UI-only until the audio engine grows the
-    // corresponding hooks. Raw types are chosen so the key names survive any
-    // later enum/struct refactor — a Double for the slider is portable and the
-    // Bool toggles are the obvious shape.
+    // #116 gap-fill knobs. Gapless / stop-after-current / normalization /
+    // pre-gain are wired; crossfade is gated behind `model.supportsCrossfade`
+    // until the engine grows an overlapping-playback path. Raw types are
+    // chosen so the key names survive any later enum/struct refactor — a
+    // Double for the slider is portable and the Bool toggles are the obvious
+    // shape.
     @AppStorage("playback.crossfadeSeconds") private var crossfadeSeconds: Double = 0
     @AppStorage("playback.gaplessEnabled") private var gaplessEnabled: Bool = true
     @AppStorage("playback.normalization") private var normalizationRaw: String = NormalizationMode.off.rawValue
@@ -83,47 +82,8 @@ struct PreferencesPlayback: View {
             header
 
             PreferenceSection(
-                title: "Streaming",
-                footnote: "Applies when playing over the network. \"Automatic\" lets Lyrebird pick based on your connection."
-            ) {
-                PreferenceRow(
-                    label: "Quality",
-                    help: streamingQuality.subtitle
-                ) {
-                    QualityPicker(selection: $streamingQuality)
-                        .accessibilityLabel("Streaming quality")
-                }
-            }
-
-            PreferenceSection(
-                title: "Downloads",
-                footnote: "Quality used for offline copies. Higher settings use more disk space."
-            ) {
-                PreferenceRow(
-                    label: "Quality",
-                    help: downloadQuality.subtitle
-                ) {
-                    QualityPicker(selection: $downloadQuality)
-                        .accessibilityLabel("Download quality")
-                }
-            }
-
-            PreferenceSection(
-                title: "Audio Codec",
-                footnote: "Preferred codec when transcoding is required. \"Automatic\" trusts the server."
-            ) {
-                PreferenceRow(
-                    label: "Preferred codec",
-                    help: preferredCodec.subtitle
-                ) {
-                    CodecPicker(selection: $preferredCodec)
-                        .accessibilityLabel("Preferred audio codec")
-                }
-            }
-
-            PreferenceSection(
                 title: "Transitions",
-                footnote: "Gapless joins tracks with no silence when the source supports it. Crossfade overlaps the last and next track by the selected number of seconds."
+                footnote: transitionsFootnote
             ) {
                 PreferenceRow(
                     label: "Gapless playback",
@@ -143,10 +103,15 @@ struct PreferencesPlayback: View {
 
                 PreferenceRow(
                     label: "Crossfade",
-                    help: crossfadeHelp
+                    help: model.supportsCrossfade ? crossfadeHelp : "Coming soon."
                 ) {
                     CrossfadeSlider(seconds: $crossfadeSeconds)
+                        .disabled(!model.supportsCrossfade)
                 }
+                // Dim the whole row when crossfade isn't available so it reads
+                // as not-yet-functional rather than broken — matching the
+                // disabled Last.fm row in `PreferencesScrobbling`.
+                .opacity(model.supportsCrossfade ? 1 : 0.55)
             }
 
             PreferenceSection(
@@ -199,10 +164,21 @@ struct PreferencesPlayback: View {
             Text("Playback")
                 .font(Theme.font(28, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
-            Text("Streaming, downloads, transitions, and normalization.")
+            Text("Transitions, normalization, and queue behaviour.")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }
+    }
+
+    /// Footnote under the Transitions section. Describes gapless always, and
+    /// crossfade only when the engine actually supports it — otherwise the
+    /// section would promise a working crossfade feature that doesn't exist.
+    private var transitionsFootnote: String {
+        let gapless = "Gapless joins tracks with no silence when the source supports it."
+        if model.supportsCrossfade {
+            return gapless + " Crossfade overlaps the last and next track by the selected number of seconds."
+        }
+        return gapless + " Crossfade is planned and isn't available in this build yet."
     }
 
     /// Subtitle under the crossfade row. Reads "Off" when the slider is at
@@ -342,41 +318,9 @@ enum PreferredAudioCodec: String, CaseIterable, Identifiable {
 
 // MARK: - Pickers
 
-/// Segmented control for the 5-option quality tiers. Uses a native
-/// `SegmentedPickerStyle` so keyboard/accessibility comes for free, then
-/// restyles the surround with theme tokens so it matches the rest of the
-/// Preferences pane.
-private struct QualityPicker: View {
-    @Binding var selection: PlaybackQuality
-
-    var body: some View {
-        Picker("", selection: $selection) {
-            ForEach(PlaybackQuality.allCases) { q in
-                Text(q.label).tag(q)
-            }
-        }
-        .labelsHidden()
-        .pickerStyle(.segmented)
-        .frame(maxWidth: 420)
-    }
-}
-
-/// Inline menu picker for codec. Four short options fit comfortably in a
-/// dropdown; a segmented control would feel noisy next to the quality row.
-private struct CodecPicker: View {
-    @Binding var selection: PreferredAudioCodec
-
-    var body: some View {
-        Picker("", selection: $selection) {
-            ForEach(PreferredAudioCodec.allCases) { c in
-                Text(c.label).tag(c)
-            }
-        }
-        .labelsHidden()
-        .pickerStyle(.menu)
-        .frame(width: 140)
-    }
-}
+// Note: the streaming/download `QualityPicker` and the `CodecPicker` that used
+// to live here moved to the Audio pane (#117) — the single home for quality and
+// codec selection now that the duplicate sections were removed from this pane.
 
 /// Segmented picker for the three-option normalization mode. Off / Track /
 /// Album — a segmented control reads best for a mutually-exclusive short

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -53,14 +53,6 @@ struct SearchView: View {
     /// Increment applied when the user taps "Load more" for a scope.
     private let revealStep = 10
 
-    /// Soft cap on how many items a single scope section will render
-    /// from the already-fetched bucket. Aligns with the "about 20 per
-    /// category" intent — once the user has revealed this many, any
-    /// further "Load more" triggers a backend fetch through
-    /// `AppModel.loadMoreFullSearch`. Chosen on the higher side (30)
-    /// so a tall Tracks bucket gets room to breathe before we round-trip.
-    private let perSectionLocalCap = 30
-
     var body: some View {
         @Bindable var model = model
         ScrollView {
@@ -301,11 +293,8 @@ struct SearchView: View {
     @ViewBuilder
     private var sectionedResults: some View {
         VStack(alignment: .leading, spacing: 28) {
-            let allScopes: [SearchScope] = model.supportsGenreActions
-                ? [.artists, .albums, .tracks, .playlists, .genres]
-                : [.artists, .albums, .tracks, .playlists]
             let scopes = model.activeSearchScope == .all
-                ? allScopes
+                ? composedScopes
                 : [model.activeSearchScope]
             ForEach(scopes, id: \.self) { scope in
                 SectionView(
@@ -320,14 +309,31 @@ struct SearchView: View {
         }
     }
 
+    /// The ordered scopes the `.all` view composes. Genres and playlists
+    /// are each gated by a capability flag so the page never renders a
+    /// section that can only say "no … matched this query": genres via
+    /// `supportsGenreActions`, playlists via `supportsPlaylistSearch`
+    /// (the core search backend doesn't return playlists yet).
+    private var composedScopes: [SearchScope] {
+        var scopes: [SearchScope] = [.artists, .albums, .tracks]
+        if model.supportsPlaylistSearch { scopes.append(.playlists) }
+        if model.supportsGenreActions { scopes.append(.genres) }
+        return scopes
+    }
+
     /// Scope chips to render in the chip row. Drops `.genres` when the
-    /// genre actions feature is hidden so users can't navigate to a scope
-    /// where every action is a stub.
+    /// genre actions feature is hidden, and `.playlists` until the core
+    /// search backend returns playlists (`supportsPlaylistSearch`), so
+    /// users can't navigate to a scope that is either all-stub (genres)
+    /// or permanently empty (playlists).
     private var visibleScopes: [SearchScope] {
-        if model.supportsGenreActions {
-            return SearchScope.allCases
+        SearchScope.allCases.filter { scope in
+            switch scope {
+            case .genres: return model.supportsGenreActions
+            case .playlists: return model.supportsPlaylistSearch
+            default: return true
+            }
         }
-        return SearchScope.allCases.filter { $0 != .genres }
     }
 
     private func bucket(for scope: SearchScope) -> [SearchItem] {
@@ -341,42 +347,41 @@ struct SearchView: View {
     }
 
     /// "Load more" is visible when there's another row to reveal in the
-    /// local bucket, OR when the local bucket is exhausted but the server
-    /// has more results for the overall query.
+    /// local bucket, OR — for server-paged scopes only — when the local
+    /// bucket is exhausted but the server still has more results for the
+    /// overall query. Derived / not-yet-paged scopes (genres, playlists)
+    /// never consult the server signal, so their button disappears the
+    /// moment the whole bucket is on screen instead of staying perpetual.
     private func canLoadMore(for scope: SearchScope) -> Bool {
-        let loaded = bucket(for: scope).count
         let revealed = revealedCount(for: scope)
-        if revealed < loaded { return true }
-        // Locally exhausted — does the server still have more?
-        return model.searchPageLoaded < Int(model.searchPageTotal)
+        if revealed < bucket(for: scope).count { return true }
+        // Locally exhausted — only server-paged scopes can fetch more.
+        return scope.isServerPaged && model.searchPageHasMore
     }
 
-    /// Bump the reveal count for this scope and, if that exhausts the
-    /// local bucket, fetch a follow-up page from the server. The
-    /// revealed count is bumped *past* the current bucket end when a
-    /// server fetch is kicked off so new rows coming back land inside
-    /// the visible window without forcing a second click.
+    /// Bump the reveal count for this scope by `revealStep`, and — for a
+    /// server-paged scope whose buffered bucket is fully revealed — kick
+    /// off a follow-up page fetch. The reveal grows straight to
+    /// `bucketSize` (no artificial sub-page cap) so every locally-loaded
+    /// row is reachable; the page size already bounds how much arrives at
+    /// once. When a server fetch is started the reveal window is nudged
+    /// one step past the current bucket end so freshly-fetched rows land
+    /// inside the visible window without forcing a second click.
     private func handleLoadMore(for scope: SearchScope) {
         let key = scope.storageKey
         let current = revealedCount(for: scope)
         let bucketSize = bucket(for: scope).count
-        let serverHasMore = model.searchPageLoaded < Int(model.searchPageTotal)
+        let serverHasMore = scope.isServerPaged && model.searchPageHasMore
 
-        // Cap the in-bucket reveal at `perSectionLocalCap`, but if the
-        // server has more rows we want the reveal window to spill past
-        // the current bucket so freshly-fetched rows are visible straight
-        // away. `nextLocalCap` is the bucket-bounded target; we extend
-        // past it when there's more to fetch.
-        let nextLocalCap = min(current + revealStep, max(bucketSize, current), perSectionLocalCap)
-        let next = serverHasMore
-            ? max(nextLocalCap, current + revealStep)
-            : nextLocalCap
-
-        if next > current {
-            revealedCounts[key] = next
-        }
-
-        if (current + revealStep) > bucketSize && serverHasMore {
+        if current < bucketSize {
+            // Still rows buffered locally — reveal the next chunk, clamped
+            // to what the bucket actually holds.
+            revealedCounts[key] = min(current + revealStep, bucketSize)
+        } else if serverHasMore {
+            // Bucket fully revealed and the server has more: spill the
+            // window past the current end so the incoming page is visible
+            // on arrival, then fetch it.
+            revealedCounts[key] = current + revealStep
             Task { await model.loadMoreFullSearch() }
         }
     }
@@ -389,9 +394,13 @@ struct SearchView: View {
     private func commitQuery(_ query: String) {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        // Cancel any pending debounce so the committed search isn't chased
+        // ~300ms later by a duplicate that would also cancel this request
+        // mid-flight. `clearQuery` cancels both; mirror that here.
+        searchDebounce?.cancel()
+        searchTask?.cancel()
         AppModel.addRecentSearch(trimmed, into: &recentSearchesJSON)
         revealedCounts = [:]
-        searchTask?.cancel()
         let scope = model.activeSearchScope
         searchTask = Task { await model.runFullSearch(query: trimmed, scope: scope) }
     }

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -688,16 +688,23 @@ private struct SearchPageTrackRow: View {
     let queue: [Track]
 
     var body: some View {
+        // Resolve this row's position in the shared queue once; reuse it for
+        // both tap-to-play and arrow-key focus navigation. A track absent
+        // from `queue` (shouldn't happen — every Tracks-section row is built
+        // from it) falls back to a one-track queue and disables nav.
+        let queueIndex = queue.firstIndex(where: { $0.id == track.id })
         TrackRow(
             track: track,
             number: number,
             onPlay: {
-                guard let idx = queue.firstIndex(where: { $0.id == track.id }) else {
+                guard let idx = queueIndex else {
                     model.play(tracks: [track], startIndex: 0)
                     return
                 }
                 model.play(tracks: queue, startIndex: idx)
-            }
+            },
+            tracks: queueIndex == nil ? [] : queue,
+            index: queueIndex ?? 0
         )
     }
 }

--- a/macos/Sources/Lyrebird/System/AboutInfo.swift
+++ b/macos/Sources/Lyrebird/System/AboutInfo.swift
@@ -95,28 +95,11 @@ enum AboutInfo {
     /// - `music.example.com:8096` → `music.example.com`
     /// - `""` → `nil`
     static func connectedServerHost(from urlString: String) -> String? {
-        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        // Structured parse first: `URLComponents` cleanly separates host from
-        // userinfo / port / path / query.
-        if let host = URLComponents(string: trimmed)?.host, !host.isEmpty {
-            return host
-        }
-
-        // Fallback for bare `host[:port][/path]` strings with no scheme, which
-        // `URLComponents` parses as a path rather than a host. Strip any
-        // `scheme://`, then any `user:pw@` userinfo, then cut at the first
-        // `/`, `:`, or `?`.
-        var rest = trimmed
-        if let schemeRange = rest.range(of: "://") {
-            rest = String(rest[schemeRange.upperBound...])
-        }
-        if let atIndex = rest.firstIndex(of: "@") {
-            rest = String(rest[rest.index(after: atIndex)...])
-        }
-        let host = rest.prefix { $0 != "/" && $0 != ":" && $0 != "?" }
-        return host.isEmpty ? nil : String(host)
+        // Shared with `DiagnosticBundle.redactServerHost` so the two never
+        // drift; the only difference is the empty/signed-out spelling, which
+        // this surface renders as `nil` (the row is hidden) rather than a
+        // placeholder string.
+        ServerHostRedaction.host(from: urlString)
     }
 
     // MARK: - Credits

--- a/macos/Sources/Lyrebird/System/CoreDataLocation.swift
+++ b/macos/Sources/Lyrebird/System/CoreDataLocation.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Resolves the on-disk directory the Rust core uses for its database, so the
+/// app can offer a "reset local data" affordance when core construction fails
+/// (audit L31). This mirrors `core/src/storage.rs::default_data_dir()` exactly:
+/// the app passes an empty `dataDir` to `CoreConfig`, which makes the core fall
+/// back to its platform default, so the Swift side has to reproduce the same
+/// derivation to know which directory to move aside.
+///
+/// Derivation (macOS): prefer a non-empty `XDG_DATA_HOME`, else
+/// `~/Library/Application Support`, then append `lyrebird-desktop`. Pulled into
+/// a pure function of an environment map so it stays unit-testable.
+enum CoreDataLocation {
+    /// The directory the core stores its data in for the current process.
+    static var defaultDataDirectory: URL? {
+        resolve(environment: ProcessInfo.processInfo.environment,
+                home: NSHomeDirectory())
+    }
+
+    /// Pure resolver used by `defaultDataDirectory` and the tests. Returns `nil`
+    /// only when neither `XDG_DATA_HOME` nor a home directory is available
+    /// (matching the core's `dirs_next_like()` returning `None`).
+    static func resolve(environment: [String: String], home: String?) -> URL? {
+        if let xdg = environment["XDG_DATA_HOME"], !xdg.isEmpty {
+            return URL(fileURLWithPath: xdg, isDirectory: true)
+                .appendingPathComponent(folderName, isDirectory: true)
+        }
+        guard let home, !home.isEmpty else { return nil }
+        return URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(folderName, isDirectory: true)
+    }
+
+    /// The app's data subfolder name, matching the core's `default_data_dir`.
+    static let folderName = "lyrebird-desktop"
+
+    /// Move the core's data directory aside to a timestamped sibling so the next
+    /// launch starts from a clean slate without destroying the user's old data
+    /// outright (it can still be recovered from the renamed folder). Returns the
+    /// backup location on success. A no-op (returns `nil`) when the directory
+    /// doesn't exist yet.
+    @discardableResult
+    static func quarantineDataDirectory(
+        _ directory: URL? = CoreDataLocation.defaultDataDirectory,
+        fileManager: FileManager = .default,
+        now: Date = Date()
+    ) throws -> URL? {
+        guard let directory, fileManager.fileExists(atPath: directory.path) else { return nil }
+        let stamp = backupStamp(now)
+        let backup = directory.deletingLastPathComponent()
+            .appendingPathComponent("\(directory.lastPathComponent).corrupt-\(stamp)", isDirectory: true)
+        try fileManager.moveItem(at: directory, to: backup)
+        return backup
+    }
+
+    /// Filename-safe timestamp for the quarantine folder suffix.
+    static func backupStamp(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        f.dateFormat = "yyyy-MM-dd-HHmmss"
+        return f.string(from: date)
+    }
+}

--- a/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
+++ b/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
@@ -133,29 +133,7 @@ enum DiagnosticBundle {
     /// - `music.example.com:8096` → `music.example.com`
     /// - `""` → `(not signed in)`
     static func redactServerHost(_ urlString: String) -> String {
-        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "(not signed in)" }
-
-        // Try a structured parse first. `URLComponents` cleanly separates the
-        // host from userinfo / port / path / query.
-        if let host = URLComponents(string: trimmed)?.host, !host.isEmpty {
-            return host
-        }
-
-        // Fallback for bare `host[:port][/path]` strings with no scheme, which
-        // `URLComponents` parses as a path rather than a host. Strip any
-        // `scheme://`, then any `user:pw@` userinfo, then cut at the first
-        // `/`, `:`, or `?`.
-        var rest = trimmed
-        if let schemeRange = rest.range(of: "://") {
-            rest = String(rest[schemeRange.upperBound...])
-        }
-        if let atIndex = rest.firstIndex(of: "@") {
-            rest = String(rest[rest.index(after: atIndex)...])
-        }
-        let host = rest.prefix { $0 != "/" && $0 != ":" && $0 != "?" }
-        let result = String(host)
-        return result.isEmpty ? "(not signed in)" : result
+        ServerHostRedaction.host(from: urlString) ?? "(not signed in)"
     }
 
     // MARK: - Manifest

--- a/macos/Sources/Lyrebird/System/FullScreenChromeController.swift
+++ b/macos/Sources/Lyrebird/System/FullScreenChromeController.swift
@@ -169,9 +169,15 @@ struct FullScreenChromeObserver: NSViewRepresentable {
                 NotificationCenter.default.removeObserver(observer)
                 exitObserver = nil
             }
-            // Defensive: if we're torn down mid-full-screen, restore default
-            // presentation so the app never gets stuck with a hidden menu bar.
-            if NSApp.presentationOptions != [] {
+            // `NSApp.presentationOptions` is *app-global*: a single value shared
+            // across every window. Only clear it when *this* window is the one
+            // currently in full-screen — i.e. we're being torn down mid-full-
+            // screen and must not strand a hidden menu bar. If this window is
+            // windowed, the full-screen override (if any) belongs to a
+            // different window's full-screen space; blindly resetting it here
+            // would yank that other window's auto-hide chrome out from under it.
+            if window?.styleMask.contains(.fullScreen) == true,
+               NSApp.presentationOptions != [] {
                 NSApp.presentationOptions = []
             }
             window = nil

--- a/macos/Sources/Lyrebird/System/MoveToApplications.swift
+++ b/macos/Sources/Lyrebird/System/MoveToApplications.swift
@@ -394,25 +394,31 @@ enum MoveToApplications {
         return running ? .differentRunning : .differentIdle
     }
 
-    /// Move `url` to the Trash via `NSWorkspace.recycle`, returning whether it
-    /// succeeded. Recoverable by design — the user can restore from the Trash if
-    /// the subsequent copy fails.
+    /// Move `url` to the Trash, returning whether it succeeded. Recoverable by
+    /// design — the user can restore from the Trash if the subsequent copy
+    /// fails.
+    ///
+    /// Uses the synchronous `FileManager.trashItem(at:resultingItemURL:)`
+    /// rather than the async `NSWorkspace.recycle(_:completionHandler:)`. This
+    /// is reached from `move(...)`, a synchronous `@MainActor` function invoked
+    /// after `alert.runModal()` returns — i.e. while the main run loop is
+    /// blocked. `NSWorkspace.recycle` delivers its completion handler on the
+    /// main thread, so blocking the main thread on a semaphore until that
+    /// handler fires deadlocks permanently (the handler can never run). The
+    /// `FileManager` variant returns on the calling thread and never hangs,
+    /// matching the original synchronous removal's non-blocking behaviour while
+    /// keeping the to-Trash recoverability.
     @MainActor
     private static func recycle(_ url: URL) -> Bool {
-        var recycleError: Error?
-        let semaphore = DispatchSemaphore(value: 0)
-        NSWorkspace.shared.recycle([url]) { _, error in
-            recycleError = error
-            semaphore.signal()
-        }
-        semaphore.wait()
-        if let recycleError {
+        do {
+            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+            return true
+        } catch {
             Log.app.error(
-                "MoveToApplications recycle failed: \(recycleError.localizedDescription, privacy: .public)"
+                "MoveToApplications recycle failed: \(error.localizedDescription, privacy: .public)"
             )
             return false
         }
-        return true
     }
 
     /// Ask the user before replacing a *different* app of the same name already

--- a/macos/Sources/Lyrebird/System/MoveToApplications.swift
+++ b/macos/Sources/Lyrebird/System/MoveToApplications.swift
@@ -103,21 +103,96 @@ enum MoveToApplications {
         return path == root || path.hasPrefix(root + "/")
     }
 
-    /// Heuristic for "this path is a translocation mount, a still-mounted disk
-    /// image, or a quarantined download we shouldn't try to relocate yet".
-    ///
-    /// - **App Translocation**: Gatekeeper runs quarantined apps from a
-    ///   randomized, read-only mount under
-    ///   `/private/var/folders/.../AppTranslocation/`. The move is pointless
-    ///   there — the bytes are a shadow copy.
-    /// - **Mounted DMG**: a path under `/Volumes/` means the user double-
-    ///   clicked the app inside the disk image. We don't move *out* of a DMG
-    ///   (the source is read-only and the user expects to drag it themselves),
-    ///   so we hold the prompt until they've copied it somewhere writable.
-    static func isTranslocatedOrEphemeral(path: String) -> Bool {
+    /// Flags describing the volume a bundle lives on, used to tell a mounted
+    /// disk image apart from a persistent secondary disk. Injected in tests so
+    /// the volume-based branch of `isTranslocatedOrEphemeral` is exercisable
+    /// without a real mount; resolved from `URLResourceValues` in production.
+    struct VolumeFlags {
+        var isReadOnly: Bool
+        var isInternal: Bool
+        var isRemovable: Bool
+        var isEjectable: Bool
+    }
+
+    /// Whether `path` is a Gatekeeper App Translocation mount. Gatekeeper runs
+    /// quarantined apps from a randomized, read-only mount under
+    /// `/private/var/folders/.../AppTranslocation/`; a move from there is
+    /// pointless because the bytes are a shadow copy. Pure and path-based —
+    /// the marker is always present in the path itself.
+    static func isTranslocated(path: String) -> Bool {
         path.contains("/AppTranslocation/")
-            || path.hasPrefix("/Volumes/")
-            || path.contains("/.dmg/")
+    }
+
+    /// Whether a bundle on a `/Volumes/`-mounted volume with the given flags is
+    /// running from an ephemeral disk image (a mounted DMG) rather than a
+    /// persistent secondary disk.
+    ///
+    /// A mounted DMG presents as read-only (you can't write back into the
+    /// image) and, being a synthesized device, is not an internal volume. A
+    /// persistent external SSD or a secondary internal partition mounted at
+    /// `/Volumes/<Disk>` is writable (or, if read-only, is a real removable
+    /// disk the user can eject and re-mount) — those are supported install
+    /// locations and must *not* suppress the prompt.
+    ///
+    /// The discriminator is "read-only **and** not a real removable device":
+    /// a DMG is read-only and neither ejectable nor removable in the
+    /// physical-media sense, whereas a write-protected USB stick reports
+    /// `isRemovable`/`isEjectable` and is left alone here (we don't try to move
+    /// *onto* read-only removable media, but we also don't misclassify it as a
+    /// DMG shadow copy).
+    static func isEphemeralVolume(path: String, flags: VolumeFlags) -> Bool {
+        guard path.hasPrefix("/Volumes/") else { return false }
+        // A disk image is read-only and not backed by internal storage, and is
+        // not a physically removable/ejectable device.
+        return flags.isReadOnly && !flags.isInternal && !flags.isRemovable && !flags.isEjectable
+    }
+
+    /// Heuristic for "this path is a translocation mount or a still-mounted
+    /// disk image we shouldn't try to relocate yet".
+    ///
+    /// - **App Translocation** — handled by `isTranslocated(path:)`.
+    /// - **Mounted DMG** — a path under `/Volumes/` whose volume reports
+    ///   disk-image flags (`isEphemeralVolume`). We don't move *out* of a DMG
+    ///   (the source is read-only and the user expects to drag it themselves),
+    ///   so we hold the prompt until they've copied it somewhere writable. A
+    ///   persistent secondary disk mounted at `/Volumes/<Disk>/Applications`
+    ///   is a supported, writable install location and is *not* treated as
+    ///   ephemeral.
+    ///
+    /// Volume flags are read from `URLResourceValues`; if they can't be
+    /// resolved we conservatively treat a `/Volumes/` path as ephemeral (the
+    /// same fail-safe as before — better to skip the prompt than to copy out
+    /// of something that turns out to be read-only).
+    static func isTranslocatedOrEphemeral(path: String) -> Bool {
+        if isTranslocated(path: path) { return true }
+        guard path.hasPrefix("/Volumes/") else { return false }
+        guard let flags = volumeFlags(forPath: path) else { return true }
+        return isEphemeralVolume(path: path, flags: flags)
+    }
+
+    /// Resolve the live volume flags for `path` via `URLResourceValues`.
+    /// Returns `nil` when the values can't be read (a missing path or a
+    /// filesystem that doesn't vend them), leaving the fail-safe to the caller.
+    private static func volumeFlags(forPath path: String) -> VolumeFlags? {
+        let url = URL(fileURLWithPath: path)
+        guard let values = try? url.resourceValues(forKeys: [
+            .volumeIsReadOnlyKey,
+            .volumeIsInternalKey,
+            .volumeIsRemovableKey,
+            .volumeIsEjectableKey,
+        ]) else { return nil }
+        guard
+            let readOnly = values.volumeIsReadOnly,
+            let isInternal = values.volumeIsInternal,
+            let removable = values.volumeIsRemovable,
+            let ejectable = values.volumeIsEjectable
+        else { return nil }
+        return VolumeFlags(
+            isReadOnly: readOnly,
+            isInternal: isInternal,
+            isRemovable: removable,
+            isEjectable: ejectable
+        )
     }
 
     // MARK: - Runtime entry point
@@ -195,10 +270,12 @@ enum MoveToApplications {
     /// Move the running bundle into `/Applications` and relaunch from the new
     /// location, then terminate the current (old-location) instance.
     ///
-    /// Uses `FileManager` for the copy/replace and `NSWorkspace` to relaunch.
-    /// On any failure the move is abandoned and the app keeps running from its
-    /// current location — a failed move must never strand the user without a
-    /// running app. Errors surface in Console under the `app` category.
+    /// Uses `FileManager` for the copy and a detached `/bin/sh` trampoline plus
+    /// `open` for the relaunch. On any failure the move is abandoned and the app
+    /// keeps running from its current location — a failed move must never strand
+    /// the user without a running app. Errors surface in Console under the `app`
+    /// category and, where the user is left with a non-obvious state, via an
+    /// `NSAlert`.
     @MainActor
     private static func move(fromBundlePath bundlePath: String) {
         let fileManager = FileManager.default
@@ -206,41 +283,206 @@ enum MoveToApplications {
         let appName = sourceURL.lastPathComponent
         let destURL = URL(fileURLWithPath: applicationsRoot).appendingPathComponent(appName)
 
-        do {
-            // Replace any stale copy already sitting at the destination
-            // (e.g. an older version the user dragged over before) so the
-            // copy below doesn't fail with "file exists".
-            if fileManager.fileExists(atPath: destURL.path) {
-                try fileManager.removeItem(at: destURL)
+        // A copy may already sit at the destination. Only clear it after
+        // confirming it's safe to do so — a different app/version there must
+        // not be silently destroyed, and a *running* different instance must
+        // not be clobbered at all.
+        if fileManager.fileExists(atPath: destURL.path) {
+            switch resolveExistingDestination(source: sourceURL, destination: destURL) {
+            case .sameApp:
+                // Same bundle identifier — replacing our own prior install is
+                // expected. Recycle (Trash) rather than hard-remove so a botched
+                // copy below is recoverable, and so removing a copy that might be
+                // open elsewhere can't leave a half-deleted bundle.
+                guard recycle(destURL) else {
+                    presentMoveFailure(
+                        "Lyrebird couldn’t replace the existing copy in your "
+                            + "Applications folder. Move “\(appName)” to the Trash "
+                            + "manually and try again."
+                    )
+                    return
+                }
+            case .differentRunning:
+                // A different app with the same name is live at the destination.
+                // Tearing it down underneath itself corrupts that app, so refuse.
+                presentMoveFailure(
+                    "A different app named “\(appName)” is already open from your "
+                        + "Applications folder. Quit it first, or move it aside, "
+                        + "then try moving Lyrebird again."
+                )
+                return
+            case .differentIdle:
+                // A different (not-running) app/version is at the destination.
+                // Confirm before replacing it, and recycle rather than destroy.
+                guard confirmOverwriteDifferentApp(named: appName) else { return }
+                guard recycle(destURL) else {
+                    presentMoveFailure(
+                        "Lyrebird couldn’t move the existing “\(appName)” to the "
+                            + "Trash. Move it aside manually and try again."
+                    )
+                    return
+                }
             }
+        }
+
+        do {
             try fileManager.copyItem(at: sourceURL, to: destURL)
         } catch {
             Log.app.error(
                 "MoveToApplications copy failed: \(error.localizedDescription, privacy: .public)"
             )
+            presentMoveFailure(
+                "Lyrebird couldn’t copy itself to your Applications folder "
+                    + "(\(error.localizedDescription)). It will keep running from "
+                    + "its current location."
+            )
             return
         }
 
-        // Relaunch from the installed copy, then quit this instance. The new
-        // process opening is what lets us tear the old one down cleanly.
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.createsNewApplicationInstance = true
-        NSWorkspace.shared.openApplication(at: destURL, configuration: configuration) { _, error in
-            if let error {
-                Log.app.error(
-                    "MoveToApplications relaunch failed: \(error.localizedDescription, privacy: .public)"
-                )
-                // The copy already succeeded; leaving the old instance running
-                // is the safe fallback rather than terminating into nothing.
-                return
-            }
-            DispatchQueue.main.async {
-                // Best-effort cleanup of the old (source) copy once the new
-                // instance is up. A failure here is cosmetic — the installed
-                // copy is already running — so it's logged, not surfaced.
-                try? fileManager.removeItem(at: sourceURL)
-                NSApp.terminate(nil)
-            }
+        // Relaunch via a detached trampoline that waits for *this* process to
+        // exit before opening the installed copy and deleting the source. This
+        // guarantees only one instance is ever live: we terminate immediately
+        // below, and the new instance is opened only after we're gone — so the
+        // two never overlap holding the core mutex / writing persisted state.
+        guard spawnRelaunchTrampoline(source: sourceURL, destination: destURL) else {
+            // Couldn't even start the trampoline. Roll the copy back so the user
+            // isn't left with a silent duplicate, and keep running where we are.
+            try? fileManager.removeItem(at: destURL)
+            presentMoveFailure(
+                "Lyrebird couldn’t relaunch from your Applications folder, so the "
+                    + "move was undone. It will keep running from its current "
+                    + "location."
+            )
+            return
         }
+
+        // Hand off: quit now so the trampoline's `open` brings up the installed
+        // copy as the sole live instance.
+        NSApp.terminate(nil)
+    }
+
+    /// Classification of whatever already occupies the move destination.
+    private enum ExistingDestination {
+        /// Same bundle identifier as the source — our own earlier install.
+        case sameApp
+        /// A different bundle that is currently running.
+        case differentRunning
+        /// A different bundle that is not running.
+        case differentIdle
+    }
+
+    /// Compare the app already at `destination` against the `source` we're about
+    /// to install. Identity is the bundle identifier (a version bump keeps the
+    /// same id, so an upgrade reads as `sameApp`); a missing/unreadable id at
+    /// either side is treated as "different" so we err toward asking rather than
+    /// destroying.
+    @MainActor
+    private static func resolveExistingDestination(
+        source: URL,
+        destination: URL
+    ) -> ExistingDestination {
+        let sourceID = Bundle(url: source)?.bundleIdentifier
+        let destID = Bundle(url: destination)?.bundleIdentifier
+        let sameIdentity = sourceID != nil && sourceID == destID
+        if sameIdentity {
+            return .sameApp
+        }
+        // Different (or unknowable) identity: is that app live right now?
+        let running = NSWorkspace.shared.runningApplications.contains { app in
+            app.bundleURL?.standardizedFileURL == destination.standardizedFileURL
+        }
+        return running ? .differentRunning : .differentIdle
+    }
+
+    /// Move `url` to the Trash via `NSWorkspace.recycle`, returning whether it
+    /// succeeded. Recoverable by design — the user can restore from the Trash if
+    /// the subsequent copy fails.
+    @MainActor
+    private static func recycle(_ url: URL) -> Bool {
+        var recycleError: Error?
+        let semaphore = DispatchSemaphore(value: 0)
+        NSWorkspace.shared.recycle([url]) { _, error in
+            recycleError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+        if let recycleError {
+            Log.app.error(
+                "MoveToApplications recycle failed: \(recycleError.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+        return true
+    }
+
+    /// Ask the user before replacing a *different* app of the same name already
+    /// installed in `/Applications`. Returns `true` if they confirm the replace.
+    @MainActor
+    private static func confirmOverwriteDifferentApp(named appName: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Replace the existing “\(appName)”?"
+        alert.informativeText = """
+        A different version of “\(appName)” is already in your Applications \
+        folder. Moving Lyrebird there will move the existing copy to the Trash. \
+        You can restore it from the Trash if you change your mind.
+        """
+        alert.alertStyle = .warning
+        let replace = alert.addButton(withTitle: "Move to Trash and Replace")
+        replace.keyEquivalent = "\r"
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    /// Surface a move failure to the user. The move flow is rare and one-shot,
+    /// so a silent log line isn't enough — the user needs to know whether they
+    /// still have a working app and where it is.
+    @MainActor
+    private static func presentMoveFailure(_ message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Couldn’t move Lyrebird"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    /// Spawn a detached `/bin/sh` that waits for this process (`getpid()`) to
+    /// exit, then deletes the source bundle and opens the installed copy.
+    /// Returns whether the helper was launched. Running the relaunch from a
+    /// process that outlives us is what lets us terminate *first*, so only one
+    /// app instance is ever live.
+    @MainActor
+    private static func spawnRelaunchTrampoline(source: URL, destination: URL) -> Bool {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        // Poll until our PID is gone, then clean up the source and relaunch.
+        // `kill -0` probes liveness without signalling; `rm -rf` clears the
+        // now-stale source copy; `open` brings up the installed bundle.
+        let script = """
+        while /bin/kill -0 \(pid) >/dev/null 2>&1; do
+            /bin/sleep 0.1
+        done
+        /bin/rm -rf \(shellQuoted(source.path))
+        /usr/bin/open \(shellQuoted(destination.path))
+        """
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        do {
+            try process.run()
+            return true
+        } catch {
+            Log.app.error(
+                "MoveToApplications trampoline launch failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    /// Single-quote a path for safe interpolation into the `/bin/sh` trampoline,
+    /// escaping any embedded single quotes. Paths under `/Applications` and
+    /// `/Volumes` can contain spaces and other shell metacharacters.
+    static func shellQuoted(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/macos/Sources/Lyrebird/System/ServerHostRedaction.swift
+++ b/macos/Sources/Lyrebird/System/ServerHostRedaction.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Single source of truth for reducing a server URL to its bare host.
+///
+/// Both ``DiagnosticBundle/redactServerHost(_:)`` (manifest.json) and
+/// ``AboutInfo/connectedServerHost(from:)`` (the screenshot-prone About row)
+/// must redact identically — they only differ in how they spell "no host"
+/// (`"(not signed in)"` vs `nil`). Sharing the parse here keeps the two from
+/// drifting; the parity is also asserted by `AboutInfoTests`.
+///
+/// ## Why not hand-roll the userinfo split
+///
+/// An earlier version stripped userinfo by cutting at the *first* `@`, which
+/// leaked part of an embedded `user:p@ss@host` password into the manifest.
+/// `URLComponents` already implements the correct RFC-3986 split (userinfo is
+/// everything up to the *last* `@` of the authority), so we lean on it instead
+/// of re-deriving the rule by hand.
+///
+/// Examples:
+/// - `https://music.example.com/jellyfin` → `music.example.com`
+/// - `https://user:pw@host:8443/x?token=abc` → `host`
+/// - `music.example.com:8096` → `music.example.com`
+/// - `ht!tp://weird host/with space` → `nil` (no plausible host)
+/// - `""` → `nil`
+enum ServerHostRedaction {
+
+    /// Bare host of `urlString`, dropping scheme, userinfo, port, path, and
+    /// query. `nil` when the input is empty or yields no plausible host.
+    static func host(from urlString: String) -> String? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Structured parse first. `URLComponents` cleanly separates the host
+        // from userinfo / port / path / query and splits userinfo on the last
+        // `@`, so an embedded `user:p@ss@host` password can't leak through.
+        if let host = URLComponents(string: trimmed)?.host, !host.isEmpty {
+            return host
+        }
+
+        // Bare `host[:port][/path]` and `user:pw@host` strings have no scheme,
+        // so `URLComponents` parses the whole thing as a path and finds no
+        // host. Prepend a default scheme and let the same parser do the work —
+        // this still drops userinfo/port/path correctly rather than guessing.
+        if let host = URLComponents(string: "https://" + trimmed)?.host,
+           isPlausibleHost(host) {
+            return host
+        }
+
+        // Malformed scheme-less input (e.g. `ht!tp://weird host`) can parse to
+        // a junk "host" full of illegal characters. Reject it rather than write
+        // garbage into a manifest / About row.
+        return nil
+    }
+
+    /// Hostname / IP-literal characters only: ASCII letters, digits, `.`, `-`,
+    /// plus `:` and `[` / `]` for IPv6 literals. Anything else (spaces, `!`,
+    /// `?`, …) means `URLComponents` latched onto non-host text, so the
+    /// candidate is rejected.
+    private static let plausibleHostCharacters = CharacterSet(charactersIn:
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-:[]")
+
+    private static func isPlausibleHost(_ host: String) -> Bool {
+        guard !host.isEmpty else { return false }
+        return host.unicodeScalars.allSatisfy { plausibleHostCharacters.contains($0) }
+    }
+}

--- a/macos/Sources/Lyrebird/Theme/Theme.swift
+++ b/macos/Sources/Lyrebird/Theme/Theme.swift
@@ -265,14 +265,18 @@ enum ThemePreset: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    /// Map from the persisted `AppearanceTheme` selection. Presets that don't
-    /// yet ship a colour-blind-verified pair (sunset / peanut) fall back to
-    /// `purple` so callers always get a concrete, validated palette.
+    /// Map from the persisted `AppearanceTheme` selection. `AppearanceTheme`
+    /// now offers only presets with a colour-blind-verified pair, so each maps
+    /// one-to-one. Any legacy on-disk value (e.g. a "sunset"/"peanut" string
+    /// written before those cases were dropped) never reaches here: the
+    /// `@AppStorage` getter decodes through `AppearanceTheme(rawValue:) ??
+    /// .purple`, so an unknown string already collapses to `.purple` — a
+    /// concrete, validated palette — before this initializer sees it.
     init(appearanceTheme: AppearanceTheme) {
         switch appearanceTheme {
         case .ocean: self = .ocean
         case .forest: self = .forest
-        default: self = .purple
+        case .purple: self = .purple
         }
     }
 

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -50,12 +50,15 @@ public protocol AudioEngineDelegate: AnyObject {
     /// affordance — the engine will NOT retry again on its own.
     func audioEngineDidFail(_ message: String)
 
-    /// Called when an `AVPlayerItem` reports a transient network failure
+    /// Called when an `AVPlayerItem` transient network failure
     /// (`NSURLErrorNetworkConnectionLost` / `Timeout` /
-    /// `NotConnectedToInternet`). The engine has already cancelled the
-    /// blind stall watchdog and triggered a queue advance via
-    /// `onTrackEnded`; the owner only needs to surface a transient toast
-    /// (e.g. "Connection lost — skipping"). See issue #806.
+    /// `NotConnectedToInternet`) has *exhausted* the engine's bounded retry
+    /// budget. Up to `maxAutoRetries`, the engine first rebuilds and retries
+    /// the current track (surfacing `audioEngineDidStall` / `audioEngineDidRecover`,
+    /// the same as a buffering stall); this hook only fires once retries are
+    /// spent, at which point the engine has triggered a queue advance via
+    /// `onTrackEnded`. The owner only needs to surface a transient toast
+    /// (e.g. "Connection lost — skipping"). See issue #806 / audit L863.
     func audioEngineDidEncounterTransientError(_ message: String)
 
     /// Called after a stall recovery has rebuilt the current `AVPlayerItem`
@@ -119,8 +122,17 @@ public final class AudioEngine: NSObject {
     private var stallWorkItem: DispatchWorkItem?
 
     /// How many silent restart attempts we've made on the *current* stream.
-    /// Reset to 0 every time `play(_:)` loads a brand-new track.
+    /// Reset to 0 every time `play(_:)` loads a brand-new track, and on a
+    /// genuine queue auto-advance — but NOT on an in-place stall recovery.
     private var stallRetryCount: Int = 0
+
+    /// Set around `recoverFromStall`'s `replaceCurrentItem` swap so the
+    /// `currentItem` KVO observer can tell an in-place stall rebuild apart
+    /// from a genuine gapless queue advance. Without this, the rebuild's
+    /// `currentItem` change would reset `stallRetryCount` to 0 and defeat the
+    /// `maxAutoRetries` cap, letting a permanently-stalled stream retry-loop
+    /// forever instead of surfacing "Couldn't play, tap to retry." (#439).
+    private var isRecoveringFromStall: Bool = false
 
     /// Monotonically-increasing counter used to detect stale seek completions
     /// (#582). Each call to `seek(toSeconds:)` increments this; the completion
@@ -235,6 +247,37 @@ public final class AudioEngine: NSObject {
         guard let player else { return }
         recoverFromStall(player: player, url: url)
     }
+
+    /// Test seam: the number of silent restart attempts charged against the
+    /// current stream. Lets a test assert that an in-place stall recovery
+    /// does *not* reset the budget (which would defeat `maxAutoRetries`). See
+    /// audit L752 / #439.
+    var stallRetryCountForTesting: Int { stallRetryCount }
+
+    /// Test seam: seed the URL `recoverFromStall` / `handleItemFailure` rebuild
+    /// from, without a live `play(_:)`.
+    func setCurrentStreamURLForTesting(_ url: URL?) {
+        currentStreamURL = url
+    }
+
+    /// Test seam: drive the transient-item-failure path directly with a
+    /// synthesized `NSError`, so the bounded retry-then-skip behaviour (audit
+    /// L863/L879) can be verified without a real network blip.
+    func handleItemFailureForTesting(_ error: NSError) {
+        handleItemFailure(error)
+    }
+
+    /// Test seam: invoke the production give-up path
+    /// (`quiesceAfterTerminalFailure`) directly so the audit-L974 quiescing
+    /// (player paused, watchdog cancelled, heartbeat stopped, delegate
+    /// notified) is asserted against the *real* code, not a copy.
+    func failTerminallyForTesting() {
+        quiesceAfterTerminalFailure()
+    }
+
+    /// Test seam: whether a stall watchdog is currently armed. Lets a test
+    /// confirm the give-up path actually cancels it.
+    var hasPendingStallWatchdogForTesting: Bool { stallWorkItem != nil }
     #endif
 
     // MARK: - Private helpers
@@ -309,35 +352,58 @@ public final class AudioEngine: NSObject {
             isPaused: false,
             isMuted: false
         )
-        try? core.reportPlaybackStarted(info: info)
+        // Set the reporting triple synchronously on the actor so a later
+        // `reportStopped` (which also dispatches off-main) reads the matching
+        // itemId + source + session. The `POST /Sessions/Playing` FFI itself
+        // blocks on a network round-trip, so it runs off the main actor.
         reportingItemId = trackId
         reportingMediaSourceId = mediaSourceId
         reportingPlaySessionId = playSessionId
+        let core = self.core
+        Task.detached { try? core.reportPlaybackStarted(info: info) }
     }
 
     /// Fire `POST /Sessions/Playing/Stopped` for the previously-reported
     /// session, then clear the reporting triple. Safe to call when nothing
     /// is active — it no-ops when `reportingItemId` is `nil`.
-    private func reportStopped() {
+    ///
+    /// `positionTicks` defaults to the live player's current position, but the
+    /// caller may pass an explicit value when the player is about to be (or has
+    /// already been) replaced — e.g. on a track change `play(_:)` swaps
+    /// `self.player` to the *new* item before this runs, so reading the live
+    /// position here would report the new item's position (0) for the old
+    /// track's stop. See the capture at the top of `play(_:)`.
+    ///
+    /// The `POST /Sessions/Playing/Stopped` FFI blocks on a network round-trip
+    /// (`runtime.block_on` in Rust), so it's dispatched off the main actor.
+    /// Clearing the reporting triple stays on the actor and happens
+    /// synchronously so a follow-up `reportStarted` can't race it.
+    private func reportStopped(positionTicks explicitPosition: Int64? = nil) {
         guard let itemId = reportingItemId else { return }
         let info = PlaybackStopInfo(
             itemId: itemId,
             failed: false,
-            positionTicks: positionTicks(),
+            positionTicks: explicitPosition ?? positionTicks(),
             mediaSourceId: reportingMediaSourceId,
             playSessionId: reportingPlaySessionId,
             sessionId: nil
         )
-        try? core.reportPlaybackStopped(info: info)
         reportingItemId = nil
         reportingMediaSourceId = nil
         reportingPlaySessionId = nil
+        let core = self.core
+        Task.detached { try? core.reportPlaybackStopped(info: info) }
     }
 
     /// Fire a single `PlaybackProgressInfo` report — used on pause / resume /
     /// seek transitions so the server sees state changes promptly rather
     /// than waiting for the next heartbeat tick. Best-effort: swallow
     /// errors, the periodic heartbeat (if running) will catch up.
+    ///
+    /// `core.reportPlaybackProgress` blocks on a network round-trip
+    /// (`runtime.block_on` in Rust), so the FFI is dispatched off the main
+    /// actor. The position snapshot is read on the actor first so it reflects
+    /// the player state at call time, not whenever the detached task runs.
     private func reportProgressSnapshot(isPaused: Bool) {
         guard let itemId = reportingItemId else { return }
         let info = PlaybackProgressInfo(
@@ -354,7 +420,8 @@ public final class AudioEngine: NSObject {
             audioStreamIndex: nil,
             sessionId: nil
         )
-        try? core.reportPlaybackProgress(info: info)
+        let core = self.core
+        Task.detached { try? core.reportPlaybackProgress(info: info) }
     }
 
     /// Pin (or unpin) the given player to the selected Core Audio output
@@ -437,6 +504,12 @@ public final class AudioEngine: NSObject {
     // MARK: - Public
 
     public func play(track: Track) async throws {
+        // A stall watchdog scheduled for the *old* track would otherwise fire
+        // mid-load of the new one and kick a perfectly healthy fresh stream.
+        // `removePlayerObservers()` below tears down the KVO observers but does
+        // not touch the pending `stallWorkItem`, so cancel it explicitly here.
+        cancelStallWatchdog()
+
         // Resolve media source + play session id via PlaybackInfo so the
         // server picks the right source for multi-version items and can
         // correlate subsequent /Sessions/Playing* reports with the stream.
@@ -462,6 +535,15 @@ public final class AudioEngine: NSObject {
             ]
         )
         let item = AVPlayerItem(asset: asset)
+
+        // Capture the *outgoing* track's playback position while `self.player`
+        // still points at the old item (it's reassigned just below). The
+        // matching Stopped report further down must carry where the previous
+        // track actually stopped — reading the position after
+        // `self.player = newPlayer` would report the new item's position (0)
+        // for the old track. `positionTicks()` no-ops to 0 when nothing's
+        // loaded, so the first-ever play reports 0 correctly.
+        let previousPositionTicks = positionTicks()
 
         // Tear down the old player cleanly before switching.
         removePlayerObservers()
@@ -491,10 +573,16 @@ public final class AudioEngine: NSObject {
 
         // Any previous session needs a matching Stopped report before we
         // start the new one — Jellyfin keys sessions by PlaySessionId and
-        // leaks a transcode job otherwise.
-        reportStopped()
+        // leaks a transcode job otherwise. Pass the position captured from
+        // the *old* player just before the swap; `self.player` already points
+        // at the new item by now, so the default live read would report 0.
+        reportStopped(positionTicks: previousPositionTicks)
 
-        core.markTrackStarted(track: track)
+        // `markTrackStarted` does a synchronous `db.record_play` SQLite write
+        // in Rust; keep it off the main thread (fire-and-forget — the play
+        // history row isn't read back synchronously by anything on this path).
+        let core = self.core
+        Task.detached { core.markTrackStarted(track: track) }
         core.markState(state: .playing)
         newPlayer.play()
         // Publish the new track to MPNowPlayingInfoCenter. `MediaSession`
@@ -640,7 +728,12 @@ public final class AudioEngine: NSObject {
         // preload has superseded this one.
         preloadGeneration &+= 1
         let generation = preloadGeneration
-        Task.detached {
+        // `[weak self]` so an engine torn down mid-resolve (track change,
+        // stop) doesn't get pinned alive for the duration of the network FFI —
+        // matches `applyReplayGain`. The network work below only touches the
+        // locally-captured `core`, so it runs regardless; the marshal-back bails
+        // if `self` is gone.
+        Task.detached { [weak self] in
             do {
                 let info = try? core.playbackInfo(itemId: track.id, opts: opts)
                 let mediaSourceId = info?.mediaSources.first?.id
@@ -666,6 +759,7 @@ public final class AudioEngine: NSObject {
                 let nextItem = AVPlayerItem(asset: asset)
 
                 await MainActor.run {
+                    guard let self else { return }
                     guard generation == self.preloadGeneration else { return }
                     guard let player = self.player else { return }
                     // Remove any previously queued (not-yet-playing) items so we never
@@ -734,6 +828,15 @@ public final class AudioEngine: NSObject {
             // Guard: only act when the item actually changed (not on initial
             // attachment where old == new == firstItem).
             guard change.oldValue != change.newValue else { return }
+            // Capture the recovery flag *synchronously*. KVO on `currentItem`
+            // fires inline on the main thread during `replaceCurrentItem`, so
+            // reading `isRecoveringFromStall` here sees the value set by
+            // `recoverFromStall` before it clears it — the deferred `Task`
+            // below would always observe the cleared (false) value and so
+            // can't be used to gate the retry-count reset. `assumeIsolated`
+            // is sound: this engine is `@MainActor` and the callback only
+            // ever runs on the main thread.
+            let wasStallRecovery = MainActor.assumeIsolated { self?.isRecoveringFromStall ?? false }
             Task { @MainActor in
                 guard let self else { return }
                 // Re-register end-of-item notification for the newly-current item.
@@ -749,7 +852,15 @@ public final class AudioEngine: NSObject {
                 if let urlAsset = player.currentItem?.asset as? AVURLAsset {
                     self.currentStreamURL = urlAsset.url
                 }
-                self.stallRetryCount = 0
+                // Only a genuine queue advance gets a fresh retry budget. An
+                // in-place stall rebuild (`replaceCurrentItem`) also fires this
+                // observer, but resetting here would defeat `maxAutoRetries`
+                // and let a permanently-stalled stream retry-loop forever
+                // (#439). `play(_:)` still resets the count for brand-new
+                // tracks, so the legitimate-advance case stays covered.
+                if !wasStallRecovery {
+                    self.stallRetryCount = 0
+                }
             }
         }
 
@@ -806,9 +917,10 @@ public final class AudioEngine: NSObject {
     /// -1009 path described in the issue). `.status` covers items that
     /// flip to `.failed` before they ever reach `.readyToPlay` (early-
     /// track death — same root causes, different surface). Both call
-    /// through to `handleItemFailure(_:)` which inspects the error and
-    /// either short-circuits to fail-fast or no-ops for unrelated codes
-    /// (which the existing stall watchdog still handles).
+    /// through to `handleItemFailure(_:)` which inspects the error and, for
+    /// transient codes, drives the same bounded rebuild-and-retry the stall
+    /// watchdog uses before skipping; unrelated codes are left to the 5s
+    /// stall watchdog.
     private func attachItemFailureObservers(to item: AVPlayerItem) {
         itemErrorObservation?.invalidate()
         itemErrorObservation = item.observe(\.error, options: [.new]) { [weak self] item, _ in
@@ -855,13 +967,50 @@ public final class AudioEngine: NSObject {
     }
 
     /// Branch on whether the failing item carries a transient network
-    /// error code. For transient codes we fail fast: cancel the blind
-    /// 5s stall watchdog, notify the delegate so the UI can surface a
-    /// transient toast, and signal `onTrackEnded` so AppModel advances
-    /// the queue (same contract as natural end-of-item). Non-transient
-    /// errors fall through to the existing stall path. See #806.
+    /// error code. Transient codes get the *same* bounded recovery the stall
+    /// watchdog uses: rebuild the current item from `currentStreamURL` /
+    /// `currentAuthHeader` and retry, up to `maxAutoRetries`, before giving
+    /// up. A brief connection blip then retries the current track instead of
+    /// instantly skipping it — matching the stall path's behaviour for an
+    /// equivalent condition (#806, audit L863/L879). Only after the shared
+    /// retry budget is exhausted do we surface the transient indicator and
+    /// advance the queue via `onTrackEnded` (the same contract as a natural
+    /// end-of-item). Non-transient errors fall through to the existing 5s
+    /// stall path.
     private func handleItemFailure(_ error: NSError) {
         guard isTransientNetworkError(error) else { return }
+        // Short-circuit the blind 5s watchdog — we drive recovery explicitly
+        // below, and letting the watchdog also fire would double-rebuild.
+        cancelStallWatchdog()
+
+        // Recovery needs a live player + a URL to rebuild from. If either is
+        // gone (engine torn down, or we never captured a stream), there's
+        // nothing to retry — skip straight to the queue advance.
+        guard let player = self.player, let url = self.currentStreamURL else {
+            skipAfterTransientFailure()
+            return
+        }
+
+        stallRetryCount += 1
+        if stallRetryCount > maxAutoRetries {
+            // Budget exhausted: this track is genuinely unreachable. Advance
+            // the queue rather than wedging on the dead item.
+            skipAfterTransientFailure()
+            return
+        }
+
+        // Within budget: rebuild + retry the current track. `recoverFromStall`
+        // re-attaches fresh failure observers to the rebuilt item, so a repeat
+        // transient failure re-enters here and counts against the same budget.
+        // It also fires `audioEngineDidRecover()` so the owner re-arms gapless.
+        delegate?.audioEngineDidStall()
+        recoverFromStall(player: player, url: url)
+    }
+
+    /// Terminal branch for a transient item failure whose retry budget is
+    /// spent (or that had nothing to retry): drop the per-item observers,
+    /// surface the transient indicator, and advance the queue.
+    private func skipAfterTransientFailure() {
         // Idempotent: invalidate the per-item observers so a follow-up
         // `.status` flip on the same dead item doesn't re-fire this path
         // before the queue advance lands.
@@ -869,9 +1018,6 @@ public final class AudioEngine: NSObject {
         itemErrorObservation = nil
         itemStatusObservation?.invalidate()
         itemStatusObservation = nil
-        // Short-circuit the 5s blind-rebuild path — rebuilding the same
-        // URL against the same broken connection would just refail.
-        cancelStallWatchdog()
         // Surface the transient indicator and advance the queue. The
         // delegate hook is best-effort; the `onTrackEnded` callback is
         // the same path natural end-of-item takes, so AppModel's queue
@@ -972,12 +1118,28 @@ public final class AudioEngine: NSObject {
 
         stallRetryCount += 1
         if stallRetryCount > maxAutoRetries {
-            delegate?.audioEngineDidFail("Couldn't play, tap to retry.")
+            quiesceAfterTerminalFailure()
             return
         }
 
         delegate?.audioEngineDidStall()
         recoverFromStall(player: player, url: url)
+    }
+
+    /// Stop everything and surface a terminal failure. Called when the stall
+    /// retry budget is exhausted (#439, audit L974). Leaving the player parked
+    /// in `.waitingToPlayAtSpecifiedRate` would keep CoreMedia spinning on the
+    /// dead stream and leave the UI / server believing playback is still
+    /// "live", so quiesce honestly: pause the player, drop the watchdog, mark
+    /// the core paused, and stop the heartbeat so the server's session goes
+    /// idle. The delegate hook lets the owner offer tap-to-retry.
+    private func quiesceAfterTerminalFailure() {
+        player?.pause()
+        cancelStallWatchdog()
+        core.markState(state: .paused)
+        core.stopHeartbeat()
+        mediaSession?.rateChanged(isPlaying: false)
+        delegate?.audioEngineDidFail("Couldn't play, tap to retry.")
     }
 
     /// Rebuild `AVPlayerItem` from the remembered URL + auth header and
@@ -1013,7 +1175,13 @@ public final class AudioEngine: NSObject {
         // 5s rebuild cycles.
         attachItemFailureObservers(to: item)
 
+        // Flag the in-place swap so the `currentItem` KVO observer (which
+        // fires synchronously inside `replaceCurrentItem`) doesn't mistake it
+        // for a genuine queue advance and reset `stallRetryCount`, which would
+        // defeat the `maxAutoRetries` cap (#439).
+        isRecoveringFromStall = true
         player.replaceCurrentItem(with: item)
+        isRecoveringFromStall = false
         // Re-apply ReplayGain to the rebuilt item — the swap drops the old
         // item's audioMix, so without this a normalized track would lose its
         // gain after a stall recovery (#42).
@@ -1028,7 +1196,27 @@ enum AudioEngineError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .invalidURL(let s): return "Invalid stream URL: \(s)"
+        case .invalidURL(let s):
+            // The raw stream URL carries the Jellyfin access token in its
+            // `api_key` query parameter. Never surface it in a user-visible or
+            // loggable description — strip the query (and anything after it) so
+            // only the scheme + host + path remain. Falls back to a fully
+            // redacted placeholder when the string won't even parse as a URL.
+            return "Invalid stream URL: \(AudioEngineError.redactURL(s))"
         }
+    }
+
+    /// Drop the query string (which holds `api_key`) and fragment, keeping just
+    /// enough of the URL — scheme, host, path — to be diagnostically useful.
+    private static func redactURL(_ raw: String) -> String {
+        guard var components = URLComponents(string: raw) else { return "<redacted>" }
+        components.query = nil
+        components.fragment = nil
+        if let scrubbed = components.string, !scrubbed.isEmpty {
+            return scrubbed
+        }
+        // No scheme/host (e.g. a bare malformed path); fall back to the path
+        // alone, and to a placeholder if even that is empty.
+        return components.path.isEmpty ? "<redacted>" : components.path
     }
 }

--- a/macos/Sources/LyrebirdAudio/ReplayGain.swift
+++ b/macos/Sources/LyrebirdAudio/ReplayGain.swift
@@ -182,30 +182,47 @@ public enum ReplayGain {
 
     /// Derive a best-effort dB adjustment from an iTunes `iTunNORM` atom.
     ///
-    /// `iTunNORM` is a string of ten space-separated 8-digit hex values; the
-    /// first two are the per-channel loudness measurements on a scale where
-    /// `1000` ≈ 0 dB. The volume adjustment for a channel is
+    /// `iTunNORM` is a string of ten space-separated 8-digit hex values. The
+    /// volume-base measurements live in two redundant pairs: fields 0/1 are the
+    /// 1000-relative bases for the left/right channels, and fields 2/3 are a
+    /// second base pair (often the more reliable of the two). Each value sits
+    /// on a scale where `1000` ≈ 0 dB, so a channel's adjustment is
     /// `-10 * log10(value / 1000)` — a value above 1000 means a loud channel
-    /// that should be attenuated. We take the *smaller-magnitude* (less
-    /// aggressive) of the two channels so a single hot channel can't drive the
-    /// whole track to silence, then clamp.
+    /// that wants attenuation (a negative dB), below means a quiet one.
+    ///
+    /// We gather every nonzero base across both pairs and take the **loudest**
+    /// channel — the most-negative adjustment — so a loud track is brought down
+    /// far enough to actually match quieter material rather than being left hot
+    /// by deferring to its quietest channel. Reading both pairs also means a
+    /// zeroed first pair (fields 0/1 == 0) falls through to the second instead
+    /// of giving up. The result keeps the `isFinite` guard and ±``maxAbsGainDb``
+    /// clamp.
     ///
     /// This is intentionally a fallback only — `iTunNORM` is iTunes' own
     /// loudness scheme, not ReplayGain, and is less precise. `nil` when the
-    /// atom is malformed or the channels read as zero.
+    /// atom is malformed or every base reads as zero.
     static func iTunNormDb(from raw: String) -> Double? {
         let fields = raw.split(whereSeparator: { $0 == " " || $0 == "\t" })
         guard fields.count >= 2 else { return nil }
-        guard
-            let left = UInt32(fields[0], radix: 16),
-            let right = UInt32(fields[1], radix: 16)
-        else { return nil }
-        guard left > 0, right > 0 else { return nil }
-        let leftDb = -10.0 * log10(Double(left) / 1000.0)
-        let rightDb = -10.0 * log10(Double(right) / 1000.0)
-        // Less aggressive of the two channels (smaller absolute adjustment).
-        let chosen = abs(leftDb) <= abs(rightDb) ? leftDb : rightDb
-        guard chosen.isFinite else { return nil }
+
+        // Volume bases live in fields 0/1 and (when present) 2/3. Hex-parse
+        // each available base; a field that isn't valid hex sinks the whole
+        // parse since the atom is then malformed.
+        let baseCount = fields.count >= 4 ? 4 : 2
+        var bases: [UInt32] = []
+        bases.reserveCapacity(baseCount)
+        for index in 0..<baseCount {
+            guard let value = UInt32(fields[index], radix: 16) else { return nil }
+            bases.append(value)
+        }
+
+        // Drop zero bases (an unmeasured channel) and convert each to dB. The
+        // loudest channel is the most-negative adjustment, so `min` yields the
+        // largest attenuation across whichever bases were actually measured.
+        let adjustments = bases
+            .filter { $0 > 0 }
+            .map { -10.0 * log10(Double($0) / 1000.0) }
+        guard let chosen = adjustments.min(), chosen.isFinite else { return nil }
         return chosen.clamped(to: -maxAbsGainDb...maxAbsGainDb)
     }
 

--- a/macos/Tests/LyrebirdTests/AboutInfoTests.swift
+++ b/macos/Tests/LyrebirdTests/AboutInfoTests.swift
@@ -130,6 +130,23 @@ final class AboutInfoTests: XCTestCase {
         )
     }
 
+    func testHostSchemelessUserinfoDoesNotLeakPassword() {
+        // The whole `user:pw@` userinfo must be dropped even when the password
+        // itself contains an `@` — splitting on the first `@` would leak it.
+        XCTAssertEqual(
+            AboutInfo.connectedServerHost(from: "admin:p@ssw0rd@host.internal:8443/jf"),
+            "host.internal"
+        )
+    }
+
+    func testHostMalformedSchemelessInputReturnsNil() {
+        // Garbage that parses to a space-containing non-host must map to nil so
+        // the About row hides rather than render junk.
+        XCTAssertNil(AboutInfo.connectedServerHost(from: "ht!tp://weird host/with space"))
+        XCTAssertNil(AboutInfo.connectedServerHost(from: "weird host"))
+        XCTAssertNil(AboutInfo.connectedServerHost(from: "???"))
+    }
+
     func testHostTrimsSurroundingWhitespace() {
         XCTAssertEqual(
             AboutInfo.connectedServerHost(from: "  https://music.example.com  "),
@@ -156,6 +173,12 @@ final class AboutInfoTests: XCTestCase {
             "music.example.com:8096",
             "http://10.0.0.5:8096/",
             "https://sub.domain.example.org/path/deeper?a=b&c=d",
+            // Scheme-less + embedded creds (incl. an `@` inside the password):
+            // both redactors must extract the same bare host. (Malformed inputs
+            // that yield NO host are the one intentional divergence — About →
+            // nil, bundle → "(not signed in)" — so they're asserted separately.)
+            "admin:p@ssw0rd@host.internal:8443/jf",
+            "user:pw@bare.example.com:9000",
         ]
         for input in inputs {
             XCTAssertEqual(

--- a/macos/Tests/LyrebirdTests/AlbumDetailViewAuditTests.swift
+++ b/macos/Tests/LyrebirdTests/AlbumDetailViewAuditTests.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the AlbumDetailView audit-fix pass:
+///
+/// - #475: "Read more" on the editorial "About this album" blurb is shown only
+///   when the overview actually overflows its 4-line clamp. The truncation
+///   decision lives in the pure `AboutOverviewTruncation` type (mirroring
+///   `LinerNotesDrawerPresentation`) and is exercised directly here.
+/// - #67 / #83: album-scoped `@State` (tracks / detail / moreByArtist /
+///   fetchedAlbum) is reset at the start of the `.task(id:)` so a prior
+///   album's data never paints during the reload window, and `moreByArtist` is
+///   cleared when the new album has no artist so the old shelf can't persist.
+/// - #176: the hero "Minutes" stat and the liner-note "Runtime" row read the
+///   same `totalRuntimeTicks(album:)` source so they can't disagree.
+///
+/// The pure decision is unit-tested; the view wiring is asserted against the
+/// source text (the `LinerNotesDrawerTests` idiom) so a regression that drops a
+/// reset or re-shows the unconditional button is caught here, not in the field.
+final class AlbumDetailViewAuditTests: XCTestCase {
+
+    // MARK: - #475 About-overview truncation decision
+
+    /// A full text taller than the clamped text means the overview is cut off,
+    /// so "Read more" should appear.
+    func testTruncatedWhenFullExceedsClamped() {
+        XCTAssertTrue(
+            AboutOverviewTruncation.isTruncated(clamped: 80, full: 240),
+            "A full height well above the clamp must register as truncated")
+    }
+
+    /// When the overview fits inside the clamp the two heights match, so there
+    /// is nothing to expand and the button must be omitted.
+    func testNotTruncatedWhenHeightsMatch() {
+        XCTAssertFalse(
+            AboutOverviewTruncation.isTruncated(clamped: 80, full: 80),
+            "Equal clamped/full heights mean the text fits — no Read more")
+    }
+
+    /// A short overview (one or two lines, well under the 4-line clamp) is not
+    /// truncated — the clamped Text renders the whole thing.
+    func testNotTruncatedForShortOverview() {
+        // A single line is shorter than the four-line clamp budget, so the
+        // clamped render equals the full render.
+        XCTAssertFalse(AboutOverviewTruncation.isTruncated(clamped: 20, full: 20))
+    }
+
+    /// Sub-point rounding between the two independent measurements must not
+    /// register a fits-exactly overview as truncated — the epsilon absorbs it.
+    func testEpsilonAbsorbsSubPointRounding() {
+        let clamped: CGFloat = 80
+        let full = clamped + AboutOverviewTruncation.epsilon - 0.01
+        XCTAssertFalse(
+            AboutOverviewTruncation.isTruncated(clamped: clamped, full: full),
+            "A difference under epsilon must not count as truncation")
+    }
+
+    /// A difference comfortably above epsilon (e.g. one extra wrapped line) is
+    /// truncated.
+    func testDifferenceAboveEpsilonIsTruncated() {
+        let clamped: CGFloat = 80
+        let full = clamped + AboutOverviewTruncation.epsilon + 18 // ~one line
+        XCTAssertTrue(AboutOverviewTruncation.isTruncated(clamped: clamped, full: full))
+    }
+
+    /// Before measurement settles either height is zero; the button must stay
+    /// hidden so it never flashes in during the first layout pass.
+    func testNotTruncatedBeforeMeasurement() {
+        XCTAssertFalse(AboutOverviewTruncation.isTruncated(clamped: 0, full: 0),
+                       "Unmeasured (0/0) must not be truncated")
+        XCTAssertFalse(AboutOverviewTruncation.isTruncated(clamped: 0, full: 200),
+                       "Clamp unmeasured must not be truncated")
+        XCTAssertFalse(AboutOverviewTruncation.isTruncated(clamped: 80, full: 0),
+                       "Full unmeasured must not be truncated")
+    }
+
+    // MARK: - #475 View wiring
+
+    /// The "Read more" button must be gated behind the truncation flag, not
+    /// rendered unconditionally — the core of the #475 fix.
+    func testReadMoreButtonIsConditional() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains("@State private var isOverviewTruncated = false"),
+            "AlbumDetailView must own a truncation flag, default false")
+        XCTAssertTrue(
+            code.contains("if isOverviewTruncated {"),
+            "The Read more button must be gated behind isOverviewTruncated")
+        // The Read more label must live inside the gated branch.
+        XCTAssertTrue(code.contains("\"Read more\""),
+                      "The conditional CTA must still be labelled \"Read more\"")
+    }
+
+    /// The truncation flag must be driven by the pure `AboutOverviewTruncation`
+    /// policy fed by the measured clamped vs. full heights — never a hard-coded
+    /// `true`.
+    func testTruncationRoutesThroughPolicy() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains("AboutOverviewTruncation.isTruncated("),
+            "Truncation must be derived from the testable policy")
+        XCTAssertTrue(code.contains("ClampedOverviewHeightKey"),
+                      "The clamped height must be measured via a preference key")
+        XCTAssertTrue(code.contains("FullOverviewHeightKey"),
+                      "The full height must be measured via a preference key")
+    }
+
+    // MARK: - #67 / #83 Stale-state reset on album change
+
+    /// Every album-scoped `@State` must be reset at the top of `.task(id:)`
+    /// before the awaits so a prior album's data can't paint during the reload
+    /// (#67) and a new album can't inherit the old `moreByArtist` (#83).
+    func testTaskResetsAlbumScopedState() throws {
+        let code = try albumDetailSource()
+        let task = try taskBody()
+        // The resets must appear, and they must come before the first await so
+        // they take effect during the reload window rather than after it.
+        for marker in [
+            "tracks = []",
+            "moreByArtist = []",
+            "fetchedAlbum = nil",
+            "detail = AlbumDetail(label: nil, releaseDate: nil, people: [], overview: nil)",
+        ] {
+            XCTAssertTrue(task.contains(marker),
+                          "The .task must reset album-scoped state: \(marker)")
+        }
+        // Sanity: the existing popover/drawer resets are still there.
+        XCTAssertTrue(code.contains("isAboutExpanded = false"))
+        XCTAssertTrue(code.contains("isLinerNotesDrawerPresented = false"))
+    }
+
+    /// The first `tracks = []` reset must precede the first `await` so stale
+    /// tracks don't render while the new ones load.
+    func testStateResetHappensBeforeAwaits() throws {
+        let task = try taskBody()
+        guard let resetRange = task.range(of: "tracks = []"),
+              let firstAwait = task.range(of: "await ") else {
+            XCTFail("Expected both a reset and an await in the .task body")
+            return
+        }
+        XCTAssertTrue(
+            resetRange.lowerBound < firstAwait.lowerBound,
+            "Album-scoped state must be reset before the first await")
+    }
+
+    /// When the new album has no artist, `moreByArtist` must be explicitly
+    /// cleared (the `else` branch of the artistId guard) so the previous
+    /// album's shelf can't persist under the new header (#83).
+    func testMoreByArtistClearedWhenNoArtist() throws {
+        let task = try taskBody()
+        // The artistId guard opens with the populate branch and must carry an
+        // else branch that zeroes the shelf. Locate the guard, then assert an
+        // `else` clearing `moreByArtist` follows it within the task body.
+        guard let guardRange = task.range(of: "if let artistId = album?.artistId") else {
+            XCTFail("Expected the artistId guard in the .task body")
+            return
+        }
+        let afterGuard = task[guardRange.upperBound...]
+        guard let elseRange = afterGuard.range(of: "} else {") else {
+            XCTFail("The artistId guard must have an else branch")
+            return
+        }
+        let elseBody = afterGuard[elseRange.upperBound...]
+        // The first statement of the else branch clears the shelf (before the
+        // closing brace of the else).
+        guard let braceRange = elseBody.range(of: "}") else {
+            XCTFail("Malformed else branch")
+            return
+        }
+        XCTAssertTrue(
+            elseBody[..<braceRange.lowerBound].contains("moreByArtist = []"),
+            "The artistId guard's else branch must clear moreByArtist (#83)")
+    }
+
+    // MARK: - #176 Hero / runtime-row consistency
+
+    /// Both the hero "Minutes" stat and the liner-note "Runtime" row must read
+    /// the shared `totalRuntimeTicks(album:)` source so they can never disagree.
+    func testRuntimeSourceIsShared() throws {
+        let code = try albumDetailSource()
+        XCTAssertTrue(
+            code.contains("func totalRuntimeTicks(album: Album)"),
+            "A single runtime-ticks source must back both runtime surfaces")
+        // The hero stat feeds the shared source into formatMinutes.
+        XCTAssertTrue(
+            code.contains("formatMinutes(totalRuntimeTicks(album: album))"),
+            "The hero Minutes stat must use the shared track-sum source")
+        // The liner-note Runtime row consumes the same source.
+        XCTAssertTrue(
+            code.contains("let ticks = totalRuntimeTicks(album: album)"),
+            "The Runtime row must use the shared track-sum source")
+        // Guard against a regression back to the album-only hero value.
+        XCTAssertFalse(
+            code.contains("formatMinutes(album.runtimeTicks)"),
+            "The hero must not read album.runtimeTicks directly (would diverge)")
+    }
+
+    // MARK: - Helpers
+
+    /// Loads `AlbumDetailView.swift` relative to this test file via `#filePath`.
+    private func albumDetailSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let source = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Screens/AlbumDetailView.swift")
+        guard let data = try? Data(contentsOf: source),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read AlbumDetailView.swift at \(source.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+
+    /// Extracts the body of the `.task(id: albumID)` closure so order-sensitive
+    /// assertions (resets before awaits) aren't fooled by matches elsewhere in
+    /// the file.
+    private func taskBody(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let code = try albumDetailSource()
+        guard let start = code.range(of: ".task(id: albumID) {") else {
+            XCTFail("Could not locate the .task(id:) closure", file: file, line: line)
+            return ""
+        }
+        // The task closure runs until the next top-level "// MARK: - Hero" which
+        // immediately follows `body` in this file.
+        let rest = code[start.upperBound...]
+        guard let end = rest.range(of: "// MARK: - Hero") else {
+            return String(rest)
+        }
+        return String(rest[..<end.lowerBound])
+    }
+}

--- a/macos/Tests/LyrebirdTests/ArtistDetailTransportTests.swift
+++ b/macos/Tests/LyrebirdTests/ArtistDetailTransportTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the ArtistDetailView transport-row polish (audit fixes):
+///
+/// - The primary play button's label must match what it *actually* plays:
+///   "Play top songs" when there is play history (the common case, where the
+///   button plays the loaded Top Songs), and "Play all tracks" only in the
+///   no-history fallback that plays the full catalog. Previously the label
+///   always claimed "Play all tracks" regardless.
+/// - `AppModel.resolveImageURLs` must resolve a batch of artwork URLs off the
+///   main thread and return one entry per distinct requested id, deduping
+///   repeats and handling empty input — so the eager discography carousel can
+///   hand each tile a pre-resolved URL instead of taking the Rust `Inner`
+///   mutex on the MainActor inside every tile body.
+///
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore`; we redirect the
+/// core's data dir to a throwaway temp dir via `XDG_DATA_HOME` so the test
+/// never touches the real app database. With no authenticated server the
+/// image-URL FFI yields `nil`, which is exactly the "not resolvable yet" path
+/// the carousel tolerates — the keys-present / dedup contract still holds.
+@MainActor
+final class ArtistDetailTransportTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Primary play button label (audit L363)
+
+    func testPrimaryPlayHelpReflectsTopSongsWhenHistoryPresent() {
+        // Common case: history present → button plays Top Songs, so it must
+        // say so rather than promising the full catalog.
+        XCTAssertEqual(ArtistDetailView.primaryPlayHelp(hasTopTracks: true), "Play top songs")
+    }
+
+    func testPrimaryPlayHelpReflectsAllTracksWhenNoHistory() {
+        // Fallback case: no history → button plays the full catalog.
+        XCTAssertEqual(ArtistDetailView.primaryPlayHelp(hasTopTracks: false), "Play all tracks")
+    }
+
+    func testPrimaryPlayAccessibilityLabelNamesArtistAndMatchesBehavior() {
+        XCTAssertEqual(
+            ArtistDetailView.primaryPlayAccessibilityLabel(
+                hasTopTracks: true, artistName: "Radiohead"
+            ),
+            "Play top songs by Radiohead"
+        )
+        XCTAssertEqual(
+            ArtistDetailView.primaryPlayAccessibilityLabel(
+                hasTopTracks: false, artistName: "Radiohead"
+            ),
+            "Play all tracks by Radiohead"
+        )
+    }
+
+    // MARK: - resolveImageURLs (audit L565)
+
+    func testResolveImageURLsReturnsEntryPerDistinctID() async throws {
+        let model = try AppModel()
+        let result = await model.resolveImageURLs(
+            for: [
+                (id: "al1", tag: "t1"),
+                (id: "al2", tag: nil),
+                (id: "al3", tag: "t3"),
+            ],
+            maxWidth: 400
+        )
+        // One entry per requested id, regardless of whether the URL resolves
+        // (no server in tests → values are nil). The carousel keys off the id.
+        XCTAssertEqual(Set(result.keys), ["al1", "al2", "al3"])
+    }
+
+    func testResolveImageURLsDedupesRepeatedIDs() async throws {
+        let model = try AppModel()
+        let result = await model.resolveImageURLs(
+            for: [
+                (id: "dup", tag: "t"),
+                (id: "dup", tag: "t"),
+                (id: "dup", tag: "t"),
+            ],
+            maxWidth: 400
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(Set(result.keys), ["dup"])
+    }
+
+    func testResolveImageURLsEmptyInputReturnsEmpty() async throws {
+        let model = try AppModel()
+        let result = await model.resolveImageURLs(for: [], maxWidth: 400)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testResolveImageURLsIsConsistentAcrossCalls() async throws {
+        // Second call (served from the warmed cache for already-seen tuples)
+        // must agree with the first — the carousel relies on a stable URL per
+        // id across re-renders.
+        let model = try AppModel()
+        let items = [(id: "al1", tag: "t1"), (id: "al2", tag: nil)]
+        let first = await model.resolveImageURLs(for: items, maxWidth: 400)
+        let second = await model.resolveImageURLs(for: items, maxWidth: 400)
+        XCTAssertEqual(Set(first.keys), Set(second.keys))
+        for key in first.keys {
+            // URL? equality across the two calls.
+            XCTAssertEqual(first[key] ?? nil, second[key] ?? nil)
+        }
+    }
+}

--- a/macos/Tests/LyrebirdTests/AudioEngineRecoveryTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEngineRecoveryTests.swift
@@ -1,0 +1,214 @@
+import AVFoundation
+import XCTest
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Recovery / failure-handling behaviour for `AudioEngine`, covering the
+/// 2.0-polish audit findings:
+///   * L752 — in-place stall recovery must NOT reset the retry budget.
+///   * L863/L879 — a transient item failure retries the current track up to
+///     `maxAutoRetries` before skipping, matching the stall path.
+///   * L974 — the give-up branch quiesces the player + heartbeat.
+///   * L1031 — `invalidURL` errors must not leak the `api_key` token.
+///
+/// All tests build a real (un-authed) core against a throwaway data dir, the
+/// same pattern as `AudioEnginePreloadTests`. None touch the network: the
+/// failure paths under test are driven through DEBUG test seams with a bare
+/// `AVQueuePlayer` and synthesized errors.
+@MainActor
+final class AudioEngineRecoveryTests: XCTestCase {
+    private func makeEngine() throws -> AudioEngine {
+        let dir = NSTemporaryDirectory() + "lyrebird-recovery-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "recovery-test"))
+        let engine = AudioEngine(core: core)
+        engine.installEmptyPlayerForTesting()
+        return engine
+    }
+
+    private func transientError() -> NSError {
+        // -1005 == NSURLErrorNetworkConnectionLost — one of the transient codes
+        // the item-failure path recovers from.
+        NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)
+    }
+
+    // MARK: - L752: stall recovery preserves the retry budget
+
+    /// An in-place stall recovery (`replaceCurrentItem`) fires the
+    /// `currentItem` KVO observer, which on a *genuine* queue advance resets
+    /// `stallRetryCount`. The recovery flag must suppress that reset, otherwise
+    /// a permanently-stalled stream would retry forever and never surface
+    /// "Couldn't play, tap to retry." We seed a non-zero count, run a
+    /// recovery, and assert the count is preserved (not clobbered to 0).
+    func testStallRecoveryDoesNotResetRetryBudget() throws {
+        let engine = try makeEngine()
+        let url = URL(string: "https://example.invalid/stream")!
+        engine.setCurrentStreamURLForTesting(url)
+
+        // Drive two transient failures: each increments the shared budget and
+        // recovers in place. After two, the count must read 2 — proving the
+        // recovery's currentItem KVO change did not reset it.
+        engine.handleItemFailureForTesting(transientError())
+        engine.handleItemFailureForTesting(transientError())
+
+        // The KVO observer marshals its (suppressed) reset through a Task hop;
+        // give the main run loop a turn so any erroneous reset would have
+        // landed before we assert.
+        let drained = expectation(description: "run loop drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertEqual(
+            engine.stallRetryCountForTesting,
+            2,
+            "an in-place recovery must not reset the stall retry budget (#439)"
+        )
+    }
+
+    // MARK: - L863/L879: transient item failure retries before skipping
+
+    /// A single transient item failure must NOT immediately skip the track.
+    /// Within the retry budget it recovers in place (fires
+    /// `audioEngineDidStall` / `audioEngineDidRecover`) and leaves the queue
+    /// alone — `onTrackEnded` must not fire yet.
+    func testTransientFailureRetriesInsteadOfSkippingOnFirstError() throws {
+        let engine = try makeEngine()
+        let spy = RecoveryDelegateSpy()
+        engine.delegate = spy
+        engine.setCurrentStreamURLForTesting(URL(string: "https://example.invalid/stream")!)
+
+        var trackEndedFired = false
+        engine.onTrackEnded = { trackEndedFired = true }
+
+        engine.handleItemFailureForTesting(transientError())
+
+        XCTAssertFalse(trackEndedFired, "a transient blip must retry, not skip, on the first error")
+        XCTAssertEqual(spy.didStallCount, 1, "the retry must surface a stall indicator")
+        XCTAssertEqual(spy.didRecoverCount, 1, "the in-place rebuild must fire didRecover")
+        XCTAssertEqual(spy.transientErrorCount, 0, "no terminal skip while retries remain")
+    }
+
+    /// Once the shared retry budget (`maxAutoRetries`) is exhausted, the next
+    /// transient failure skips: it surfaces the transient indicator and
+    /// advances the queue via `onTrackEnded`, rather than wedging on the dead
+    /// item. maxAutoRetries == 2, so the 3rd failure is the one that skips.
+    func testTransientFailureSkipsAfterRetriesExhausted() throws {
+        let engine = try makeEngine()
+        let spy = RecoveryDelegateSpy()
+        engine.delegate = spy
+        engine.setCurrentStreamURLForTesting(URL(string: "https://example.invalid/stream")!)
+
+        var trackEndedCount = 0
+        engine.onTrackEnded = { trackEndedCount += 1 }
+
+        // Failures 1 and 2 recover in place (within budget).
+        engine.handleItemFailureForTesting(transientError())
+        engine.handleItemFailureForTesting(transientError())
+        XCTAssertEqual(trackEndedCount, 0, "still within retry budget after two failures")
+
+        // Failure 3 exhausts the budget — skip.
+        engine.handleItemFailureForTesting(transientError())
+
+        XCTAssertEqual(trackEndedCount, 1, "the queue must advance once retries are spent")
+        XCTAssertEqual(spy.transientErrorCount, 1, "the terminal skip surfaces the transient toast")
+    }
+
+    /// With no recoverable URL captured there's nothing to rebuild, so a
+    /// transient failure skips immediately rather than charging the budget.
+    func testTransientFailureWithoutStreamURLSkipsImmediately() throws {
+        let engine = try makeEngine()
+        let spy = RecoveryDelegateSpy()
+        engine.delegate = spy
+        engine.setCurrentStreamURLForTesting(nil)
+
+        var trackEndedFired = false
+        engine.onTrackEnded = { trackEndedFired = true }
+
+        engine.handleItemFailureForTesting(transientError())
+
+        XCTAssertTrue(trackEndedFired, "no URL to rebuild from means skip straight to the advance")
+        XCTAssertEqual(spy.transientErrorCount, 1)
+        XCTAssertEqual(spy.didStallCount, 0, "no retry attempted without a URL")
+    }
+
+    /// A non-transient error (e.g. a 403) must be left to the blind 5s stall
+    /// watchdog — `handleItemFailure` ignores it entirely, so neither a retry
+    /// nor a skip happens here.
+    func testNonTransientFailureIsIgnoredByItemFailurePath() throws {
+        let engine = try makeEngine()
+        let spy = RecoveryDelegateSpy()
+        engine.delegate = spy
+        engine.setCurrentStreamURLForTesting(URL(string: "https://example.invalid/stream")!)
+
+        var trackEndedFired = false
+        engine.onTrackEnded = { trackEndedFired = true }
+
+        // -11800 is a generic AVFoundation error, not in the transient set.
+        engine.handleItemFailureForTesting(NSError(domain: "CoreMediaErrorDomain", code: -11800))
+
+        XCTAssertFalse(trackEndedFired)
+        XCTAssertEqual(spy.didStallCount, 0)
+        XCTAssertEqual(spy.transientErrorCount, 0)
+        XCTAssertEqual(engine.stallRetryCountForTesting, 0, "non-transient errors don't charge the budget")
+    }
+
+    // MARK: - L974: give-up branch quiesces
+
+    /// When the retry budget is exhausted, the give-up path must pause the
+    /// player, cancel the watchdog, and notify the delegate so the UI/server
+    /// reflect the failed state instead of a player wedged in
+    /// `.waitingToPlayAtSpecifiedRate`.
+    func testTerminalFailureQuiescesPlayerAndNotifies() throws {
+        let engine = try makeEngine()
+        let spy = RecoveryDelegateSpy()
+        engine.delegate = spy
+
+        engine.failTerminallyForTesting()
+
+        XCTAssertFalse(engine.hasPendingStallWatchdogForTesting, "watchdog must be cancelled on give-up")
+        XCTAssertEqual(spy.didFailCount, 1, "the terminal failure must reach the delegate")
+        XCTAssertEqual(spy.lastFailMessage, "Couldn't play, tap to retry.")
+    }
+
+    // MARK: - L1031: invalidURL redaction
+
+    /// `AudioEngineError.invalidURL.errorDescription` must never echo the raw
+    /// stream URL, which carries the Jellyfin access token as `api_key`.
+    func testInvalidURLErrorRedactsAccessToken() {
+        let raw = "https://music.example.com/Audio/abc123/universal?api_key=SECRET_TOKEN_VALUE&container=mp3"
+        let description = AudioEngineError.invalidURL(raw).errorDescription ?? ""
+
+        XCTAssertFalse(description.contains("SECRET_TOKEN_VALUE"), "the api_key token must not leak into the description")
+        XCTAssertFalse(description.contains("api_key"), "the query string must be stripped entirely")
+        XCTAssertFalse(description.contains("?"), "everything from the query onward must be dropped")
+        // The path should still be there for diagnostics.
+        XCTAssertTrue(description.contains("/Audio/abc123/universal"), "the path should survive for diagnostics")
+    }
+
+    /// A string that won't parse as a URL falls back to a fully redacted
+    /// placeholder rather than echoing the input.
+    func testInvalidURLErrorRedactsUnparseableString() {
+        // A control character makes URLComponents(string:) return nil.
+        let raw = "ht\u{0001}tp://broken?api_key=SECRET"
+        let description = AudioEngineError.invalidURL(raw).errorDescription ?? ""
+
+        XCTAssertFalse(description.contains("SECRET"))
+        XCTAssertTrue(description.contains("<redacted>"))
+    }
+}
+
+@MainActor
+private final class RecoveryDelegateSpy: AudioEngineDelegate {
+    var didStallCount = 0
+    var didRecoverCount = 0
+    var didFailCount = 0
+    var transientErrorCount = 0
+    var lastFailMessage: String?
+
+    func audioEngineDidStall() { didStallCount += 1 }
+    func audioEngineDidRecover() { didRecoverCount += 1 }
+    func audioEngineDidFail(_ message: String) {
+        didFailCount += 1
+        lastFailMessage = message
+    }
+    func audioEngineDidEncounterTransientError(_ message: String) { transientErrorCount += 1 }
+}

--- a/macos/Tests/LyrebirdTests/CapabilityGatedControlsTests.swift
+++ b/macos/Tests/LyrebirdTests/CapabilityGatedControlsTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the capability flags that gate inert preference controls so
+/// they aren't presented as working settings while their backing work is
+/// unwired (audit fixes for the Appearance Theme picker and the General
+/// Language picker).
+///
+/// `AppModel` is `@MainActor`, so the suite is main-actor isolated. We redirect
+/// the core's data dir to a throwaway temp dir via `XDG_DATA_HOME` so the tests
+/// never touch the real app database.
+@MainActor
+final class CapabilityGatedControlsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    /// Theme selection stays gated off until the theme engine (#405) actually
+    /// resolves `Theme.primary` / `Theme.accent` from the persisted preset.
+    /// Until then the Appearance Theme picker renders as a disabled "coming
+    /// soon" preview rather than a working selector.
+    func testThemeSelectionGatedOff() throws {
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.supportsThemeSelection,
+            "Theme selection must stay gated until the theme engine consumes appearance.theme"
+        )
+    }
+
+    /// Language selection stays gated off until in-app localization (#345) is
+    /// wired — nothing reads `general.language` back to re-render the UI, so the
+    /// General Language picker is hidden rather than shown as an inert control.
+    func testLanguageSelectionGatedOff() throws {
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.supportsLanguageSelection,
+            "Language selection must stay gated until a runtime locale override is wired"
+        )
+    }
+
+    // MARK: - Appearance theme offerings
+
+    /// The Theme picker only offers presets the engine can actually render —
+    /// Purple plus the two colour-blind-verified alternatives. Sunset / Peanut
+    /// were dropped because they had no backing `ThemePreset` (they silently
+    /// folded into Purple), so offering them would promise a palette the engine
+    /// can't produce.
+    func testAppearanceThemeOffersOnlyRenderablePresets() {
+        XCTAssertEqual(AppearanceTheme.allCases, [.purple, .ocean, .forest])
+    }
+
+    /// The persisted raw values are an on-disk contract; renaming one silently
+    /// resets a user's saved theme. Pin the three that remain.
+    func testAppearanceThemeStableRawValues() {
+        XCTAssertEqual(AppearanceTheme.purple.rawValue, "purple")
+        XCTAssertEqual(AppearanceTheme.ocean.rawValue, "ocean")
+        XCTAssertEqual(AppearanceTheme.forest.rawValue, "forest")
+    }
+
+    /// A legacy persisted value for a dropped case decodes to `nil` so the
+    /// `@AppStorage` getter's `?? .purple` fallback keeps the user on a valid,
+    /// renderable theme rather than crashing or stranding an unknown value.
+    func testDroppedThemeRawValuesNoLongerDecode() {
+        XCTAssertNil(AppearanceTheme(rawValue: "sunset"))
+        XCTAssertNil(AppearanceTheme(rawValue: "peanut"))
+    }
+}

--- a/macos/Tests/LyrebirdTests/CommandPaletteSearchTests.swift
+++ b/macos/Tests/LyrebirdTests/CommandPaletteSearchTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the command-palette action matcher
+/// (`CommandPalette.actionMatches`).
+///
+/// The matcher replaced a `hasPrefix`-only filter that returned zero actions
+/// for common substring queries — typing "preferences", "shuffle", "queue",
+/// "favorites", or "library" matched nothing because every shipped action
+/// title starts with a different word ("Open Preferences", "Toggle Shuffle",
+/// "Clear Queue", "Go to Favorites", "Go to Library"). These tests pin the
+/// substring + token-prefix contract so that regression can't return.
+final class CommandPaletteSearchTests: XCTestCase {
+
+	/// The exact queries called out in the audit: each is a substring of a
+	/// shipped action title that the old prefix-only matcher dropped.
+	func testSubstringQueriesThatPrefixMatchingMissed() {
+		XCTAssertTrue(CommandPalette.actionMatches("Open Preferences", query: "preferences"))
+		XCTAssertTrue(CommandPalette.actionMatches("Toggle Shuffle", query: "shuffle"))
+		XCTAssertTrue(CommandPalette.actionMatches("Clear Queue", query: "queue"))
+		XCTAssertTrue(CommandPalette.actionMatches("Go to Favorites", query: "favorites"))
+		XCTAssertTrue(CommandPalette.actionMatches("Go to Library", query: "library"))
+	}
+
+	/// Matching is case-insensitive on both sides.
+	func testCaseInsensitive() {
+		XCTAssertTrue(CommandPalette.actionMatches("Toggle Shuffle", query: "SHUFFLE"))
+		XCTAssertTrue(CommandPalette.actionMatches("Clear Queue", query: "Queue"))
+	}
+
+	/// A leading-edge prefix of the whole title still matches (the old
+	/// behaviour stays valid — we widened, not replaced, the match).
+	func testWholeTitlePrefixStillMatches() {
+		XCTAssertTrue(CommandPalette.actionMatches("Play Next", query: "play"))
+		XCTAssertTrue(CommandPalette.actionMatches("Play Next", query: "play n"))
+	}
+
+	/// A prefix of a non-leading word matches via the token-prefix pass even
+	/// when it isn't a contiguous substring of the leading word.
+	func testTokenPrefixMatches() {
+		XCTAssertTrue(CommandPalette.actionMatches("Go to Favorites", query: "fav"))
+		XCTAssertTrue(CommandPalette.actionMatches("Add to Queue", query: "que"))
+	}
+
+	/// Mid-word substrings match (contains is the primary pass).
+	func testInteriorSubstringMatches() {
+		XCTAssertTrue(CommandPalette.actionMatches("Toggle Shuffle", query: "ggle"))
+	}
+
+	/// A query that appears in no title (and is no token prefix) does not match.
+	func testNonMatchReturnsFalse() {
+		XCTAssertFalse(CommandPalette.actionMatches("Clear Queue", query: "xyz"))
+		XCTAssertFalse(CommandPalette.actionMatches("Go to Home", query: "library"))
+	}
+
+	/// Whitespace-only / empty queries are treated as "match" (the caller
+	/// routes the empty-query case to the pinned/recent ordering, but the
+	/// matcher itself must not spuriously reject a blank needle).
+	func testEmptyAndWhitespaceQueryMatches() {
+		XCTAssertTrue(CommandPalette.actionMatches("Anything", query: ""))
+		XCTAssertTrue(CommandPalette.actionMatches("Anything", query: "   "))
+	}
+
+	/// Leading/trailing whitespace around a real query is trimmed before
+	/// matching so a stray space doesn't drop an otherwise-valid hit.
+	func testQueryIsTrimmed() {
+		XCTAssertTrue(CommandPalette.actionMatches("Clear Queue", query: "  queue  "))
+	}
+}

--- a/macos/Tests/LyrebirdTests/CoreDataLocationTests.swift
+++ b/macos/Tests/LyrebirdTests/CoreDataLocationTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `CoreDataLocation` (audit L31). The core-init failure recovery
+/// screen offers a "Reset Local Data" affordance that moves the core's data
+/// directory aside. To target the *right* directory, the Swift side must mirror
+/// `core/src/storage.rs::default_data_dir()` exactly; these tests pin that
+/// derivation plus the quarantine move.
+final class CoreDataLocationTests: XCTestCase {
+
+    // MARK: - resolve (mirrors default_data_dir)
+
+    /// A non-empty `XDG_DATA_HOME` wins and the app folder is appended — exactly
+    /// what the core does, and what the test harness relies on to redirect data.
+    func testPrefersXdgDataHome() {
+        let url = CoreDataLocation.resolve(
+            environment: ["XDG_DATA_HOME": "/tmp/xdg"],
+            home: "/Users/someone"
+        )
+        XCTAssertEqual(url?.path, "/tmp/xdg/lyrebird-desktop")
+    }
+
+    /// An empty `XDG_DATA_HOME` is ignored (matching the core's `!val.is_empty()`
+    /// guard) and we fall back to Application Support.
+    func testEmptyXdgFallsBackToApplicationSupport() {
+        let url = CoreDataLocation.resolve(
+            environment: ["XDG_DATA_HOME": ""],
+            home: "/Users/someone"
+        )
+        XCTAssertEqual(
+            url?.path,
+            "/Users/someone/Library/Application Support/lyrebird-desktop"
+        )
+    }
+
+    /// No XDG var → Application Support under the home directory.
+    func testFallsBackToApplicationSupport() {
+        let url = CoreDataLocation.resolve(
+            environment: [:],
+            home: "/Users/someone"
+        )
+        XCTAssertEqual(
+            url?.path,
+            "/Users/someone/Library/Application Support/lyrebird-desktop"
+        )
+    }
+
+    /// Neither XDG nor a home dir → nil (matching `dirs_next_like()` → None).
+    func testReturnsNilWithoutXdgOrHome() {
+        XCTAssertNil(CoreDataLocation.resolve(environment: [:], home: nil))
+        XCTAssertNil(CoreDataLocation.resolve(environment: [:], home: ""))
+    }
+
+    // MARK: - quarantineDataDirectory
+
+    /// Moving an existing directory aside returns the timestamped backup, leaves
+    /// the original gone, and preserves the contents at the new location.
+    func testQuarantineMovesExistingDirectory() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("lyrebird-quarantine-\(UUID().uuidString)", isDirectory: true)
+        let dataDir = root.appendingPathComponent("lyrebird-desktop", isDirectory: true)
+        try fm.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        let marker = dataDir.appendingPathComponent("db.sqlite")
+        try Data("corrupt".utf8).write(to: marker)
+        defer { try? fm.removeItem(at: root) }
+
+        let backup = try CoreDataLocation.quarantineDataDirectory(dataDir, fileManager: fm)
+
+        let unwrapped = try XCTUnwrap(backup, "an existing directory must report its backup location")
+        XCTAssertFalse(fm.fileExists(atPath: dataDir.path), "the original data dir should be moved away")
+        XCTAssertTrue(fm.fileExists(atPath: unwrapped.path), "the backup directory should exist")
+        XCTAssertTrue(
+            fm.fileExists(atPath: unwrapped.appendingPathComponent("db.sqlite").path),
+            "contents should survive the move so the user can recover them"
+        )
+        XCTAssertTrue(
+            unwrapped.lastPathComponent.hasPrefix("lyrebird-desktop.corrupt-"),
+            "backup folder should be a clearly-labelled sibling, got \(unwrapped.lastPathComponent)"
+        )
+    }
+
+    /// Quarantining a directory that doesn't exist is a no-op (returns nil), so
+    /// the recovery screen can show a "nothing to reset" message instead of
+    /// throwing.
+    func testQuarantineMissingDirectoryIsNoOp() throws {
+        let fm = FileManager.default
+        let missing = fm.temporaryDirectory
+            .appendingPathComponent("lyrebird-missing-\(UUID().uuidString)", isDirectory: true)
+        let backup = try CoreDataLocation.quarantineDataDirectory(missing, fileManager: fm)
+        XCTAssertNil(backup)
+    }
+}

--- a/macos/Tests/LyrebirdTests/DiagnosticBundleTests.swift
+++ b/macos/Tests/LyrebirdTests/DiagnosticBundleTests.swift
@@ -90,6 +90,33 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertEqual(DiagnosticBundle.redactServerHost("   "), "(not signed in)")
     }
 
+    func testRedactSchemelessUserinfoDoesNotLeakPassword() {
+        // A scheme-less URL with embedded credentials must drop the WHOLE
+        // `user:pw@` userinfo, not just the part before the first `@`. A
+        // password that itself contains `@` is the worst case.
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("admin:p@ssw0rd@host.internal:8443/jf"),
+            "host.internal",
+            "an embedded password (even one containing '@') must not leak into the host"
+        )
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("user:pw@bare.example.com:9000"),
+            "bare.example.com"
+        )
+    }
+
+    func testRedactMalformedSchemelessInputIsNotSignedIn() {
+        // Garbage that parses to a non-host (spaces / illegal chars) must NOT be
+        // written verbatim into the manifest — it falls back to "(not signed in)".
+        XCTAssertEqual(
+            DiagnosticBundle.redactServerHost("ht!tp://weird host/with space"),
+            "(not signed in)",
+            "a non-host candidate must not be emitted as the server host"
+        )
+        XCTAssertEqual(DiagnosticBundle.redactServerHost("???"), "(not signed in)")
+        XCTAssertEqual(DiagnosticBundle.redactServerHost("weird host"), "(not signed in)")
+    }
+
     // MARK: - Secret exclusion (the core safety property)
 
     func testBundleNeverContainsTokenOrPassword() throws {

--- a/macos/Tests/LyrebirdTests/EmptyStateAccessibilityTests.swift
+++ b/macos/Tests/LyrebirdTests/EmptyStateAccessibilityTests.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import XCTest
+
+@testable import Lyrebird
+
+/// Accessibility coverage for the empty-state surfaces (#99 / #294).
+///
+/// The bug these pin: `.accessibilityElement(children: .combine)` *flattens* a
+/// subtree into one static element. Applied to a view that contains an
+/// interactive CTA button, it strips the button of its `.isButton` trait and
+/// tap action, so VoiceOver users can't reach or activate it. The fix is to
+/// `.contain` (keep descendants individually focusable) whenever a CTA is
+/// present.
+///
+/// `EmptyStateView`'s container strategy is a `private` computed property and
+/// the resolved accessibility tree can't be introspected headlessly, so the
+/// contract is asserted against source — the same structural-read pattern
+/// `FullScreenChromeTests` uses for window-server-dependent wiring. A second
+/// group exercises the public `hasCTA`-driven factories so a regression in the
+/// *presence* of CTAs (which selects the strategy) is also caught at runtime.
+final class EmptyStateAccessibilityTests: XCTestCase {
+
+    // MARK: - Source-read: container strategy
+
+    /// `EmptyStateView` must `.contain` (not `.combine`) when CTAs are present
+    /// so the primary/secondary buttons stay individually actionable.
+    func testEmptyStateViewUsesContainWhenCTAPresent() throws {
+        let source = try Self.readSource("Sources/Lyrebird/Components/EmptyStateView.swift")
+        XCTAssertTrue(
+            source.contains(".accessibilityElement(children: hasCTA ? .contain : .combine)"),
+            "EmptyStateView must switch to .contain when a CTA is present so its buttons stay reachable"
+        )
+        // The unconditional `.combine` that swallowed the buttons must be gone.
+        XCTAssertFalse(
+            source.contains(".accessibilityElement(children: .combine)\n    }"),
+            "EmptyStateView must not unconditionally .combine — that flattens the CTA buttons"
+        )
+    }
+
+    /// `EmptyLibraryState` contains the "Open Jellyfin web" button, so it must
+    /// `.contain`, not `.combine`.
+    func testEmptyLibraryStateUsesContain() throws {
+        let source = try Self.readSource("Sources/Lyrebird/Components/EmptyLibraryState.swift")
+        XCTAssertTrue(
+            source.contains(".accessibilityElement(children: .contain)"),
+            "EmptyLibraryState must .contain so the 'Open Jellyfin web' button stays actionable"
+        )
+        XCTAssertFalse(
+            source.contains(".accessibilityElement(children: .combine)"),
+            "EmptyLibraryState must not .combine — it flattens the interactive button"
+        )
+    }
+
+    // MARK: - Runtime: CTA presence drives the strategy
+
+    /// The text-only presets carry no CTA — they're free to `.combine`. The
+    /// presets that take a handler must expose one. These pin the inputs that
+    /// select the accessibility strategy in `body`.
+    func testFactoryPresetsCTAPresenceMatchesAccessibilityNeed() {
+        // No CTA: text-only, safe to combine.
+        XCTAssertNil(EmptyStateView.noFavorites().primaryCTA)
+        XCTAssertNil(EmptyStateView.noFavorites().secondaryCTA)
+        XCTAssertNil(EmptyStateView.noDownloads().primaryCTA)
+        XCTAssertNil(EmptyStateView.emptyPlaylist(onAddTracks: nil).primaryCTA)
+
+        // Has CTA: must keep the button reachable → .contain.
+        XCTAssertNotNil(EmptyStateView.firstRunNoLibrary(onChangeLibrary: {}).primaryCTA)
+        XCTAssertNotNil(EmptyStateView.emptyPlaylist(onAddTracks: {}).primaryCTA)
+    }
+
+    // MARK: - Helpers
+
+    private static func readSource(_ relativePath: String) throws -> String {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let macosDir = thisFile
+            .deletingLastPathComponent() // LyrebirdTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // macos
+        let url = macosDir.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/macos/Tests/LyrebirdTests/FullScreenChromeTests.swift
+++ b/macos/Tests/LyrebirdTests/FullScreenChromeTests.swift
@@ -140,7 +140,55 @@ final class FullScreenChromeTests: XCTestCase {
         )
     }
 
+    /// `detach()` must not blindly reset the *app-global*
+    /// `NSApp.presentationOptions` to `[]`: that's a single value shared across
+    /// every window, so clobbering it on one window's teardown would yank a
+    /// *different* window's full-screen auto-hide chrome out from under it. The
+    /// reset must be gated on *this* window actually being in full-screen
+    /// (`styleMask.contains(.fullScreen)`) — only then do we own the override
+    /// and must clear it to avoid stranding a hidden menu bar. Asserted against
+    /// source because realizing a live full-screen `NSWindow` needs a
+    /// window-server connection a headless run lacks.
+    func testDetachGatesGlobalPresentationResetOnOwnFullScreenState() throws {
+        let source = try Self.readSource("Sources/Lyrebird/System/FullScreenChromeController.swift")
+        // The reset must be guarded by this window's own full-screen state.
+        XCTAssertTrue(
+            source.contains("window?.styleMask.contains(.fullScreen) == true"),
+            "detach() must gate the global presentation-options reset on this window being full-screen"
+        )
+        // And it must only ever clear to empty inside that guarded block, never
+        // unconditionally at function scope.
+        let detachBody = try Self.slice(
+            source,
+            from: "func detach() {",
+            to: "window = nil"
+        )
+        if let resetRange = detachBody.range(of: "NSApp.presentationOptions = []") {
+            let beforeReset = detachBody[detachBody.startIndex..<resetRange.lowerBound]
+            XCTAssertTrue(
+                beforeReset.contains("styleMask.contains(.fullScreen)"),
+                "the presentationOptions reset must sit behind the full-screen guard"
+            )
+        } else {
+            XCTFail("detach() should still clear presentationOptions when this window owns full-screen")
+        }
+    }
+
     // MARK: - Helpers
+
+    /// Return the substring of `source` between the first occurrence of `from`
+    /// and the next occurrence of `to` (exclusive of `to`). Traps the test with
+    /// a clear failure if either marker is missing.
+    private static func slice(_ source: String, from: String, to: String) throws -> Substring {
+        guard let start = source.range(of: from) else {
+            throw XCTSkip("marker '\(from)' not found")
+        }
+        let rest = source[start.upperBound...]
+        guard let end = rest.range(of: to) else {
+            throw XCTSkip("marker '\(to)' not found after '\(from)'")
+        }
+        return rest[rest.startIndex..<end.lowerBound]
+    }
 
     /// Resolve a repo-relative source path from this test file's location so
     /// the structural assertions don't depend on the CWD of the test runner.

--- a/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
+++ b/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
@@ -78,4 +78,34 @@ final class LibraryFilterTests: XCTestCase {
         f.durations = [.short]
         XCTAssertEqual(f.activeGroupCount, 5)
     }
+
+    /// `onlyDownloaded` must NOT count toward the active-group total: no
+    /// `passesFilter` overload can honor it until a download-state query
+    /// exists, and the toggle is UI-gated off, so counting it would light the
+    /// dot badge and trip the no-results path while filtering nothing. See
+    /// audit L724.
+    func testOnlyDownloadedDoesNotMarkFilterActive() {
+        var f = LibraryFilter()
+        f.onlyDownloaded = true
+        XCTAssertEqual(
+            f.activeGroupCount, 0,
+            "onlyDownloaded is inert until a download-state query lands; it must not count as an active group"
+        )
+        XCTAssertFalse(
+            f.isActive,
+            "a filter whose only set flag is the unhonorable onlyDownloaded must read as inactive"
+        )
+    }
+
+    func testOnlyDownloadedDoesNotInflateAlongsideRealGroups() {
+        var f = LibraryFilter()
+        f.onlyFavorited = true
+        f.genres = ["Rock"]
+        let withoutDownloaded = f.activeGroupCount
+        f.onlyDownloaded = true
+        XCTAssertEqual(
+            f.activeGroupCount, withoutDownloaded,
+            "toggling the inert onlyDownloaded flag must not change the active-group count"
+        )
+    }
 }

--- a/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
+++ b/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
@@ -104,34 +104,6 @@ final class LibraryFilterTests: XCTestCase {
         XCTAssertEqual(f.activeGroupCount, 5)
     }
 
-    /// `onlyDownloaded` must NOT count toward the active-group total: no
-    /// `passesFilter` overload can honor it until a download-state query
-    /// exists, and the toggle is UI-gated off, so counting it would light the
-    /// dot badge and trip the no-results path while filtering nothing. See
-    /// audit L724.
-    func testOnlyDownloadedDoesNotMarkFilterActive() {
-        var f = LibraryFilter()
-        f.onlyDownloaded = true
-        XCTAssertEqual(
-            f.activeGroupCount, 0,
-            "onlyDownloaded is inert until a download-state query lands; it must not count as an active group"
-        )
-        XCTAssertFalse(
-            f.isActive,
-            "a filter whose only set flag is the unhonorable onlyDownloaded must read as inactive"
-        )
-    }
-
-    func testOnlyDownloadedDoesNotInflateAlongsideRealGroups() {
-        var f = LibraryFilter()
-        f.onlyFavorited = true
-        f.genres = ["Rock"]
-        let withoutDownloaded = f.activeGroupCount
-        f.onlyDownloaded = true
-        XCTAssertEqual(
-            f.activeGroupCount, withoutDownloaded,
-            "toggling the inert onlyDownloaded flag must not change the active-group count"
-        )
     // MARK: - Per-tab applicability
 
     func testGenreAppliesOnlyToAlbumsAndArtists() {

--- a/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
+++ b/macos/Tests/LyrebirdTests/LibraryFilterTests.swift
@@ -28,10 +28,35 @@ final class LibraryFilterTests: XCTestCase {
         XCTAssertFalse(TrackFormat.alac.matches(container: "flac"))
     }
 
+    func testAlacAndAacShareTheM4aMp4Container() {
+        // ALAC and AAC both live in m4a/mp4; the loaded Track payload has no
+        // codec field, so the filter can only match at container granularity.
+        // Both formats therefore match the shared containers — selecting either
+        // keeps every m4a/mp4 track. This is the deliberate (documented)
+        // limitation; it replaces the old behaviour where ALAC silently kept
+        // lossy AAC files while pretending to be codec-accurate.
+        for container in ["m4a", "MP4", "M4B"] {
+            XCTAssertTrue(
+                TrackFormat.alac.matches(container: container),
+                "ALAC should match \(container)")
+            XCTAssertTrue(
+                TrackFormat.aac.matches(container: container),
+                "AAC should match \(container)")
+        }
+        // Lossless FLAC is a distinct container and must not be swept in.
+        XCTAssertFalse(TrackFormat.aac.matches(container: "flac"))
+        XCTAssertFalse(TrackFormat.alac.matches(container: "flac"))
+    }
+
+    func testAacIsAnOfferedFormat() {
+        XCTAssertTrue(TrackFormat.allCases.contains(.aac))
+    }
+
     func testMp3MatchesMpegSpelling() {
         XCTAssertTrue(TrackFormat.mp3.matches(container: "mp3"))
         XCTAssertTrue(TrackFormat.mp3.matches(container: "MPEG"))
-        XCTAssertFalse(TrackFormat.mp3.matches(container: "aac"))
+        // mp3 is its own container and must not collide with the m4a family.
+        XCTAssertFalse(TrackFormat.mp3.matches(container: "m4a"))
     }
 
     // MARK: - DurationBucket
@@ -77,5 +102,84 @@ final class LibraryFilterTests: XCTestCase {
         f.yearRange = 1990...2000
         f.durations = [.short]
         XCTAssertEqual(f.activeGroupCount, 5)
+    }
+
+    // MARK: - Per-tab applicability
+
+    func testGenreAppliesOnlyToAlbumsAndArtists() {
+        XCTAssertTrue(LibraryFilter.appliesGenre(on: .albums))
+        XCTAssertTrue(LibraryFilter.appliesGenre(on: .artists))
+        XCTAssertFalse(LibraryFilter.appliesGenre(on: .tracks))
+        XCTAssertFalse(LibraryFilter.appliesGenre(on: .playlists))
+        XCTAssertFalse(LibraryFilter.appliesGenre(on: .downloaded))
+    }
+
+    func testYearAppliesOnlyToAlbumsAndTracks() {
+        XCTAssertTrue(LibraryFilter.appliesYear(on: .albums))
+        XCTAssertTrue(LibraryFilter.appliesYear(on: .tracks))
+        XCTAssertFalse(LibraryFilter.appliesYear(on: .artists))
+        XCTAssertFalse(LibraryFilter.appliesYear(on: .playlists))
+        XCTAssertFalse(LibraryFilter.appliesYear(on: .downloaded))
+    }
+
+    func testFormatAndDurationApplyOnlyToTracks() {
+        XCTAssertTrue(LibraryFilter.appliesTrackFields(on: .tracks))
+        for tab: LibraryTab in [.albums, .artists, .playlists, .downloaded] {
+            XCTAssertFalse(
+                LibraryFilter.appliesTrackFields(on: tab),
+                "format/duration must not apply to \(tab)")
+        }
+    }
+
+    // MARK: - RangeSlider drag math
+
+    // The container is 216pt wide with a 16pt thumb, so the usable thumb-centre
+    // travel is 200pt and the track's left edge (thumb centre at x=8) maps to
+    // the lower bound. These lock down the fix for the year-slider snapping bug:
+    // the cursor is read against the track, offset by half a thumb.
+    private let usable: CGFloat = 200
+    private let thumbSize: CGFloat = 16
+    private let bounds: ClosedRange<Double> = 2000...2020
+
+    func testCursorAtThumbCentreMapsToLowerBound() {
+        // Cursor sitting exactly on the resting thumb centre (thumbSize/2) must
+        // resolve to the lower bound — not snap somewhere else.
+        let v = RangeSlider.value(
+            forCursorX: thumbSize / 2, usable: usable, thumbSize: thumbSize, bounds: bounds)
+        XCTAssertEqual(v, 2000, accuracy: 0.001)
+    }
+
+    func testCursorBeforeTrackClampsToLowerBound() {
+        // Anything left of the track origin clamps to the lower bound rather
+        // than going negative.
+        let v = RangeSlider.value(
+            forCursorX: 0, usable: usable, thumbSize: thumbSize, bounds: bounds)
+        XCTAssertEqual(v, 2000, accuracy: 0.001)
+    }
+
+    func testCursorAtTrackEndMapsToUpperBound() {
+        // Thumb centre travels to `usable + thumbSize/2` at the far end.
+        let v = RangeSlider.value(
+            forCursorX: usable + thumbSize / 2,
+            usable: usable, thumbSize: thumbSize, bounds: bounds)
+        XCTAssertEqual(v, 2020, accuracy: 0.001)
+    }
+
+    func testCursorAtTrackMidpointMapsToMidValue() {
+        // Halfway along the usable travel (centre at thumbSize/2 + usable/2).
+        let v = RangeSlider.value(
+            forCursorX: thumbSize / 2 + usable / 2,
+            usable: usable, thumbSize: thumbSize, bounds: bounds)
+        XCTAssertEqual(v, 2010, accuracy: 0.001)
+    }
+
+    func testCursorTracksProportionallyNotAtLowerBound() {
+        // Regression guard for the original bug, where mid-track drags collapsed
+        // toward the lower bound. A cursor 3/4 of the way along must read ~2015,
+        // nowhere near the lower bound.
+        let v = RangeSlider.value(
+            forCursorX: thumbSize / 2 + usable * 0.75,
+            usable: usable, thumbSize: thumbSize, bounds: bounds)
+        XCTAssertEqual(v, 2015, accuracy: 0.001)
     }
 }

--- a/macos/Tests/LyrebirdTests/LibrarySortLogicTests.swift
+++ b/macos/Tests/LyrebirdTests/LibrarySortLogicTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the pure Library sort/filter/pagination logic extracted out of
+/// `LibraryView` (audit batch: L196, L578, L783, L871). These are deliberately
+/// View- and `AppModel`-free — the SwiftUI glue stays thin and the arithmetic
+/// that decides display order, when a stable random reshuffles, when a near-end
+/// scroll pages the server, and which sort orders a tab offers is locked down
+/// here. Mirrors the `TrackSelectionResolverTests` pattern.
+final class LibrarySortLogicTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func album(_ id: String, _ name: String = "n") -> Album {
+        Album(
+            id: id, name: name, artistName: "a", artistId: nil, year: nil,
+            trackCount: 0, runtimeTicks: 0, genres: [], imageTag: nil, userData: nil
+        )
+    }
+
+    // MARK: - seededShuffle (audit L871)
+
+    func testSeededShuffleIsStableForSameSeed() {
+        let items = (0..<50).map { album("id-\($0)") }
+        let seed = UUID()
+        let a = LibrarySortLogic.seededShuffle(items, seed: seed, id: \.id)
+        let b = LibrarySortLogic.seededShuffle(items, seed: seed, id: \.id)
+        XCTAssertEqual(
+            a.map(\.id), b.map(\.id),
+            "the same (items, seed) pair must produce the same order so the grid doesn't reorder on every re-render/hover"
+        )
+    }
+
+    func testSeededShuffleIsAPermutation() {
+        let items = (0..<50).map { album("id-\($0)") }
+        let shuffled = LibrarySortLogic.seededShuffle(items, seed: UUID(), id: \.id)
+        XCTAssertEqual(
+            Set(shuffled.map(\.id)), Set(items.map(\.id)),
+            "a shuffle must preserve membership — no rows dropped or duplicated"
+        )
+        XCTAssertEqual(shuffled.count, items.count)
+    }
+
+    func testSeededShuffleDiffersAcrossSeeds() {
+        // A re-roll (user re-picks Random) should generally change the order.
+        // With 50 items the odds of two distinct seeds colliding are negligible.
+        let items = (0..<50).map { album("id-\($0)") }
+        let a = LibrarySortLogic.seededShuffle(items, seed: UUID(), id: \.id)
+        let b = LibrarySortLogic.seededShuffle(items, seed: UUID(), id: \.id)
+        XCTAssertNotEqual(
+            a.map(\.id), b.map(\.id),
+            "a fresh seed should reshuffle, so the explicit Random re-pick gesture visibly re-orders"
+        )
+    }
+
+    func testSeededShuffleKeepsExistingRowsStableWhenItemsAppended() {
+        // Appending a page must not reshuffle already-visible rows: the
+        // relative order of the original ids is preserved under the same seed.
+        let seed = UUID()
+        let first = (0..<30).map { album("id-\($0)") }
+        let firstOrder = LibrarySortLogic.seededShuffle(first, seed: seed, id: \.id)
+
+        let appended = first + (30..<60).map { album("id-\($0)") }
+        let secondOrder = LibrarySortLogic.seededShuffle(appended, seed: seed, id: \.id)
+
+        let originalIds = Set(first.map(\.id))
+        let projected = secondOrder.map(\.id).filter { originalIds.contains($0) }
+        XCTAssertEqual(
+            projected, firstOrder.map(\.id),
+            "paging in more items must not visibly reorder the rows already on screen under Random"
+        )
+    }
+
+    // MARK: - shouldLoadMore (audit L578)
+
+    func testShouldLoadMoreFiresNearDisplayedEnd() {
+        // 30 displayed rows, trigger distance 20 → threshold 10.
+        XCTAssertFalse(LibrarySortLogic.shouldLoadMore(index: 9, displayedCount: 30, triggerDistance: 20))
+        XCTAssertTrue(LibrarySortLogic.shouldLoadMore(index: 10, displayedCount: 30, triggerDistance: 20))
+        XCTAssertTrue(LibrarySortLogic.shouldLoadMore(index: 29, displayedCount: 30, triggerDistance: 20))
+    }
+
+    func testShouldLoadMoreUsesDisplayedCountNotRawLoaded() {
+        // The bug: a filter shrinks the displayed list to 5 while 200 raw rows
+        // are loaded. The old code compared against `loaded - distance` (180),
+        // which the index of the last filtered row (4) never reached, so
+        // pagination stalled. Against the displayed count the last row trips it.
+        let displayedCount = 5
+        let lastIndex = displayedCount - 1
+        XCTAssertTrue(
+            LibrarySortLogic.shouldLoadMore(
+                index: lastIndex, displayedCount: displayedCount, triggerDistance: 20
+            ),
+            "with a sparse filter the displayed tail must still trigger a page (audit L578)"
+        )
+    }
+
+    func testShouldLoadMoreFalseForEmptyDisplayedList() {
+        XCTAssertFalse(
+            LibrarySortLogic.shouldLoadMore(index: 0, displayedCount: 0, triggerDistance: 20),
+            "no rows means no near-end trigger — eager paging covers the empty-filter case instead"
+        )
+    }
+
+    // MARK: - shouldEagerlyPageForFilter (audit L783)
+
+    func testEagerPagingOffWhenNoFilter() {
+        XCTAssertFalse(
+            LibrarySortLogic.shouldEagerlyPageForFilter(
+                filterActive: false, displayedCount: 0, loadedCount: 100, total: 20000, prefetchTarget: 60
+            ),
+            "no filter → ordinary scroll-driven pagination, no eager fetch"
+        )
+    }
+
+    func testEagerPagingOnWhenFilterSparseAndMoreRemain() {
+        XCTAssertTrue(
+            LibrarySortLogic.shouldEagerlyPageForFilter(
+                filterActive: true, displayedCount: 3, loadedCount: 100, total: 20000, prefetchTarget: 60
+            ),
+            "a sparse filter with the dataset far from exhausted must keep paging so results aren't silently truncated (audit L783)"
+        )
+    }
+
+    func testEagerPagingStopsWhenEnoughMatchesAccumulated() {
+        XCTAssertFalse(
+            LibrarySortLogic.shouldEagerlyPageForFilter(
+                filterActive: true, displayedCount: 60, loadedCount: 500, total: 20000, prefetchTarget: 60
+            ),
+            "once enough filtered matches are on hand, back off the eager fetch"
+        )
+    }
+
+    func testEagerPagingStopsWhenDatasetExhausted() {
+        XCTAssertFalse(
+            LibrarySortLogic.shouldEagerlyPageForFilter(
+                filterActive: true, displayedCount: 1, loadedCount: 20000, total: 20000, prefetchTarget: 60
+            ),
+            "no raw items left on the server → nothing to page even if matches are sparse"
+        )
+    }
+
+    // MARK: - supportedOrders / fallback (audit L196)
+
+    func testAlbumsAndTracksSupportEveryOrder() {
+        XCTAssertEqual(
+            Set(LibrarySortOrder.supportedOrders(for: .albums)),
+            Set(LibrarySortOrder.allCases),
+            "albums carry every sort dimension"
+        )
+        XCTAssertEqual(
+            Set(LibrarySortOrder.supportedOrders(for: .tracks)),
+            Set(LibrarySortOrder.allCases),
+            "tracks carry every sort dimension"
+        )
+    }
+
+    func testArtistsOmitYearRuntimeAndArtistOrders() {
+        let supported = LibrarySortOrder.supportedOrders(for: .artists)
+        for unsupported in [LibrarySortOrder.artist, .longest, .shortest, .yearAscending, .yearDescending, .recentlyAdded] {
+            XCTAssertFalse(
+                supported.contains(unsupported),
+                "artists can't honor \(unsupported); offering it would make the menu label lie (audit L196)"
+            )
+        }
+        XCTAssertTrue(supported.contains(.nameAscending))
+        XCTAssertTrue(supported.contains(.mostPlayed))
+    }
+
+    func testPlaylistsOmitYearAndPlayCountOrders() {
+        let supported = LibrarySortOrder.supportedOrders(for: .playlists)
+        for unsupported in [LibrarySortOrder.artist, .mostPlayed, .recentlyPlayed, .yearAscending, .yearDescending, .recentlyAdded] {
+            XCTAssertFalse(supported.contains(unsupported), "playlists can't honor \(unsupported)")
+        }
+        XCTAssertTrue(supported.contains(.longest))
+        XCTAssertTrue(supported.contains(.shortest))
+    }
+
+    func testIsSupportedAndFallbackAgree() {
+        for tab in LibraryTab.allCases {
+            let fallback = LibrarySortOrder.fallback(for: tab)
+            XCTAssertTrue(
+                fallback.isSupported(by: tab),
+                "the fallback order for \(tab) must itself be supported by \(tab)"
+            )
+        }
+    }
+
+    func testFallbackIsAlphabeticalForEveryTab() {
+        for tab in LibraryTab.allCases {
+            XCTAssertEqual(
+                LibrarySortOrder.fallback(for: tab), .nameAscending,
+                "A–Z is the truthful default when a tab can't honor the active sort"
+            )
+        }
+    }
+
+    func testUnsupportedOrderIsDetected() {
+        XCTAssertFalse(
+            LibrarySortOrder.yearDescending.isSupported(by: .artists),
+            "year sort isn't an artist dimension"
+        )
+        XCTAssertTrue(
+            LibrarySortOrder.nameDescending.isSupported(by: .artists),
+            "Z–A is a real artist dimension"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/LyrebirdErrorPresenterTests.swift
+++ b/macos/Tests/LyrebirdTests/LyrebirdErrorPresenterTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `LyrebirdErrorPresenter.key(for:)` — the substring routing that
+/// maps a flat-error `localizedDescription` onto a banner key.
+///
+/// Because the core declares `LyrebirdError` as a UniFFI `flat_error`, Swift
+/// only sees the rendered `Display` string. These tests construct `NSError`s
+/// whose `localizedDescription` mirrors the exact `thiserror` Display text the
+/// core emits, and pin the routing for the cases the audit pass fixed:
+///
+/// - A `429` `RateLimit` renders "rate limited (retry after …)" WITHOUT the
+///   "server returned an error:" prefix, so it must match at the top level
+///   (previously it fell through to `error.other`).
+/// - A `SelfSignedCertificate` renders "… uses a certificate that could not be
+///   verified …" and must route to a cert-specific banner (previously there
+///   was no certificate branch at all).
+final class LyrebirdErrorPresenterTests: XCTestCase {
+    /// Helper: an error whose `localizedDescription` is exactly `message`.
+    private func error(_ message: String) -> Error {
+        NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    func testRateLimitDisplayRoutesToRateLimitKey() {
+        // Matches the core's `RateLimit` Display after the audit fix.
+        let withRetry = error("rate limited (retry after 30s)")
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: withRetry), "error.rate_limit")
+
+        let withoutRetry = error("rate limited")
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: withoutRetry), "error.rate_limit")
+    }
+
+    func testSelfSignedCertificateRoutesToCertificateKey() {
+        // Matches the core's `SelfSignedCertificate` Display.
+        let cert = error(
+            "the server at 'music.example.com' uses a certificate that could not be verified — it may be self-signed"
+        )
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: cert), "error.certificate")
+    }
+
+    func testServerRateLimitInsideServerErrorStillRoutesToRateLimit() {
+        // A 429 that arrived as `Server { 429, .. }` carries the
+        // "server returned an error:" prefix and must still resolve to the
+        // rate-limit key (the in-block branch).
+        let server = error("server returned an error: 429 slow down")
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: server), "error.rate_limit")
+    }
+
+    func testAuthFamilyTakesPriority() {
+        // Regression guard: the auth branch is checked first.
+        let auth = error("authentication expired — please sign in again")
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: auth), "error.auth.expired")
+    }
+
+    func testUnknownErrorFallsThroughToOther() {
+        let unknown = error("something totally unrecognized")
+        XCTAssertEqual(LyrebirdErrorPresenter.key(for: unknown), "error.other")
+    }
+}

--- a/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
+++ b/macos/Tests/LyrebirdTests/MenuBarVisibilityTests.swift
@@ -57,4 +57,53 @@ final class MenuBarVisibilityTests: XCTestCase {
             "both toggles on: icon visible"
         )
     }
+
+    // MARK: - Persistent-toggle startup restore
+
+    /// The persistent "Show in menu bar" key is a stable on-disk identifier
+    /// shared between PreferencesGeneral (the writer) and AppDelegate (which
+    /// re-applies it at launch). A drift would silently disconnect the toggle
+    /// from the value restored at startup.
+    func testShowInMenuBarKeyIsStable() {
+        XCTAssertEqual(PreferencesGeneral.showInMenuBarKey, "general.showInMenuBar")
+    }
+
+    /// `setVisible(_:)` resolving the actual icon needs a window server, so the
+    /// restore behaviour is verified structurally: `AppDelegate`'s launch path
+    /// must read the persisted key and call `setVisible(_:)`, so a user who
+    /// enabled the icon last session sees it again before opening Settings.
+    /// Previously the toggle's only call sites were inside PreferencesGeneral,
+    /// so the icon never came back at launch.
+    func testAppDelegateRestoresPersistentVisibilityAtLaunch() throws {
+        let code = try appDelegateSource()
+        XCTAssertTrue(
+            code.contains("func applicationDidFinishLaunching"),
+            "AppDelegate must own the launch hook"
+        )
+        XCTAssertTrue(
+            code.contains("MenuBarController.shared.setVisible("),
+            "AppDelegate must (re-)apply the persistent menu-bar toggle at launch"
+        )
+        XCTAssertTrue(
+            code.contains("PreferencesGeneral.showInMenuBarKey"),
+            "The launch restore must read the same key PreferencesGeneral writes"
+        )
+    }
+
+    /// Loads `AppDelegate.swift` relative to this test file via `#filePath`, so
+    /// the lookup is independent of the test runner's working directory.
+    private func appDelegateSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let appDelegate = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/AppDelegate.swift")
+        guard let data = try? Data(contentsOf: appDelegate),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read AppDelegate.swift at \(appDelegate.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
 }

--- a/macos/Tests/LyrebirdTests/MoveToApplicationsTests.swift
+++ b/macos/Tests/LyrebirdTests/MoveToApplicationsTests.swift
@@ -128,6 +128,10 @@ final class MoveToApplicationsTests: XCTestCase {
     }
 
     func testMountedDMGVolumeIsEphemeral() {
+        // A /Volumes/ path whose volume flags can't be resolved (this one
+        // doesn't exist) falls back to the conservative "treat as ephemeral"
+        // branch, so a DMG-shaped path still suppresses the prompt. The actual
+        // disk-image discrimination is exercised purely in `isEphemeralVolume`.
         XCTAssertTrue(
             MoveToApplications.isTranslocatedOrEphemeral(path: "/Volumes/Lyrebird 2.0/Lyrebird.app"),
             "an app opened from a mounted DMG (/Volumes) must not move out of it"
@@ -144,6 +148,126 @@ final class MoveToApplicationsTests: XCTestCase {
     func testInstalledPathIsNotEphemeral() {
         XCTAssertFalse(
             MoveToApplications.isTranslocatedOrEphemeral(path: "/Applications/Lyrebird.app")
+        )
+    }
+
+    // MARK: - isTranslocated (pure)
+
+    func testIsTranslocatedMatchesAppTranslocationMarker() {
+        let path = "/private/var/folders/ab/cd/X/AppTranslocation/EF-12/d/Lyrebird.app"
+        XCTAssertTrue(MoveToApplications.isTranslocated(path: path))
+    }
+
+    func testIsTranslocatedIsFalseForOrdinaryPaths() {
+        XCTAssertFalse(MoveToApplications.isTranslocated(path: "/Applications/Lyrebird.app"))
+        XCTAssertFalse(
+            MoveToApplications.isTranslocated(path: "/Volumes/External SSD/Applications/Lyrebird.app")
+        )
+    }
+
+    // MARK: - isEphemeralVolume (pure, injected flags)
+
+    func testMountedDiskImageIsEphemeral() {
+        // A DMG is read-only, not internal, and not a physically removable or
+        // ejectable device — the disk-image fingerprint.
+        let flags = MoveToApplications.VolumeFlags(
+            isReadOnly: true,
+            isInternal: false,
+            isRemovable: false,
+            isEjectable: false
+        )
+        XCTAssertTrue(
+            MoveToApplications.isEphemeralVolume(path: "/Volumes/Lyrebird 2.0/Lyrebird.app", flags: flags),
+            "a read-only synthesized mount under /Volumes is a DMG and must not be a move source"
+        )
+    }
+
+    func testPersistentSecondaryDiskIsNotEphemeral() {
+        // A writable secondary disk mounted at /Volumes/<Disk>/Applications is a
+        // supported, persistent install location — it must still prompt.
+        let flags = MoveToApplications.VolumeFlags(
+            isReadOnly: false,
+            isInternal: false,
+            isRemovable: false,
+            isEjectable: false
+        )
+        XCTAssertFalse(
+            MoveToApplications.isEphemeralVolume(
+                path: "/Volumes/Macintosh SSD/Applications/Lyrebird.app",
+                flags: flags
+            ),
+            "a writable secondary volume is a permanent install location, not a DMG"
+        )
+    }
+
+    func testWriteProtectedRemovableMediaIsNotTreatedAsDiskImage() {
+        // A read-only USB stick reports removable/ejectable; it's real media,
+        // not a DMG shadow copy, so it isn't classified as ephemeral here.
+        let flags = MoveToApplications.VolumeFlags(
+            isReadOnly: true,
+            isInternal: false,
+            isRemovable: true,
+            isEjectable: true
+        )
+        XCTAssertFalse(
+            MoveToApplications.isEphemeralVolume(
+                path: "/Volumes/THUMBDRIVE/Lyrebird.app",
+                flags: flags
+            ),
+            "read-only removable media is a physical device, not a mounted disk image"
+        )
+    }
+
+    func testNonVolumesPathIsNeverEphemeralVolume() {
+        // The volume branch only applies under /Volumes/; a Downloads path is
+        // never reclassified by volume flags.
+        let dmgLikeFlags = MoveToApplications.VolumeFlags(
+            isReadOnly: true,
+            isInternal: false,
+            isRemovable: false,
+            isEjectable: false
+        )
+        XCTAssertFalse(
+            MoveToApplications.isEphemeralVolume(
+                path: "/Users/jane/Downloads/Lyrebird.app",
+                flags: dmgLikeFlags
+            )
+        )
+    }
+
+    // MARK: - shellQuoted (relaunch trampoline safety)
+
+    func testShellQuotedWrapsPlainPath() {
+        XCTAssertEqual(
+            MoveToApplications.shellQuoted("/Applications/Lyrebird.app"),
+            "'/Applications/Lyrebird.app'"
+        )
+    }
+
+    func testShellQuotedPreservesSpaces() {
+        // Spaces survive intact inside the single quotes — no word-splitting.
+        XCTAssertEqual(
+            MoveToApplications.shellQuoted("/Volumes/External SSD/Lyrebird.app"),
+            "'/Volumes/External SSD/Lyrebird.app'"
+        )
+    }
+
+    func testShellQuotedEscapesEmbeddedSingleQuote() {
+        // An embedded apostrophe (e.g. a volume named "Jane's Disk") is closed,
+        // escaped, and reopened so the shell can't break out of the quoting.
+        XCTAssertEqual(
+            MoveToApplications.shellQuoted("/Volumes/Jane's Disk/Lyrebird.app"),
+            "'/Volumes/Jane'\\''s Disk/Lyrebird.app'"
+        )
+    }
+
+    func testShellQuotedNeutralizesMetacharacters() {
+        // Shell metacharacters are inert inside single quotes; the round-trip
+        // value is the literal path bracketed by quotes.
+        let path = "/tmp/a b;rm -rf $HOME/Lyrebird.app"
+        XCTAssertEqual(
+            MoveToApplications.shellQuoted(path),
+            "'" + path + "'"
         )
     }
 

--- a/macos/Tests/LyrebirdTests/OnboardingFirstSyncGateTests.swift
+++ b/macos/Tests/LyrebirdTests/OnboardingFirstSyncGateTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `FirstSyncGate` — the decision that unlocks onboarding's
+/// "Continue to Home" CTA (#293).
+///
+/// The regression this guards against: the CTA used to unlock purely from a
+/// hard-coded cosmetic timer, so a user whose library failed to load (or never
+/// started loading) could be sent straight into an empty Home. The gate is now
+/// driven exclusively by real `AppModel` signals; these tests pin that contract
+/// so a future edit can't quietly reintroduce the timer-only behaviour.
+final class OnboardingFirstSyncGateTests: XCTestCase {
+
+    // MARK: - The load hasn't finished yet
+
+    func testClosedWhileLoadStillInFlight() {
+        // No matter how full the cosmetic bar looks, the CTA stays closed until
+        // the initial load actually finishes. `finishedLoading: false` models
+        // "fetch in flight".
+        XCTAssertFalse(
+            FirstSyncGate.isReady(
+                finishedLoading: false,
+                hasError: false,
+                hasAnyData: true,
+                librarySyncRatio: 1.0,
+                serverReportsEmptyLibrary: false
+            ),
+            "CTA must not unlock before the initial library load finishes"
+        )
+    }
+
+    func testClosedBeforeLoadStartsEvenIfTotalsLookEmpty() {
+        // Pre-load render: nothing loaded, totals unresolved (so they read as
+        // zero). This must NOT be mistaken for a finished empty-library load —
+        // `finishedLoading` is the guard.
+        XCTAssertFalse(
+            FirstSyncGate.isReady(
+                finishedLoading: false,
+                hasError: false,
+                hasAnyData: false,
+                librarySyncRatio: 0.0,
+                serverReportsEmptyLibrary: true
+            ),
+            "an unresolved (pre-load) empty-looking state must keep the CTA closed"
+        )
+    }
+
+    // MARK: - Failures
+
+    func testClosedOnErrorEvenWithData() {
+        // A partial failure that still produced some data must not silently
+        // wave the user through — the error needs surfacing first.
+        XCTAssertFalse(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: true,
+                hasAnyData: true,
+                librarySyncRatio: 1.0,
+                serverReportsEmptyLibrary: false
+            ),
+            "an errored load must keep the CTA closed regardless of partial data"
+        )
+    }
+
+    func testClosedOnErrorWithNoData() {
+        XCTAssertFalse(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: true,
+                hasAnyData: false,
+                librarySyncRatio: 0.0,
+                serverReportsEmptyLibrary: false
+            ),
+            "a failed load with no data is the empty-library trap; CTA stays closed"
+        )
+    }
+
+    // MARK: - Large library (more than one page)
+
+    func testOpensForLargeLibraryViaDataEvenBelowThreshold() {
+        // The real server has ~20k albums. The initial page is ~100 of each, so
+        // the ratio sits far below 0.8 forever. The CTA must still unlock once
+        // the first page landed without error — Home paginates on scroll.
+        let ratio = Double(300) / Double(24_000)  // ≈ 0.0125
+        XCTAssertLessThan(ratio, FirstSyncGate.readyThreshold)
+        XCTAssertTrue(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: false,
+                hasAnyData: true,
+                librarySyncRatio: ratio,
+                serverReportsEmptyLibrary: false
+            ),
+            "a large library must unlock on first-page data, not on the 0.8 ratio"
+        )
+    }
+
+    // MARK: - Small library (fits in one page)
+
+    func testOpensForSmallLibraryViaThreshold() {
+        // A library small enough that the first page is the whole thing crosses
+        // the 0.8 ratio. Unlock via the threshold branch.
+        XCTAssertTrue(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: false,
+                hasAnyData: true,
+                librarySyncRatio: 1.0,
+                serverReportsEmptyLibrary: false
+            ),
+            "a fully-loaded small library must unlock the CTA"
+        )
+    }
+
+    func testThresholdIsInclusiveAtExactly80Percent() {
+        XCTAssertTrue(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: false,
+                hasAnyData: false,
+                librarySyncRatio: FirstSyncGate.readyThreshold,
+                serverReportsEmptyLibrary: false
+            ),
+            "the 0.8 threshold must be inclusive"
+        )
+    }
+
+    // MARK: - Genuinely empty server
+
+    func testOpensForGenuinelyEmptyServerAfterLoad() {
+        // A brand-new server with nothing in it: the load finished, no error,
+        // no data, totals all zero. There's nothing to wait for, so the user
+        // shouldn't be stranded on the sync screen — unlock.
+        XCTAssertTrue(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: false,
+                hasAnyData: false,
+                librarySyncRatio: 0.0,
+                serverReportsEmptyLibrary: true
+            ),
+            "a finished, error-free, genuinely-empty library must unlock the CTA"
+        )
+    }
+
+    func testClosedWhenLoadedButNothingYetAndServerNotEmpty() {
+        // Defensive: load reported finished, but we somehow hold no data and the
+        // server is NOT empty (totals non-zero) and the ratio is below
+        // threshold. Treat as not-ready rather than risk an empty Home.
+        XCTAssertFalse(
+            FirstSyncGate.isReady(
+                finishedLoading: true,
+                hasError: false,
+                hasAnyData: false,
+                librarySyncRatio: 0.1,
+                serverReportsEmptyLibrary: false
+            ),
+            "finished-but-empty against a non-empty server must keep the CTA closed"
+        )
+    }
+
+    // MARK: - Threshold constant
+
+    func testReadyThresholdMatchesSpec() {
+        // The spec says the CTA activates "when sync crosses 80%". Pin the
+        // constant so a drift is a deliberate, test-breaking change.
+        XCTAssertEqual(FirstSyncGate.readyThreshold, 0.8, accuracy: 0.0001)
+    }
+}

--- a/macos/Tests/LyrebirdTests/PaletteRowCoverageTests.swift
+++ b/macos/Tests/LyrebirdTests/PaletteRowCoverageTests.swift
@@ -1,25 +1,21 @@
+import SwiftUI
 import XCTest
 
 @testable import Lyrebird
 
-/// Coverage for the command-palette row label/icon lookup tables.
+/// Coverage for the command-palette action model as the single source of
+/// truth for row labels + icons.
 ///
-/// `PaletteRow` labels and icons each action by id through two hand-maintained
-/// static maps (`actionTitleById` / `actionSymbolById`), kept in sync with the
-/// roster emitted by `AppModel.paletteActions`. A drift between the two renders
-/// the raw id string and a generic bolt icon (the key-miss fallbacks) — a
-/// `nav.favorites` row showing its raw id is the regression this guards. This
-/// gate fails if any registered action id is missing from either map.
+/// `PaletteRow` used to label/icon each action through two hand-maintained
+/// static maps that drifted from `AppModel.paletteActions`. Those maps are
+/// gone: the row now renders `Text(action.title)` and
+/// `Image(systemName: action.symbol)` straight off the model, and search
+/// matches on the owned `action.searchTitle`. This gate fails if any
+/// registered action ships an empty `symbol` or `searchTitle` (which would
+/// render a blank icon or make the action unsearchable) or if `searchTitle`
+/// drifts away from the displayed `title`.
 @MainActor
 final class PaletteRowCoverageTests: XCTestCase {
-
-	/// Action ids that `paletteActions` only appends behind a capability flag
-	/// (`supportsDownloads`, etc.), so the default `AppModel` roster never
-	/// surfaces them. They still need map entries because the row renders the
-	/// same way once the flag flips, so cover them explicitly.
-	private static let conditionalActionIds: Set<String> = [
-		"download.current"
-	]
 
 	override class func setUp() {
 		super.setUp()
@@ -27,21 +23,37 @@ final class PaletteRowCoverageTests: XCTestCase {
 		setenv("XDG_DATA_HOME", dir, 1)
 	}
 
-	func testEveryPaletteActionHasATitleAndSymbolEntry() throws {
+	/// Every action exposes a non-empty symbol + searchTitle. A blank symbol
+	/// renders an empty icon column; a blank searchTitle makes the verb
+	/// impossible to find by typing.
+	func testEveryPaletteActionHasSymbolAndSearchTitle() throws {
 		let model = try AppModel()
-		let actionIds = Set(model.paletteActions.map(\.id))
-			.union(Self.conditionalActionIds)
+		for action in model.paletteActions {
+			XCTAssertFalse(
+				action.symbol.isEmpty,
+				"action \(action.id) has an empty symbol"
+			)
+			XCTAssertFalse(
+				action.searchTitle.isEmpty,
+				"action \(action.id) has an empty searchTitle"
+			)
+		}
+	}
 
-		let titleKeys = Set(PaletteRow.actionTitleById.keys)
-		XCTAssertTrue(
-			actionIds.isSubset(of: titleKeys),
-			"actions missing from actionTitleById: \(actionIds.subtracting(titleKeys))"
-		)
-
-		let symbolKeys = Set(PaletteRow.actionSymbolById.keys)
-		XCTAssertTrue(
-			actionIds.isSubset(of: symbolKeys),
-			"actions missing from actionSymbolById: \(actionIds.subtracting(symbolKeys))"
-		)
+	/// `searchTitle` must stay in lockstep with the displayed `title`. The two
+	/// are separate fields (one plain `String`, one `LocalizedStringKey`)
+	/// because `LocalizedStringKey` can't be read back as a string; this guard
+	/// is the contract that they don't silently diverge. We compare against
+	/// the `LocalizedStringKey` built from `searchTitle` — equal keys mean the
+	/// search text matches the (unlocalized) display literal.
+	func testSearchTitleMatchesDisplayTitle() throws {
+		let model = try AppModel()
+		for action in model.paletteActions {
+			XCTAssertEqual(
+				action.title,
+				LocalizedStringKey(action.searchTitle),
+				"action \(action.id): searchTitle '\(action.searchTitle)' drifted from its display title"
+			)
+		}
 	}
 }

--- a/macos/Tests/LyrebirdTests/PinnedStationsHomeTests.swift
+++ b/macos/Tests/LyrebirdTests/PinnedStationsHomeTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the Home "Pinned Stations" row (#253) becoming a real reader
+/// of the genre pin-to-home write path.
+///
+/// Before this fix `HomeView.pinnedStationsRow` was defined but never mounted
+/// in `body`, while `AppModel.pinGenreToHome` (reachable from the genre Pin
+/// button and the genre context menu) kept writing pins into
+/// `PinnedStationsStore`. That is a write path with no reader. These tests pin
+/// the now-load-bearing contracts:
+///
+///   1. A genre pinned via `pinGenreToHome` lands in `PinnedStationsStore`,
+///      which is exactly the slice `pinnedStationsRow` decodes and renders.
+///   2. The dedupe + 6-entry cap that keeps the row bounded.
+///   3. `PinnedStationsStore.defaultsKey` matches the `@AppStorage` key the
+///      Home row reads ("pinned_stations") — a silent rename would desync the
+///      writer (`AppModel`) from the reader (`HomeView`) and make every pin
+///      vanish again, which is the very regression this fix closes.
+///   4. `startStationRadio(seedId:)`, the routing entry point the row uses for
+///      artist / mood / mix tiles, exists and is callable.
+///
+/// `AppModel` is `@MainActor` and boots a live core, so the suite is
+/// main-actor isolated and redirects the core's data dir to a throwaway temp
+/// dir via `XDG_DATA_HOME`. Persistence runs against the standard
+/// `UserDefaults` domain, so each test scrubs the key before and after to stay
+/// hermetic (same pattern as `PaletteRecentPinnedTests`).
+@MainActor
+final class PinnedStationsHomeTests: XCTestCase {
+
+    private let pinnedKey = PinnedStationsStore.defaultsKey
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-pinned-stations-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: pinnedKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: pinnedKey)
+        super.tearDown()
+    }
+
+    // MARK: - Write path now has a reader
+
+    /// Pinning a genre persists a `.genre` station into the store the Home row
+    /// reads. The genre's `id` doubles as its `title` because `Genre(name:)`
+    /// sets `id == name`.
+    func testPinGenrePersistsIntoStore() throws {
+        let model = try AppModel()
+        model.pinGenreToHome(genre: Genre(name: "Jazz"))
+
+        let stations = PinnedStationsStore.load()
+        XCTAssertEqual(stations.count, 1)
+        let station = try XCTUnwrap(stations.first)
+        XCTAssertEqual(station.type, .genre)
+        XCTAssertEqual(station.title, "Jazz")
+        XCTAssertEqual(station.id, "Jazz")
+    }
+
+    /// The most-recently pinned genre lands at the front so the row reads
+    /// newest-first.
+    func testPinGenreInsertsAtFront() throws {
+        let model = try AppModel()
+        model.pinGenreToHome(genre: Genre(name: "Jazz"))
+        model.pinGenreToHome(genre: Genre(name: "Soul"))
+
+        XCTAssertEqual(PinnedStationsStore.load().map(\.title), ["Soul", "Jazz"])
+    }
+
+    /// Re-pinning an already-pinned genre promotes it to the front rather than
+    /// duplicating it — the row never shows the same genre twice.
+    func testPinGenreDedupesAndPromotes() throws {
+        let model = try AppModel()
+        model.pinGenreToHome(genre: Genre(name: "Jazz"))
+        model.pinGenreToHome(genre: Genre(name: "Soul"))
+        model.pinGenreToHome(genre: Genre(name: "Jazz"))
+
+        XCTAssertEqual(PinnedStationsStore.load().map(\.title), ["Jazz", "Soul"])
+    }
+
+    /// The store keeps at most six pins so the Home shelf stays bounded; the
+    /// oldest pin falls off the end.
+    func testPinGenreCapsAtSix() throws {
+        let model = try AppModel()
+        for name in ["A", "B", "C", "D", "E", "F", "G"] {
+            model.pinGenreToHome(genre: Genre(name: name))
+        }
+
+        let titles = PinnedStationsStore.load().map(\.title)
+        XCTAssertEqual(titles.count, 6)
+        XCTAssertEqual(titles, ["G", "F", "E", "D", "C", "B"])
+        XCTAssertFalse(titles.contains("A"), "the oldest pin must be evicted past the cap")
+    }
+
+    // MARK: - Writer/reader key contract
+
+    /// `HomeView` reads the row via `@AppStorage(PinnedStationsStore.defaultsKey)`
+    /// and `AppModel` writes via `PinnedStationsStore.save`. Both sides resolve
+    /// to this one on-disk key; renaming it silently desyncs them and re-opens
+    /// the "pins vanish" bug, so the literal is pinned here.
+    func testPersistedKeyIsStable() {
+        XCTAssertEqual(PinnedStationsStore.defaultsKey, "pinned_stations")
+    }
+
+    /// A genre written through `pinGenreToHome` is decodable straight off the
+    /// raw `UserDefaults` blob the `@AppStorage` reader observes — i.e. the
+    /// writer and the Home reader agree on the encoded shape end to end.
+    func testPinIsReadableFromRawDefaultsBlob() throws {
+        let model = try AppModel()
+        model.pinGenreToHome(genre: Genre(name: "Ambient"))
+
+        let data = try XCTUnwrap(UserDefaults.standard.data(forKey: pinnedKey))
+        let decoded = try JSONDecoder().decode([PinnedStation].self, from: data)
+        XCTAssertEqual(decoded.map(\.title), ["Ambient"])
+    }
+
+    // MARK: - Station-tap routing entry point
+
+    /// The artist / mood / mix tiles route through `startStationRadio(seedId:)`.
+    /// It must exist and run without throwing for an arbitrary seed id (the
+    /// async instant-mix FFI it kicks off is fire-and-forget; we only assert
+    /// the synchronous entry point is wired and callable).
+    func testStartStationRadioIsCallable() throws {
+        let model = try AppModel()
+        model.startStationRadio(seedId: "seed-artist-1")
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlayPauseSpaceDecisionTests.swift
+++ b/macos/Tests/LyrebirdTests/PlayPauseSpaceDecisionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the bare-Space Play/Pause decision (audit L383). The old
+/// menu-level ⎵ shortcut fired even while a text field was focused, swallowing
+/// the space the user meant to type. The replacement routes Space through an
+/// `NSEvent` monitor whose pure decision lives in `PlayPauseSpaceDecision`; this
+/// asserts each branch of that decision so the regression can't silently return.
+final class PlayPauseSpaceDecisionTests: XCTestCase {
+
+    /// Plain Space with a track loaded and no text field focused → toggle.
+    func testTogglesWhenIdleWithTrackLoaded() {
+        XCTAssertEqual(
+            PlayPauseSpaceDecision.decide(
+                hasModifiers: false,
+                isTextEditing: false,
+                hasCurrentTrack: true
+            ),
+            .togglePlayback
+        )
+    }
+
+    /// The core regression: while editing text, Space must type, never toggle —
+    /// even with a track loaded.
+    func testPassesThroughWhileEditingText() {
+        XCTAssertEqual(
+            PlayPauseSpaceDecision.decide(
+                hasModifiers: false,
+                isTextEditing: true,
+                hasCurrentTrack: true
+            ),
+            .passThrough,
+            "Space in a focused text field must type a space, not toggle playback"
+        )
+    }
+
+    /// Nothing loaded → nothing to toggle; don't eat the key.
+    func testPassesThroughWhenNoTrackLoaded() {
+        XCTAssertEqual(
+            PlayPauseSpaceDecision.decide(
+                hasModifiers: false,
+                isTextEditing: false,
+                hasCurrentTrack: false
+            ),
+            .passThrough
+        )
+    }
+
+    /// A modified Space (e.g. ⌥Space) is never a transport toggle.
+    func testPassesThroughWithModifiers() {
+        XCTAssertEqual(
+            PlayPauseSpaceDecision.decide(
+                hasModifiers: true,
+                isTextEditing: false,
+                hasCurrentTrack: true
+            ),
+            .passThrough
+        )
+    }
+
+    /// Modifier + text editing also passes through (both reasons hold).
+    func testPassesThroughWithModifiersWhileEditing() {
+        XCTAssertEqual(
+            PlayPauseSpaceDecision.decide(
+                hasModifiers: true,
+                isTextEditing: true,
+                hasCurrentTrack: true
+            ),
+            .passThrough
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaybackBehaviorPreferencesTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaybackBehaviorPreferencesTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Coverage for the #116 playback-behaviour preferences that are now wired
+/// into the engine / queue rather than persisting a value nothing reads:
+///
+/// - **Gapless playback** (`playback.gaplessEnabled`) gates
+///   `AppModel.armNextTrackPreload`. Default-on (an unset key must read
+///   `true`, not `bool(forKey:)`'s `false`); when off the engine is never
+///   handed a queued-ahead item.
+/// - **Stop after current track** (`playback.stopAfterCurrent`) is a one-shot:
+///   `consumeStopAfterCurrent()` returns `true` exactly once then disarms, and
+///   starting a fresh queue via `play(tracks:)` resets a leftover arming —
+///   matching the toggle's "Resets to off the next time you start playback".
+///
+/// `AppModel` is `@MainActor`, so the suite is main-actor isolated.
+/// Constructing it boots a live `LyrebirdCore`; the data dir is redirected to a
+/// throwaway temp dir via `XDG_DATA_HOME` so tests never touch the real app
+/// database — same pattern as `AutoplayWhenQueueEndsTests` /
+/// `AppModelAdvancePreloadTests`. Both keys live in the standard `UserDefaults`
+/// domain shared with `AppModelAdvancePreloadTests` (which relies on gapless
+/// defaulting on), so each test scrubs them before and after to stay hermetic.
+@MainActor
+final class PlaybackBehaviorPreferencesTests: XCTestCase {
+
+    /// Persisted keys, kept in sync with `PreferencesPlayback`'s `@AppStorage`
+    /// and `AppModel`'s private key constants. If those strings drift, the
+    /// gating here goes stale, so this suite pins the contract.
+    private let gaplessKey = "playback.gaplessEnabled"
+    private let stopAfterKey = "playback.stopAfterCurrent"
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-playback-prefs-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        // A stale value would mask the default-on / default-off probes and
+        // could leak into sibling suites that share `UserDefaults.standard`.
+        UserDefaults.standard.removeObject(forKey: gaplessKey)
+        UserDefaults.standard.removeObject(forKey: stopAfterKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: gaplessKey)
+        UserDefaults.standard.removeObject(forKey: stopAfterKey)
+        super.tearDown()
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - Gapless default-on contract
+
+    /// With the key never written, `gaplessEnabled` must read `true`. A naive
+    /// `bool(forKey:)` would return `false` and silently disable gapless for
+    /// everyone who never opened the pane.
+    func testGaplessDefaultsToOnWhenKeyUnset() throws {
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: gaplessKey),
+            "precondition: key must be unset for the default probe"
+        )
+        XCTAssertTrue(AppModel.gaplessEnabled, "an unset gapless preference must default to on")
+    }
+
+    func testGaplessHonoursPersistedOff() throws {
+        UserDefaults.standard.set(false, forKey: gaplessKey)
+        XCTAssertFalse(AppModel.gaplessEnabled, "a persisted opt-out must be restored, not reset to the default")
+    }
+
+    // MARK: - Gapless gates the engine pre-load
+
+    /// Default-on: arming runs through to the engine and pre-loads the track
+    /// after the current one — the #931 behaviour, unchanged when gapless is
+    /// left at its default.
+    func testArmPreloadRunsWhenGaplessDefaultOn() throws {
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertEqual(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "t1",
+            "with gapless on (default), arming must pre-load the next track"
+        )
+    }
+
+    /// Gapless off: arming must be a no-op — the engine is never handed a
+    /// queued-ahead item, so each track ends cleanly before the next is built.
+    /// This is the bug the audit flagged: the toggle previously did nothing
+    /// because preload ran unconditionally.
+    func testArmPreloadIsSuppressedWhenGaplessOff() throws {
+        UserDefaults.standard.set(false, forKey: gaplessKey)
+
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+        model.armNextTrackPreloadForTesting()
+
+        XCTAssertNil(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "with gapless off, arming must not hand the engine a pre-loaded item"
+        )
+    }
+
+    /// The normal end-of-track advance seam must also honour the gapless flag:
+    /// with gapless off the playhead still advances (the queue keeps playing)
+    /// but no item is pre-loaded for the following transition.
+    func testAdvanceDoesNotPreloadWhenGaplessOff() throws {
+        UserDefaults.standard.set(false, forKey: gaplessKey)
+
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1"), makeTrack("t2")], startIndex: 0)
+        let landed = model.advanceAndArmPreloadForTesting()
+
+        XCTAssertEqual(landed?.id, "t1", "advance must still move the playhead even with gapless off")
+        XCTAssertNil(
+            model.audio.lastPreloadedTrackIdForTesting,
+            "gapless off must suppress the pre-load on a normal advance too"
+        )
+    }
+
+    // MARK: - Stop after current track (one-shot)
+
+    /// Default-off: an unset key reads `false`, so `consumeStopAfterCurrent`
+    /// returns `false` and the queue advances normally.
+    func testStopAfterCurrentDefaultsOff() throws {
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: stopAfterKey),
+            "precondition: key must be unset"
+        )
+        XCTAssertFalse(
+            AppModel.consumeStopAfterCurrent(),
+            "an unset stop-after-current key must not halt playback"
+        )
+    }
+
+    /// Armed: the first consume returns `true` (caller stops), and the key is
+    /// cleared so the *next* end-of-track transition advances normally — the
+    /// one-shot contract the audit required.
+    func testStopAfterCurrentIsConsumedExactlyOnce() throws {
+        UserDefaults.standard.set(true, forKey: stopAfterKey)
+
+        XCTAssertTrue(AppModel.consumeStopAfterCurrent(), "first end-of-track must honour the armed stop")
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: stopAfterKey),
+            "honouring the stop must disarm the toggle"
+        )
+        XCTAssertFalse(
+            AppModel.consumeStopAfterCurrent(),
+            "a consumed one-shot must not fire again on the following track"
+        )
+    }
+
+    /// Starting a fresh queue disarms a leftover stop-after-current — "Resets
+    /// to off the next time you start playback." Without this an arming left
+    /// over from a previous session would stop the user one track into a brand
+    /// new queue.
+    func testPlayResetsStopAfterCurrent() throws {
+        UserDefaults.standard.set(true, forKey: stopAfterKey)
+
+        let model = try AppModel()
+        model.audio.installEmptyPlayerForTesting()
+        model.play(tracks: [makeTrack("t0"), makeTrack("t1")], startIndex: 0)
+
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: stopAfterKey),
+            "starting playback must reset a leftover stop-after-current arming"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaylistDetailInteractionTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistDetailInteractionTests.swift
@@ -1,0 +1,183 @@
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Pure-logic coverage for the `PlaylistDetailView` interaction fixes (2.0
+/// polish audit): the drop-to-add payload parser that drives drop acceptance
+/// and error surfacing (#236), and the row-click selection arithmetic the view
+/// shares with `LibraryView` (#74 / #236).
+///
+/// These are deliberately View-, FFI-, and `AppModel`-free — the row-click glue
+/// in `PlaylistDetailView.handleRowClick` now delegates to the same
+/// `TrackSelectionResolver.resolve` exercised here, so the out-of-bounds (stale
+/// index) guard and the Cmd-over-Shift precedence are locked down without a
+/// SwiftUI scene graph.
+final class PlaylistDetailInteractionTests: XCTestCase {
+
+    // MARK: - Drop payload parsing (drop acceptance + empty-ids branch)
+
+    func testParseTrackIdsReadsJSONArray() {
+        let data = Data(#"["id-1","id-2","id-3"]"#.utf8)
+        XCTAssertEqual(PlaylistDropPayload.parseTrackIds(from: data), ["id-1", "id-2", "id-3"])
+    }
+
+    func testParseTrackIdsReadsNewlineSeparatedText() {
+        let data = Data("id-1\nid-2\n  id-3  \n".utf8)
+        XCTAssertEqual(PlaylistDropPayload.parseTrackIds(from: data), ["id-1", "id-2", "id-3"])
+    }
+
+    func testParseTrackIdsSkipsBlankJSONEntries() {
+        let data = Data(#"["id-1","   ","id-2"]"#.utf8)
+        XCTAssertEqual(PlaylistDropPayload.parseTrackIds(from: data), ["id-1", "id-2"])
+    }
+
+    func testParseTrackIdsReturnsEmptyForBlankText() {
+        // An all-whitespace / empty payload yields no ids — the signal
+        // `handleDroppedPayload` uses to surface the "no tracks to add" error
+        // instead of firing an empty add.
+        XCTAssertTrue(PlaylistDropPayload.parseTrackIds(from: Data("\n   \n".utf8)).isEmpty)
+        XCTAssertTrue(PlaylistDropPayload.parseTrackIds(from: Data()).isEmpty)
+    }
+
+    func testParseTrackIdsIgnoresNonStringJSON() {
+        // A JSON object / number array isn't a `[String]`, so it falls through
+        // to the newline path and (finding nothing line-like) yields nothing
+        // usable beyond the raw blob — never a crash.
+        let data = Data(#"{"ids":["a"]}"#.utf8)
+        // The object serializes to a single non-id line; what matters is it
+        // does not decode as a string array, so no structured ids come back.
+        XCTAssertEqual(PlaylistDropPayload.parseTrackIds(from: data), [#"{"ids":["a"]}"#])
+    }
+
+    // MARK: - Row-click bounds safety (stale index → no-op, no crash)
+
+    func testStaleIndexBeyondShrunkListIsRejected() {
+        // Simulates the L337 crash setup: a row's index was captured at render
+        // time as 4, but the array shrank to 2 entries before the click landed.
+        // The resolver returns nil so `handleRowClick` does nothing instead of
+        // force-indexing `tracks[4]`.
+        let shrunk = ["a", "b"]
+        XCTAssertNil(
+            TrackSelectionResolver.resolve(
+                clickedIndex: 4,
+                trackIds: shrunk,
+                currentSelection: ["a"],
+                anchorIndex: 0,
+                modifiers: []
+            )
+        )
+    }
+
+    func testBareClickWithinBoundsPlaysAndClears() {
+        let ids = ["a", "b", "c"]
+        let outcome = TrackSelectionResolver.resolve(
+            clickedIndex: 1,
+            trackIds: ids,
+            currentSelection: ["a", "c"],
+            anchorIndex: 0,
+            modifiers: []
+        )
+        XCTAssertEqual(outcome, .init(selection: [], anchorIndex: 1, shouldPlay: true))
+    }
+
+    // MARK: - Multiselect precedence (the L603 .gesture fix's contract)
+
+    func testCommandClickTogglesWithoutPlaying() {
+        // The whole point of the `.gesture` (not `.simultaneousGesture`) fix:
+        // a Cmd+Click must toggle selection only — never also play+clear.
+        let ids = ["a", "b", "c"]
+        let outcome = TrackSelectionResolver.resolve(
+            clickedIndex: 2,
+            trackIds: ids,
+            currentSelection: ["a"],
+            anchorIndex: 0,
+            modifiers: .command
+        )
+        XCTAssertEqual(outcome, .init(selection: ["a", "c"], anchorIndex: 2, shouldPlay: false))
+        XCTAssertFalse(outcome?.shouldPlay ?? true)
+    }
+
+    func testCommandTakesPrecedenceWhenCmdAndShiftBothHeld() {
+        let ids = ["a", "b", "c", "d"]
+        let outcome = TrackSelectionResolver.resolve(
+            clickedIndex: 3,
+            trackIds: ids,
+            currentSelection: ["a"],
+            anchorIndex: 0,
+            modifiers: [.command, .shift]
+        )
+        // Cmd checked first → single-row toggle, not a range extend.
+        XCTAssertEqual(outcome, .init(selection: ["a", "d"], anchorIndex: 3, shouldPlay: false))
+    }
+}
+
+/// `AppModel`-level coverage for the `loadPlaylistTracks` cache contract that
+/// backs the drop-to-add list refresh (#236). `AppModel` is `@MainActor` and
+/// boots a live (logged-out) `LyrebirdCore`; the data dir is redirected to a
+/// throwaway temp dir so the test never touches the real app database and the
+/// cache-hit path resolves without any network round trip.
+@MainActor
+final class PlaylistTracksCacheTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(id: String) -> Track {
+        Track(
+            id: id,
+            name: "Track \(id)",
+            albumId: "alb-1",
+            albumName: "Album",
+            artistName: "Artist",
+            artistId: "art-1",
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 1_000_000_000,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: "pli-\(id)",
+            userData: nil
+        )
+    }
+
+    /// A cached playlist resolves into `currentPlaylistTracks` synchronously,
+    /// without hitting the network — the fast path the detail view relies on
+    /// when switching back to a playlist (unchanged by the `forceRefresh` add).
+    func testLoadPlaylistTracksServesFromCacheWhenNotForced() async throws {
+        let model = try AppModel()
+        let cached = [makeTrack(id: "1"), makeTrack(id: "2")]
+        model.playlistTracks["pl-1"] = cached
+        model.currentPlaylistTracks = []
+
+        await model.loadPlaylistTracks(playlistId: "pl-1")
+
+        XCTAssertEqual(model.currentPlaylistTracks.map(\.id), ["1", "2"])
+        // Cache untouched and no error raised on the happy cache-hit path.
+        XCTAssertEqual(model.playlistTracks["pl-1"]?.map(\.id), ["1", "2"])
+        XCTAssertNil(model.errorMessage)
+    }
+
+    /// `forceRefresh: true` must bypass the cache. Logged out, the underlying
+    /// fetch fails, so the stale cache value is NOT promoted into
+    /// `currentPlaylistTracks` — proving the early cache return was skipped.
+    func testForceRefreshBypassesCache() async throws {
+        let model = try AppModel()
+        model.playlistTracks["pl-2"] = [makeTrack(id: "9")]
+        model.currentPlaylistTracks = []
+
+        await model.loadPlaylistTracks(playlistId: "pl-2", forceRefresh: true)
+
+        // The cache short-circuit was skipped, so the (failed, logged-out)
+        // fetch left currentPlaylistTracks empty rather than serving "9".
+        XCTAssertTrue(model.currentPlaylistTracks.isEmpty)
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaylistExportTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistExportTests.swift
@@ -134,6 +134,93 @@ final class PlaylistExportTests: XCTestCase {
         XCTAssertEqual(out, "#EXTM3U\n#PLAYLIST:Empty\n")
     }
 
+    // MARK: - M3U: playable (authenticated) stream URLs
+
+    /// With an `apiKey`, entries must use the static-download `/stream` form
+    /// with the key embedded so an external player can fetch them from the URL
+    /// alone. A bare `/universal` path requires the Authorization header and
+    /// 401s for a generic M3U player, which is the bug this fixes (#237).
+    func testM3UWithApiKeyEmitsPlayableStreamURL() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "abc", name: "Song")],
+            serverURL: "https://music.example.com",
+            apiKey: "TOKEN123"
+        )
+        XCTAssertTrue(out.contains("https://music.example.com/Audio/abc/stream.mp3?api_key=TOKEN123&Static=true"))
+        // The non-playable bare universal path must NOT be emitted when a key
+        // is available.
+        XCTAssertFalse(out.contains("/Audio/abc/universal"))
+    }
+
+    /// The stream URL extension follows the track's source container so the
+    /// receiving player gets a correct content-type hint.
+    func testM3UStreamExtensionFollowsTrackContainer() {
+        let track = Track(
+            id: "x", name: "T", albumId: nil, albumName: nil,
+            artistName: "A", artistId: nil, indexNumber: nil, discNumber: nil,
+            year: nil, runtimeTicks: 0, isFavorite: false, playCount: 0,
+            container: "FLAC", bitrate: nil, imageTag: nil,
+            playlistItemId: nil, userData: nil
+        )
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix", tracks: [track],
+            serverURL: "https://m.example.com", apiKey: "K"
+        )
+        // Container is lower-cased into the extension hint.
+        XCTAssertTrue(out.contains("/Audio/x/stream.flac?api_key=K&Static=true"))
+    }
+
+    /// An unknown container falls back to a `.mp3` extension hint.
+    func testM3UStreamExtensionDefaultsToMP3WhenContainerUnknown() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "y", name: "T")],  // fixture has container: nil
+            serverURL: "https://m.example.com",
+            apiKey: "K"
+        )
+        XCTAssertTrue(out.contains("/Audio/y/stream.mp3?api_key=K&Static=true"))
+    }
+
+    /// A token with URL-significant characters is percent-encoded so the query
+    /// string stays well-formed.
+    func testM3UApiKeyIsPercentEncoded() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "z", name: "T")],
+            serverURL: "https://m.example.com",
+            apiKey: "a b&c"
+        )
+        XCTAssertTrue(out.contains("api_key=a%20b%26c"))
+        XCTAssertFalse(out.contains("api_key=a b&c"))
+    }
+
+    /// Backward-compatible: with no `apiKey` (the default), entries stay on the
+    /// auth-free bare universal path — a well-formed file that prompts for auth
+    /// in the player rather than embedding a credential.
+    func testM3UWithoutApiKeyKeepsAuthFreeUniversalPath() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "abc", name: "Song")],
+            serverURL: "https://music.example.com"
+        )
+        XCTAssertTrue(out.contains("https://music.example.com/Audio/abc/universal"))
+        XCTAssertFalse(out.lowercased().contains("api_key"))
+    }
+
+    /// An empty `apiKey` is treated as "no key" — the bare path, not a
+    /// dangling `?api_key=&Static=true`.
+    func testM3UEmptyApiKeyFallsBackToUniversalPath() {
+        let out = PlaylistExport.m3u8(
+            playlistName: "Mix",
+            tracks: [makeTrack(id: "abc", name: "Song")],
+            serverURL: "https://music.example.com",
+            apiKey: ""
+        )
+        XCTAssertTrue(out.contains("/Audio/abc/universal"))
+        XCTAssertFalse(out.contains("api_key="))
+    }
+
     // MARK: - JSON
 
     func testJSONRoundTripsThroughManifest() throws {

--- a/macos/Tests/LyrebirdTests/PlaylistReorderHandleTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistReorderHandleTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for drag-to-reorder of tracks inside a playlist (#73 / #235).
+///
+/// Two surfaces:
+///   * `PlaylistReorderPayload` — the pure `"<index>|<trackId>"` drag-payload
+///     codec. The source index is what makes a *duplicated* track move
+///     correctly, so the codec is pinned independently of the model.
+///   * `AppModel.applyPlaylistDrop(playlistId:sourceIndex:destinationIndex:)` —
+///     the index-addressed drop path. The regression it fixes: when the same
+///     track id appears more than once in a playlist, resolving the moved row
+///     by id alone always grabs the *first* copy, so dragging a later copy
+///     moved the wrong one. Routing by index moves the exact copy grabbed.
+///
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore`; we redirect the
+/// core's data dir to a throwaway temp via `XDG_DATA_HOME` (the same hermetic
+/// setup `AutoplayWhenQueueEndsTests` uses) so the test never touches the real
+/// app DB. The drop only mutates the in-memory `playlistTracks` cache
+/// synchronously before kicking off the (here unauthenticated, harmless)
+/// server round-trip, so the local-order assertions are deterministic.
+@MainActor
+final class PlaylistReorderHandleTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Payload codec
+
+    func testPayloadEncodeJoinsIndexAndId() {
+        XCTAssertEqual(PlaylistReorderPayload.encode(index: 3, trackId: "abc"), "3|abc")
+    }
+
+    func testPayloadDecodeSplitsIndexAndId() {
+        let parsed = PlaylistReorderPayload.decode("3|abc")
+        XCTAssertEqual(parsed.sourceIndex, 3)
+        XCTAssertEqual(parsed.trackId, "abc")
+    }
+
+    func testPayloadEncodeDecodeRoundTrip() {
+        let parsed = PlaylistReorderPayload.decode(
+            PlaylistReorderPayload.encode(index: 0, trackId: "track-xyz")
+        )
+        XCTAssertEqual(parsed.sourceIndex, 0)
+        XCTAssertEqual(parsed.trackId, "track-xyz")
+    }
+
+    /// A track id that itself contains a `|` must survive: only the *first*
+    /// separator delimits the index, so the id keeps its remaining pipes.
+    func testPayloadDecodeSplitsOnlyOnFirstSeparator() {
+        let parsed = PlaylistReorderPayload.decode("5|weird|id|with|pipes")
+        XCTAssertEqual(parsed.sourceIndex, 5)
+        XCTAssertEqual(parsed.trackId, "weird|id|with|pipes")
+    }
+
+    /// A legacy payload that's a bare track id (no separator) decodes with a
+    /// nil index so the caller falls back to id-based resolution.
+    func testPayloadDecodeBareIdYieldsNilIndex() {
+        let parsed = PlaylistReorderPayload.decode("just-an-id")
+        XCTAssertNil(parsed.sourceIndex)
+        XCTAssertEqual(parsed.trackId, "just-an-id")
+    }
+
+    /// A non-integer leading segment is not a valid index, so it falls back to
+    /// the id path rather than silently moving row 0.
+    func testPayloadDecodeNonIntegerIndexYieldsNilIndex() {
+        let parsed = PlaylistReorderPayload.decode("notanumber|abc")
+        XCTAssertNil(parsed.sourceIndex)
+        XCTAssertEqual(parsed.trackId, "abc")
+    }
+
+    // MARK: - applyPlaylistDrop (index-addressed) — duplicate-track fix
+
+    /// The regression: a playlist with the *same* track id at two positions.
+    /// Dragging the second copy (index 2) to the front must move *that* copy,
+    /// identified by its distinct `playlistItemId`, not the first copy at
+    /// index 0. The id-based path would have moved index 0 instead.
+    func testApplyPlaylistDropByIndexMovesTheGrabbedDuplicate() throws {
+        let model = try AppModel()
+        let playlistId = "pl-dup"
+        // Order: A(dup, item-1), B(item-2), A(dup, item-3)
+        model.playlistTracks[playlistId] = [
+            track(id: "A", playlistItemId: "item-1"),
+            track(id: "B", playlistItemId: "item-2"),
+            track(id: "A", playlistItemId: "item-3"),
+        ]
+
+        // Drag the *second* "A" (index 2) to the top (destination 0).
+        model.applyPlaylistDrop(playlistId: playlistId, sourceIndex: 2, destinationIndex: 0)
+
+        let result = model.playlistTracks[playlistId] ?? []
+        // The moved copy must be item-3 (the one the user grabbed), landing
+        // first — item-1 stays put relative to B.
+        XCTAssertEqual(result.map(\.playlistItemId), ["item-3", "item-1", "item-2"])
+        XCTAssertEqual(result.map(\.id), ["A", "A", "B"])
+    }
+
+    /// The first copy moves independently of the second when *it* is grabbed.
+    func testApplyPlaylistDropByIndexMovesFirstDuplicateToEnd() throws {
+        let model = try AppModel()
+        let playlistId = "pl-dup2"
+        model.playlistTracks[playlistId] = [
+            track(id: "A", playlistItemId: "item-1"),
+            track(id: "B", playlistItemId: "item-2"),
+            track(id: "A", playlistItemId: "item-3"),
+        ]
+
+        // Drag the *first* "A" (index 0) to the end (destination 3 = past last).
+        model.applyPlaylistDrop(playlistId: playlistId, sourceIndex: 0, destinationIndex: 3)
+
+        let result = model.playlistTracks[playlistId] ?? []
+        XCTAssertEqual(result.map(\.playlistItemId), ["item-2", "item-3", "item-1"])
+    }
+
+    /// An out-of-range source index (e.g. a stale snapshot from a list that
+    /// mutated mid-drag) is a safe no-op rather than a move of the wrong row.
+    func testApplyPlaylistDropByIndexIgnoresOutOfRangeIndex() throws {
+        let model = try AppModel()
+        let playlistId = "pl-oob"
+        let original = [
+            track(id: "A", playlistItemId: "item-1"),
+            track(id: "B", playlistItemId: "item-2"),
+        ]
+        model.playlistTracks[playlistId] = original
+
+        model.applyPlaylistDrop(playlistId: playlistId, sourceIndex: 9, destinationIndex: 0)
+
+        XCTAssertEqual(model.playlistTracks[playlistId]?.map(\.playlistItemId),
+                       original.map(\.playlistItemId),
+                       "an out-of-range source index must leave the order untouched")
+    }
+
+    // MARK: - Fixture
+
+    private func track(id: String, playlistItemId: String) -> Track {
+        Track(
+            id: id,
+            name: "Track \(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: playlistItemId,
+            userData: nil
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/PreferencesAdvancedCacheTests.swift
+++ b/macos/Tests/LyrebirdTests/PreferencesAdvancedCacheTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `PreferencesAdvanced`'s "Clear Caches" filesystem contract.
+///
+/// The earlier implementation recursively deleted the entire user caches
+/// root, which also destroyed offline downloads stored at `Caches/Downloads`
+/// (see `PreferencesDownloads`) — a p0 because the dialog explicitly promises
+/// the library isn't affected. The fix narrows the clear to the artwork
+/// `DataCache` subdirectory and surfaces failures instead of always reporting
+/// success. These tests pin three invariants:
+///
+///  1. The operation never targets the caches root or a downloads store.
+///  2. Clearing the artwork directory leaves a sibling `Downloads` intact.
+///  3. Failures and degenerate inputs produce honest `Result` outcomes.
+final class PreferencesAdvancedCacheTests: XCTestCase {
+
+    private let fm = FileManager.default
+
+    /// Make a throwaway directory tree mirroring the sandbox shape:
+    /// `…/<root>/Caches/<artwork>` alongside `…/<root>/Caches/Downloads`.
+    private func makeCachesTree() throws -> (caches: URL, artwork: URL, downloads: URL) {
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("PrefAdvCacheTests-\(UUID().uuidString)", isDirectory: true)
+        let caches = root.appendingPathComponent("Caches", isDirectory: true)
+        let artwork = caches.appendingPathComponent("com.lyrebird.macos.artwork", isDirectory: true)
+        let downloads = caches.appendingPathComponent("Downloads", isDirectory: true)
+        try fm.createDirectory(at: artwork, withIntermediateDirectories: true)
+        try fm.createDirectory(at: downloads, withIntermediateDirectories: true)
+        return (caches, artwork, downloads)
+    }
+
+    // MARK: - Safety guard
+
+    /// The guard must reject the caches root itself so a config drift can never
+    /// turn the clear back into the download-destroying recursive nuke.
+    func testGuardRejectsCachesRoot() {
+        let caches = URL(fileURLWithPath: "/Users/test/Library/Caches", isDirectory: true)
+        XCTAssertFalse(PreferencesAdvanced.isSafeArtworkCacheDirectory(caches))
+    }
+
+    /// The guard must reject any `Downloads` directory — that's where offline
+    /// tracks live and they must survive a cache clear.
+    func testGuardRejectsDownloadsDirectory() {
+        let downloads = URL(fileURLWithPath: "/Users/test/Library/Caches/Downloads", isDirectory: true)
+        XCTAssertFalse(PreferencesAdvanced.isSafeArtworkCacheDirectory(downloads))
+    }
+
+    /// A named artwork subdirectory is the intended, safe target.
+    func testGuardAllowsNamedArtworkSubdirectory() {
+        let artwork = URL(
+            fileURLWithPath: "/Users/test/Library/Caches/com.lyrebird.macos.artwork",
+            isDirectory: true
+        )
+        XCTAssertTrue(PreferencesAdvanced.isSafeArtworkCacheDirectory(artwork))
+    }
+
+    // MARK: - Clearing behaviour
+
+    /// Clearing the artwork directory removes its contents, recreates the empty
+    /// directory, and — critically — leaves the sibling `Downloads` and its
+    /// contents untouched.
+    func testClearRemovesArtworkButPreservesDownloads() throws {
+        let tree = try makeCachesTree()
+        defer { try? fm.removeItem(at: tree.caches.deletingLastPathComponent()) }
+
+        // Seed both directories with a file so we can prove what survived.
+        let artworkFile = tree.artwork.appendingPathComponent("tile.dat")
+        let downloadFile = tree.downloads.appendingPathComponent("song.flac")
+        try Data("art".utf8).write(to: artworkFile)
+        try Data("audio".utf8).write(to: downloadFile)
+
+        let result = PreferencesAdvanced.clearArtworkCacheDirectory(at: tree.artwork)
+
+        guard case .success = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        // Artwork dir still exists (recreated) but is empty.
+        XCTAssertTrue(fm.fileExists(atPath: tree.artwork.path))
+        XCTAssertFalse(fm.fileExists(atPath: artworkFile.path), "Cached artwork should be gone")
+        let remaining = try fm.contentsOfDirectory(atPath: tree.artwork.path)
+        XCTAssertTrue(remaining.isEmpty, "Artwork dir should be empty after clear")
+
+        // Offline downloads must be completely untouched.
+        XCTAssertTrue(fm.fileExists(atPath: tree.downloads.path), "Downloads dir must survive")
+        XCTAssertTrue(fm.fileExists(atPath: downloadFile.path), "Downloaded track must survive")
+        XCTAssertEqual(try Data(contentsOf: downloadFile), Data("audio".utf8))
+    }
+
+    /// Pointing the clear at the caches root must refuse and remove nothing,
+    /// returning a failure rather than wiping the tree.
+    func testClearRefusesCachesRootAndRemovesNothing() throws {
+        let tree = try makeCachesTree()
+        defer { try? fm.removeItem(at: tree.caches.deletingLastPathComponent()) }
+
+        let downloadFile = tree.downloads.appendingPathComponent("song.flac")
+        try Data("audio".utf8).write(to: downloadFile)
+
+        let result = PreferencesAdvanced.clearArtworkCacheDirectory(at: tree.caches)
+
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected failure for caches root, got \(result)")
+        }
+        XCTAssertTrue(error is PreferencesAdvanced.CacheClearError)
+        // Nothing under the caches root may have been touched.
+        XCTAssertTrue(fm.fileExists(atPath: tree.downloads.path))
+        XCTAssertTrue(fm.fileExists(atPath: downloadFile.path))
+        XCTAssertTrue(fm.fileExists(atPath: tree.artwork.path))
+    }
+
+    /// A `nil` directory (no on-disk cache configured) is a no-op success — the
+    /// in-memory eviction in `clearCaches()` already did the meaningful work.
+    func testClearWithNilDirectoryIsSuccess() {
+        let result = PreferencesAdvanced.clearArtworkCacheDirectory(at: nil)
+        guard case .success = result else {
+            return XCTFail("nil directory should be a no-op success, got \(result)")
+        }
+    }
+
+    /// Clearing a not-yet-created artwork directory still succeeds and leaves an
+    /// empty directory ready for the next write.
+    func testClearCreatesMissingDirectory() throws {
+        let dir = fm.temporaryDirectory
+            .appendingPathComponent("PrefAdvCacheTests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("com.lyrebird.macos.artwork", isDirectory: true)
+        defer { try? fm.removeItem(at: dir.deletingLastPathComponent()) }
+
+        XCTAssertFalse(fm.fileExists(atPath: dir.path))
+        let result = PreferencesAdvanced.clearArtworkCacheDirectory(at: dir)
+        guard case .success = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+        XCTAssertTrue(fm.fileExists(atPath: dir.path), "Directory should be recreated")
+    }
+
+    /// The refusal error carries a user-readable message so the surfaced alert
+    /// isn't blank.
+    func testRefusalErrorHasDescription() {
+        let error = PreferencesAdvanced.CacheClearError.refusedUnsafePath("/tmp/Caches")
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
+    }
+}

--- a/macos/Tests/LyrebirdTests/QueueInspectorActionsTests.swift
+++ b/macos/Tests/LyrebirdTests/QueueInspectorActionsTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+import LyrebirdCore
+
+@testable import Lyrebird
+
+/// Coverage for the Queue Inspector's mutating actions on `AppModel`
+/// (#79 / #80 / #282 / #284):
+///
+///  * `removeFromUpNext(id:)` removes a single addressable instance by its
+///    per-queue `id`, so a track queued twice loses only the tapped row.
+///  * `shuffleUpNext()` honours the short-list guard and preserves the set of
+///    queued tracks (only their order may change).
+///  * `queueJumpPlan(for:)` — the pure index resolver behind the
+///    double-click "jump to track" gesture — flattens the three inspector
+///    sections into play order and lands `startIndex` on the right slot,
+///    correctly accounting for the currently-playing track occupying slot 0.
+///
+/// `AppModel` is `@MainActor` and boots a live `LyrebirdCore`; we redirect the
+/// core data dir to a throwaway temp dir via `XDG_DATA_HOME` so tests never
+/// touch the real database (mirrors `SessionPlayHistoryTests` /
+/// `MiniPlayerStateTests`). The reorder/remove actions also call
+/// `core.setQueue`; with no authenticated session that FFI is a no-op or a
+/// caught throw — the Swift overlay mutation under test still happens, so the
+/// state assertions remain deterministic.
+@MainActor
+final class QueueInspectorActionsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "a-\(id)",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    private func status(currentTrack: Track?) -> PlayerStatus {
+        PlayerStatus(
+            state: currentTrack == nil ? .idle : .playing,
+            currentTrack: currentTrack,
+            positionSeconds: 0,
+            durationSeconds: 0,
+            volume: 1,
+            queuePosition: 0,
+            queueLength: 0,
+            shuffle: false,
+            repeatMode: .off,
+            playSessionId: nil
+        )
+    }
+
+    // MARK: - removeFromUpNext
+
+    func testRemoveFromUpNextDropsTheTargetedInstanceOnly() throws {
+        let model = try AppModel()
+        let keepA = Queue(track: makeTrack("a"))
+        let drop = Queue(track: makeTrack("b"))
+        let keepC = Queue(track: makeTrack("c"))
+        model.upNextUserAdded = [keepA, drop, keepC]
+
+        model.removeFromUpNext(id: drop.id)
+
+        XCTAssertEqual(
+            model.upNextUserAdded.map(\.id),
+            [keepA.id, keepC.id],
+            "only the entry whose queueId was passed should be removed"
+        )
+    }
+
+    /// The whole reason `Queue` carries a per-instance `id` distinct from
+    /// `track.id`: the same track queued twice must be individually
+    /// removable. Removing one instance must leave the other in place.
+    func testRemoveFromUpNextRemovesOneOfTwoIdenticalTracks() throws {
+        let model = try AppModel()
+        let first = Queue(track: makeTrack("dup"))
+        let second = Queue(track: makeTrack("dup"))
+        model.upNextUserAdded = [first, second]
+
+        model.removeFromUpNext(id: first.id)
+
+        XCTAssertEqual(
+            model.upNextUserAdded.map(\.id),
+            [second.id],
+            "removing one instance of a doubly-queued track must keep the other"
+        )
+        XCTAssertEqual(model.upNextUserAdded.first?.track.id, "dup")
+    }
+
+    func testRemoveFromUpNextWithUnknownIdIsANoOp() throws {
+        let model = try AppModel()
+        let a = Queue(track: makeTrack("a"))
+        model.upNextUserAdded = [a]
+
+        model.removeFromUpNext(id: UUID())
+
+        XCTAssertEqual(model.upNextUserAdded.map(\.id), [a.id])
+    }
+
+    // MARK: - shuffleUpNext
+
+    /// One item (or none) is a no-op — the guard keeps the order stable so a
+    /// single-item queue doesn't churn the core queue for nothing.
+    func testShuffleUpNextNoOpsBelowTwoItems() throws {
+        let model = try AppModel()
+        let only = Queue(track: makeTrack("a"))
+        model.upNextUserAdded = [only]
+
+        model.shuffleUpNext()
+
+        XCTAssertEqual(model.upNextUserAdded.map(\.id), [only.id])
+    }
+
+    /// Shuffle may reorder but must never add, drop, or mutate entries — the
+    /// multiset of queued tracks is invariant under shuffle.
+    func testShuffleUpNextPreservesTheSetOfEntries() throws {
+        let model = try AppModel()
+        let entries = (0..<12).map { Queue(track: makeTrack("t\($0)")) }
+        model.upNextUserAdded = entries
+
+        model.shuffleUpNext()
+
+        XCTAssertEqual(
+            Set(model.upNextUserAdded.map(\.id)),
+            Set(entries.map(\.id)),
+            "shuffle must preserve exactly the same queue entries"
+        )
+        XCTAssertEqual(model.upNextUserAdded.count, entries.count)
+    }
+
+    // MARK: - queueJumpPlan (double-click "jump to track")
+
+    /// With a track playing, the current track sits at index 0, so the first
+    /// auto-queue entry resolves to index (1 + userAdded.count).
+    func testJumpPlanAccountsForCurrentTrackAtSlotZero() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: makeTrack("now"))
+        let up1 = Queue(track: makeTrack("u1"))
+        let up2 = Queue(track: makeTrack("u2"))
+        let auto1 = Queue(track: makeTrack("a1"))
+        let auto2 = Queue(track: makeTrack("a2"))
+        model.upNextUserAdded = [up1, up2]
+        model.upNextAutoQueue = [auto1, auto2]
+
+        let plan = try XCTUnwrap(model.queueJumpPlan(for: auto2.id))
+
+        // Flattened order: [now, u1, u2, a1, a2] → a2 is index 4.
+        XCTAssertEqual(plan.startIndex, 4)
+        XCTAssertEqual(plan.tracks.map(\.id), ["now", "u1", "u2", "a1", "a2"])
+        XCTAssertEqual(plan.tracks[plan.startIndex].id, "a2")
+    }
+
+    /// A double-click on a user-added row also resolves — jump isn't limited
+    /// to the auto tail.
+    func testJumpPlanResolvesUserAddedEntry() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: makeTrack("now"))
+        let up1 = Queue(track: makeTrack("u1"))
+        let up2 = Queue(track: makeTrack("u2"))
+        model.upNextUserAdded = [up1, up2]
+
+        let plan = try XCTUnwrap(model.queueJumpPlan(for: up2.id))
+
+        // [now, u1, u2] → u2 is index 2.
+        XCTAssertEqual(plan.startIndex, 2)
+        XCTAssertEqual(plan.tracks[plan.startIndex].id, "u2")
+    }
+
+    /// With nothing playing there's no slot-0 offset, so the first auto entry
+    /// is index 0.
+    func testJumpPlanWithoutCurrentTrackHasNoOffset() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: nil)
+        let auto1 = Queue(track: makeTrack("a1"))
+        let auto2 = Queue(track: makeTrack("a2"))
+        model.upNextAutoQueue = [auto1, auto2]
+
+        let plan = try XCTUnwrap(model.queueJumpPlan(for: auto1.id))
+
+        XCTAssertEqual(plan.startIndex, 0)
+        XCTAssertEqual(plan.tracks.map(\.id), ["a1", "a2"])
+    }
+
+    func testJumpPlanReturnsNilForUnknownEntry() throws {
+        let model = try AppModel()
+        model.status = status(currentTrack: makeTrack("now"))
+        model.upNextAutoQueue = [Queue(track: makeTrack("a1"))]
+
+        XCTAssertNil(
+            model.queueJumpPlan(for: UUID()),
+            "an id not present in any queue section must resolve to nil"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/ReconnectStalenessTests.swift
+++ b/macos/Tests/LyrebirdTests/ReconnectStalenessTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `AppModel.reconnectResultIsStale`, the guard that stops a
+/// wake-from-sleep reconnect probe from grafting stale-server results onto a
+/// session the user switched to while the (off-main, possibly slow) probe was
+/// in flight. The probe snapshots `(url, token)` before suspending; this
+/// predicate decides whether the resolved success may apply.
+final class ReconnectStalenessTests: XCTestCase {
+
+    private let url = "https://music.example.com"
+    private let token = "tok-original"
+
+    /// Unchanged session context: the probe's success applies.
+    func testUnchangedContextIsNotStale() {
+        XCTAssertFalse(
+            AppModel.reconnectResultIsStale(
+                probedURL: url,
+                probedToken: token,
+                currentURL: url,
+                currentToken: token,
+                authExpired: false
+            )
+        )
+    }
+
+    /// User switched servers mid-probe: drop the result.
+    func testServerSwitchIsStale() {
+        XCTAssertTrue(
+            AppModel.reconnectResultIsStale(
+                probedURL: url,
+                probedToken: token,
+                currentURL: "https://other.example.com",
+                currentToken: token,
+                authExpired: false
+            )
+        )
+    }
+
+    /// Re-auth / different account rotated the token mid-probe: drop the result.
+    func testTokenRotationIsStale() {
+        XCTAssertTrue(
+            AppModel.reconnectResultIsStale(
+                probedURL: url,
+                probedToken: token,
+                currentURL: url,
+                currentToken: "tok-rotated",
+                authExpired: false
+            )
+        )
+    }
+
+    /// Signed out mid-probe (no live session → nil token): drop the result.
+    func testSignedOutIsStale() {
+        XCTAssertTrue(
+            AppModel.reconnectResultIsStale(
+                probedURL: url,
+                probedToken: token,
+                currentURL: url,
+                currentToken: nil,
+                authExpired: false
+            )
+        )
+    }
+
+    /// Session marked auth-expired while the probe ran: drop the result so we
+    /// don't fire authenticated refreshes against a dead token.
+    func testAuthExpiredIsStale() {
+        XCTAssertTrue(
+            AppModel.reconnectResultIsStale(
+                probedURL: url,
+                probedToken: token,
+                currentURL: url,
+                currentToken: token,
+                authExpired: true
+            )
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/ReplayGainTests.swift
+++ b/macos/Tests/LyrebirdTests/ReplayGainTests.swift
@@ -111,26 +111,43 @@ final class ReplayGainTests: XCTestCase {
 
     // MARK: - iTunNORM fallback
 
-    func testITunNormParsesFirstTwoFields() {
+    func testITunNormParsesVolumeBases() {
         // 1000 (hex 0x3E8) ≈ 0 dB. A value of 2000 (0x7D0) is twice as loud →
-        // -10*log10(2) ≈ -3.01 dB of attenuation.
-        let db = ReplayGain.iTunNormDb(from: "000007D0 000007D0 00000000 00000000")
+        // -10*log10(2) ≈ -3.01 dB of attenuation. Both base pairs read 2000.
+        let db = ReplayGain.iTunNormDb(from: "000007D0 000007D0 000007D0 000007D0")
         XCTAssertNotNil(db)
         XCTAssertEqual(db ?? .nan, -3.0103, accuracy: 1e-3)
     }
 
-    func testITunNormPicksLessAggressiveChannel() {
+    func testITunNormPicksLoudestChannel() {
         // Left = 0x7D0 (2000 → -3.01 dB), right = 0x3E8 (1000 → 0 dB). The
-        // less-aggressive (smaller magnitude) channel wins so a single hot
-        // channel can't drag the whole track down: 0 dB.
+        // louder channel (more-negative correction) wins so a loud track is
+        // actually attenuated rather than left hot: -3.01 dB.
         let db = ReplayGain.iTunNormDb(from: "000007D0 000003E8")
-        XCTAssertEqual(db ?? .nan, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(db ?? .nan, -3.0103, accuracy: 1e-3)
+    }
+
+    func testITunNormConsidersSecondBasePair() {
+        // First pair is quiet (1000/1000 → 0 dB); the second pair is hot
+        // (4000 → -6.02 dB). The loudest channel across BOTH pairs wins, so the
+        // second (often more reliable) pair is not ignored.
+        let db = ReplayGain.iTunNormDb(from: "000003E8 000003E8 00000FA0 00000FA0")
+        XCTAssertEqual(db ?? .nan, -6.0206, accuracy: 1e-3)
+    }
+
+    func testITunNormFallsBackToSecondPairWhenFirstIsZero() {
+        // First pair reads zero (unmeasured); the second pair carries the real
+        // measurement (2000 → -3.01 dB). Reading both pairs means we don't give
+        // up just because fields 0/1 are 0.
+        let db = ReplayGain.iTunNormDb(from: "00000000 00000000 000007D0 000007D0")
+        XCTAssertEqual(db ?? .nan, -3.0103, accuracy: 1e-3)
     }
 
     func testITunNormRejectsMalformed() {
         XCTAssertNil(ReplayGain.iTunNormDb(from: ""))
         XCTAssertNil(ReplayGain.iTunNormDb(from: "000003E8"))          // only one field
         XCTAssertNil(ReplayGain.iTunNormDb(from: "00000000 00000000")) // both zero
+        XCTAssertNil(ReplayGain.iTunNormDb(from: "00000000 00000000 00000000 00000000")) // all four zero
         XCTAssertNil(ReplayGain.iTunNormDb(from: "ZZ YY"))             // non-hex
     }
 

--- a/macos/Tests/LyrebirdTests/ResumeOnceTests.swift
+++ b/macos/Tests/LyrebirdTests/ResumeOnceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `ResumeOnce`, the one-shot continuation guard that makes the
+/// Dock-badge observer's `withTaskCancellationHandler` safe.
+///
+/// The observer suspends on a `CheckedContinuation` that can be resumed by two
+/// racers: the `withObservationTracking` `onChange` (main actor) and the
+/// `withTaskCancellationHandler` `onCancel` (any thread). A bare
+/// `CheckedContinuation` *traps* on a second resume and *warns/leaks* if never
+/// resumed, so these tests lean on a real `withCheckedContinuation` to assert
+/// the "resume exactly once, never park" contract end-to-end: if the guard
+/// double-resumed, the test would crash; if it failed to resume, the test
+/// would hang and time out.
+final class ResumeOnceTests: XCTestCase {
+
+    /// The common path: install the continuation, then a single `resume()`
+    /// (e.g. an `onChange`) wakes the awaiter exactly once.
+    func testStoreThenResumeWakesAwaiterOnce() async {
+        let box = ResumeOnce()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            box.store(continuation)
+            box.resume()
+        }
+        // Reaching here means the continuation resumed. A second resume must be
+        // an inert no-op rather than a fatal double-resume of the (now consumed)
+        // continuation.
+        box.resume()
+        box.resume()
+    }
+
+    /// Cancellation can fire *before* the continuation is installed (the
+    /// `onCancel` racing ahead of `withCheckedContinuation`'s body). The late
+    /// `store` must resume immediately so the task never parks forever.
+    func testResumeBeforeStoreResumesLateContinuation() async {
+        let box = ResumeOnce()
+        // Simulate onCancel landing first.
+        box.resume()
+        // The body installs its continuation afterwards; it must not hang.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            box.store(continuation)
+        }
+    }
+
+    /// Many concurrent `resume()` callers plus the `store` must still resume the
+    /// continuation exactly once — no trap, no hang. Models the worst-case
+    /// onChange/onCancel collision across threads.
+    func testConcurrentResumeAndStoreResumeExactlyOnce() async {
+        let box = ResumeOnce()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            box.store(continuation)
+            DispatchQueue.concurrentPerform(iterations: 64) { _ in
+                box.resume()
+            }
+        }
+        // Survived the storm without a double-resume trap; further resumes inert.
+        box.resume()
+    }
+
+    /// A `resume()` with no continuation ever stored (e.g. cancellation before
+    /// the loop ever suspends) must be a harmless no-op.
+    func testResumeWithoutStoreIsNoOp() {
+        let box = ResumeOnce()
+        box.resume()
+        box.resume()
+    }
+}

--- a/macos/Tests/LyrebirdTests/SearchPagePaginationTests.swift
+++ b/macos/Tests/LyrebirdTests/SearchPagePaginationTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the full Search page's pagination + scope accounting,
+/// targeting the audit findings on `SearchView` / `AppModel`:
+///
+///  * Playlists are a permanently-empty scope today (`core.search` doesn't
+///    return them) — `bucketSearchResults` must leave the bucket empty and
+///    the scope is gated behind `supportsPlaylistSearch`.
+///  * `searchPageHasMore` / `searchPageExhausted` must settle so the
+///    "Load more" button can't stay live forever when the server's
+///    `TotalRecordCount` counts types we don't page.
+///  * `SearchScope.isServerPaged` distinguishes server-paged scopes
+///    (artists / albums / tracks) from derived / not-yet-paged scopes
+///    (genres / playlists), which must never consult the server signal.
+///  * `runFullSearch` records the trimmed query in `searchPageActiveQuery`
+///    without clobbering the user-facing `searchPageQuery` binding.
+///
+/// `AppModel` is `@MainActor`, so the suite is main-actor isolated. We
+/// redirect the core's data dir to a throwaway temp dir via
+/// `XDG_DATA_HOME` so the tests never touch the real app database, and we
+/// drive the deterministic, network-free surfaces directly.
+@MainActor
+final class SearchPagePaginationTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-search-page-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTrack(id: String, name: String) -> Track {
+        Track(
+            id: id, name: name, albumId: nil, albumName: nil, artistName: "Artist",
+            artistId: nil, indexNumber: nil, discNumber: nil, year: nil,
+            runtimeTicks: 0, isFavorite: false, playCount: 0, container: nil,
+            bitrate: nil, imageTag: nil, playlistItemId: nil, userData: nil
+        )
+    }
+
+    private func makeAlbum(id: String, name: String, genres: [String] = []) -> Album {
+        Album(
+            id: id, name: name, artistName: "Artist", artistId: nil, year: nil,
+            trackCount: 0, runtimeTicks: 0, genres: genres, imageTag: nil, userData: nil
+        )
+    }
+
+    private func makeArtist(id: String, name: String, genres: [String] = []) -> Artist {
+        Artist(
+            id: id, name: name, albumCount: 0, songCount: 0, genres: genres,
+            imageTag: nil, userData: nil
+        )
+    }
+
+    private func results(
+        artists: [Artist] = [],
+        albums: [Album] = [],
+        tracks: [Track] = [],
+        totalRecordCount: UInt32? = nil
+    ) -> SearchResults {
+        SearchResults(
+            artists: artists,
+            albums: albums,
+            tracks: tracks,
+            totalRecordCount: totalRecordCount ?? UInt32(artists.count + albums.count + tracks.count)
+        )
+    }
+
+    // MARK: - Playlists are a permanently-empty bucket (gap-stub)
+
+    func testBucketSearchResultsLeavesPlaylistsEmpty() {
+        // The core `SearchResults` type has no playlists field — the
+        // backend can't return them — so the bucket must come back empty.
+        let buckets = AppModel.bucketSearchResults(
+            results(
+                artists: [makeArtist(id: "ar1", name: "A")],
+                albums: [makeAlbum(id: "al1", name: "B")],
+                tracks: [makeTrack(id: "t1", name: "C")]
+            )
+        )
+        XCTAssertEqual(buckets[SearchScope.playlists.storageKey], [])
+    }
+
+    func testPlaylistsScopeHiddenWhileUnsupported() throws {
+        // The Playlists scope must stay hidden until the core search backend
+        // returns playlists, exactly like Genres are gated by the genre
+        // capability. Default ships with playlist search unsupported.
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.supportsPlaylistSearch,
+            "playlist search is off until core.search returns playlists"
+        )
+    }
+
+    // MARK: - SearchScope.isServerPaged
+
+    func testServerPagedScopes() {
+        XCTAssertTrue(SearchScope.artists.isServerPaged)
+        XCTAssertTrue(SearchScope.albums.isServerPaged)
+        XCTAssertTrue(SearchScope.tracks.isServerPaged)
+        // Derived / not-yet-paged scopes must never consult the server
+        // has-more signal, otherwise their "Load more" is perpetual.
+        XCTAssertFalse(SearchScope.genres.isServerPaged)
+        XCTAssertFalse(SearchScope.playlists.isServerPaged)
+    }
+
+    // MARK: - searchPageHasMore / searchPageExhausted
+
+    func testHasMoreFalseWhenLoadedReachesTotal() throws {
+        let model = try AppModel()
+        model.searchPageExhausted = false
+        model.searchPageTotal = 50
+        model.searchPageLoaded = 50
+        XCTAssertFalse(
+            model.searchPageHasMore,
+            "caught up to the total — nothing more to fetch"
+        )
+    }
+
+    func testHasMoreTrueWhenLoadedBelowTotalAndNotExhausted() throws {
+        let model = try AppModel()
+        model.searchPageExhausted = false
+        model.searchPageTotal = 200
+        model.searchPageLoaded = 100
+        XCTAssertTrue(model.searchPageHasMore)
+    }
+
+    func testExhaustedFlagOverridesStaleTotal() throws {
+        // The crux of the load-more bug: the server's TotalRecordCount can
+        // count item types we don't page (or be deduped), so loaded can sit
+        // permanently below total. Once a page adds nothing the exhausted
+        // flag must force has-more to false so the button disappears.
+        let model = try AppModel()
+        model.searchPageTotal = 999     // server still claims more…
+        model.searchPageLoaded = 100    // …but loaded is stuck below it
+        model.searchPageExhausted = true
+        XCTAssertFalse(
+            model.searchPageHasMore,
+            "exhausted flag must win over a never-reachable total"
+        )
+    }
+
+    // MARK: - runFullSearch query handling
+
+    func testRunFullSearchDoesNotClobberFieldBindingOnFailure() async throws {
+        // No live server here, so `core.search` throws — but the contract
+        // we care about holds regardless of network: `runFullSearch` must
+        // never trim-and-write the user-facing field binding. The user may
+        // have typed a trailing space mid-edit; deleting it under them is
+        // the bug. The trimmed query lives in `searchPageActiveQuery`.
+        let model = try AppModel()
+        model.searchPageQuery = "radiohead "   // trailing space the user typed
+
+        await model.runFullSearch(query: "radiohead ", scope: .all)
+
+        XCTAssertEqual(
+            model.searchPageQuery,
+            "radiohead ",
+            "the live field binding must be left exactly as the user typed it"
+        )
+        XCTAssertEqual(
+            model.searchPageActiveQuery,
+            "radiohead",
+            "the trimmed query that drives results is recorded separately"
+        )
+    }
+
+    func testRunFullSearchEmptyQueryClearsActiveQueryAndState() async throws {
+        let model = try AppModel()
+        model.searchPageActiveQuery = "stale"
+        model.searchPageResults = [SearchScope.tracks.storageKey: [.track(makeTrack(id: "t", name: "x"))]]
+        model.searchPageTotal = 5
+        model.searchPageLoaded = 5
+        model.searchPageExhausted = true
+
+        await model.runFullSearch(query: "   ", scope: .all)
+
+        XCTAssertEqual(model.searchPageActiveQuery, "", "whitespace-only query clears the active query")
+        XCTAssertTrue(model.searchPageResults.isEmpty)
+        XCTAssertEqual(model.searchPageTotal, 0)
+        XCTAssertEqual(model.searchPageLoaded, 0)
+        XCTAssertFalse(model.searchPageExhausted, "exhaustion resets on a fresh (empty) query")
+    }
+}

--- a/macos/Tests/LyrebirdTests/ServerUnreachableBannerTests.swift
+++ b/macos/Tests/LyrebirdTests/ServerUnreachableBannerTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the audit fixes to `ServerUnreachableBanner`:
+///   1. **Accessibility** — the banner must not flatten itself into a single
+///      static-text element (`children: .combine` + `.isStaticText`), which
+///      folds the Retry Button in and makes the action unreachable by
+///      VoiceOver. It must use `children: .contain` so the Button stays a
+///      separately focusable, actionable element.
+///   2. **Localization** — the user-facing strings must come from the string
+///      catalog (`LocalizedStringKey` / `Localizable.xcstrings`) rather than
+///      hard-coded English literals, matching the rest of the UI and the
+///      sibling `OfflineBanner`.
+///
+/// SwiftUI exposes no public hook to introspect a `some View`'s accessibility
+/// tree or resolved copy headlessly, so the behaviour is verified structurally:
+/// the banner source is read via `#filePath` and the catalog source is parsed
+/// as JSON. A regression that reintroduces the flatten or the hard-coded
+/// strings is caught here rather than in the field.
+final class ServerUnreachableBannerTests: XCTestCase {
+
+    // MARK: - Accessibility structure
+
+    /// The Retry Button must remain individually reachable: the banner uses
+    /// `children: .contain` and drops the `.combine` flatten + `.isStaticText`
+    /// trait that previously made the action unreachable by VoiceOver.
+    func testBannerDoesNotFlattenRetryButton() throws {
+        let code = try bannerSource()
+        XCTAssertTrue(
+            code.contains(".accessibilityElement(children: .contain)"),
+            "Banner must use children: .contain so the Retry button stays actionable"
+        )
+        XCTAssertFalse(
+            code.contains("children: .combine"),
+            "children: .combine flattens the Retry button into inert static text"
+        )
+        XCTAssertFalse(
+            code.contains(".isStaticText"),
+            "The banner must not mark itself static text — the Retry button is actionable"
+        )
+    }
+
+    // MARK: - Localization
+
+    /// The banner's strings must route through the catalog. The message is a
+    /// `LocalizedStringKey` (so SwiftUI looks the copy up rather than rendering
+    /// a literal), and the source references the catalog keys for the generic
+    /// message, the named-host format, and the shared `common.retry` button.
+    func testBannerStringsAreLocalized() throws {
+        let code = try bannerSource()
+        XCTAssertTrue(code.contains("private var message: LocalizedStringKey"),
+                      "The banner message must be a LocalizedStringKey, not a raw String literal")
+        XCTAssertTrue(code.contains("banner.server_unreachable.generic"),
+                      "Generic message must use the catalog key")
+        XCTAssertTrue(code.contains("banner.server_unreachable.named \\(host)"),
+                      "Named-host message must interpolate the host into the catalog key")
+        XCTAssertTrue(code.contains("Text(\"common.retry\")"),
+                      "Retry label must reuse the shared common.retry catalog key")
+    }
+
+    /// The three catalog keys the banner depends on must exist in the source
+    /// `Localizable.xcstrings` with a translated English value, and the named
+    /// variant must carry the `%@` host placeholder so the host interpolates.
+    func testBannerCatalogKeysExist() throws {
+        let strings = try catalogStrings()
+
+        for key in [
+            "banner.server_unreachable.generic",
+            "banner.server_unreachable.named %@",
+            "banner.server_unreachable.retry.a11y",
+        ] {
+            guard let value = englishValue(strings, key) else {
+                XCTFail("Missing catalog key: \(key)")
+                continue
+            }
+            XCTAssertFalse(value.isEmpty, "\(key) must have a non-empty English value")
+        }
+
+        // The named variant interpolates the user's host — the placeholder must
+        // be present so the host actually appears in the rendered copy.
+        let named = englishValue(strings, "banner.server_unreachable.named %@")
+        XCTAssertEqual(named?.contains("%@"), true,
+                       "Named banner copy must contain the %@ host placeholder")
+    }
+
+    // MARK: - Helpers
+
+    private func bannerSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let url = sourcesRoot()
+            .appendingPathComponent("Components/ServerUnreachableBanner.swift")
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read ServerUnreachableBanner.swift at \(url.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+
+    /// Parses the source `Localizable.xcstrings` and returns its `strings` map.
+    private func catalogStrings(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let url = sourcesRoot()
+            .appendingPathComponent("Resources/Localizable.xcstrings")
+        guard let data = try? Data(contentsOf: url) else {
+            XCTFail("Could not read Localizable.xcstrings at \(url.path)", file: file, line: line)
+            return [:]
+        }
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return (json?["strings"] as? [String: Any]) ?? [:]
+    }
+
+    /// Digs the English `stringUnit` value out of an `.xcstrings` entry.
+    private func englishValue(_ strings: [String: Any], _ key: String) -> String? {
+        guard
+            let entry = strings[key] as? [String: Any],
+            let locs = entry["localizations"] as? [String: Any],
+            let en = locs["en"] as? [String: Any],
+            let unit = en["stringUnit"] as? [String: Any],
+            let value = unit["value"] as? String
+        else { return nil }
+        return value
+    }
+
+    /// `macos/Sources/Lyrebird`, resolved relative to this test file via
+    /// `#filePath` so the lookup is independent of the runner's working dir.
+    private func sourcesRoot() -> URL {
+        URL(fileURLWithPath: "\(#filePath)")
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird")
+    }
+}

--- a/macos/Tests/LyrebirdTests/SidebarAutoHideTests.swift
+++ b/macos/Tests/LyrebirdTests/SidebarAutoHideTests.swift
@@ -172,6 +172,27 @@ final class SidebarAutoHideTests: XCTestCase {
         }
     }
 
+    // MARK: - Preference gating (sidebar audit)
+
+    /// Width-driven auto-hide is opt-in: only the `.autoHide` Appearance
+    /// preference enables it. `.visible` and `.hidden` skip the reducer so the
+    /// rail stays put — which is what makes the three picker options
+    /// behaviourally distinct (previously `.autoHide` was a no-op alias for
+    /// `.visible` because the reducer ran for everyone).
+    func testAutoHideIsEnabledOnlyForAutoHidePreference() {
+        XCTAssertTrue(SidebarAutoHide.isEnabled(for: .autoHide))
+        XCTAssertFalse(SidebarAutoHide.isEnabled(for: .visible))
+        XCTAssertFalse(SidebarAutoHide.isEnabled(for: .hidden))
+    }
+
+    /// Every `AppearanceSidebar` case has a defined enablement, and exactly one
+    /// (`.autoHide`) opts in — a guard so a future case added to the enum is
+    /// forced to make an explicit choice here rather than silently defaulting.
+    func testExactlyOneSidebarPreferenceEnablesAutoHide() {
+        let enabled = AppearanceSidebar.allCases.filter { SidebarAutoHide.isEnabled(for: $0) }
+        XCTAssertEqual(enabled, [.autoHide])
+    }
+
     // MARK: - Persistence key stability
 
     /// The `@AppStorage` key is a stable on-disk identifier; renaming it
@@ -215,6 +236,16 @@ final class SidebarAutoHideTests: XCTestCase {
                       "The Toggle Sidebar button must register a manual override")
         XCTAssertTrue(code.contains("userDidOverrideAutoHide = true"),
                       "The manual override must be persisted via @AppStorage")
+    }
+
+    /// The width-driven auto-hide must be gated on the Appearance `Sidebar`
+    /// preference so the reducer only runs for `.autoHide` (sidebar audit). A
+    /// regression that drops the gate would make `.autoHide` a no-op alias for
+    /// `.visible` again.
+    func testMainShellGatesAutoHideOnPreference() throws {
+        let code = try mainShellSource()
+        XCTAssertTrue(code.contains("SidebarAutoHide.isEnabled(for:"),
+                      "applySidebarAutoHide must gate the reducer on the Sidebar preference")
     }
 
     // MARK: - Helpers

--- a/macos/Tests/LyrebirdTests/SidebarPlaylistRenameCommitTests.swift
+++ b/macos/Tests/LyrebirdTests/SidebarPlaylistRenameCommitTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the inline playlist-rename commit contract behind the audit
+/// fix for the double-commit bug.
+///
+/// In the sidebar, pressing Return fired `commitSidebarPlaylistEdit()` and the
+/// resulting resign-first-responder then flipped the field's focus, which ran
+/// the `onChange(of: isFocused)` blur branch as a *second* commit. The view now
+/// guards that with a `committed` flag, but the model itself must also be
+/// idempotent so a stray second commit (from any path) can't double-apply: the
+/// up-front clearing of `sidebarEditingPlaylistId` turns the second call into a
+/// guarded no-op. These tests pin that model-level backstop.
+///
+/// `AppModel` is `@MainActor`; constructing it boots a live `LyrebirdCore`, so
+/// the suite redirects the core's data dir to a throwaway temp dir via
+/// `XDG_DATA_HOME` (honoured by `storage::default_data_dir()`) to avoid
+/// touching the real app database. No session is established, so no network
+/// round-trip runs — the tests exercise only the synchronous edit-state
+/// transitions.
+@MainActor
+final class SidebarPlaylistRenameCommitTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makePlaylist(id: String, name: String) -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            trackCount: 0,
+            runtimeTicks: 0,
+            imageTag: nil,
+            userData: nil
+        )
+    }
+
+    /// A commit clears the edit session up-front. This is the property the
+    /// second (blur-driven) commit relies on: once the id is `nil`, the repeat
+    /// call has nothing to act on.
+    func testCommitClearsEditingState() async throws {
+        let model = try AppModel()
+        model.playlists = [makePlaylist(id: "pl-1", name: "Old Name")]
+        model.sidebarEditingPlaylistId = "pl-1"
+        model.sidebarEditingDraft = "Old Name" // same name → no network Task
+
+        await model.commitSidebarPlaylistEdit()
+
+        XCTAssertNil(
+            model.sidebarEditingPlaylistId,
+            "commit must clear the editing id so a follow-on blur can't re-commit"
+        )
+        XCTAssertEqual(
+            model.sidebarEditingDraft,
+            "",
+            "commit must clear the draft"
+        )
+    }
+
+    /// The double-commit guard: invoking commit a second time after the first
+    /// has cleared the editing id is a no-op. Reproduces the Return-then-blur
+    /// sequence at the model layer — the second call must not mutate playlists
+    /// or crash. Uses an unchanged name so the (single legitimate) commit
+    /// itself launches no async core call, keeping the assertion deterministic.
+    func testSecondCommitAfterClearIsNoOp() async throws {
+        let model = try AppModel()
+        let original = makePlaylist(id: "pl-1", name: "Keep Me")
+        model.playlists = [original]
+        model.sidebarEditingPlaylistId = "pl-1"
+        model.sidebarEditingDraft = "Keep Me"
+
+        await model.commitSidebarPlaylistEdit() // first (Return)
+        XCTAssertNil(model.sidebarEditingPlaylistId)
+
+        // Second commit, simulating the blur that Return's focus loss triggers.
+        await model.commitSidebarPlaylistEdit()
+
+        XCTAssertEqual(model.playlists.count, 1, "no phantom playlist from a repeat commit")
+        XCTAssertEqual(
+            model.playlists.first?.name,
+            "Keep Me",
+            "a repeat commit with no live edit session must not mutate the list"
+        )
+        XCTAssertNil(model.sidebarEditingPlaylistId, "editing state stays cleared")
+    }
+
+    /// The Escape-then-blur path: cancelling clears the editing id, and a
+    /// subsequent commit (from the blur the cancel triggers) must also no-op.
+    func testCommitAfterCancelIsNoOp() async throws {
+        let model = try AppModel()
+        model.playlists = [makePlaylist(id: "pl-1", name: "Untouched")]
+        model.sidebarEditingPlaylistId = "pl-1"
+        model.sidebarEditingDraft = "Edited But Cancelled"
+
+        model.cancelSidebarPlaylistEdit()
+        XCTAssertNil(model.sidebarEditingPlaylistId)
+
+        await model.commitSidebarPlaylistEdit()
+
+        XCTAssertEqual(
+            model.playlists.first?.name,
+            "Untouched",
+            "a commit after cancel must not apply the abandoned draft"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/SidebarServerStatusTests.swift
+++ b/macos/Tests/LyrebirdTests/SidebarServerStatusTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `SidebarServerStatus.decide` — the pure reducer behind the
+/// sidebar's server-footer indicator (audit fix for the hard-coded "Connected"
+/// dot + label).
+///
+/// The footer previously painted a green "live" dot and the literal word
+/// "Connected" regardless of reachability, so it kept claiming a healthy link
+/// straight through a server outage. The fix routes the dot tint, the
+/// status copy, and (implicitly) the album-count line through this reducer,
+/// which only reports `.connected` when a session exists *and* the server is
+/// actually answering. Exercised through the pure helper so the truth table is
+/// verified without realizing a SwiftUI scene.
+final class SidebarServerStatusTests: XCTestCase {
+
+    /// The happy path: a live session against a reachable server is the only
+    /// combination that reads `.connected` (teal dot + "Connected · N albums").
+    func testConnectedRequiresSessionAndReachability() {
+        XCTAssertEqual(
+            SidebarServerStatus.decide(hasSession: true, isReachable: true),
+            .connected,
+            "a live session against a reachable server is the only connected state"
+        )
+    }
+
+    /// A signed-in user whose server has gone dark (5xx / refused / repeated
+    /// timeouts flip `ServerReachability.isServerReachable` to `false`) must
+    /// read `.disconnected` — this is the exact bug the audit flagged: the
+    /// footer used to stay "Connected" during an outage.
+    func testUnreachableWithSessionIsDisconnected() {
+        XCTAssertEqual(
+            SidebarServerStatus.decide(hasSession: true, isReachable: false),
+            .disconnected,
+            "a live session whose server is unreachable must not read as connected"
+        )
+    }
+
+    /// No session (cold launch / signed out) is disconnected even though
+    /// reachability starts optimistically `true` — there's nothing to be
+    /// connected *to* without a session.
+    func testNoSessionIsDisconnectedEvenWhenOptimisticallyReachable() {
+        XCTAssertEqual(
+            SidebarServerStatus.decide(hasSession: false, isReachable: true),
+            .disconnected,
+            "no session means disconnected regardless of the optimistic reachability default"
+        )
+    }
+
+    /// Neither a session nor reachability — plainly disconnected.
+    func testNoSessionAndUnreachableIsDisconnected() {
+        XCTAssertEqual(
+            SidebarServerStatus.decide(hasSession: false, isReachable: false),
+            .disconnected,
+            "no session and unreachable is disconnected"
+        )
+    }
+}

--- a/macos/Tests/LyrebirdTests/SpaceGuardDetectionTests.swift
+++ b/macos/Tests/LyrebirdTests/SpaceGuardDetectionTests.swift
@@ -1,0 +1,160 @@
+import AppKit
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the space-bar text-field guard (#585).
+///
+/// The detection logic is factored into `SpaceGuardDetection` so the
+/// "is this a bare space?" and "is the first responder an editable text
+/// control?" decisions can be verified directly. `SpaceGuardMonitor`'s
+/// ref-counting is exercised so we know exactly one process-level monitor
+/// exists no matter how many guarded views mount.
+final class SpaceGuardDetectionTests: XCTestCase {
+
+    // MARK: isBareSpace
+
+    func testBareSpaceIsDetected() {
+        XCTAssertTrue(SpaceGuardDetection.isBareSpace(keyCode: 49, modifierFlags: []))
+    }
+
+    func testNonSpaceKeyIsRejected() {
+        XCTAssertFalse(SpaceGuardDetection.isBareSpace(keyCode: 0, modifierFlags: []))
+    }
+
+    func testModifiedSpaceIsRejected() {
+        // Command/Option/Control/Shift + Space are deliberate combos and must
+        // pass through untouched (e.g. ⌃Space for input-source switching).
+        for flag: NSEvent.ModifierFlags in [.command, .option, .control, .shift] {
+            XCTAssertFalse(
+                SpaceGuardDetection.isBareSpace(keyCode: 49, modifierFlags: flag),
+                "space + \(flag) should not be treated as a bare space"
+            )
+        }
+    }
+
+    func testSpaceIgnoresNonInputModifierFlags() {
+        // CapsLock / numeric-pad / function bits aren't in the intercept set,
+        // so a space carrying only those is still a bare space.
+        XCTAssertTrue(
+            SpaceGuardDetection.isBareSpace(keyCode: 49, modifierFlags: [.capsLock])
+        )
+    }
+
+    // MARK: editableTextView — window-free cases
+
+    @MainActor
+    func testStandaloneEditableTextViewIsDetected() {
+        let window = NSWindow()
+        let textView = NSTextView(frame: .init(x: 0, y: 0, width: 100, height: 40))
+        textView.isEditable = true
+        XCTAssertTrue(SpaceGuardDetection.editableTextView(for: textView, in: window) === textView)
+    }
+
+    @MainActor
+    func testNonEditableTextViewIsRejected() {
+        let window = NSWindow()
+        let textView = NSTextView(frame: .init(x: 0, y: 0, width: 100, height: 40))
+        textView.isEditable = false
+        XCTAssertNil(SpaceGuardDetection.editableTextView(for: textView, in: window))
+    }
+
+    @MainActor
+    func testNonTextResponderIsRejected() {
+        let window = NSWindow()
+        // A plain button is a control but not editable text — space must pass
+        // through so it can activate the button / fire the transport shortcut.
+        let button = NSButton(frame: .init(x: 0, y: 0, width: 40, height: 20))
+        XCTAssertNil(SpaceGuardDetection.editableTextView(for: button, in: window))
+    }
+
+    @MainActor
+    func testNonEditableTextFieldIsRejected() {
+        let window = NSWindow()
+        let label = NSTextField(labelWithString: "read-only")
+        XCTAssertNil(SpaceGuardDetection.editableTextView(for: label, in: window))
+    }
+
+    // MARK: editableTextView — field-editor path (the L101 broadening)
+
+    /// When a field-style control owns the first responder, detection must
+    /// resolve its shared field editor. This is the case that the old
+    /// NSTextField-delegate check missed for NSSearchField. We exercise both a
+    /// plain editable NSTextField and an NSSearchField to prove the single
+    /// NSTextField-subclass cast covers the search field too.
+    @MainActor
+    func testEditableFieldControlsResolveFieldEditor() {
+        let window = NSWindow(
+            contentRect: .init(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+
+        let field = NSTextField(string: "")
+        let search = NSSearchField(string: "")
+        let container = NSView(frame: .init(x: 0, y: 0, width: 200, height: 60))
+        container.addSubview(field)
+        container.addSubview(search)
+        window.contentView = container
+
+        for control in [field, search] {
+            XCTAssertTrue(
+                window.makeFirstResponder(control),
+                "could not focus \(type(of: control)) — skipping field-editor assertion"
+            )
+            // The active field editor for the focused control should be the
+            // editable NSTextView we route the space into.
+            let resolved = SpaceGuardDetection.editableTextView(for: window.firstResponder!, in: window)
+            XCTAssertNotNil(
+                resolved,
+                "\(type(of: control)) should resolve to an editable field editor"
+            )
+            XCTAssertTrue(resolved?.isEditable ?? false)
+        }
+    }
+
+    // MARK: SpaceGuardMonitor ref-counting
+
+    @MainActor
+    func testMonitorIsRefCountedAcrossHosts() {
+        let monitor = SpaceGuardMonitor.shared
+        // Other tests in the suite may have mounted guarded views; capture the
+        // baseline so this test is order-independent.
+        let baseline = monitor.activeRetainCount
+
+        monitor.retain()
+        XCTAssertEqual(monitor.activeRetainCount, baseline + 1)
+        XCTAssertTrue(monitor.isInstalled, "first retain should install the monitor")
+
+        monitor.retain()
+        XCTAssertEqual(monitor.activeRetainCount, baseline + 2)
+        XCTAssertTrue(monitor.isInstalled, "a second host must not install a second monitor")
+
+        monitor.release()
+        XCTAssertEqual(monitor.activeRetainCount, baseline + 1)
+        XCTAssertTrue(monitor.isInstalled, "monitor stays installed while a host remains")
+
+        monitor.release()
+        XCTAssertEqual(monitor.activeRetainCount, baseline)
+        // Only assert removal when nothing else holds the monitor.
+        if baseline == 0 {
+            XCTAssertFalse(monitor.isInstalled, "last release should remove the monitor")
+        }
+    }
+
+    @MainActor
+    func testMonitorReleaseBelowZeroIsSafe() {
+        let monitor = SpaceGuardMonitor.shared
+        let baseline = monitor.activeRetainCount
+        // Unbalanced release must not drive the count negative or crash.
+        monitor.release()
+        XCTAssertGreaterThanOrEqual(monitor.activeRetainCount, 0)
+        // Restore baseline if we actually decremented a pre-existing retain.
+        if monitor.activeRetainCount < baseline {
+            monitor.retain()
+        }
+        XCTAssertEqual(monitor.activeRetainCount, baseline)
+    }
+}

--- a/macos/Tests/LyrebirdTests/ThemePresetTests.swift
+++ b/macos/Tests/LyrebirdTests/ThemePresetTests.swift
@@ -82,12 +82,27 @@ final class ThemePresetTests: XCTestCase {
     }
 
     func testAppearanceThemeMapsToVerifiedPreset() {
+        // Every offered `AppearanceTheme` maps one-to-one to a verified
+        // `ThemePreset`. Sunset / Peanut were dropped from `AppearanceTheme`
+        // (they had no backing pair and silently folded into Purple), so the
+        // picker only offers themes the engine can actually render.
         XCTAssertEqual(ThemePreset(appearanceTheme: .ocean), .ocean)
         XCTAssertEqual(ThemePreset(appearanceTheme: .forest), .forest)
-        // Presets without a verified CVD pair fall back to purple.
-        XCTAssertEqual(ThemePreset(appearanceTheme: .sunset), .purple)
-        XCTAssertEqual(ThemePreset(appearanceTheme: .peanut), .purple)
         XCTAssertEqual(ThemePreset(appearanceTheme: .purple), .purple)
+    }
+
+    /// Guards the picker against silently re-acquiring a theme the engine can't
+    /// render: every `AppearanceTheme` case must back a real `ThemePreset` whose
+    /// swatch is derived from that preset's primary (no hard-coded swatch that
+    /// could drift from what the theme would actually apply).
+    func testEveryAppearanceThemeBacksAVerifiedPreset() {
+        for theme in AppearanceTheme.allCases {
+            let preset = ThemePreset(appearanceTheme: theme)
+            XCTAssertEqual(
+                theme.swatch, Color(hex: preset.primaryHex),
+                "\(theme.rawValue) swatch must derive from its ThemePreset primary"
+            )
+        }
     }
 }
 

--- a/macos/Tests/LyrebirdTests/TrackRowKeyboardTests.swift
+++ b/macos/Tests/LyrebirdTests/TrackRowKeyboardTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for `TrackRow`'s extracted keyboard-handling decisions.
+///
+/// The arrow-key focus traversal and the Space-transport scoping are pulled
+/// into `TrackRowKeyboard` so they can be exercised without realizing a live
+/// SwiftUI view (mirrors `MenuBarNowPlayingTests`). These guard the two
+/// behaviour fixes: arrow keys must only be *claimed* when focus can actually
+/// move (otherwise default focus-ring traversal is restored), and Space must
+/// only toggle transport from the active row.
+final class TrackRowKeyboardTests: XCTestCase {
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    private func makeTracks(_ count: Int) -> [Track] {
+        (0..<count).map { makeTrack("\($0)") }
+    }
+
+    // MARK: focusTarget bounds
+
+    func testFocusTargetMovesDownWithinBounds() {
+        let tracks = makeTracks(3)
+        XCTAssertEqual(
+            TrackRowKeyboard.focusTarget(tracks: tracks, index: 0, delta: 1),
+            tracks[1].id
+        )
+    }
+
+    func testFocusTargetMovesUpWithinBounds() {
+        let tracks = makeTracks(3)
+        XCTAssertEqual(
+            TrackRowKeyboard.focusTarget(tracks: tracks, index: 2, delta: -1),
+            tracks[1].id
+        )
+    }
+
+    func testFocusTargetReturnsNilPastTopEdge() {
+        let tracks = makeTracks(3)
+        // Up arrow on the first row has nowhere to go — the key should be
+        // declined, not swallowed, so the OS can move the focus ring out of
+        // the list.
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: tracks, index: 0, delta: -1))
+    }
+
+    func testFocusTargetReturnsNilPastBottomEdge() {
+        let tracks = makeTracks(3)
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: tracks, index: 2, delta: 1))
+    }
+
+    func testFocusTargetReturnsNilForEmptySiblings() {
+        // The regression this fixes: when no track list is threaded the row
+        // must NOT claim the arrow key (previously it returned `.handled`
+        // unconditionally, killing focus traversal even though nothing moved).
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: [], index: 0, delta: 1))
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: [], index: 0, delta: -1))
+    }
+
+    func testFocusTargetReturnsNilWhenIndexOutOfRange() {
+        // Defensive: a stale index shouldn't crash or wrap.
+        let tracks = makeTracks(2)
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: tracks, index: 5, delta: 1))
+        XCTAssertNil(TrackRowKeyboard.focusTarget(tracks: tracks, index: 5, delta: -1))
+    }
+
+    // MARK: Space transport scoping
+
+    func testSpaceTogglesTransportOnlyOnActiveRow() {
+        // Only the current player-target row claims Space; every other row
+        // declines so the key isn't trapped away from default handling.
+        XCTAssertTrue(TrackRowKeyboard.spaceTogglesTransport(isActive: true))
+        XCTAssertFalse(TrackRowKeyboard.spaceTogglesTransport(isActive: false))
+    }
+}

--- a/macos/Tests/LyrebirdTests/ViewMenuBindingsTests.swift
+++ b/macos/Tests/LyrebirdTests/ViewMenuBindingsTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the View-menu command wiring that the audit flagged as dead or
+/// decoupled:
+///   • "Show Sidebar" / "Show Queue" used to be permanently-disabled stubs with
+///     empty actions (L251) — now they drive real `AppModel` state.
+///   • the Mini Player `Toggle` discarded the value SwiftUI passed and blindly
+///     toggled (L365) — the binding now drives to the requested value.
+///
+/// `AppModel` is `@MainActor`; constructing it boots a live `LyrebirdCore`, so
+/// the suite redirects the core's data dir to a throwaway temp dir.
+@MainActor
+final class ViewMenuBindingsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    // MARK: - Show Sidebar (L251)
+
+    /// The menu can't reach `MainShell`'s private `columnVisibility`, so it
+    /// drives a monotonic request counter that `MainShell` observes. Each tap
+    /// must produce a fresh, observable bump even when the rail is already in
+    /// the requested state.
+    func testRequestSidebarToggleBumpsMonotonically() throws {
+        let model = try AppModel()
+        let start = model.sidebarToggleRequest
+
+        model.requestSidebarToggle()
+        XCTAssertEqual(model.sidebarToggleRequest, start + 1)
+
+        model.requestSidebarToggle()
+        XCTAssertEqual(
+            model.sidebarToggleRequest, start + 2,
+            "a repeat request must still change the counter so MainShell re-fires"
+        )
+    }
+
+    /// The menu `Toggle` renders its checkmark from `isSidebarVisible`, which
+    /// `MainShell` mirrors from the real column visibility. Confirm it's a
+    /// writable mirror the shell can keep in sync.
+    func testSidebarVisibleMirrorIsWritable() throws {
+        let model = try AppModel()
+        XCTAssertTrue(model.isSidebarVisible, "fresh model assumes the sidebar is showing")
+
+        model.isSidebarVisible = false
+        XCTAssertFalse(model.isSidebarVisible)
+        model.isSidebarVisible = true
+        XCTAssertTrue(model.isSidebarVisible)
+    }
+
+    // MARK: - Show Queue (L251)
+
+    /// "Show Queue" now toggles the real inspector both ways (it used to be a
+    /// permanently-disabled no-op).
+    func testToggleQueueInspectorFlipsBothWays() throws {
+        let model = try AppModel()
+        XCTAssertFalse(model.isQueueInspectorOpen, "fresh model starts with the inspector closed")
+
+        model.toggleQueueInspector()
+        XCTAssertTrue(model.isQueueInspectorOpen, "first toggle opens the inspector")
+
+        model.toggleQueueInspector()
+        XCTAssertFalse(model.isQueueInspectorOpen, "second toggle closes it")
+    }
+
+    // MARK: - Mini Player setter (L365)
+
+    /// The Mini Player menu `Toggle`'s setter now assigns the requested value
+    /// directly (`isMiniPlayerVisible = $0`) instead of calling
+    /// `toggleMiniPlayer()` and discarding it. Simulate SwiftUI delivering the
+    /// same value twice (e.g. a redundant set) and confirm the state tracks the
+    /// requested value rather than flipping away from it.
+    func testMiniPlayerDirectSetTracksRequestedValue() throws {
+        let model = try AppModel()
+        XCTAssertFalse(model.isMiniPlayerVisible)
+
+        // Drive to `true` twice. The old toggling setter would have closed it on
+        // the second call; the direct-set binding keeps it open.
+        model.isMiniPlayerVisible = true
+        model.isMiniPlayerVisible = true
+        XCTAssertTrue(
+            model.isMiniPlayerVisible,
+            "driving the bound value to true twice must leave it open, not toggle it back"
+        )
+
+        model.isMiniPlayerVisible = false
+        XCTAssertFalse(model.isMiniPlayerVisible)
+    }
+}


### PR DESCRIPTION
Fixes ~214 of the 527 audit findings (all p0/p1 + co-located p2) from the comment-blind audit (docs/audit/AUDIT-2.0.md). Built green: clean build + 738 Swift tests + cargo test + clippy `-D warnings` + `cargo fmt --check`.

Highlights:
- **p0 data-loss**: "Clear Caches" no longer wipes the entire caches dir (incl. downloaded music) — scoped to the app's own cache.
- **Security**: scrobble token moved from plaintext SQLite to the **OS keyring** (legacy plaintext scrubbed); `device_id` sanitized in the auth header.
- **Correctness**: non-idempotent POST retries fixed (add/create playlist no longer risk duplicates); `rename_playlist` no longer wipes Genres/Overview/Tags; `public_playlists` stub removed; `latest_albums` reports honest pagination totals.
- **Concurrency/perf**: removed a synchronous SQLite write on the MainActor (dead play-history); `playlists_containing_artist` now probes with bounded concurrency; heartbeat skips Ended/Stopped (no ghost now-playing).
- **Error handling**: rate-limit/certificate errors routed to specific banners; storage errors propagated instead of swallowed.
- Plus ~200 smaller bug/consistency/a11y/test-coverage fixes across AppModel and the screens/components.

Deferred to a follow-up (merge-conflict or superseded): PreferencesAudio (#11-grp), MediaSession+SearchInstantDropdown, FullQueueView. The 225 p3 nits remain catalogued in the audit report for later triage.