### PR TITLE
fix(core): de-flake retry test + fix rustdoc intra-doc links (CI red on main)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2119,7 +2119,7 @@ impl JellyfinClient {
     /// dropped. Positional insert is a separate primitive on
     /// `POST /Playlists/{id}/Items` (deferred; see #282).
     ///
-    /// Sent via [`Self::send_mutation_no_retry`] because it creates a
+    /// Sent via `Self::send_mutation_no_retry` because it creates a
     /// resource: a blanket transport/5xx retry could create a *duplicate*
     /// playlist if the first POST committed but its response was lost.
     ///
@@ -2548,7 +2548,7 @@ impl JellyfinClient {
     /// Rename a playlist by updating its `Name` field via `POST /Items/{id}`.
     ///
     /// The `POST /Items/{id}` (UpdateItem) endpoint does a *blind assign* of
-    /// the posted [`BaseItemDto`] onto the stored item: every editable field
+    /// the posted `BaseItemDto` onto the stored item: every editable field
     /// it reads is overwritten with whatever the body carries, and fields
     /// absent from the body are reset. So we must fetch the existing item with
     /// the full editable field projection first and round-trip it intact,

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -243,7 +243,7 @@ impl CredentialStore {
     }
 
     /// Persist the ListenBrainz scrobble token in the OS keyring (same secure
-    /// store as the Jellyfin access token), keyed on [`SCROBBLE_ACCOUNT`].
+    /// store as the Jellyfin access token), keyed on `SCROBBLE_ACCOUNT`.
     pub fn save_scrobble_token(token: &str) -> Result<()> {
         let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
         entry.set_password(token)?;

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -7233,27 +7233,7 @@ async fn structured_error_rate_limit_parses_retry_after() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let client = std::sync::Arc::new(client);
-
-    // Pause AFTER the real auth round-trip so reqwest's connection setup ran
-    // on the live clock. From here `advance` drives the retry backoff.
-    tokio::time::pause();
-    let call = tokio::spawn({
-        let client = std::sync::Arc::clone(&client);
-        async move { client.albums(Paging::new(0, 10)).await }
-    });
-
-    // Pump virtual time: each retry waits 5s, so step in 1s ticks (yielding
-    // so the spawned request can hit wiremock + the backoff timer can fire)
-    // for well past the two 5s backoffs.
-    for _ in 0..15 {
-        tokio::time::advance(std::time::Duration::from_secs(1)).await;
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-    }
-
-    let err = call.await.unwrap().unwrap_err();
+    let err = client.albums(Paging::new(0, 10)).await.unwrap_err();
     match err {
         crate::error::LyrebirdError::RateLimit { retry_after } => {
             assert_eq!(retry_after, Some(42));


### PR DESCRIPTION
main's CI went red after the polish-fix: a virtualized rate-limit test raced wiremock on CI runners, and 3 rustdoc intra-doc links pointed at private/non-crate items (failing `-D warnings`). Reverted the test to its real-clock form and de-linked the doc references. Verified locally: cargo test 0 failed, clippy clean, fmt clean, rustdoc -D warnings clean.