### PR TITLE
feat: 2.0 — Smart Playlists + i18n infrastructure (pluralization, durations, InfoPlist)

### DIFF
--- a/macos/Scripts/make-bundle.sh
+++ b/macos/Scripts/make-bundle.sh
@@ -110,16 +110,26 @@ cp "$EXE" "$APP/Contents/MacOS/Lyrebird"
 # Bundle.main, so no Swift-side change for the i18n path.
 RES_SRC="$MACOS/Sources/Lyrebird/Resources"
 if [[ -d "$RES_SRC" ]]; then
-    # Localizable.xcstrings is the source format. SwiftUI's
-    # LocalizedStringKey can't read xcstrings directly — it looks for
-    # compiled `<lang>.lproj/Localizable.strings` files. Compile via
-    # xcstringstool so the .app gets the runtime layout SwiftUI expects.
-    # Without this step, every LocalizedStringKey site falls through to
-    # rendering its lookup key (`auth.sign_in`, `app.name`, etc.).
-    if [[ -f "$RES_SRC/Localizable.xcstrings" ]] && command -v xcrun >/dev/null 2>&1; then
-        xcrun xcstringstool compile "$RES_SRC/Localizable.xcstrings" \
-            -o "$APP/Contents/Resources/" 2>/dev/null || \
-            cp "$RES_SRC/Localizable.xcstrings" "$APP/Contents/Resources/"
+    # *.xcstrings are the source format. SwiftUI's LocalizedStringKey and
+    # macOS's bundle-metadata loader can't read xcstrings directly — they
+    # look for compiled `<lang>.lproj/<Name>.strings` files. Compile each
+    # catalog via xcstringstool so the .app gets the runtime layout they
+    # expect:
+    #   - Localizable.xcstrings → <lang>.lproj/Localizable.strings. Without
+    #     this, every LocalizedStringKey site falls through to rendering its
+    #     lookup key (`auth.sign_in`, `app.name`, etc.).
+    #   - InfoPlist.xcstrings → <lang>.lproj/InfoPlist.strings. macOS reads
+    #     this to localize CFBundleDisplayName / CFBundleName /
+    #     NSHumanReadableCopyright (the Dock/Finder name + About copyright);
+    #     without it those fall back to the Info.plist literals (#359).
+    if command -v xcrun >/dev/null 2>&1; then
+        for catalog in Localizable InfoPlist; do
+            if [[ -f "$RES_SRC/$catalog.xcstrings" ]]; then
+                xcrun xcstringstool compile "$RES_SRC/$catalog.xcstrings" \
+                    -o "$APP/Contents/Resources/" 2>/dev/null || \
+                    cp "$RES_SRC/$catalog.xcstrings" "$APP/Contents/Resources/"
+            fi
+        done
     fi
     # Fonts/*.otf — flatten into Contents/Resources/ so Bundle.main
     # finds them with `url(forResource: "Figtree-Bold", withExtension:

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -6672,10 +6672,12 @@ extension Track {
         Double(runtimeTicks) / 10_000_000.0
     }
     var durationFormatted: String {
-        let total = Int(durationSeconds)
-        let m = total / 60
-        let s = total % 60
-        return String(format: "%d:%02d", m, s)
+        DurationFormatter.colon(durationSeconds)
+    }
+    /// Spelled-out duration ("3 minutes 5 seconds") for VoiceOver
+    /// `accessibilityValue` on track-duration labels. See #349.
+    var durationAccessibilityValue: String {
+        DurationFormatter.spokenAccessibility(durationSeconds)
     }
 }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -47,6 +47,10 @@ final class AppModel {
         case album(String)
         case artist(String)
         case playlist(String)
+        /// A client-side smart playlist (#77 / #238), addressed by its local
+        /// `SmartPlaylist.id`. The track set is evaluated live from the
+        /// library snapshot rather than fetched, so this carries no server id.
+        case smartPlaylist(UUID)
         case genre(Genre)
         case nowPlaying
         case fullQueue
@@ -178,6 +182,13 @@ final class AppModel {
     /// here on navigation so a subsequent `.playlist(id)` doesn't have to
     /// re-fetch. See #234.
     var playlists: [Playlist] = []
+    /// Client-side smart playlists (#77 / #238). Rule-driven playlists that
+    /// the app evaluates live over the in-memory library snapshot — no server
+    /// round-trip. Persisted locally as JSON in Application Support by the
+    /// store itself; all CRUD goes through it so disk stays in sync. The
+    /// sidebar renders `smartPlaylists.playlists`; `SmartPlaylistDetailView`
+    /// evaluates the selected one via `SmartPlaylistEvaluator`.
+    let smartPlaylists = SmartPlaylistStore()
     var albumTracks: [String: [Track]] = [:]          // albumID → tracks
     /// Per-playlist track caches, mirroring `albumTracks`. Populated by
     /// `loadPlaylistTracks(playlist:)`; held for the session; cleared on
@@ -3378,6 +3389,26 @@ final class AppModel {
         navPath.append(Route.playlist(playlist.id))
     }
 
+    /// Drill into a saved smart playlist's detail page (#77 / #238). The
+    /// detail view evaluates the rules live from the library snapshot, so
+    /// there's nothing to pre-fetch here.
+    func goToSmartPlaylist(_ playlist: SmartPlaylist) {
+        navPath.append(Route.smartPlaylist(playlist.id))
+    }
+
+    /// Create a new smart playlist from the sidebar's "New Smart Playlist…"
+    /// entry: seed a draft, persist it immediately so it appears in the
+    /// sidebar, and drill into its detail page (where the builder sheet can
+    /// be opened to refine the rules). Returns the created playlist's id so
+    /// callers / tests can address it.
+    @discardableResult
+    func createSmartPlaylist() -> UUID {
+        let draft = SmartPlaylist.newDraft()
+        smartPlaylists.add(draft)
+        navPath.append(Route.smartPlaylist(draft.id))
+        return draft.id
+    }
+
 
     /// Switch to the Search screen and request keyboard focus in the search
     /// field. Called from the ⌘F menu command. Writes both the legacy
@@ -3396,7 +3427,7 @@ final class AppModel {
     /// top-of-stack route, and exposed for tests.
     var scopedSearchRoute: Route? {
         switch navPath.last {
-        case .artist, .playlist: return navPath.last
+        case .artist, .playlist, .smartPlaylist: return navPath.last
         default: return nil
         }
     }

--- a/macos/Sources/Lyrebird/Components/ArtistCard.swift
+++ b/macos/Sources/Lyrebird/Components/ArtistCard.swift
@@ -119,10 +119,10 @@ struct ArtistCard: View {
     /// this artist" rather than an orphaned label.
     private var albumCountLabel: String {
         if artist.albumCount > 0 {
-            return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
+            return CountStrings.label(Int(artist.albumCount), .albums)
         }
         if artist.songCount > 0 {
-            return artist.songCount == 1 ? "1 song" : "\(artist.songCount) songs"
+            return CountStrings.label(Int(artist.songCount), .songs)
         }
         return "Artist"
     }

--- a/macos/Sources/Lyrebird/Components/CommandPalette.swift
+++ b/macos/Sources/Lyrebird/Components/CommandPalette.swift
@@ -704,7 +704,9 @@ struct PaletteRow: View {
             let albums = a.albumCount
             let songs = a.songCount
             if albums == 0 && songs == 0 { return "Artist" }
-            return "Artist \u{00B7} \(albums) album\(albums == 1 ? "" : "s") \u{00B7} \(songs) song\(songs == 1 ? "" : "s")"
+            let albumPart = CountStrings.label(Int(albums), .albums)
+            let songPart = CountStrings.label(Int(songs), .songs)
+            return "Artist \u{00B7} \(albumPart) \u{00B7} \(songPart)"
         case .album(let a):
             return "Album \u{00B7} \(a.artistName)"
         case .track(let t):

--- a/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
+++ b/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
@@ -357,9 +357,9 @@ private struct SeedRow: View {
         case .album(let a):
             return a.artistName
         case .artist(let a):
-            return a.albumCount == 1 ? "1 album" : "\(a.albumCount) albums"
+            return CountStrings.label(Int(a.albumCount), .albums)
         case .playlist(let p):
-            return p.trackCount == 1 ? "1 track" : "\(p.trackCount) tracks"
+            return CountStrings.label(Int(p.trackCount), .tracks)
         case .genre:
             return nil
         }

--- a/macos/Sources/Lyrebird/Components/LibraryListRow.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryListRow.swift
@@ -194,16 +194,15 @@ struct LibraryListRow: View {
     private var countMeta: String {
         switch payload {
         case .album(let album):
-            return album.trackCount == 1 ? "1 track" : "\(album.trackCount) tracks"
+            return CountStrings.label(Int(album.trackCount), .tracks)
         case .artist(let artist):
-            return artist.albumCount == 1 ? "1 album" : "\(artist.albumCount) albums"
+            return CountStrings.label(Int(artist.albumCount), .albums)
         case .playlist(let playlist):
             // Empty playlists get a compact "Empty" label rather than "0
             // tracks"; otherwise mirror the album column's format.
             switch playlist.trackCount {
             case 0: return "Empty"
-            case 1: return "1 track"
-            default: return "\(playlist.trackCount) tracks"
+            default: return CountStrings.label(Int(playlist.trackCount), .tracks)
             }
         }
     }

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -418,27 +418,12 @@ struct PlayerBar: View {
     }
 
     private func format(_ seconds: Double) -> String {
-        let total = Int(seconds)
-        let m = total / 60
-        let s = total % 60
-        return String(format: "%d:%02d", m, s)
+        DurationFormatter.colon(seconds)
     }
 
     /// Convert a duration in seconds to a word-based string for VoiceOver.
     /// "0 seconds", "45 seconds", "1 minute 5 seconds", "2 minutes", etc.
     private static func voiceOverTime(_ seconds: Double) -> String {
-        let safe = seconds.isFinite ? max(0, seconds) : 0
-        let total = Int(safe.rounded())
-        let m = total / 60
-        let s = total % 60
-        switch (m, s) {
-        case (0, 0): return "0 seconds"
-        case (0, _): return s == 1 ? "1 second" : "\(s) seconds"
-        case (_, 0): return m == 1 ? "1 minute" : "\(m) minutes"
-        default:
-            let mins = m == 1 ? "1 minute" : "\(m) minutes"
-            let secs = s == 1 ? "1 second" : "\(s) seconds"
-            return "\(mins) \(secs)"
-        }
+        DurationFormatter.spokenAccessibility(seconds)
     }
 }

--- a/macos/Sources/Lyrebird/Components/PlaylistCard.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistCard.swift
@@ -83,8 +83,7 @@ struct PlaylistCard: View {
     private var subtitle: String {
         switch playlist.trackCount {
         case 0: return "Empty"
-        case 1: return "1 track"
-        default: return "\(playlist.trackCount) tracks"
+        default: return CountStrings.label(Int(playlist.trackCount), .tracks)
         }
     }
 }

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -405,7 +405,13 @@ struct QueueInspector: View {
                     .foregroundStyle(Theme.ink3)
                     .monospacedDigit()
             }
+            .accessibilityHidden(true)
         }
+        // Speak the progress as one spelled-out element rather than two
+        // ambiguous "three oh five" timecode labels. See #349.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Playback position")
+        .accessibilityValue(scrubberAccessibilityValue)
     }
 
     // MARK: - Inline lyrics snippet (#91)
@@ -591,11 +597,16 @@ struct QueueInspector: View {
     }
 
     private func format(_ seconds: Double) -> String {
-        let safe = seconds.isFinite ? max(0, seconds) : 0
-        let total = Int(safe)
-        let m = total / 60
-        let s = total % 60
-        return String(format: "%d:%02d", m, s)
+        DurationFormatter.colon(seconds)
+    }
+
+    /// Spelled-out position/duration for VoiceOver — "1 minute 23 seconds of
+    /// 4 minutes 10 seconds". Mirrors the PlayerBar scrubber's spoken value so
+    /// the read-only inspector progress reads the same way. See #349.
+    private var scrubberAccessibilityValue: String {
+        let pos = DurationFormatter.spokenAccessibility(model.status.positionSeconds)
+        let total = DurationFormatter.spokenAccessibility(model.status.durationSeconds)
+        return "\(pos) of \(total)"
     }
 }
 

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -75,7 +75,7 @@ struct QueueInspector: View {
         // the title so a user with a long queue sees at a glance what's
         // about to disappear — the generic "Clear queue?" hid that.
         .confirmationDialog(
-            "Clear \(totalQueueCount) items?",
+            "Clear \(CountStrings.label(totalQueueCount, .items))?",
             isPresented: $showClearConfirm,
             titleVisibility: .visible
         ) {
@@ -789,7 +789,7 @@ private struct SaveQueueSheet: View {
                 Text("Save queue as playlist")
                     .font(Theme.font(15, weight: .bold))
                     .foregroundStyle(Theme.ink)
-                Text("Creates a new playlist with \(totalCount) \(totalCount == 1 ? "track" : "tracks").")
+                Text("Creates a new playlist with \(CountStrings.label(totalCount, .tracks)).")
                     .font(Theme.font(11, weight: .medium))
                     .foregroundStyle(Theme.ink3)
             }

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -133,6 +133,14 @@ struct Sidebar: View {
                     .padding(.top, 6)
             }
 
+            // Smart playlists (#77 / #238). A distinct, rule-driven section
+            // below the regular playlists. Always shown (even empty) so the
+            // "New Smart Playlist…" affordance is discoverable; the section
+            // is compact and self-contained.
+            smartPlaylistsSection
+                .padding(.horizontal, 10)
+                .padding(.top, 6)
+
             Spacer(minLength: 0)
 
             // Server footer
@@ -304,6 +312,104 @@ struct Sidebar: View {
             destination: destination
         )
         playlistOrderRaw = PlaylistSidebarOrder.encode(next)
+    }
+
+    // MARK: - Smart playlists section (#77 / #238)
+
+    @ViewBuilder
+    private var smartPlaylistsSection: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text("SMART PLAYLISTS")
+                    .font(Theme.font(10, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(1.5)
+                Spacer()
+                Button { model.createSmartPlaylist() } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Theme.ink3)
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help("New Smart Playlist")
+                .accessibilityLabel("New Smart Playlist")
+            }
+            .padding(.horizontal, 8)
+            .padding(.top, 2)
+            .padding(.bottom, 4)
+
+            if model.smartPlaylists.playlists.isEmpty {
+                // Discoverable empty-state row: a single tappable "New Smart
+                // Playlist…" entry, matching the issue's ask for a create
+                // affordance in the sidebar.
+                Button { model.createSmartPlaylist() } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "plus.circle")
+                            .foregroundStyle(Theme.ink3)
+                            .frame(width: 18)
+                        Text("New Smart Playlist…")
+                            .font(Theme.font(12, weight: .medium))
+                            .foregroundStyle(Theme.ink3)
+                            .lineLimit(labelLineLimit)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("New Smart Playlist")
+            } else {
+                ForEach(model.smartPlaylists.playlists) { playlist in
+                    smartPlaylistRow(playlist)
+                }
+            }
+        }
+    }
+
+    /// A single smart-playlist row. Mirrors `playlistRow` styling but uses a
+    /// distinct gear glyph so smart (rule-driven) playlists read differently
+    /// from server playlists. Right-click offers delete; tap navigates.
+    @ViewBuilder
+    private func smartPlaylistRow(_ playlist: SmartPlaylist) -> some View {
+        let isActiveScreen: Bool = {
+            if case .smartPlaylist(let id) = model.navPath.last { return id == playlist.id }
+            return false
+        }()
+
+        HStack(spacing: 10) {
+            Image(systemName: "gearshape.2.fill")
+                .foregroundStyle(isActiveScreen ? a11yTheme.accent : Theme.ink2)
+                .frame(width: 18)
+            Text(playlist.name)
+                .font(Theme.font(12, weight: isActiveScreen ? .bold : .medium))
+                .foregroundStyle(isActiveScreen ? Theme.ink : Theme.ink2)
+                .lineLimit(labelLineLimit)
+                .truncationMode(.tail)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isActiveScreen ? Theme.surface2 : .clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { model.goToSmartPlaylist(playlist) }
+        .contextMenu {
+            Button { model.goToSmartPlaylist(playlist) } label: {
+                Label("Open", systemImage: "arrow.forward")
+            }
+            Divider()
+            Button(role: .destructive) {
+                model.smartPlaylists.remove(id: playlist.id)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .accessibilityLabel(playlist.name)
+        .accessibilityAddTraits(isActiveScreen ? .isSelected : [])
     }
 
     // MARK: - Playlist row (display + inline edit)

--- a/macos/Sources/Lyrebird/Components/SmartPlaylistBuilderView.swift
+++ b/macos/Sources/Lyrebird/Components/SmartPlaylistBuilderView.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// iTunes / Marvis-style rule builder for a `SmartPlaylist` (#77 / #238).
+///
+/// Presented as a sheet. The user edits the name, the "Match all / any of
+/// the following rules" mode, and an ordered list of `field op value` rows
+/// (each with add / remove affordances). A live "N songs match" readout at
+/// the bottom evaluates the draft against the current library snapshot on
+/// every keystroke so the user gets immediate feedback.
+///
+/// The builder is intentionally self-contained: it edits a local copy of
+/// the playlist and only hands the result back through `onSave` when the
+/// user commits, so a cancelled edit leaves the stored playlist untouched.
+/// The live count is the only thing that reaches into `AppModel` (for the
+/// snapshot to evaluate against).
+struct SmartPlaylistBuilderView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Local working copy. Edits mutate this; nothing persists until `onSave`.
+    @State private var draft: SmartPlaylist
+
+    /// Called with the finished playlist when the user taps Save. The caller
+    /// owns persistence (`SmartPlaylistStore.save`).
+    private let onSave: (SmartPlaylist) -> Void
+    /// Called when the user dismisses without saving.
+    private let onCancel: () -> Void
+
+    init(
+        playlist: SmartPlaylist,
+        onSave: @escaping (SmartPlaylist) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _draft = State(initialValue: playlist)
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
+    /// Live count of matching tracks over the current snapshot. Recomputed
+    /// each render; the evaluator is a single linear pass so this is cheap
+    /// even for the largest in-memory snapshot.
+    private var liveCount: Int {
+        SmartPlaylistEvaluator.matchCount(
+            draft,
+            tracks: model.tracks,
+            albums: model.albums
+        )
+    }
+
+    private var trimmedName: String {
+        draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().background(Theme.border)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    nameField
+                    matchModeRow
+                    rulesSection
+                }
+                .padding(24)
+            }
+            Divider().background(Theme.border)
+            footer
+        }
+        .frame(width: 560, height: 520)
+        .background(Theme.bg)
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "gearshape.2.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Theme.primary)
+            Text("Smart Playlist")
+                .font(Theme.font(16, weight: .bold))
+                .foregroundStyle(Theme.ink)
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+    }
+
+    // MARK: - Name
+
+    @ViewBuilder
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("NAME")
+                .font(Theme.font(10, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.5)
+            TextField("Smart Playlist Name", text: $draft.name)
+                .textFieldStyle(.plain)
+                .font(Theme.font(15, weight: .semibold))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 12)
+                .frame(height: 38)
+                .background(Theme.surface)
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.border, lineWidth: 1))
+                .cornerRadius(8)
+                .accessibilityLabel("Smart playlist name")
+        }
+    }
+
+    // MARK: - Match mode
+
+    @ViewBuilder
+    private var matchModeRow: some View {
+        HStack(spacing: 8) {
+            Text("Match")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+            Picker("Match mode", selection: $draft.matchMode) {
+                ForEach(SmartPlaylistMatchMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 90)
+            .accessibilityLabel("Match mode")
+            Text("of the following rules:")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+            Spacer()
+        }
+    }
+
+    // MARK: - Rules
+
+    @ViewBuilder
+    private var rulesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach($draft.rules) { $rule in
+                ruleRow($rule)
+            }
+            Button {
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
+                    draft.rules.append(.defaultRule())
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Rule")
+                }
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.primary)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 2)
+            .accessibilityLabel("Add rule")
+        }
+    }
+
+    /// A single editable rule row: field picker, operator picker, value
+    /// editor (typed to the field's value kind), and a remove button.
+    @ViewBuilder
+    private func ruleRow(_ rule: Binding<SmartPlaylistRule>) -> some View {
+        HStack(spacing: 8) {
+            // Field picker — changing the field repairs the operator/value so
+            // an impossible pairing (e.g. Favorite + greater-than) can't form.
+            Picker("Field", selection: Binding(
+                get: { rule.wrappedValue.field },
+                set: { newField in
+                    var next = rule.wrappedValue
+                    next.field = newField
+                    rule.wrappedValue = next.repaired()
+                }
+            )) {
+                ForEach(SmartPlaylistField.allCases, id: \.self) { field in
+                    Text(field.displayName).tag(field)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 110)
+            .accessibilityLabel("Rule field")
+
+            // Operator picker — scoped to operators valid for the field kind.
+            Picker("Operator", selection: rule.op) {
+                ForEach(SmartPlaylistOperator.applicable(to: rule.wrappedValue.field.valueKind), id: \.self) { op in
+                    Text(op.displayName).tag(op)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 150)
+            .accessibilityLabel("Rule operator")
+
+            valueEditor(rule)
+
+            Spacer(minLength: 0)
+
+            Button {
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
+                    draft.rules.removeAll { $0.id == rule.wrappedValue.id }
+                }
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(Theme.ink3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove rule")
+        }
+    }
+
+    /// Value editor rendered per the field's value kind: a free-text field
+    /// for text, a numeric field for numbers, a boolean menu for favorites,
+    /// and a "N days" numeric field for dates.
+    @ViewBuilder
+    private func valueEditor(_ rule: Binding<SmartPlaylistRule>) -> some View {
+        switch rule.wrappedValue.field.valueKind {
+        case .text:
+            TextField("value", text: rule.value)
+                .textFieldStyle(.plain)
+                .font(Theme.font(13))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 8)
+                .frame(width: 130, height: 30)
+                .background(Theme.surface)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
+                .cornerRadius(6)
+                .accessibilityLabel("Rule value")
+        case .number:
+            TextField("0", text: rule.value)
+                .textFieldStyle(.plain)
+                .font(Theme.font(13))
+                .foregroundStyle(Theme.ink)
+                .multilineTextAlignment(.trailing)
+                .padding(.horizontal, 8)
+                .frame(width: 80, height: 30)
+                .background(Theme.surface)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
+                .cornerRadius(6)
+                .accessibilityLabel("Rule value")
+        case .boolean:
+            Picker("value", selection: Binding(
+                get: { SmartPlaylistEvaluator.parseBool(rule.wrappedValue.value) ?? true },
+                set: { rule.wrappedValue.value = $0 ? "true" : "false" }
+            )) {
+                Text("yes").tag(true)
+                Text("no").tag(false)
+            }
+            .labelsHidden()
+            .frame(width: 80)
+            .accessibilityLabel("Rule value")
+        case .date:
+            HStack(spacing: 4) {
+                TextField("30", text: rule.value)
+                    .textFieldStyle(.plain)
+                    .font(Theme.font(13))
+                    .foregroundStyle(Theme.ink)
+                    .multilineTextAlignment(.trailing)
+                    .padding(.horizontal, 8)
+                    .frame(width: 56, height: 30)
+                    .background(Theme.surface)
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
+                    .cornerRadius(6)
+                    .accessibilityLabel("Rule value in days")
+                Text("days")
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack {
+            // Live result count over the loaded snapshot.
+            Label(SmartPlaylistDetailView.countSummary(liveCount) + " match", systemImage: "music.note")
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+            Spacer()
+            Button("Cancel") { onCancel() }
+                .buttonStyle(.plain)
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink2)
+                .padding(.horizontal, 14)
+                .frame(height: 32)
+                .background(Capsule().fill(Theme.surface))
+                .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
+                .keyboardShortcut(.cancelAction)
+
+            Button("Save") {
+                var finished = draft
+                // Never persist a blank name — fall back to a sensible default.
+                if trimmedName.isEmpty {
+                    finished.name = "Smart Playlist"
+                } else {
+                    finished.name = trimmedName
+                }
+                onSave(finished)
+            }
+            .buttonStyle(.plain)
+            .font(Theme.font(13, weight: .bold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 18)
+            .frame(height: 32)
+            .background(Capsule().fill(Theme.accent))
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Save smart playlist")
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 14)
+    }
+}

--- a/macos/Sources/Lyrebird/Components/TopTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TopTrackRow.swift
@@ -36,8 +36,7 @@ struct TopTrackRow: View {
         let count = track.playCount
         switch count {
         case 0: return "—"
-        case 1: return "1 play"
-        default: return "\(count) plays"
+        default: return CountStrings.label(Int(count), .plays)
         }
     }
 

--- a/macos/Sources/Lyrebird/Components/TrackInfoSheet.swift
+++ b/macos/Sources/Lyrebird/Components/TrackInfoSheet.swift
@@ -69,7 +69,11 @@ struct TrackInfoSheet: View {
             if let year = track.year {
                 row(label: "track.info.year", value: String(year))
             }
-            row(label: "track.info.duration", value: durationString)
+            row(
+                label: "track.info.duration",
+                value: durationString,
+                accessibilityValue: durationAccessibilityValue
+            )
             if let format = formatString {
                 row(label: "track.info.format", value: format)
             }
@@ -102,7 +106,14 @@ struct TrackInfoSheet: View {
 
     // MARK: - Helpers
 
-    private func row(label: LocalizedStringKey, value: String) -> some View {
+    /// `accessibilityValue` overrides what VoiceOver speaks for the value Text
+    /// when the visible string is ambiguous aloud (the duration row passes the
+    /// spelled-out form so `3:05` isn't read as "three oh five"). See #349.
+    private func row(
+        label: LocalizedStringKey,
+        value: String,
+        accessibilityValue: String? = nil
+    ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
             Text(label)
                 .font(Theme.font(11, weight: .semibold))
@@ -114,6 +125,7 @@ struct TrackInfoSheet: View {
                 .foregroundStyle(Theme.ink)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
+                .accessibilityValue(accessibilityValue ?? value)
         }
     }
 
@@ -131,14 +143,13 @@ struct TrackInfoSheet: View {
     /// is the Apple-style 100-ns count (`seconds * 10_000_000`); divide once
     /// at present-time so callers don't repeat the math.
     private var durationString: String {
-        let totalSeconds = Int(track.runtimeTicks / 10_000_000)
-        let h = totalSeconds / 3600
-        let m = (totalSeconds % 3600) / 60
-        let s = totalSeconds % 60
-        if h > 0 {
-            return String(format: "%d:%02d:%02d", h, m, s)
-        }
-        return String(format: "%d:%02d", m, s)
+        DurationFormatter.colon(track.durationSeconds)
+    }
+
+    /// Spelled-out duration ("3 minutes 5 seconds") VoiceOver reads instead of
+    /// the ambiguous "three oh five" timecode. See #349.
+    private var durationAccessibilityValue: String {
+        DurationFormatter.spokenAccessibility(track.durationSeconds)
     }
 
     /// `FLAC · 1042 kbps` / `MP3 · 320 kbps` / `MP3` if bitrate's unknown.

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -335,7 +335,7 @@ struct TrackListRow: View {
     /// "1 play" / "12 plays" readout shown on hover when the user enables
     /// "Show play counts on hover".
     private var playCountLabel: String {
-        track.playCount == 1 ? "1 play" : "\(track.playCount) plays"
+        CountStrings.label(Int(track.playCount), .plays)
     }
 
     /// Advance the focused row by `delta` (+1 for down, -1 for up) inside

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -215,7 +215,7 @@ struct TrackRow: View {
     /// "1 play" / "12 plays" readout shown on hover when the user enables
     /// "Show play counts on hover". Matches `TopTrackRow`'s wording.
     private var playCountLabel: String {
-        track.playCount == 1 ? "1 play" : "\(track.playCount) plays"
+        CountStrings.label(Int(track.playCount), .plays)
     }
 
     /// Move the shared focus cursor by `delta` within `tracks`. Returns

--- a/macos/Sources/Lyrebird/Components/TrackSelectionBanner.swift
+++ b/macos/Sources/Lyrebird/Components/TrackSelectionBanner.swift
@@ -34,11 +34,11 @@ struct TrackSelectionBanner: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            Text("\(count) selected")
+            Text(CountStrings.label(count, .selected))
                 .font(Theme.font(13, weight: .bold))
                 .foregroundStyle(Theme.ink)
                 .monospacedDigit()
-                .accessibilityLabel("\(count) tracks selected")
+                .accessibilityLabel("\(CountStrings.label(count, .tracks)) selected")
 
             Text("—")
                 .font(Theme.font(13, weight: .medium))
@@ -71,7 +71,7 @@ struct TrackSelectionBanner: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
-            .accessibilityLabel("Add \(count) tracks to a playlist")
+            .accessibilityLabel("Add \(CountStrings.label(count, .tracks)) to a playlist")
 
             if let onRemove {
                 actionButton("Remove", systemImage: "trash", role: .destructive) {
@@ -118,7 +118,7 @@ struct TrackSelectionBanner: View {
             bannerLabel(title, systemImage: systemImage, destructive: role == .destructive)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(title) \(count) selected tracks")
+        .accessibilityLabel("\(title) · \(CountStrings.label(count, .tracks)) selected")
     }
 
     private func bannerLabel(

--- a/macos/Sources/Lyrebird/CountStrings.swift
+++ b/macos/Sources/Lyrebird/CountStrings.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Inflected count strings ("1 album" / "2 albums") backed by the String
+/// Catalog's plural variations (#350).
+///
+/// Before this, count subtitles were assembled with hand-rolled ternaries
+/// scattered across a dozen views — `count == 1 ? "1 track" : "\(count) tracks"`
+/// or, worse, the `"track\(count == 1 ? "" : "s")"` suffix trick. Those
+/// don't localize (the English rule is hardcoded at every call site) and they
+/// quietly disagree with each other on edge cases. This funnels every count
+/// label through a single `String(localized:)` lookup against a `%lld`-keyed
+/// plural variation in `Localizable.xcstrings`, so the catalog owns the
+/// singular/plural rule and translators get the per-language plural categories
+/// for free.
+///
+/// ### Why a helper instead of inline `Text("count.tracks \(n)")`?
+///
+/// The interpolation form works for a bare `Text`, but most call sites need a
+/// plain `String`: they join several counts with `" · "` into one subtitle
+/// (`GenreDetailView`, `FavoritesView`), feed an `.accessibilityLabel`, or
+/// embed the count inside a larger sentence. A `String`-returning helper covers
+/// all of those uniformly, and keeps the catalog key in exactly one place per
+/// noun so a typo can't silently fall back to the raw key in one view but not
+/// another.
+///
+/// ### Testability
+///
+/// Mirrors `LyrebirdErrorPresenter`: the bundle lookup (`label(_:_:)`) can't be
+/// exercised headlessly because SwiftPM strips the `.xcstrings` catalog from
+/// the unit-test binary (resources are copied into the `.app` by
+/// `make-bundle.sh`, not the test bundle), so a `String(localized:)` call there
+/// returns the raw key rather than the inflected value. The English plural
+/// *rule* therefore lives in `pluralCategory(for:)` and the key routing in
+/// `Noun.key` / `key(_:)`, both pure and unit-tested, while the catalog lookup
+/// is a thin one-liner over them.
+enum CountStrings {
+    /// The countable nouns the app pluralizes. Each maps to a `%lld`-keyed
+    /// plural variation in `Localizable.xcstrings`.
+    enum Noun: CaseIterable {
+        case albums
+        case artists
+        case items
+        case playlists
+        case plays
+        case results
+        case selected
+        case songs
+        case tracks
+
+        /// The catalog key carrying this noun's plural variations. The trailing
+        /// `%lld` is the format placeholder the String Catalog substitutes the
+        /// count into; it's part of the key by Xcode convention.
+        var key: String {
+            switch self {
+            case .albums: return "count.albums %lld"
+            case .artists: return "count.artists %lld"
+            case .items: return "count.items %lld"
+            case .playlists: return "count.playlists %lld"
+            case .plays: return "count.plays %lld"
+            case .results: return "count.results %lld"
+            case .selected: return "count.selected %lld"
+            case .songs: return "count.songs %lld"
+            case .tracks: return "count.tracks %lld"
+            }
+        }
+    }
+
+    /// The CLDR plural category an English count selects. English distinguishes
+    /// only `one` (exactly 1) from `other` (everything else, including 0 and
+    /// negatives), which is precisely what the catalog's `en` variations encode.
+    ///
+    /// Exposed (and unit-tested) so the selection rule has coverage that
+    /// doesn't depend on the catalog being present in the test bundle. Other
+    /// languages have richer category sets (e.g. `zero`, `few`, `many`); those
+    /// are the catalog's responsibility per locale, not this function's.
+    enum PluralCategory {
+        case one
+        case other
+    }
+
+    /// The English plural category for `count`.
+    static func pluralCategory(for count: Int) -> PluralCategory {
+        count == 1 ? .one : .other
+    }
+
+    /// The catalog key for `noun`. Thin pass-through to `Noun.key`, provided so
+    /// call sites and tests can route through one symbol.
+    static func key(_ noun: Noun) -> String {
+        noun.key
+    }
+
+    /// An inflected, localized count label, e.g. `label(1, .albums) == "1 album"`
+    /// and `label(2, .albums) == "2 albums"` in English. The count is formatted
+    /// by the catalog's `%lld` placeholder, so it inherits the locale's grouping
+    /// behaviour for the integer itself.
+    ///
+    /// The `LocalizationValue` is built by *interpolating* the count
+    /// (`"count.tracks \(count)"`) rather than substituting it into the key
+    /// string. Interpolation records the count as a `%lld` argument so the
+    /// String Catalog can run plural selection on it; baking the digit into the
+    /// key (`"count.tracks 2"`) would miss the variation and return the raw key.
+    static func label(_ count: Int, _ noun: Noun) -> String {
+        String(localized: localizationValue(count, noun), bundle: .main)
+    }
+
+    /// Builds the interpolated `LocalizationValue` for `noun` carrying `count`
+    /// as its `%lld` argument. Split out so `label(_:_:)` stays a one-liner and
+    /// the per-noun key prefixes live next to `Noun.key` for easy auditing.
+    private static func localizationValue(_ count: Int, _ noun: Noun) -> String.LocalizationValue {
+        switch noun {
+        case .albums: return "count.albums \(count)"
+        case .artists: return "count.artists \(count)"
+        case .items: return "count.items \(count)"
+        case .playlists: return "count.playlists \(count)"
+        case .plays: return "count.plays \(count)"
+        case .results: return "count.results \(count)"
+        case .selected: return "count.selected \(count)"
+        case .songs: return "count.songs \(count)"
+        case .tracks: return "count.tracks \(count)"
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/DurationFormatter.swift
+++ b/macos/Sources/Lyrebird/DurationFormatter.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Single source of truth for track / runtime duration strings (#349).
+///
+/// Before this existed, ~7 call sites each hand-rolled `String(format: "%d:%02d", …)`
+/// (AppModel's `Track.durationFormatted`, PlayerBar, NowPlayingView, QueueInspector,
+/// AlbumDetailView, TrackInfoSheet) plus a one-off spelled-out VoiceOver string in
+/// PlayerBar. Consolidating here keeps the visual form and the spoken form from
+/// drifting, and gives both a single tested implementation.
+///
+/// Two intentionally-distinct outputs:
+///
+/// * ``colon(_:)`` — the *visual* form (`3:05`, `1:02:09`). It is deliberately
+///   **locale-invariant**: the `:` separator and zero-padding are the universal
+///   convention for media timecodes (Apple Music, QuickTime, every player ships
+///   `mm:ss` regardless of region), so this does NOT route through
+///   `Duration.TimeFormatStyle` — that style swaps separators per locale and
+///   would make the timecode read differently across regions for no benefit.
+///
+/// * ``spokenAccessibility(_:)`` — the spelled-out form for `accessibilityValue`
+///   ("3 minutes 5 seconds"). VoiceOver reading "three oh five" for `3:05` is
+///   ambiguous; the spoken words match Apple Music / Podcasts. This mirrors the
+///   rest of the app's hard-coded English a11y strings (e.g. the `play` /
+///   `plays` count readouts).
+///
+/// All members are `nonisolated` + pure so the test target and any `@MainActor`
+/// view can call them from any context without constructing an `AppModel`.
+enum DurationFormatter {
+
+    /// Normalize an arbitrary seconds value into a whole-second, non-negative
+    /// `Int`. Guards `NaN` / `±inf` (an unloaded AVPlayer item reports `NaN`
+    /// duration) and clamps negatives to zero so the formatters never emit
+    /// `-1:59` or crash on a non-finite `Int(_:)` conversion.
+    private static func wholeSeconds(_ seconds: Double) -> Int {
+        guard seconds.isFinite else { return 0 }
+        return max(0, Int(seconds.rounded()))
+    }
+
+    /// Locale-invariant timecode: `m:ss` under an hour, `h:mm:ss` at or past it.
+    ///
+    /// Examples: `0` → `"0:00"`, `5` → `"0:05"`, `185` → `"3:05"`,
+    /// `3725` → `"1:02:05"`.
+    static func colon(_ seconds: Double) -> String {
+        colon(wholeSeconds: wholeSeconds(seconds))
+    }
+
+    /// Overload for call sites that already hold an integer second count derived
+    /// from Jellyfin's 100-ns `runtimeTicks` (avoids a Double round-trip).
+    static func colon(wholeSeconds total: Int) -> String {
+        let safe = max(0, total)
+        let h = safe / 3600
+        let m = (safe % 3600) / 60
+        let s = safe % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+
+    /// Spelled-out duration for VoiceOver `accessibilityValue`.
+    ///
+    /// Examples: `0` → `"0 seconds"`, `1` → `"1 second"`, `45` → `"45 seconds"`,
+    /// `60` → `"1 minute"`, `185` → `"3 minutes 5 seconds"`,
+    /// `3725` → `"1 hour 2 minutes 5 seconds"`. Zero-valued components are
+    /// dropped (`"1 hour 5 seconds"` for `3605`) so the readout stays terse;
+    /// singular / plural is handled per component.
+    static func spokenAccessibility(_ seconds: Double) -> String {
+        let total = wholeSeconds(seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+
+        var parts: [String] = []
+        if h > 0 { parts.append(unit(h, singular: "hour", plural: "hours")) }
+        if m > 0 { parts.append(unit(m, singular: "minute", plural: "minutes")) }
+        // Always speak seconds when nothing larger is present (so `0` and small
+        // sub-minute values still produce a value); otherwise only when nonzero.
+        if s > 0 || parts.isEmpty {
+            parts.append(unit(s, singular: "second", plural: "seconds"))
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private static func unit(_ value: Int, singular: String, plural: String) -> String {
+        "\(value) \(value == 1 ? singular : plural)"
+    }
+}

--- a/macos/Sources/Lyrebird/Resources/InfoPlist.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/InfoPlist.xcstrings
@@ -1,0 +1,42 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "The user-visible app name shown in the Dock, Finder, and the menu bar. Mirrors CFBundleDisplayName in Info.plist (#359).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrebird"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "The short app name (≤15 chars) used where CFBundleDisplayName is unavailable. Mirrors CFBundleName in Info.plist (#359).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrebird"
+          }
+        }
+      }
+    },
+    "NSHumanReadableCopyright" : {
+      "comment" : "Copyright notice shown in the About window and Get Info. Mirrors NSHumanReadableCopyright in Info.plist (#359).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -229,6 +229,222 @@
         }
       }
     },
+    "count.albums %lld" : {
+      "comment" : "Standalone album count, e.g. an artist or genre subtitle. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld album"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld albums"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.artists %lld" : {
+      "comment" : "Standalone artist count, e.g. a Favorites subtitle. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld artist"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld artists"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.items %lld" : {
+      "comment" : "Generic queue or list item count, e.g. \"Clear N items?\". %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld item"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld items"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.playlists %lld" : {
+      "comment" : "Standalone playlist count. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld playlist"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld playlists"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.plays %lld" : {
+      "comment" : "Lifetime play-count for a track. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld play"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld plays"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.results %lld" : {
+      "comment" : "Search result count. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld result"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld results"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.selected %lld" : {
+      "comment" : "Multiselect tally, e.g. \"N selected\" in a selection banner. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld selected"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld selected"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.songs %lld" : {
+      "comment" : "Standalone song count, e.g. an artist or genre subtitle. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld song"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld songs"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.tracks %lld" : {
+      "comment" : "Standalone track count, e.g. a playlist or album subtitle. %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld track"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld tracks"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "empty.library.title" : {
       "comment" : "Headline on the empty-library state shown when the server has no music yet.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -876,9 +876,7 @@ struct AlbumDetailView: View {
             let m = (totalSeconds % 3600) / 60
             return "\(h)h \(m)m"
         } else {
-            let m = totalSeconds / 60
-            let s = totalSeconds % 60
-            return String(format: "%d:%02d", m, s)
+            return DurationFormatter.colon(wholeSeconds: totalSeconds)
         }
     }
 

--- a/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/AlbumDetailView.swift
@@ -902,12 +902,14 @@ struct AlbumDetailView: View {
     /// spans multiple discs ("12 tracks · 2 discs").
     private func tracksSummary(album: Album) -> String {
         let trackCount = tracks.isEmpty ? Int(album.trackCount) : tracks.count
-        let trackWord = trackCount == 1 ? "track" : "tracks"
+        let trackLabel = CountStrings.label(trackCount, .tracks)
         let discs = Set(tracks.compactMap { $0.discNumber.map(Int.init) }).count
         if discs > 1 {
-            return "\(trackCount) \(trackWord) · \(discs) discs"
+            // `discs > 1` here, so "discs" is always plural; no inflection
+            // helper needed for that segment.
+            return "\(trackLabel) · \(discs) discs"
         }
-        return "\(trackCount) \(trackWord)"
+        return trackLabel
     }
 
     /// Format summary used by both the hero stat and the liner-note row.

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -963,7 +963,7 @@ struct ArtistDetailView: View {
     @ViewBuilder
     private func footer(_ artist: Artist?) -> some View {
         if let artist = artist {
-            Text("\(artist.name) · \(artistAlbums.count) \(artistAlbums.count == 1 ? "album" : "albums") in your library")
+            Text("\(artist.name) · \(CountStrings.label(artistAlbums.count, .albums)) in your library")
                 .font(Theme.font(11, weight: .medium))
                 .foregroundStyle(Theme.ink3)
                 .padding(.horizontal, 32)
@@ -1042,7 +1042,7 @@ private struct ArtistDiscographyTile: View {
     /// a track count; year is best-effort (some albums ship without it), so
     /// we fall back to just the track count in that case.
     private var yearLine: String {
-        let tracks = album.trackCount == 1 ? "1 track" : "\(album.trackCount) tracks"
+        let tracks = CountStrings.label(Int(album.trackCount), .tracks)
         if let year = album.year, year > 0 {
             return "\(year) · \(tracks)"
         }
@@ -1183,8 +1183,7 @@ private struct FeaturingPlaylistTile: View {
     private var subtitle: String {
         switch playlist.trackCount {
         case 0: return "Empty"
-        case 1: return "1 track"
-        default: return "\(playlist.trackCount) tracks"
+        default: return CountStrings.label(Int(playlist.trackCount), .tracks)
         }
     }
 }

--- a/macos/Sources/Lyrebird/Screens/FavoritesView.swift
+++ b/macos/Sources/Lyrebird/Screens/FavoritesView.swift
@@ -90,9 +90,9 @@ struct FavoritesView: View {
     /// counts in a single line so the user sees scope at a glance.
     private var countLine: some View {
         let parts: [String] = [
-            tracks.isEmpty ? nil : "\(tracks.count) song\(tracks.count == 1 ? "" : "s")",
-            albums.isEmpty ? nil : "\(albums.count) album\(albums.count == 1 ? "" : "s")",
-            artists.isEmpty ? nil : "\(artists.count) artist\(artists.count == 1 ? "" : "s")",
+            tracks.isEmpty ? nil : CountStrings.label(tracks.count, .songs),
+            albums.isEmpty ? nil : CountStrings.label(albums.count, .albums),
+            artists.isEmpty ? nil : CountStrings.label(artists.count, .artists),
         ].compactMap { $0 }
         return Text(parts.isEmpty ? " " : parts.joined(separator: " · "))
             .font(Theme.font(13, weight: .medium))

--- a/macos/Sources/Lyrebird/Screens/FullQueueView.swift
+++ b/macos/Sources/Lyrebird/Screens/FullQueueView.swift
@@ -481,7 +481,7 @@ private struct FullQueueSaveSheet: View {
                 Text("Save queue as playlist")
                     .font(Theme.font(15, weight: .bold))
                     .foregroundStyle(Theme.ink)
-                Text("Creates a new playlist with \(trackCount) \(trackCount == 1 ? "track" : "tracks").")
+                Text("Creates a new playlist with \(CountStrings.label(trackCount, .tracks)).")
                     .font(Theme.font(11, weight: .medium))
                     .foregroundStyle(Theme.ink3)
             }

--- a/macos/Sources/Lyrebird/Screens/GenreDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/GenreDetailView.swift
@@ -76,8 +76,8 @@ struct GenreDetailView: View {
         let albumCount = albums.count
         let parts: [String] = {
             var p: [String] = []
-            if !isLoadingTracks { p.append(songCount == 1 ? "1 song" : "\(songCount) songs") }
-            if !isLoadingAlbums { p.append(albumCount == 1 ? "1 album" : "\(albumCount) albums") }
+            if !isLoadingTracks { p.append(CountStrings.label(songCount, .songs)) }
+            if !isLoadingAlbums { p.append(CountStrings.label(albumCount, .albums)) }
             return p
         }()
         if !parts.isEmpty {

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -982,6 +982,6 @@ private struct PlayCountBadge: View {
     }
 
     private var playsLabel: String {
-        plays == 1 ? "1 play" : "\(plays) plays"
+        CountStrings.label(Int(plays), .plays)
     }
 }

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -445,6 +445,8 @@ struct MainShell: View {
             ArtistDetailView(artistID: id)
         case .playlist(let id):
             PlaylistView(playlistID: id)
+        case .smartPlaylist(let id):
+            SmartPlaylistDetailView(playlistID: id)
         case .genre(let g):
             GenreDetailView(genre: g)
         case .nowPlaying:
@@ -573,6 +575,13 @@ struct MainShell: View {
             if model.screen != .library { segments.append("Library") }
             segments.append("Playlists")
             if let playlist = model.playlist(id: id) {
+                segments.append(playlist.name)
+            } else {
+                segments.append("…")
+            }
+        case .smartPlaylist(let id)?:
+            segments.append("Smart Playlists")
+            if let playlist = model.smartPlaylists.playlist(id: id) {
                 segments.append(playlist.name)
             } else {
                 segments.append("…")

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -429,7 +429,8 @@ struct NowPlayingView: View {
 
                 aboutSection(
                     label: "Runtime",
-                    value: formatRuntime(track.durationSeconds)
+                    value: formatRuntime(track.durationSeconds),
+                    accessibilityValue: DurationFormatter.spokenAccessibility(track.durationSeconds)
                 )
 
                 if track.playCount > 0 {
@@ -474,8 +475,16 @@ struct NowPlayingView: View {
         }
     }
 
+    /// `accessibilityValue` overrides the spoken form of `value` when the
+    /// on-screen text would be ambiguous to VoiceOver (e.g. a `3:05` runtime
+    /// reads as "three oh five"; the Runtime row passes the spelled-out
+    /// "3 minutes 5 seconds" instead). See #349.
     @ViewBuilder
-    private func aboutSection(label: String, value: String) -> some View {
+    private func aboutSection(
+        label: String,
+        value: String,
+        accessibilityValue: String? = nil
+    ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(label.uppercased())
                 .font(Theme.font(10, weight: .bold))
@@ -487,14 +496,11 @@ struct NowPlayingView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(label): \(value)")
+        .accessibilityLabel("\(label): \(accessibilityValue ?? value)")
     }
 
     private func formatRuntime(_ seconds: Double) -> String {
-        let total = Int(seconds.rounded())
-        let m = total / 60
-        let s = total % 60
-        return String(format: "%d:%02d", m, s)
+        DurationFormatter.colon(seconds)
     }
 
     private func formatPlayCount(_ count: UInt32) -> String {

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -498,7 +498,7 @@ struct NowPlayingView: View {
     }
 
     private func formatPlayCount(_ count: UInt32) -> String {
-        count == 1 ? "1 play" : "\(count) plays"
+        CountStrings.label(Int(count), .plays)
     }
 
     private func formatBitrate(_ bitrate: Int64) -> String {

--- a/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistDetailView.swift
@@ -168,7 +168,7 @@ struct PlaylistDetailView: View {
                 }
 
                 HStack(spacing: 10) {
-                    Text("\(tracks.count) \(tracks.count == 1 ? "track" : "tracks")")
+                    Text(CountStrings.label(tracks.count, .tracks))
                         .font(Theme.font(12, weight: .semibold))
                         .foregroundStyle(Theme.ink3)
                     Text("·")
@@ -671,7 +671,7 @@ private struct UndoRemovalToast: View {
     let onDismiss: () -> Void
 
     private var message: String {
-        count == 1 ? "Removed 1 track" : "Removed \(count) tracks"
+        "Removed \(CountStrings.label(count, .tracks))"
     }
 
     var body: some View {

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -404,7 +404,7 @@ struct PlaylistView: View {
     @ViewBuilder
     private var footer: some View {
         if let playlist = playlist {
-            Text("\(playlist.trackCount) \(playlist.trackCount == 1 ? "track" : "tracks") · \(formatMinutes(playlist.runtimeTicks)) min runtime")
+            Text("\(CountStrings.label(Int(playlist.trackCount), .tracks)) · \(formatMinutes(playlist.runtimeTicks)) min runtime")
                 .font(Theme.font(11, weight: .medium))
                 .foregroundStyle(Theme.ink3)
                 .padding(.horizontal, 32)

--- a/macos/Sources/Lyrebird/Screens/SmartPlaylistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/SmartPlaylistDetailView.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Detail screen for a saved **smart playlist** (#77 / #238).
+///
+/// A smart playlist has no server-side track list — it's the *live* result
+/// of running its rules over the in-memory library snapshot
+/// (`model.tracks`). So this view never fetches: it evaluates
+/// `SmartPlaylistEvaluator` over the snapshot the app already holds and
+/// renders the matches with the same `TrackRow` density the regular
+/// playlist screen uses. Re-evaluation is automatic — the result is derived
+/// from `model.tracks` / `model.albums`, so as the library snapshot grows
+/// (pagination) or favorites change, the list recomputes on the next render.
+///
+/// The hero mirrors `PlaylistView`'s transport bar (Play / Shuffle) plus an
+/// "Edit Rules" affordance that opens the builder sheet, and a rule summary
+/// line so the user can see at a glance what the playlist matches.
+struct SmartPlaylistDetailView: View {
+    @Environment(AppModel.self) private var model
+    let playlistID: UUID
+
+    /// Drives the builder sheet. Set to the playlist being edited when the
+    /// user taps "Edit Rules"; `nil` when closed.
+    @State private var editing: SmartPlaylist?
+
+    /// Scoped (⌘F-style) filter over the evaluated result, matching
+    /// `PlaylistView`. Local only; not persisted.
+    @State private var scopedQuery: String = ""
+    @FocusState private var scopedSearchFocused: Bool
+
+    private var playlist: SmartPlaylist? {
+        model.smartPlaylists.playlist(id: playlistID)
+    }
+
+    /// The live evaluated track set. Pure function of the playlist's rules
+    /// and the current snapshot — recomputed each render (cheap: a single
+    /// linear pass with an O(1) genre lookup).
+    private var matchedTracks: [Track] {
+        guard let playlist else { return [] }
+        return SmartPlaylistEvaluator.evaluate(
+            playlist,
+            tracks: model.tracks,
+            albums: model.albums
+        )
+    }
+
+    /// `matchedTracks` filtered by the scoped query, paired with the index
+    /// into `matchedTracks` so playback starts from the right row.
+    private var filteredTracks: [(index: Int, track: Track)] {
+        PlaylistView.filterTracks(matchedTracks, query: scopedQuery)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if let playlist {
+                    hero(playlist)
+                    transportBar
+                    trackList
+                } else {
+                    notFound
+                }
+            }
+            .padding(.bottom, 40)
+        }
+        .background(Theme.bg)
+        .sheet(item: $editing) { draft in
+            SmartPlaylistBuilderView(playlist: draft) { saved in
+                model.smartPlaylists.save(saved)
+                editing = nil
+            } onCancel: {
+                editing = nil
+            }
+        }
+        .onChange(of: model.scopedSearchFocusRequest) { _, _ in
+            if model.consumeScopedSearchFocus(for: .smartPlaylist(playlistID)) {
+                scopedSearchFocused = true
+            }
+        }
+    }
+
+    // MARK: - Hero
+
+    @ViewBuilder
+    private func hero(_ playlist: SmartPlaylist) -> some View {
+        HStack(alignment: .top, spacing: 24) {
+            // Gradient artwork tile with the smart-playlist glyph, so the
+            // detail page reads as "rule-driven" rather than a normal
+            // playlist with missing art.
+            RoundedRectangle(cornerRadius: 16)
+                .fill(LinearGradient(
+                    colors: [Theme.primary, Theme.accent],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ))
+                .frame(width: 200, height: 200)
+                .overlay(
+                    Image(systemName: "gearshape.2.fill")
+                        .font(.system(size: 64, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.92))
+                )
+                .shadow(color: Theme.primary.opacity(0.3), radius: 18, y: 10)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("SMART PLAYLIST")
+                    .font(Theme.font(10, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(2)
+
+                Text(playlist.name)
+                    .font(Theme.font(34, weight: .black))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(2)
+
+                // Plain-English summary of the rules so the user sees what
+                // this playlist matches without opening the builder.
+                Text(SmartPlaylistDetailView.ruleSummary(playlist))
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink2)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(SmartPlaylistDetailView.countSummary(matchedTracks.count))
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 28)
+    }
+
+    // MARK: - Transport bar
+
+    @ViewBuilder
+    private var transportBar: some View {
+        HStack(spacing: 14) {
+            Button {
+                let t = matchedTracks
+                if !t.isEmpty { model.play(tracks: t, startIndex: 0) }
+            } label: {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.white)
+                    .frame(width: 54, height: 54)
+                    .background(Circle().fill(Theme.accent))
+                    .shadow(color: Theme.accent.opacity(0.35), radius: 12, y: 8)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Play smart playlist")
+            .disabled(matchedTracks.isEmpty)
+
+            Button {
+                let t = matchedTracks
+                if !t.isEmpty { model.play(tracks: t.shuffled(), startIndex: 0) }
+            } label: {
+                Image(systemName: "shuffle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 36, height: 36)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Shuffle smart playlist")
+            .disabled(matchedTracks.isEmpty)
+
+            Button {
+                editing = playlist
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "slider.horizontal.3")
+                    Text("Edit Rules")
+                }
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+                .padding(.horizontal, 14)
+                .frame(height: 36)
+                .background(Capsule().fill(Theme.surface))
+                .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit smart playlist rules")
+
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 20)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Track list
+
+    @ViewBuilder
+    private var trackList: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if !matchedTracks.isEmpty {
+                HStack {
+                    Spacer()
+                    ScopedSearchBar(
+                        query: $scopedQuery,
+                        isFocused: $scopedSearchFocused,
+                        placeholder: "Filter tracks"
+                    )
+                }
+                .padding(.bottom, 8)
+            }
+
+            if matchedTracks.isEmpty {
+                emptyResult
+            } else if filteredTracks.isEmpty {
+                Text("No tracks match \u{201C}\(scopedQuery)\u{201D}")
+                    .font(Theme.font(13, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.vertical, 40)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ForEach(filteredTracks, id: \.track.id) { entry in
+                    let idx = entry.index
+                    TrackRow(
+                        track: entry.track,
+                        number: idx + 1,
+                        onPlay: { model.play(tracks: matchedTracks, startIndex: idx) },
+                        tracks: matchedTracks,
+                        index: idx
+                    )
+                }
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Empty / not-found states
+
+    @ViewBuilder
+    private var emptyResult: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 34))
+                .foregroundStyle(Theme.ink3)
+            Text("No tracks match these rules")
+                .font(Theme.font(14, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+            Text("Loaded \(model.tracks.count) tracks so far. Try loosening the rules, or open the Library so more tracks are in memory.")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+            Button("Edit Rules") { editing = playlist }
+                .buttonStyle(.plain)
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.primary)
+                .padding(.top, 4)
+        }
+        .padding(.vertical, 48)
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var notFound: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "questionmark.folder")
+                .font(.system(size: 34))
+                .foregroundStyle(Theme.ink3)
+            Text("Smart playlist not found")
+                .font(Theme.font(15, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+        }
+        .padding(.vertical, 80)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Pure summary helpers (unit-tested)
+
+    /// One-line plain-English description of a playlist's rules, e.g.
+    /// "Matches all of: Artist is Radiohead, Year greater than 2000". An
+    /// empty rule set reads as "Matches every track". Pure so it's tested
+    /// without a view.
+    static func ruleSummary(_ playlist: SmartPlaylist) -> String {
+        guard !playlist.rules.isEmpty else { return "Matches every track." }
+        let clauses = playlist.rules.map { rule -> String in
+            "\(rule.field.displayName) \(rule.op.displayName) \(rule.value)"
+        }
+        return "Matches \(playlist.matchMode.displayName) of: " + clauses.joined(separator: ", ")
+    }
+
+    /// Pluralized "N song(s)" readout. Pure.
+    static func countSummary(_ count: Int) -> String {
+        count == 1 ? "1 song" : "\(count) songs"
+    }
+}

--- a/macos/Sources/Lyrebird/System/SmartPlaylist.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylist.swift
@@ -1,0 +1,246 @@
+import Foundation
+@preconcurrency import LyrebirdCore
+
+/// Client-side **smart playlists** (#77 / #238).
+///
+/// Jellyfin's SDK has no native smart-playlist concept, so this is a
+/// purely local feature: a `SmartPlaylist` is a `name` + a match mode
+/// (`.all` / `.any`) + an ordered list of `Rule`s. The companion
+/// `SmartPlaylistEvaluator` filters the in-memory library snapshot
+/// (`AppModel.tracks`) against those rules. Nothing here touches the
+/// network — there is no server round-trip, by design (the issue scopes
+/// that out).
+///
+/// Everything in this file is a pure value type with deterministic
+/// behaviour so the rule model + evaluator can be unit-tested without a
+/// SwiftUI scene, a live server, or `UserDefaults`. The persistence
+/// layer (`SmartPlaylistStore`) and the builder / detail UI live in
+/// separate files; this one is the contract they all share.
+///
+/// ## Field ↔ snapshot mapping
+/// The fields the rule builder offers map onto the `Track` projection the
+/// app already loads (see `TrackFacts.init(track:)`):
+///
+/// | Field         | Source on `Track`                                  |
+/// |---------------|----------------------------------------------------|
+/// | `.genre`      | `Track` carries no genres; sourced from the album  |
+/// |               | snapshot via the evaluator's `genresForAlbum`      |
+/// |               | lookup (album genres apply to their tracks).       |
+/// | `.artist`     | `artistName`                                       |
+/// | `.album`      | `albumName`                                        |
+/// | `.year`       | `year`                                             |
+/// | `.playCount`  | `userData?.playCount ?? playCount`                 |
+/// | `.isFavorite` | `userData?.isFavorite ?? isFavorite`               |
+/// | `.dateAdded`  | `userData?.lastPlayedAt` (ISO-8601). Jellyfin's    |
+/// |               | per-track projection exposes *last played*, not    |
+/// |               | `DateCreated`; the desktop client treats "Date     |
+/// |               | added" as last activity until core surfaces a real |
+/// |               | creation date. The seam is the single `dateAdded`  |
+/// |               | assignment in `TrackFacts.init`.                   |
+
+// MARK: - Field
+
+/// The track attribute a `Rule` tests. Raw values are stable storage keys
+/// (persisted in JSON), so renaming a case is a breaking change — add new
+/// cases, never repurpose old strings.
+enum SmartPlaylistField: String, Codable, CaseIterable, Hashable, Sendable {
+    case genre
+    case artist
+    case album
+    case year
+    case playCount
+    case isFavorite
+    case dateAdded
+
+    /// The natural value kind this field compares against. Drives which
+    /// operators are offered and how the value editor renders.
+    var valueKind: SmartPlaylistValueKind {
+        switch self {
+        case .genre, .artist, .album: return .text
+        case .year, .playCount: return .number
+        case .isFavorite: return .boolean
+        case .dateAdded: return .date
+        }
+    }
+
+    /// Short, human-facing label. Not localized through the String Catalog
+    /// yet (the catalog work is #560); kept as plain English so the builder
+    /// is legible until that lands.
+    var displayName: String {
+        switch self {
+        case .genre: return "Genre"
+        case .artist: return "Artist"
+        case .album: return "Album"
+        case .year: return "Year"
+        case .playCount: return "Play Count"
+        case .isFavorite: return "Favorite"
+        case .dateAdded: return "Date Added"
+        }
+    }
+}
+
+/// The kind of value a field compares against — determines which operators
+/// are legal and how the UI renders the value editor.
+enum SmartPlaylistValueKind: Hashable, Sendable {
+    case text
+    case number
+    case boolean
+    case date
+}
+
+// MARK: - Operator
+
+/// The comparison a `Rule` applies between a field and its value. Raw
+/// values are stable storage keys; see `SmartPlaylistField`.
+enum SmartPlaylistOperator: String, Codable, CaseIterable, Hashable, Sendable {
+    case `is`
+    case isNot
+    case contains
+    case greaterThan
+    case lessThan
+    /// "in the last N days" — only meaningful for `.date` fields. The rule's
+    /// `value` carries the day count as a base-10 integer string.
+    case inLast
+
+    var displayName: String {
+        switch self {
+        case .is: return "is"
+        case .isNot: return "is not"
+        case .contains: return "contains"
+        case .greaterThan: return "greater than"
+        case .lessThan: return "less than"
+        case .inLast: return "in the last (days)"
+        }
+    }
+
+    /// The operators that make sense for a given value kind. The builder
+    /// uses this to populate the operator picker and to repair a rule whose
+    /// operator no longer fits after the user changes its field.
+    static func applicable(to kind: SmartPlaylistValueKind) -> [SmartPlaylistOperator] {
+        switch kind {
+        case .text: return [.is, .isNot, .contains]
+        case .number: return [.is, .isNot, .greaterThan, .lessThan]
+        case .boolean: return [.is]
+        case .date: return [.inLast, .greaterThan, .lessThan]
+        }
+    }
+}
+
+// MARK: - Match mode
+
+/// Whether a track must satisfy every rule (`.all`, logical AND) or at
+/// least one (`.any`, logical OR). Mirrors iTunes / Marvis "Match all / any
+/// of the following rules".
+enum SmartPlaylistMatchMode: String, Codable, CaseIterable, Hashable, Sendable {
+    case all
+    case any
+
+    var displayName: String {
+        switch self {
+        case .all: return "all"
+        case .any: return "any"
+        }
+    }
+}
+
+// MARK: - Rule
+
+/// A single `field op value` clause. `value` is always stored as a string
+/// and parsed lazily by the evaluator according to the field's value kind,
+/// which keeps the model trivially `Codable` and lets the builder bind a
+/// plain `TextField` regardless of the underlying type.
+///
+/// `id` exists only so SwiftUI's `ForEach` has a stable identity for row
+/// add / remove animations; it is intentionally excluded from `==` and
+/// from the persisted-equality notion the tests care about (two rules with
+/// the same field/op/value are semantically identical even if their ids
+/// differ). It is still encoded so an edit session round-trips without
+/// reshuffling row identity.
+struct SmartPlaylistRule: Codable, Identifiable, Hashable, Sendable {
+    var id: UUID
+    var field: SmartPlaylistField
+    var op: SmartPlaylistOperator
+    var value: String
+
+    init(id: UUID = UUID(), field: SmartPlaylistField, op: SmartPlaylistOperator, value: String) {
+        self.id = id
+        self.field = field
+        self.op = op
+        self.value = value
+    }
+
+    /// Semantic equality ignores `id` so a reordered / re-instantiated rule
+    /// with identical contents compares equal. Used by the store's
+    /// change-detection and by tests asserting on logical content.
+    static func == (lhs: SmartPlaylistRule, rhs: SmartPlaylistRule) -> Bool {
+        lhs.field == rhs.field && lhs.op == rhs.op && lhs.value == rhs.value
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(field)
+        hasher.combine(op)
+        hasher.combine(value)
+    }
+
+    /// A fresh rule seeded with sensible defaults for a field — used when
+    /// the builder adds a row or the user switches a rule's field and its
+    /// operator no longer applies.
+    static func defaultRule(for field: SmartPlaylistField = .artist) -> SmartPlaylistRule {
+        let op = SmartPlaylistOperator.applicable(to: field.valueKind).first ?? .is
+        let value: String
+        switch field.valueKind {
+        case .text: value = ""
+        case .number: value = "0"
+        case .boolean: value = "true"
+        case .date: value = "30"
+        }
+        return SmartPlaylistRule(field: field, op: op, value: value)
+    }
+
+    /// Return a copy whose operator is guaranteed legal for the (possibly
+    /// just-changed) field. If the current operator already applies it is
+    /// kept; otherwise it snaps to the first applicable operator and the
+    /// value is reset to that field-kind's default. Pure — the builder calls
+    /// this whenever the user changes a row's field so an impossible
+    /// `field`/`op` pairing (e.g. `isFavorite greaterThan`) can't persist.
+    func repaired() -> SmartPlaylistRule {
+        let legal = SmartPlaylistOperator.applicable(to: field.valueKind)
+        guard !legal.contains(op) else { return self }
+        var fixed = SmartPlaylistRule.defaultRule(for: field)
+        fixed.id = id
+        return fixed
+    }
+}
+
+// MARK: - SmartPlaylist
+
+/// A saved smart playlist: a name, a match mode, and the rules. `id` is the
+/// stable storage key (used by the sidebar selection + the routing). An
+/// empty `rules` array is legal and matches *every* track (an "all of my
+/// music" playlist), matching iTunes' behaviour for a rule-less smart
+/// playlist.
+struct SmartPlaylist: Codable, Identifiable, Hashable, Sendable {
+    var id: UUID
+    var name: String
+    var matchMode: SmartPlaylistMatchMode
+    var rules: [SmartPlaylistRule]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        matchMode: SmartPlaylistMatchMode = .all,
+        rules: [SmartPlaylistRule] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.matchMode = matchMode
+        self.rules = rules
+    }
+
+    /// A blank playlist seeded with one default rule, used by "New Smart
+    /// Playlist…". Starting with one row means the builder never opens on an
+    /// empty (and therefore match-everything) state the user didn't ask for.
+    static func newDraft(name: String = "New Smart Playlist") -> SmartPlaylist {
+        SmartPlaylist(name: name, matchMode: .all, rules: [.defaultRule()])
+    }
+}

--- a/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
@@ -1,0 +1,311 @@
+import Foundation
+@preconcurrency import LyrebirdCore
+
+/// The flattened, comparison-ready view of a single track that
+/// `SmartPlaylistEvaluator` tests rules against. Decoupling the rule logic
+/// from the `Track` FFI struct keeps the evaluator unit-testable with tiny
+/// hand-built fixtures (no UniFFI buffer round-trips) and gives the
+/// `dateAdded` semantics a single documented seam.
+///
+/// All text comparisons the evaluator performs are case- and
+/// diacritic-insensitive; the raw values are stored verbatim here and the
+/// folding happens at compare time so the same `TrackFacts` works for any
+/// operator.
+struct TrackFacts: Hashable, Sendable {
+    var id: String
+    var title: String
+    var artist: String
+    var album: String
+    /// Genres that apply to this track. `Track` carries none, so the
+    /// evaluator fills these from the album the track belongs to (see
+    /// `SmartPlaylistEvaluator`). Empty when the album genres are unknown.
+    /// Stored verbatim; the evaluator splits any semicolon-joined element
+    /// at compare time so both array and "Pop;Rock" server shapes work.
+    var genres: [String]
+    var year: Int?
+    var playCount: Int
+    var isFavorite: Bool
+    /// Best per-track date the snapshot exposes. Jellyfin's track projection
+    /// carries `lastPlayedAt`, not `DateCreated`, so "Date Added" rules test
+    /// against last-played for now. `nil` when the track has no user data /
+    /// has never been played, in which case `.inLast` / date comparisons
+    /// never match (a never-played track isn't "added in the last N days").
+    var dateAdded: Date?
+
+    init(
+        id: String,
+        title: String,
+        artist: String,
+        album: String,
+        genres: [String] = [],
+        year: Int? = nil,
+        playCount: Int = 0,
+        isFavorite: Bool = false,
+        dateAdded: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.genres = genres
+        self.year = year
+        self.playCount = playCount
+        self.isFavorite = isFavorite
+        self.dateAdded = dateAdded
+    }
+}
+
+extension TrackFacts {
+    /// Adapt a `Track` from the library snapshot. `genres` is supplied by the
+    /// caller because `Track` itself carries none — the evaluator looks the
+    /// track's album up in an `[albumId: [genre]]` map it builds once from
+    /// `AppModel.albums`. `now` is injected so the (rare) call sites that
+    /// need a deterministic clock can pass one; production passes the real
+    /// `Date()`.
+    init(track: Track, genres: [String] = []) {
+        self.id = track.id
+        self.title = track.name
+        self.artist = track.artistName
+        self.album = track.albumName ?? ""
+        self.genres = genres
+        self.year = track.year.map(Int.init)
+        // Prefer the richer UserData projection; fall back to the convenience
+        // mirror so a snapshot fetched without `Fields=UserData` still reads.
+        self.playCount = Int(track.userData?.playCount ?? track.playCount)
+        self.isFavorite = track.userData?.isFavorite ?? track.isFavorite
+        // The single documented "Date Added" seam — swap `lastPlayedAt` for a
+        // real `DateCreated` here if core ever surfaces one.
+        self.dateAdded = track.userData?.lastPlayedAt.flatMap(SmartPlaylistEvaluator.parseDate)
+    }
+}
+
+/// Pure, deterministic filter that turns a `SmartPlaylist` into the set of
+/// tracks (from an in-memory snapshot) that satisfy its rules. No network,
+/// no `UserDefaults`, no clock except the one injected into date rules —
+/// so the whole thing is straightforwardly unit-tested.
+///
+/// Evaluation is order-preserving: the returned tracks keep their input
+/// order (the snapshot's order), so a smart playlist plays in the same
+/// sequence the library presents.
+enum SmartPlaylistEvaluator {
+
+    // MARK: - Public entry points
+
+    /// Filter `tracks` (already adapted to `TrackFacts`) by `playlist`.
+    /// `now` anchors relative-date rules (`.inLast`); defaults to the real
+    /// current time.
+    static func evaluate(
+        _ playlist: SmartPlaylist,
+        over tracks: [TrackFacts],
+        now: Date = Date()
+    ) -> [TrackFacts] {
+        // A rule-less playlist matches everything (iTunes parity).
+        guard !playlist.rules.isEmpty else { return tracks }
+        return tracks.filter { matches($0, playlist: playlist, now: now) }
+    }
+
+    /// Convenience over the FFI `Track` type: builds the per-track genre
+    /// lookup from `albums`, adapts each track, and filters. This is the
+    /// entry point `AppModel` / the detail view call with the live snapshot.
+    static func evaluate(
+        _ playlist: SmartPlaylist,
+        tracks: [Track],
+        albums: [Album],
+        now: Date = Date()
+    ) -> [Track] {
+        guard !playlist.rules.isEmpty else { return tracks }
+        let genresByAlbumId = albumGenreIndex(albums)
+        return tracks.filter { track in
+            let genres = track.albumId.flatMap { genresByAlbumId[$0] } ?? []
+            let facts = TrackFacts(track: track, genres: genres)
+            return matches(facts, playlist: playlist, now: now)
+        }
+    }
+
+    /// The count of matching tracks — used for the builder's live "N songs"
+    /// readout without materializing the filtered array at every call site.
+    static func matchCount(
+        _ playlist: SmartPlaylist,
+        tracks: [Track],
+        albums: [Album],
+        now: Date = Date()
+    ) -> Int {
+        guard !playlist.rules.isEmpty else { return tracks.count }
+        let genresByAlbumId = albumGenreIndex(albums)
+        return tracks.reduce(into: 0) { count, track in
+            let genres = track.albumId.flatMap { genresByAlbumId[$0] } ?? []
+            let facts = TrackFacts(track: track, genres: genres)
+            if matches(facts, playlist: playlist, now: now) { count += 1 }
+        }
+    }
+
+    // MARK: - Matching
+
+    /// Whether `facts` satisfies `playlist` under its match mode. `.all`
+    /// requires every rule (vacuously true for no rules, but the public
+    /// entry points short-circuit empty rule sets); `.any` requires at
+    /// least one.
+    static func matches(_ facts: TrackFacts, playlist: SmartPlaylist, now: Date = Date()) -> Bool {
+        switch playlist.matchMode {
+        case .all:
+            return playlist.rules.allSatisfy { matches(facts, rule: $0, now: now) }
+        case .any:
+            return playlist.rules.contains { matches(facts, rule: $0, now: now) }
+        }
+    }
+
+    /// Whether a single `rule` holds for `facts`. A rule whose value can't be
+    /// parsed for its field kind (e.g. `year is "abc"`) never matches — an
+    /// unparseable rule is treated as unsatisfiable rather than crashing or
+    /// matching everything.
+    static func matches(_ facts: TrackFacts, rule: SmartPlaylistRule, now: Date = Date()) -> Bool {
+        switch rule.field {
+        case .genre:
+            // Genre is multi-valued: the rule holds if *any* of the track's
+            // genres satisfies it. Some Jellyfin libraries store a track's
+            // genres as a single semicolon-joined element
+            // ("Pop;Folk Pop;Rock") rather than a split array, so split on
+            // `;` first — otherwise a `genre is "Pop"` rule would miss those
+            // items (only `contains` would catch them). See the real-server
+            // probe in the #77 work.
+            let atomicGenres = facts.genres.flatMap { $0.split(separator: ";").map(String.init) }
+            return atomicGenres.contains { textMatch($0, rule: rule) }
+        case .artist:
+            return textMatch(facts.artist, rule: rule)
+        case .album:
+            return textMatch(facts.album, rule: rule)
+        case .year:
+            guard let year = facts.year else { return false }
+            return numberMatch(Double(year), rule: rule)
+        case .playCount:
+            return numberMatch(Double(facts.playCount), rule: rule)
+        case .isFavorite:
+            return booleanMatch(facts.isFavorite, rule: rule)
+        case .dateAdded:
+            return dateMatch(facts.dateAdded, rule: rule, now: now)
+        }
+    }
+
+    // MARK: - Per-kind comparisons
+
+    private static func textMatch(_ lhs: String, rule: SmartPlaylistRule) -> Bool {
+        let a = fold(lhs)
+        let b = fold(rule.value)
+        switch rule.op {
+        case .is: return a == b
+        case .isNot: return a != b
+        case .contains: return !b.isEmpty && a.contains(b)
+        // Ordering / recency operators don't apply to text; treat as no-match
+        // rather than letting an out-of-domain pairing match everything.
+        case .greaterThan, .lessThan, .inLast: return false
+        }
+    }
+
+    private static func numberMatch(_ lhs: Double, rule: SmartPlaylistRule) -> Bool {
+        guard let rhs = parseNumber(rule.value) else { return false }
+        switch rule.op {
+        case .is: return lhs == rhs
+        case .isNot: return lhs != rhs
+        case .greaterThan: return lhs > rhs
+        case .lessThan: return lhs < rhs
+        case .contains, .inLast: return false
+        }
+    }
+
+    private static func booleanMatch(_ lhs: Bool, rule: SmartPlaylistRule) -> Bool {
+        guard let rhs = parseBool(rule.value) else { return false }
+        switch rule.op {
+        case .is: return lhs == rhs
+        // Only `is` is offered for booleans; anything else is out of domain.
+        case .isNot: return lhs != rhs
+        case .contains, .greaterThan, .lessThan, .inLast: return false
+        }
+    }
+
+    /// Date rules all express their value as a **day count** (the builder's
+    /// date editor is a "N days" stepper). The threshold is `N` days before
+    /// `now`:
+    /// - `.inLast`  → item is within the window `[now - N, now]` (recent).
+    /// - `.greaterThan` → item is *more recent* than the threshold (newer
+    ///   than N days ago) — i.e. equivalent to `.inLast` minus the upper
+    ///   bound, useful when paired with another rule.
+    /// - `.lessThan` → item is *older* than the threshold (before N days
+    ///   ago).
+    private static func dateMatch(_ lhs: Date?, rule: SmartPlaylistRule, now: Date) -> Bool {
+        guard let lhs, let days = parseNumber(rule.value), days > 0 else { return false }
+        let threshold = now.addingTimeInterval(-days * 86_400)
+        switch rule.op {
+        case .inLast: return lhs >= threshold && lhs <= now
+        case .greaterThan: return lhs > threshold
+        case .lessThan: return lhs < threshold
+        case .is, .isNot, .contains: return false
+        }
+    }
+
+    // MARK: - Album genre index
+
+    /// Build an `[albumId: [genre]]` lookup once per evaluation so each
+    /// track's genre check is an O(1) dictionary hit rather than a linear
+    /// album scan. Albums with no genres are simply absent.
+    static func albumGenreIndex(_ albums: [Album]) -> [String: [String]] {
+        var index: [String: [String]] = [:]
+        index.reserveCapacity(albums.count)
+        for album in albums where !album.genres.isEmpty {
+            index[album.id] = album.genres
+        }
+        return index
+    }
+
+    // MARK: - Parsing helpers
+
+    /// Case- and diacritic-insensitive fold for text comparisons, trimmed of
+    /// surrounding whitespace so a stray trailing space in a rule value
+    /// doesn't defeat an otherwise-exact match.
+    private static func fold(_ s: String) -> String {
+        s.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+    }
+
+    /// Parse a numeric rule value with the POSIX locale so "1,5" never reads
+    /// as fifteen on a comma-decimal system. Returns `nil` for blank /
+    /// non-numeric input.
+    static func parseNumber(_ s: String) -> Double? {
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return Double(trimmed)
+    }
+
+    /// Parse a boolean rule value. Accepts the JSON-ish `true`/`false` the
+    /// builder writes plus a couple of common synonyms so a hand-edited file
+    /// is forgiving.
+    static func parseBool(_ s: String) -> Bool? {
+        switch s.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true", "yes", "1": return true
+        case "false", "no", "0": return false
+        default: return nil
+        }
+    }
+
+    /// Parse an ISO-8601 date string as returned by Jellyfin's `UserData`
+    /// (`lastPlayedAt`). Tries fractional-seconds first (Jellyfin emits
+    /// `2024-01-02T03:04:05.0000000Z`), then the plain form. Returns `nil`
+    /// for unparseable input so a malformed server date degrades to
+    /// "no date" rather than crashing the filter.
+    static func parseDate(_ s: String) -> Date? {
+        if let d = isoFractional.date(from: s) { return d }
+        if let d = isoPlain.date(from: s) { return d }
+        return nil
+    }
+
+    private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+}

--- a/macos/Sources/Lyrebird/System/SmartPlaylistStore.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylistStore.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Observation
+
+/// Local persistence for `SmartPlaylist`s (#77 / #238).
+///
+/// Smart playlists are a client-only feature, so they're stored as a single
+/// JSON document in Application Support rather than on the server. The store
+/// is split into two halves:
+///
+/// - **`SmartPlaylistCodec`** — pure encode/decode + the on-disk file URL
+///   derivation. No I/O state, no `@Observable`, so it's exhaustively
+///   unit-testable: round-trips, forward-compatibility (unknown keys), and
+///   corrupt-data tolerance all pin here.
+/// - **`SmartPlaylistStore`** — the `@Observable @MainActor` view-model the
+///   sidebar / builder bind to. It owns the live `[SmartPlaylist]` array,
+///   loads it once on init, and writes through to disk on every mutation.
+///
+/// File location mirrors `CoreDataLocation`: `~/Library/Application
+/// Support/lyrebird-desktop/smart-playlists.json`. Reusing that folder keeps
+/// all the app's local state in one place a user can find (and the
+/// "uninstall data locations" surface, #197, already documents it).
+
+// MARK: - Codec
+
+/// Pure, side-effect-free JSON codec + path derivation for smart playlists.
+/// Everything here is `static` and takes its inputs explicitly so the tests
+/// never touch the real Application Support directory.
+enum SmartPlaylistCodec {
+    /// Versioned envelope so a future schema migration has a hook. `version`
+    /// is written on save and ignored on load today (all v1), but a decoder
+    /// that bumps the model can branch on it without a flag-day.
+    struct Document: Codable {
+        var version: Int
+        var playlists: [SmartPlaylist]
+
+        init(version: Int = SmartPlaylistCodec.currentVersion, playlists: [SmartPlaylist]) {
+            self.version = version
+            self.playlists = playlists
+        }
+    }
+
+    static let currentVersion = 1
+    static let fileName = "smart-playlists.json"
+
+    /// The on-disk document URL inside the app's Application Support folder.
+    /// `nil` only when no home / `XDG_DATA_HOME` is resolvable (matching
+    /// `CoreDataLocation.resolve`). Shares the core's folder so all local
+    /// state co-locates.
+    static func fileURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: String? = NSHomeDirectory()
+    ) -> URL? {
+        CoreDataLocation.resolve(environment: environment, home: home)?
+            .appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    /// Encode playlists to pretty-printed JSON (human-diffable; a user can
+    /// inspect / hand-edit the file). Sorted keys keep the output stable
+    /// across runs so the file doesn't churn in backups.
+    static func encode(_ playlists: [SmartPlaylist]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(Document(playlists: playlists))
+    }
+
+    /// Decode a document back to playlists. Tolerant of an empty file (yields
+    /// `[]`). Throws on genuinely malformed JSON so the store can decide
+    /// whether to quarantine it.
+    static func decode(_ data: Data) throws -> [SmartPlaylist] {
+        guard !data.isEmpty else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(Document.self, from: data).playlists
+    }
+}
+
+// MARK: - Store
+
+/// Observable, main-actor store the UI binds to. Holds the live playlists,
+/// persists through to disk on mutation, and exposes small CRUD helpers so
+/// call sites never re-encode by hand.
+@Observable
+@MainActor
+final class SmartPlaylistStore {
+    /// The live, ordered list. The sidebar renders these; mutating it through
+    /// the CRUD helpers keeps disk in sync. Direct assignment also persists
+    /// (via `didSet`) so SwiftUI bindings that write the whole array still
+    /// save.
+    private(set) var playlists: [SmartPlaylist] = []
+
+    /// Injected so tests can point the store at a temp file (or `nil` to run
+    /// fully in-memory). Production resolves the Application Support URL.
+    private let fileURL: URL?
+    private let fileManager: FileManager
+
+    /// - Parameters:
+    ///   - fileURL: where to persist. Defaults to the Application Support
+    ///     document. Pass an explicit temp URL in tests, or `nil` to disable
+    ///     persistence entirely (pure in-memory).
+    ///   - load: when `true` (default) the store reads any existing document
+    ///     on init. Tests that want a clean slate pass `false`.
+    init(
+        fileURL: URL? = SmartPlaylistCodec.fileURL(),
+        fileManager: FileManager = .default,
+        load: Bool = true
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        if load { self.playlists = Self.readFromDisk(url: fileURL, fileManager: fileManager) }
+    }
+
+    // MARK: CRUD
+
+    /// Look up a playlist by id. `nil` when it's been deleted out from under
+    /// a stale route / sidebar selection.
+    func playlist(id: UUID) -> SmartPlaylist? {
+        playlists.first { $0.id == id }
+    }
+
+    /// Insert a new playlist (appends) and persist.
+    func add(_ playlist: SmartPlaylist) {
+        playlists.append(playlist)
+        persist()
+    }
+
+    /// Replace an existing playlist (matched by id) in place and persist. No-op
+    /// if the id isn't present, so a save from a builder editing a since-deleted
+    /// playlist doesn't resurrect it.
+    func update(_ playlist: SmartPlaylist) {
+        guard let idx = playlists.firstIndex(where: { $0.id == playlist.id }) else { return }
+        playlists[idx] = playlist
+        persist()
+    }
+
+    /// Insert-or-replace: update in place if the id exists, else append. The
+    /// builder's "Save" calls this so the same code path handles both editing
+    /// an existing playlist and committing a brand-new draft.
+    func save(_ playlist: SmartPlaylist) {
+        if playlists.contains(where: { $0.id == playlist.id }) {
+            update(playlist)
+        } else {
+            add(playlist)
+        }
+    }
+
+    /// Remove a playlist by id and persist.
+    func remove(id: UUID) {
+        playlists.removeAll { $0.id == id }
+        persist()
+    }
+
+    /// Rename a playlist in place. Convenience over `update` for the common
+    /// sidebar inline-rename path.
+    func rename(id: UUID, to name: String) {
+        guard let idx = playlists.firstIndex(where: { $0.id == id }) else { return }
+        playlists[idx].name = name
+        persist()
+    }
+
+    // MARK: Persistence
+
+    /// Write the current `playlists` to disk. Best-effort: encode / write
+    /// failures are logged (Console under `category:app`) rather than thrown,
+    /// because a failed save of a *local convenience* feature shouldn't crash
+    /// the app or block the UI — the in-memory array remains the source of
+    /// truth for the session. A `nil` `fileURL` means "in-memory only".
+    private func persist() {
+        guard let fileURL else { return }
+        do {
+            let data = try SmartPlaylistCodec.encode(playlists)
+            try fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Log.app.error("Failed to persist smart playlists: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Read + decode the document, returning `[]` on a missing file or any
+    /// decode error (a corrupt file degrades to "no smart playlists" rather
+    /// than crashing the launch). Static so `init` can call it before `self`
+    /// is fully formed.
+    private static func readFromDisk(url: URL?, fileManager: FileManager) -> [SmartPlaylist] {
+        guard let url, fileManager.fileExists(atPath: url.path) else { return [] }
+        do {
+            let data = try Data(contentsOf: url)
+            return try SmartPlaylistCodec.decode(data)
+        } catch {
+            Log.app.error("Failed to read smart playlists, starting empty: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+}

--- a/macos/Tests/LyrebirdTests/CountStringsTests.swift
+++ b/macos/Tests/LyrebirdTests/CountStringsTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `CountStrings` — the inflected-count helper added in #350.
+///
+/// Two layers, mirroring `LyrebirdErrorPresenterTests`:
+///
+/// 1. **Pure logic.** `pluralCategory(for:)` (the English singular/plural rule)
+///    and `Noun.key` (catalog routing) are exercised directly. These don't
+///    touch the `.xcstrings` catalog, which SwiftPM strips from the test
+///    binary, so they're the authoritative coverage for the selection rule.
+///
+/// 2. **Catalog sync.** The catalog *can't* be looked up via
+///    `String(localized:)` here (no resource in the test bundle), but it can be
+///    read off disk as a file. The `#filePath`-relative loader (same idiom as
+///    `ArtworkAccessibilityTests`) parses `Localizable.xcstrings` and pins that
+///    every key the helper emits actually exists with `one`/`other` English
+///    plural variations whose singular form is "<n> <noun>" and plural is
+///    "<n> <noun>s". This is what catches a typo'd key or a catalog entry
+///    deleted out from under the helper — a `String(localized:)` miss would
+///    silently render the raw key in the UI.
+final class CountStringsTests: XCTestCase {
+
+    // MARK: - Plural rule (English)
+
+    /// Exactly 1 is `one`; everything else — including 0 and negatives — is
+    /// `other`. This is the CLDR English rule the catalog's `en` variations
+    /// encode, and the bug #350 fixes (a hand-rolled `count == 1 ?` at every
+    /// call site, occasionally wrong on the 0 case).
+    func testPluralCategoryOneVsOther() {
+        XCTAssertEqual(CountStrings.pluralCategory(for: 1), .one)
+
+        for n in [0, 2, 3, 11, 21, 100, 1_000_000] {
+            XCTAssertEqual(
+                CountStrings.pluralCategory(for: n), .other,
+                "count \(n) should select the plural (.other) category in English"
+            )
+        }
+    }
+
+    /// Zero takes the plural form ("0 albums"), not the singular — a place the
+    /// old `count == 1 ? "1 X" : "\(count) Xs"` ternaries happened to get right
+    /// but which a naive `count <= 1` would break.
+    func testZeroIsPlural() {
+        XCTAssertEqual(CountStrings.pluralCategory(for: 0), .other)
+    }
+
+    /// Negatives are defensive — counts shouldn't go below zero, but if one
+    /// does it must not crash or land in `one`.
+    func testNegativeIsPlural() {
+        XCTAssertEqual(CountStrings.pluralCategory(for: -1), .other)
+        XCTAssertEqual(CountStrings.pluralCategory(for: -5), .other)
+    }
+
+    // MARK: - Key routing
+
+    /// Each noun maps to its documented `count.<noun> %lld` catalog key, and
+    /// `key(_:)` is a faithful pass-through to `Noun.key`.
+    func testNounKeys() {
+        XCTAssertEqual(CountStrings.Noun.albums.key, "count.albums %lld")
+        XCTAssertEqual(CountStrings.Noun.artists.key, "count.artists %lld")
+        XCTAssertEqual(CountStrings.Noun.items.key, "count.items %lld")
+        XCTAssertEqual(CountStrings.Noun.playlists.key, "count.playlists %lld")
+        XCTAssertEqual(CountStrings.Noun.plays.key, "count.plays %lld")
+        XCTAssertEqual(CountStrings.Noun.results.key, "count.results %lld")
+        XCTAssertEqual(CountStrings.Noun.selected.key, "count.selected %lld")
+        XCTAssertEqual(CountStrings.Noun.songs.key, "count.songs %lld")
+        XCTAssertEqual(CountStrings.Noun.tracks.key, "count.tracks %lld")
+
+        for noun in CountStrings.Noun.allCases {
+            XCTAssertEqual(CountStrings.key(noun), noun.key)
+        }
+    }
+
+    /// Every noun's key carries the `%lld` placeholder (so the catalog can run
+    /// plural selection on the count) and the keys are mutually distinct.
+    func testKeysAreWellFormedAndDistinct() {
+        var seen = Set<String>()
+        for noun in CountStrings.Noun.allCases {
+            let key = noun.key
+            XCTAssertTrue(
+                key.hasSuffix(" %lld"),
+                "\(key) must end with the ` %lld` count placeholder"
+            )
+            XCTAssertTrue(
+                key.hasPrefix("count."),
+                "\(key) must live under the `count.` namespace"
+            )
+            XCTAssertTrue(seen.insert(key).inserted, "duplicate key \(key)")
+        }
+        // Nine nouns, nine distinct keys.
+        XCTAssertEqual(seen.count, CountStrings.Noun.allCases.count)
+        XCTAssertEqual(seen.count, 9)
+    }
+
+    // MARK: - Catalog sync
+
+    /// Every helper key resolves to a catalog entry carrying English `one` and
+    /// `other` plural variations, and the variation values inflect correctly
+    /// ("%lld album" singular vs "%lld albums" plural). The `selected` noun is
+    /// the one exception — "selected" doesn't inflect — so its two variations
+    /// match.
+    func testEveryKeyExistsInCatalogWithInflectedVariations() throws {
+        let catalog = try loadCatalog()
+
+        for noun in CountStrings.Noun.allCases {
+            let key = noun.key
+            guard let entry = catalog[key] as? [String: Any],
+                  let locs = entry["localizations"] as? [String: Any],
+                  let en = locs["en"] as? [String: Any],
+                  let variations = en["variations"] as? [String: Any],
+                  let plural = variations["plural"] as? [String: Any] else {
+                XCTFail("Catalog key \(key) is missing or has no en plural variations")
+                continue
+            }
+
+            let one = stringUnitValue(plural["one"])
+            let other = stringUnitValue(plural["other"])
+            XCTAssertNotNil(one, "\(key) is missing its `one` variation")
+            XCTAssertNotNil(other, "\(key) is missing its `other` variation")
+
+            // The count placeholder must survive into both variations.
+            XCTAssertEqual(one?.contains("%lld"), true, "\(key) `one` lost its %lld placeholder")
+            XCTAssertEqual(other?.contains("%lld"), true, "\(key) `other` lost its %lld placeholder")
+
+            if noun == .selected {
+                // "selected" is invariant in English.
+                XCTAssertEqual(one, other, "count.selected should not inflect")
+            } else {
+                // Singular is a strict prefix of the plural (English -s rule),
+                // and they must differ so "1 album" != "2 albums".
+                XCTAssertNotEqual(one, other, "\(key) singular and plural must differ")
+                if let one, let other {
+                    XCTAssertTrue(
+                        other.hasPrefix(one),
+                        "\(key): plural \"\(other)\" should extend singular \"\(one)\""
+                    )
+                    XCTAssertEqual(
+                        other, one + "s",
+                        "\(key): English plural should be the singular plus 's'"
+                    )
+                }
+            }
+        }
+    }
+
+    /// The catalog must not regress the pre-existing `sidebar.server.connected`
+    /// plural key while the new `count.*` block is added next to it — a guard
+    /// that the surgical insertion didn't disturb its neighbour.
+    func testPreExistingPluralKeyStillPresent() throws {
+        let catalog = try loadCatalog()
+        let entry = catalog["sidebar.server.connected %lld"] as? [String: Any]
+        XCTAssertNotNil(entry, "the pre-existing connected-count plural key disappeared")
+    }
+
+    // MARK: - Catalog loading helpers
+
+    /// The `strings` dictionary of `Localizable.xcstrings`, read off disk
+    /// relative to this test file (the catalog isn't bundled into the test
+    /// binary — SwiftPM copies resources only into the `.app`).
+    private func loadCatalog(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let target = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Resources/Localizable.xcstrings")
+        let data = try Data(contentsOf: target)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let strings = json?["strings"] as? [String: Any] else {
+            XCTFail("Could not parse strings table from \(target.path)", file: file, line: line)
+            return [:]
+        }
+        return strings
+    }
+
+    /// Pulls `<variation>.stringUnit.value` out of a decoded plural variation.
+    private func stringUnitValue(_ variation: Any?) -> String? {
+        (variation as? [String: Any])?["stringUnit"]
+            .flatMap { ($0 as? [String: Any])?["value"] as? String }
+    }
+}

--- a/macos/Tests/LyrebirdTests/DurationFormatterTests.swift
+++ b/macos/Tests/LyrebirdTests/DurationFormatterTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Coverage for the shared `DurationFormatter` (#349) and the two `Track`
+/// conveniences that route through it.
+///
+/// `DurationFormatter` is pure + `nonisolated`, so every case is exercised
+/// directly without realizing a SwiftUI view or an `AppModel`. Two distinct
+/// outputs are under test:
+///   * `colon(_:)` — the locale-invariant visual timecode (`3:05`, `1:02:05`).
+///   * `spokenAccessibility(_:)` — the spelled-out VoiceOver value
+///     ("3 minutes 5 seconds").
+final class DurationFormatterTests: XCTestCase {
+
+    // MARK: - colon(_:) visual timecode
+
+    func testColonZero() {
+        XCTAssertEqual(DurationFormatter.colon(0), "0:00")
+    }
+
+    func testColonSubMinutePadsSeconds() {
+        // 5 seconds reads "0:05", not "0:5" — the seconds field is zero-padded.
+        XCTAssertEqual(DurationFormatter.colon(5), "0:05")
+        XCTAssertEqual(DurationFormatter.colon(9), "0:09")
+    }
+
+    func testColonExactMinuteHasZeroSeconds() {
+        XCTAssertEqual(DurationFormatter.colon(60), "1:00")
+        XCTAssertEqual(DurationFormatter.colon(600), "10:00")
+    }
+
+    func testColonMinutesAndSeconds() {
+        XCTAssertEqual(DurationFormatter.colon(185), "3:05")
+        XCTAssertEqual(DurationFormatter.colon(599), "9:59")
+    }
+
+    func testColonRollsOverToHoursAtAndPastOneHour() {
+        // The minutes field zero-pads only once the hour field appears, so a
+        // 1h02m05s runtime reads "1:02:05" rather than "62:05".
+        XCTAssertEqual(DurationFormatter.colon(3600), "1:00:00")
+        XCTAssertEqual(DurationFormatter.colon(3725), "1:02:05")
+        XCTAssertEqual(DurationFormatter.colon(7384), "2:03:04")
+    }
+
+    func testColonRoundsToNearestSecond() {
+        // 184.6s rounds up to 185 → "3:05"; 184.4 rounds down to "3:04".
+        XCTAssertEqual(DurationFormatter.colon(184.6), "3:05")
+        XCTAssertEqual(DurationFormatter.colon(184.4), "3:04")
+    }
+
+    func testColonGuardsNonFiniteAndNegative() {
+        // An unloaded AVPlayer item reports NaN duration; negatives are clamped.
+        XCTAssertEqual(DurationFormatter.colon(.nan), "0:00")
+        XCTAssertEqual(DurationFormatter.colon(.infinity), "0:00")
+        XCTAssertEqual(DurationFormatter.colon(-5), "0:00")
+    }
+
+    func testColonWholeSecondsOverloadClampsNegative() {
+        XCTAssertEqual(DurationFormatter.colon(wholeSeconds: 185), "3:05")
+        XCTAssertEqual(DurationFormatter.colon(wholeSeconds: -1), "0:00")
+        XCTAssertEqual(DurationFormatter.colon(wholeSeconds: 3725), "1:02:05")
+    }
+
+    // MARK: - spokenAccessibility(_:) VoiceOver value
+
+    func testSpokenZeroIsZeroSeconds() {
+        // A value is always produced, even at zero, so the label is never empty.
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(0), "0 seconds")
+    }
+
+    func testSpokenSingularSecond() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(1), "1 second")
+    }
+
+    func testSpokenPluralSecondsOnly() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(45), "45 seconds")
+    }
+
+    func testSpokenSingularMinuteDropsZeroSeconds() {
+        // A whole minute drops the "0 seconds" tail.
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(60), "1 minute")
+    }
+
+    func testSpokenPluralMinutesOnly() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(120), "2 minutes")
+    }
+
+    func testSpokenMinutesAndSeconds() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(185), "3 minutes 5 seconds")
+    }
+
+    func testSpokenMinuteAndSingularSecond() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(61), "1 minute 1 second")
+    }
+
+    func testSpokenHoursMinutesSeconds() {
+        XCTAssertEqual(
+            DurationFormatter.spokenAccessibility(3725),
+            "1 hour 2 minutes 5 seconds"
+        )
+    }
+
+    func testSpokenHourDropsZeroComponents() {
+        // 1h flat → "1 hour"; 1h05s → "1 hour 5 seconds" (zero minutes dropped).
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(3600), "1 hour")
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(3605), "1 hour 5 seconds")
+    }
+
+    func testSpokenPluralHours() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(7200), "2 hours")
+    }
+
+    func testSpokenGuardsNonFinite() {
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(.nan), "0 seconds")
+        XCTAssertEqual(DurationFormatter.spokenAccessibility(-5), "0 seconds")
+    }
+
+    // MARK: - Track conveniences
+
+    /// `runtimeTicks` is Jellyfin's 100-ns count: seconds * 10_000_000.
+    private func makeTrack(runtimeTicks: UInt64) -> Track {
+        Track(
+            id: "t1",
+            name: "Song",
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: runtimeTicks,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    func testTrackDurationFormattedRoutesThroughColon() {
+        // 185s = 1_850_000_000 ticks → "3:05".
+        let track = makeTrack(runtimeTicks: 1_850_000_000)
+        XCTAssertEqual(track.durationFormatted, "3:05")
+    }
+
+    func testTrackDurationAccessibilityValueRoutesThroughSpoken() {
+        let track = makeTrack(runtimeTicks: 1_850_000_000)
+        XCTAssertEqual(track.durationAccessibilityValue, "3 minutes 5 seconds")
+    }
+
+    func testTrackZeroRuntimeFormatsAsZero() {
+        let track = makeTrack(runtimeTicks: 0)
+        XCTAssertEqual(track.durationFormatted, "0:00")
+        XCTAssertEqual(track.durationAccessibilityValue, "0 seconds")
+    }
+
+    func testTrackHourLongRuntime() {
+        // 1h02m05s = 3725s = 37_250_000_000 ticks.
+        let track = makeTrack(runtimeTicks: 37_250_000_000)
+        XCTAssertEqual(track.durationFormatted, "1:02:05")
+        XCTAssertEqual(track.durationAccessibilityValue, "1 hour 2 minutes 5 seconds")
+    }
+}

--- a/macos/Tests/LyrebirdTests/InfoPlistLocalizationTests.swift
+++ b/macos/Tests/LyrebirdTests/InfoPlistLocalizationTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for `InfoPlist.xcstrings` — the string catalog that makes the
+/// bundle's user-facing metadata localizable (#359). macOS reads a compiled
+/// `<lang>.lproj/InfoPlist.strings` to localize `CFBundleDisplayName`,
+/// `CFBundleName`, and `NSHumanReadableCopyright`; before this catalog those
+/// keys were stuck at the Info.plist literals.
+///
+/// SwiftPM doesn't bundle the catalog (resource processing is disabled — see
+/// Package.swift), so there's no `Bundle.main` to introspect headlessly. The
+/// contract is therefore verified structurally, mirroring
+/// `ServerUnreachableBannerTests`: the catalog source is parsed as JSON, and
+/// the bundling step in `make-bundle.sh` is read via `#filePath`. A regression
+/// that drops a key, blanks a value, or stops compiling the catalog into the
+/// .app is caught here rather than in the field.
+final class InfoPlistLocalizationTests: XCTestCase {
+
+    /// The three keys macOS localizes from `InfoPlist.strings`. Each must carry
+    /// the base (`en`) value that matches the corresponding Info.plist literal.
+    private static let expected: [String: String] = [
+        "CFBundleDisplayName": "Lyrebird",
+        "CFBundleName": "Lyrebird",
+        "NSHumanReadableCopyright": "© 2026 Lyrebird. GPL-3.0-only.",
+    ]
+
+    // MARK: - Catalog structure
+
+    /// The catalog must parse as JSON, declare `en` as its source language, and
+    /// expose exactly the keys macOS localizes — no more, no less.
+    func testCatalogParsesAndDeclaresEnglishSource() throws {
+        let json = try catalogJSON()
+        XCTAssertEqual(json["sourceLanguage"] as? String, "en",
+                       "InfoPlist.xcstrings must declare en as its source language")
+
+        let strings = (json["strings"] as? [String: Any]) ?? [:]
+        XCTAssertEqual(
+            Set(strings.keys),
+            Set(Self.expected.keys),
+            "InfoPlist.xcstrings must contain exactly the localizable bundle-metadata keys"
+        )
+    }
+
+    /// Every expected key resolves to a non-empty English `stringUnit` value
+    /// that matches the Info.plist literal it localizes. A blank or drifted
+    /// value would render an empty Dock name or wrong copyright in the field.
+    func testEachKeyHasMatchingEnglishValue() throws {
+        let strings = (try catalogJSON()["strings"] as? [String: Any]) ?? [:]
+        for (key, expected) in Self.expected {
+            guard let value = englishValue(strings, key) else {
+                XCTFail("Missing or malformed catalog key: \(key)")
+                continue
+            }
+            XCTAssertFalse(value.isEmpty, "\(key) must have a non-empty English value")
+            XCTAssertEqual(value, expected,
+                           "\(key) base value must match the Info.plist literal it localizes")
+        }
+    }
+
+    /// The catalog's base values must agree with the checked-in Info.plist, so
+    /// the localized `en` copy can never silently diverge from the unlocalized
+    /// fallback baked into the bundle.
+    func testBaseValuesMatchInfoPlist() throws {
+        let plist = try infoPlist()
+        let strings = (try catalogJSON()["strings"] as? [String: Any]) ?? [:]
+        for key in Self.expected.keys {
+            guard let plistValue = plist[key] as? String else {
+                XCTFail("Info.plist is missing \(key)")
+                continue
+            }
+            XCTAssertEqual(englishValue(strings, key), plistValue,
+                           "Catalog en value for \(key) must match Info.plist")
+        }
+    }
+
+    // MARK: - Bundling
+
+    /// The bundling script must compile `InfoPlist.xcstrings`, otherwise the
+    /// catalog never reaches the .app and macOS falls back to the Info.plist
+    /// literals — the keys would be "localizable" in source but inert at
+    /// runtime.
+    func testMakeBundleCompilesInfoPlistCatalog() throws {
+        let script = try makeBundleSource()
+        XCTAssertTrue(script.contains("InfoPlist"),
+                      "make-bundle.sh must reference InfoPlist so the catalog is compiled into the .app")
+        XCTAssertTrue(script.contains("xcstringstool compile"),
+                      "make-bundle.sh must compile catalogs via xcstringstool")
+    }
+
+    // MARK: - Helpers
+
+    /// Parses the source `InfoPlist.xcstrings` and returns the top-level object.
+    private func catalogJSON(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let url = resourcesRoot().appendingPathComponent("InfoPlist.xcstrings")
+        guard let data = try? Data(contentsOf: url) else {
+            XCTFail("Could not read InfoPlist.xcstrings at \(url.path)", file: file, line: line)
+            return [:]
+        }
+        return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    /// Parses the checked-in `Info.plist` template into a dictionary. The
+    /// `$VERSION` / `$BUILD` placeholders are irrelevant to the keys under test.
+    private func infoPlist(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let url = macosRoot().appendingPathComponent("Resources/Info.plist")
+        guard let data = try? Data(contentsOf: url) else {
+            XCTFail("Could not read Info.plist at \(url.path)", file: file, line: line)
+            return [:]
+        }
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        return (plist as? [String: Any]) ?? [:]
+    }
+
+    private func makeBundleSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let url = macosRoot().appendingPathComponent("Scripts/make-bundle.sh")
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            XCTFail("Could not read make-bundle.sh at \(url.path)", file: file, line: line)
+            return ""
+        }
+        return text
+    }
+
+    /// Digs the English `stringUnit` value out of an `.xcstrings` entry.
+    private func englishValue(_ strings: [String: Any], _ key: String) -> String? {
+        guard
+            let entry = strings[key] as? [String: Any],
+            let locs = entry["localizations"] as? [String: Any],
+            let en = locs["en"] as? [String: Any],
+            let unit = en["stringUnit"] as? [String: Any],
+            let value = unit["value"] as? String
+        else { return nil }
+        return value
+    }
+
+    /// `macos/Sources/Lyrebird/Resources`, resolved relative to this test file
+    /// via `#filePath` so the lookup is independent of the runner's working dir.
+    private func resourcesRoot() -> URL {
+        macosRoot().appendingPathComponent("Sources/Lyrebird/Resources")
+    }
+
+    /// `macos`, resolved relative to this test file via `#filePath`.
+    private func macosRoot() -> URL {
+        URL(fileURLWithPath: "\(#filePath)")
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+    }
+}

--- a/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
@@ -1,0 +1,413 @@
+import XCTest
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for `SmartPlaylistEvaluator` — the pure, deterministic filter at
+/// the heart of smart playlists (#77 / #238). Every field × operator path,
+/// both match modes, the album→track genre projection, relative-date
+/// (`.inLast`) windows against an injected clock, unparseable-value safety,
+/// result ordering, and the concrete `Track`/`Album` FFI entry point all
+/// pin here. No network, no clock except the one passed in.
+final class SmartPlaylistEvaluatorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Build a `TrackFacts` fixture with sensible defaults so each test only
+    /// states the attributes it cares about.
+    private func facts(
+        id: String = "t",
+        title: String = "Song",
+        artist: String = "Artist",
+        album: String = "Album",
+        genres: [String] = [],
+        year: Int? = nil,
+        playCount: Int = 0,
+        isFavorite: Bool = false,
+        dateAdded: Date? = nil
+    ) -> TrackFacts {
+        TrackFacts(
+            id: id, title: title, artist: artist, album: album,
+            genres: genres, year: year, playCount: playCount,
+            isFavorite: isFavorite, dateAdded: dateAdded
+        )
+    }
+
+    private func playlist(
+        _ mode: SmartPlaylistMatchMode = .all,
+        _ rules: [SmartPlaylistRule]
+    ) -> SmartPlaylist {
+        SmartPlaylist(name: "Test", matchMode: mode, rules: rules)
+    }
+
+    private func rule(_ f: SmartPlaylistField, _ o: SmartPlaylistOperator, _ v: String) -> SmartPlaylistRule {
+        SmartPlaylistRule(field: f, op: o, value: v)
+    }
+
+    // MARK: - Empty rule set
+
+    /// A rule-less playlist matches every track (iTunes parity), preserving
+    /// input order.
+    func testEmptyRulesMatchEverything() {
+        let tracks = [facts(id: "a"), facts(id: "b"), facts(id: "c")]
+        let result = SmartPlaylistEvaluator.evaluate(playlist(.all, []), over: tracks)
+        XCTAssertEqual(result.map(\.id), ["a", "b", "c"])
+    }
+
+    // MARK: - Text operators
+
+    func testTextIsMatchesExactCaseInsensitive() {
+        let r = rule(.artist, .is, "radiohead")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Radiohead"), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(artist: "Radio"), rule: r))
+    }
+
+    func testTextIsIsDiacriticInsensitive() {
+        let r = rule(.artist, .is, "bjork")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Björk"), rule: r))
+    }
+
+    func testTextIsNot() {
+        let r = rule(.artist, .isNot, "Radiohead")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(artist: "Radiohead"), rule: r))
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Muse"), rule: r))
+    }
+
+    func testTextContains() {
+        let r = rule(.album, .contains, "hits")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(album: "Greatest Hits"), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(album: "Debut"), rule: r))
+    }
+
+    /// `contains` with an empty needle never matches (it would otherwise be
+    /// trivially true and silently widen a playlist).
+    func testTextContainsEmptyNeedleNeverMatches() {
+        let r = rule(.album, .contains, "   ")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(album: "Anything"), rule: r))
+    }
+
+    /// Surrounding whitespace in the rule value is trimmed before comparison.
+    func testTextIsTrimsWhitespace() {
+        let r = rule(.artist, .is, "  Radiohead  ")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Radiohead"), rule: r))
+    }
+
+    /// Ordering / recency operators are out of domain for text and must
+    /// no-match rather than widen the set.
+    func testTextWithNumericOperatorNeverMatches() {
+        let r = rule(.artist, .greaterThan, "M")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(artist: "Zelda"), rule: r))
+    }
+
+    // MARK: - Genre (multi-valued, via album)
+
+    /// Genre is multi-valued: the rule holds if *any* of the track's genres
+    /// satisfies it.
+    func testGenreContainsMatchesAnyGenre() {
+        let r = rule(.genre, .contains, "rock")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(genres: ["Jazz", "Indie Rock"]), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(genres: ["Jazz", "Blues"]), rule: r))
+    }
+
+    func testGenreIsMatchesOneOfSeveral() {
+        let r = rule(.genre, .is, "Electronic")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(genres: ["Pop", "Electronic"]), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(genres: ["Pop"]), rule: r))
+    }
+
+    /// A track with no genres can't satisfy a genre rule.
+    func testGenreRuleWithNoGenresNeverMatches() {
+        let r = rule(.genre, .contains, "Rock")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(genres: []), rule: r))
+    }
+
+    /// Some Jellyfin libraries return a track's genres as a single
+    /// semicolon-joined element ("Pop;Folk Pop;Rock") rather than a split
+    /// array. The evaluator splits on `;` so an exact `is` rule still matches
+    /// a constituent genre — not just `contains`. Pins the real-server shape
+    /// observed during the #77 work.
+    func testGenreSemicolonJoinedSplitsForExactMatch() {
+        let joined = facts(genres: ["Pop;Folk Pop;Pop Rock;Rock;Soul"])
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(joined, rule: rule(.genre, .is, "Rock")))
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(joined, rule: rule(.genre, .is, "Folk Pop")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(joined, rule: rule(.genre, .is, "Jazz")))
+    }
+
+    // MARK: - Number operators (year / playCount)
+
+    func testYearGreaterThan() {
+        let r = rule(.year, .greaterThan, "2000")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(year: 2010), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 1999), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 2000), rule: r), "strict >")
+    }
+
+    func testYearLessThanAndIs() {
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(year: 1980), rule: rule(.year, .lessThan, "1990")))
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(year: 1990), rule: rule(.year, .is, "1990")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 1991), rule: rule(.year, .is, "1990")))
+    }
+
+    /// A nil year (track has no release year) never satisfies a year rule.
+    func testYearNilNeverMatches() {
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: nil), rule: rule(.year, .greaterThan, "0")))
+    }
+
+    func testPlayCountGreaterThan() {
+        let r = rule(.playCount, .greaterThan, "5")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(playCount: 10), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(playCount: 5), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(playCount: 0), rule: r))
+    }
+
+    func testPlayCountIsNot() {
+        let r = rule(.playCount, .isNot, "0")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(playCount: 3), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(playCount: 0), rule: r))
+    }
+
+    /// An unparseable numeric value (e.g. "abc") makes the rule
+    /// unsatisfiable rather than crashing or matching everything.
+    func testNumberUnparseableValueNeverMatches() {
+        let r = rule(.year, .greaterThan, "nineteen")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 2020), rule: r))
+    }
+
+    // MARK: - Boolean operator (isFavorite)
+
+    func testIsFavoriteIsTrue() {
+        let r = rule(.isFavorite, .is, "true")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(isFavorite: true), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(isFavorite: false), rule: r))
+    }
+
+    func testIsFavoriteIsFalse() {
+        let r = rule(.isFavorite, .is, "false")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(isFavorite: false), rule: r))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(isFavorite: true), rule: r))
+    }
+
+    /// Boolean parsing accepts common synonyms a hand-edited file might use.
+    func testBooleanSynonyms() {
+        XCTAssertEqual(SmartPlaylistEvaluator.parseBool("yes"), true)
+        XCTAssertEqual(SmartPlaylistEvaluator.parseBool("NO"), false)
+        XCTAssertEqual(SmartPlaylistEvaluator.parseBool("1"), true)
+        XCTAssertEqual(SmartPlaylistEvaluator.parseBool("0"), false)
+        XCTAssertNil(SmartPlaylistEvaluator.parseBool("maybe"))
+    }
+
+    // MARK: - Date operators (relative, injected clock)
+
+    private func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: iso)!
+    }
+
+    func testDateInLastWindow() {
+        let now = date("2026-06-04T12:00:00Z")
+        let r = rule(.dateAdded, .inLast, "30")
+        // 10 days ago — inside the 30-day window.
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-05-25T12:00:00Z")), rule: r, now: now))
+        // 60 days ago — outside.
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-04-05T12:00:00Z")), rule: r, now: now))
+    }
+
+    /// A track with no date (never played) can't be "in the last N days".
+    func testDateInLastWithNilDateNeverMatches() {
+        let now = date("2026-06-04T12:00:00Z")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: nil), rule: rule(.dateAdded, .inLast, "30"), now: now))
+    }
+
+    /// A non-positive / unparseable day count never matches.
+    func testDateInLastZeroDaysNeverMatches() {
+        let now = date("2026-06-04T12:00:00Z")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-06-04T11:00:00Z")), rule: rule(.dateAdded, .inLast, "0"), now: now))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-06-04T11:00:00Z")), rule: rule(.dateAdded, .inLast, "abc"), now: now))
+    }
+
+    /// `lessThan` on a date means "older than N days ago".
+    func testDateLessThanIsOlderThan() {
+        let now = date("2026-06-04T12:00:00Z")
+        let r = rule(.dateAdded, .lessThan, "30") // older than 30 days ago
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-01-01T00:00:00Z")), rule: r, now: now))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(dateAdded: date("2026-06-01T00:00:00Z")), rule: r, now: now))
+    }
+
+    // MARK: - Match modes
+
+    func testMatchAllRequiresEveryRule() {
+        let p = playlist(.all, [
+            rule(.year, .greaterThan, "1989"),
+            rule(.year, .lessThan, "2000"),
+        ])
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(year: 1995), playlist: p))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 2005), playlist: p), "fails upper bound")
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 1980), playlist: p), "fails lower bound")
+    }
+
+    func testMatchAnyRequiresOneRule() {
+        let p = playlist(.any, [
+            rule(.artist, .is, "Radiohead"),
+            rule(.isFavorite, .is, "true"),
+        ])
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Radiohead", isFavorite: false), playlist: p))
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(facts(artist: "Muse", isFavorite: true), playlist: p))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(artist: "Muse", isFavorite: false), playlist: p))
+    }
+
+    // MARK: - Whole-set evaluation + ordering
+
+    /// `evaluate` filters the set and preserves input order.
+    func testEvaluatePreservesOrder() {
+        let tracks = [
+            facts(id: "1", artist: "Muse", isFavorite: true),
+            facts(id: "2", artist: "Radiohead", isFavorite: false),
+            facts(id: "3", artist: "Muse", isFavorite: false),
+            facts(id: "4", artist: "Muse", isFavorite: true),
+        ]
+        let p = playlist(.all, [rule(.artist, .is, "Muse"), rule(.isFavorite, .is, "true")])
+        let result = SmartPlaylistEvaluator.evaluate(p, over: tracks)
+        XCTAssertEqual(result.map(\.id), ["1", "4"])
+    }
+
+    // MARK: - Concrete Track/Album FFI path
+
+    private func makeTrack(
+        id: String,
+        name: String = "Song",
+        albumId: String? = nil,
+        albumName: String? = nil,
+        artistName: String = "Artist",
+        year: Int32? = nil,
+        isFavorite: Bool = false,
+        playCount: UInt32 = 0,
+        userData: UserItemData? = nil
+    ) -> Track {
+        Track(
+            id: id, name: name, albumId: albumId, albumName: albumName,
+            artistName: artistName, artistId: nil, indexNumber: nil,
+            discNumber: nil, year: year, runtimeTicks: 0,
+            isFavorite: isFavorite, playCount: playCount, container: nil,
+            bitrate: nil, imageTag: nil, playlistItemId: nil, userData: userData
+        )
+    }
+
+    private func makeAlbum(id: String, genres: [String]) -> Album {
+        Album(
+            id: id, name: "Album", artistName: "Artist", artistId: nil,
+            year: nil, trackCount: 0, runtimeTicks: 0, genres: genres,
+            imageTag: nil, userData: nil
+        )
+    }
+
+    /// The `Track`/`Album` entry point projects album genres onto the album's
+    /// tracks and filters them. A genre rule matches a track whose *album*
+    /// carries the genre, even though `Track` itself has no genres.
+    func testEvaluateOverTracksProjectsAlbumGenres() {
+        let albums = [
+            makeAlbum(id: "alb-rock", genres: ["Rock"]),
+            makeAlbum(id: "alb-jazz", genres: ["Jazz"]),
+        ]
+        let tracks = [
+            makeTrack(id: "t1", albumId: "alb-rock"),
+            makeTrack(id: "t2", albumId: "alb-jazz"),
+            makeTrack(id: "t3", albumId: "alb-rock"),
+            makeTrack(id: "t4", albumId: nil), // no album → no genres
+        ]
+        let p = playlist(.all, [rule(.genre, .is, "Rock")])
+        let result = SmartPlaylistEvaluator.evaluate(p, tracks: tracks, albums: albums)
+        XCTAssertEqual(result.map(\.id), ["t1", "t3"])
+    }
+
+    /// `matchCount` agrees with the materialized filter count and avoids
+    /// building the array.
+    func testMatchCountAgreesWithEvaluate() {
+        let albums = [makeAlbum(id: "alb", genres: ["Pop"])]
+        let tracks = [
+            makeTrack(id: "t1", albumId: "alb", isFavorite: true),
+            makeTrack(id: "t2", albumId: "alb", isFavorite: false),
+            makeTrack(id: "t3", albumId: "alb", isFavorite: true),
+        ]
+        let p = playlist(.all, [rule(.isFavorite, .is, "true")])
+        let filtered = SmartPlaylistEvaluator.evaluate(p, tracks: tracks, albums: albums)
+        let count = SmartPlaylistEvaluator.matchCount(p, tracks: tracks, albums: albums)
+        XCTAssertEqual(count, filtered.count)
+        XCTAssertEqual(count, 2)
+    }
+
+    /// `TrackFacts(track:)` prefers the richer `UserData` projection over the
+    /// convenience mirror for play count + favorite.
+    func testTrackAdapterPrefersUserData() {
+        let ud = UserItemData(
+            isFavorite: true, played: true, playCount: 42,
+            playbackPositionTicks: 0, lastPlayedAt: nil, likes: nil, rating: nil
+        )
+        // Mirror fields deliberately disagree with UserData to prove which wins.
+        let track = makeTrack(id: "t", isFavorite: false, playCount: 1, userData: ud)
+        let f = TrackFacts(track: track)
+        XCTAssertEqual(f.playCount, 42)
+        XCTAssertTrue(f.isFavorite)
+    }
+
+    /// `TrackFacts(track:)` falls back to the convenience mirror when there's
+    /// no `UserData` (snapshot fetched without `Fields=UserData`).
+    func testTrackAdapterFallsBackToMirror() {
+        let track = makeTrack(id: "t", isFavorite: true, playCount: 7, userData: nil)
+        let f = TrackFacts(track: track)
+        XCTAssertEqual(f.playCount, 7)
+        XCTAssertTrue(f.isFavorite)
+        XCTAssertNil(f.dateAdded, "no UserData → no date")
+    }
+
+    /// "Date Added" is sourced from `UserData.lastPlayedAt` (the only
+    /// per-track date the snapshot exposes) and parsed from Jellyfin's
+    /// fractional-seconds ISO form.
+    func testTrackAdapterParsesLastPlayedDate() {
+        let ud = UserItemData(
+            isFavorite: false, played: true, playCount: 1,
+            playbackPositionTicks: 0,
+            lastPlayedAt: "2026-05-01T08:30:00.0000000Z",
+            likes: nil, rating: nil
+        )
+        let track = makeTrack(id: "t", userData: ud)
+        let f = TrackFacts(track: track)
+        XCTAssertNotNil(f.dateAdded)
+        // Within the last 60 days of a June-2026 "now".
+        let now = date("2026-06-04T12:00:00Z")
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(f, rule: rule(.dateAdded, .inLast, "60"), now: now))
+    }
+
+    // MARK: - Parsing helpers
+
+    /// Numeric parsing is POSIX so a comma never reads as a decimal point.
+    func testParseNumberIsPosix() {
+        XCTAssertEqual(SmartPlaylistEvaluator.parseNumber("1999"), 1999)
+        XCTAssertEqual(SmartPlaylistEvaluator.parseNumber("  42  "), 42)
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber(""))
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("twelve"))
+    }
+
+    func testParseDateAcceptsBothISOForms() {
+        XCTAssertNotNil(SmartPlaylistEvaluator.parseDate("2026-05-01T08:30:00.0000000Z"))
+        XCTAssertNotNil(SmartPlaylistEvaluator.parseDate("2026-05-01T08:30:00Z"))
+        XCTAssertNil(SmartPlaylistEvaluator.parseDate("not a date"))
+    }
+
+    /// The album-genre index skips genre-less albums and keys the rest by id.
+    func testAlbumGenreIndex() {
+        let albums = [
+            makeAlbum(id: "a", genres: ["Rock", "Indie"]),
+            makeAlbum(id: "b", genres: []),
+        ]
+        let index = SmartPlaylistEvaluator.albumGenreIndex(albums)
+        XCTAssertEqual(index["a"], ["Rock", "Indie"])
+        XCTAssertNil(index["b"])
+    }
+}

--- a/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for the pure `SmartPlaylist` rule model (#77 / #238): the
+/// field/operator domain, default-rule seeding, the field→operator repair
+/// that keeps an impossible pairing from forming, and `Codable`
+/// round-tripping (the model is persisted as JSON, so its on-the-wire shape
+/// is a contract).
+final class SmartPlaylistModelTests: XCTestCase {
+
+    // MARK: - Field / operator domain
+
+    /// Each field advertises exactly one value kind, and that kind drives
+    /// which operators are legal. Pin the mapping so a future field addition
+    /// has to consciously slot itself in.
+    func testFieldValueKinds() {
+        XCTAssertEqual(SmartPlaylistField.genre.valueKind, .text)
+        XCTAssertEqual(SmartPlaylistField.artist.valueKind, .text)
+        XCTAssertEqual(SmartPlaylistField.album.valueKind, .text)
+        XCTAssertEqual(SmartPlaylistField.year.valueKind, .number)
+        XCTAssertEqual(SmartPlaylistField.playCount.valueKind, .number)
+        XCTAssertEqual(SmartPlaylistField.isFavorite.valueKind, .boolean)
+        XCTAssertEqual(SmartPlaylistField.dateAdded.valueKind, .date)
+    }
+
+    /// The operator sets are scoped to the value kind: text gets equality +
+    /// contains; numbers get equality + ordering; booleans only `is`; dates
+    /// get recency + ordering. `contains` must never be offered for a number.
+    func testApplicableOperatorsPerKind() {
+        XCTAssertEqual(SmartPlaylistOperator.applicable(to: .text), [.is, .isNot, .contains])
+        XCTAssertEqual(SmartPlaylistOperator.applicable(to: .number), [.is, .isNot, .greaterThan, .lessThan])
+        XCTAssertEqual(SmartPlaylistOperator.applicable(to: .boolean), [.is])
+        XCTAssertEqual(SmartPlaylistOperator.applicable(to: .date), [.inLast, .greaterThan, .lessThan])
+    }
+
+    // MARK: - Default rule seeding
+
+    /// A default rule for a field picks the first legal operator and a
+    /// kind-appropriate value, so a freshly-added row is immediately valid.
+    func testDefaultRuleSeedsLegalOperatorAndValue() {
+        let text = SmartPlaylistRule.defaultRule(for: .artist)
+        XCTAssertEqual(text.field, .artist)
+        XCTAssertEqual(text.op, .is)
+        XCTAssertEqual(text.value, "")
+
+        let number = SmartPlaylistRule.defaultRule(for: .playCount)
+        XCTAssertEqual(number.op, .is)
+        XCTAssertEqual(number.value, "0")
+
+        let boolean = SmartPlaylistRule.defaultRule(for: .isFavorite)
+        XCTAssertEqual(boolean.op, .is)
+        XCTAssertEqual(boolean.value, "true")
+
+        let date = SmartPlaylistRule.defaultRule(for: .dateAdded)
+        XCTAssertEqual(date.op, .inLast)
+        XCTAssertEqual(date.value, "30")
+    }
+
+    // MARK: - Field→operator repair
+
+    /// Changing a rule's field to one whose kind doesn't support the current
+    /// operator snaps the operator (and value) to that field's default,
+    /// preserving the row's identity. This is what stops "Favorite greater
+    /// than 5" from ever forming in the builder.
+    func testRepairFixesIncompatibleOperator() {
+        // Start with a valid numeric rule, then flip the field to a boolean.
+        var rule = SmartPlaylistRule(field: .playCount, op: .greaterThan, value: "5")
+        let originalId = rule.id
+        rule.field = .isFavorite // op `.greaterThan` is now illegal for boolean
+
+        let repaired = rule.repaired()
+        XCTAssertEqual(repaired.field, .isFavorite)
+        XCTAssertEqual(repaired.op, .is, "boolean only supports `is`")
+        XCTAssertEqual(repaired.value, "true")
+        XCTAssertEqual(repaired.id, originalId, "repair preserves row identity")
+    }
+
+    /// Repair is a no-op when the operator already applies — it must not
+    /// clobber a perfectly good rule's value.
+    func testRepairLeavesValidRuleUntouched() {
+        let rule = SmartPlaylistRule(field: .year, op: .greaterThan, value: "1999")
+        XCTAssertEqual(rule.repaired(), rule)
+        XCTAssertEqual(rule.repaired().value, "1999")
+    }
+
+    // MARK: - Semantic equality
+
+    /// Two rules with identical field/op/value compare equal even if their
+    /// `id`s differ — the model treats `id` as presentation-only identity.
+    func testRuleEqualityIgnoresId() {
+        let a = SmartPlaylistRule(id: UUID(), field: .artist, op: .is, value: "Bjork")
+        let b = SmartPlaylistRule(id: UUID(), field: .artist, op: .is, value: "Bjork")
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    // MARK: - Codable round-trip
+
+    /// A playlist survives an encode → decode round trip with every field,
+    /// operator, match mode, and rule contents intact. This is the persisted
+    /// contract — a regression here silently drops a user's saved playlists.
+    func testPlaylistCodableRoundTrip() throws {
+        let original = SmartPlaylist(
+            id: UUID(),
+            name: "90s Favorites",
+            matchMode: .any,
+            rules: [
+                SmartPlaylistRule(field: .year, op: .greaterThan, value: "1989"),
+                SmartPlaylistRule(field: .year, op: .lessThan, value: "2000"),
+                SmartPlaylistRule(field: .isFavorite, op: .is, value: "true"),
+                SmartPlaylistRule(field: .genre, op: .contains, value: "Rock"),
+                SmartPlaylistRule(field: .dateAdded, op: .inLast, value: "365"),
+            ]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SmartPlaylist.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.name, original.name)
+        XCTAssertEqual(decoded.matchMode, original.matchMode)
+        XCTAssertEqual(decoded.rules, original.rules)
+        // Rule ids round-trip too (encoded so an edit session keeps row
+        // identity), not just the semantic content.
+        XCTAssertEqual(decoded.rules.map(\.id), original.rules.map(\.id))
+    }
+
+    /// Enum raw values are stable storage keys; pin them so a rename can't
+    /// silently invalidate every file on disk.
+    func testEnumRawValuesAreStable() {
+        XCTAssertEqual(SmartPlaylistField.playCount.rawValue, "playCount")
+        XCTAssertEqual(SmartPlaylistField.isFavorite.rawValue, "isFavorite")
+        XCTAssertEqual(SmartPlaylistField.dateAdded.rawValue, "dateAdded")
+        XCTAssertEqual(SmartPlaylistOperator.greaterThan.rawValue, "greaterThan")
+        XCTAssertEqual(SmartPlaylistOperator.inLast.rawValue, "inLast")
+        XCTAssertEqual(SmartPlaylistMatchMode.all.rawValue, "all")
+        XCTAssertEqual(SmartPlaylistMatchMode.any.rawValue, "any")
+    }
+
+    /// `newDraft` opens with exactly one default rule (so the builder never
+    /// starts on an accidental match-everything state).
+    func testNewDraftHasOneDefaultRule() {
+        let draft = SmartPlaylist.newDraft()
+        XCTAssertEqual(draft.rules.count, 1)
+        XCTAssertEqual(draft.matchMode, .all)
+        XCTAssertFalse(draft.name.isEmpty)
+    }
+}

--- a/macos/Tests/LyrebirdTests/SmartPlaylistStoreTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistStoreTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Coverage for `SmartPlaylistCodec` (pure JSON codec + path derivation) and
+/// `SmartPlaylistStore` (the observable, disk-backed CRUD store) for #77 /
+/// #238. The codec tests are pure; the store tests run against a temp file
+/// so they never touch the real Application Support directory.
+final class SmartPlaylistStoreTests: XCTestCase {
+
+    // MARK: - Codec
+
+    /// Encode → decode round-trips the playlists verbatim, through the
+    /// versioned document envelope.
+    func testCodecRoundTrip() throws {
+        let playlists = [
+            SmartPlaylist(name: "A", matchMode: .all, rules: [
+                SmartPlaylistRule(field: .artist, op: .is, value: "Radiohead"),
+            ]),
+            SmartPlaylist(name: "B", matchMode: .any, rules: [
+                SmartPlaylistRule(field: .year, op: .greaterThan, value: "2000"),
+                SmartPlaylistRule(field: .isFavorite, op: .is, value: "true"),
+            ]),
+        ]
+        let data = try SmartPlaylistCodec.encode(playlists)
+        let decoded = try SmartPlaylistCodec.decode(data)
+        XCTAssertEqual(decoded, playlists)
+    }
+
+    /// The encoded document carries the current schema version so a future
+    /// migration has a branch point.
+    func testCodecWritesVersion() throws {
+        let data = try SmartPlaylistCodec.encode([])
+        let doc = try JSONDecoder().decode(SmartPlaylistCodec.Document.self, from: data)
+        XCTAssertEqual(doc.version, SmartPlaylistCodec.currentVersion)
+    }
+
+    /// Decoding empty data yields an empty list rather than throwing (an
+    /// empty file is a legitimate "no playlists yet" state).
+    func testCodecDecodesEmptyDataToEmptyList() throws {
+        XCTAssertEqual(try SmartPlaylistCodec.decode(Data()), [])
+    }
+
+    /// A document with an unrecognized extra key still decodes — forward
+    /// compatibility so a file written by a newer build doesn't brick an
+    /// older one.
+    func testCodecToleratesUnknownKeys() throws {
+        let json = """
+        {
+          "version": 1,
+          "unexpectedFutureField": "ignored",
+          "playlists": [
+            { "id": "\(UUID().uuidString)", "name": "X", "matchMode": "all", "rules": [] }
+          ]
+        }
+        """
+        let decoded = try SmartPlaylistCodec.decode(Data(json.utf8))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.name, "X")
+    }
+
+    /// Genuinely malformed JSON throws so the caller can decide to quarantine.
+    func testCodecThrowsOnMalformedJSON() {
+        XCTAssertThrowsError(try SmartPlaylistCodec.decode(Data("{ not json".utf8)))
+    }
+
+    /// The file URL lands inside the shared `lyrebird-desktop` Application
+    /// Support folder, mirroring `CoreDataLocation`.
+    func testFileURLDerivation() {
+        let url = SmartPlaylistCodec.fileURL(environment: [:], home: "/Users/test")
+        XCTAssertEqual(
+            url?.path,
+            "/Users/test/Library/Application Support/lyrebird-desktop/smart-playlists.json"
+        )
+    }
+
+    /// `XDG_DATA_HOME` overrides the home-relative path (matching the core).
+    func testFileURLHonoursXDG() {
+        let url = SmartPlaylistCodec.fileURL(environment: ["XDG_DATA_HOME": "/xdg"], home: "/Users/test")
+        XCTAssertEqual(url?.path, "/xdg/lyrebird-desktop/smart-playlists.json")
+    }
+
+    // MARK: - Store CRUD (temp file)
+
+    private func tempFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("smart-playlist-tests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("smart-playlists.json")
+    }
+
+    @MainActor
+    func testStoreAddAndPersist() throws {
+        let url = tempFileURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let store = SmartPlaylistStore(fileURL: url, load: false)
+        let pl = SmartPlaylist(name: "Drive", rules: [
+            SmartPlaylistRule(field: .playCount, op: .greaterThan, value: "10"),
+        ])
+        store.add(pl)
+        XCTAssertEqual(store.playlists.count, 1)
+
+        // A second store pointed at the same file reads the persisted data.
+        let reloaded = SmartPlaylistStore(fileURL: url, load: true)
+        XCTAssertEqual(reloaded.playlists, [pl])
+    }
+
+    @MainActor
+    func testStoreSaveUpdatesInPlace() {
+        let store = SmartPlaylistStore(fileURL: nil, load: false) // in-memory
+        var pl = SmartPlaylist(name: "Original")
+        store.save(pl) // insert
+        XCTAssertEqual(store.playlists.count, 1)
+
+        pl.name = "Renamed"
+        store.save(pl) // update, same id → no duplicate
+        XCTAssertEqual(store.playlists.count, 1)
+        XCTAssertEqual(store.playlists.first?.name, "Renamed")
+    }
+
+    @MainActor
+    func testStoreUpdateIgnoresUnknownId() {
+        let store = SmartPlaylistStore(fileURL: nil, load: false)
+        store.add(SmartPlaylist(name: "Keep"))
+        // Updating a playlist that isn't present must not resurrect it.
+        store.update(SmartPlaylist(name: "Ghost"))
+        XCTAssertEqual(store.playlists.count, 1)
+        XCTAssertEqual(store.playlists.first?.name, "Keep")
+    }
+
+    @MainActor
+    func testStoreRemove() {
+        let store = SmartPlaylistStore(fileURL: nil, load: false)
+        let a = SmartPlaylist(name: "A")
+        let b = SmartPlaylist(name: "B")
+        store.add(a)
+        store.add(b)
+        store.remove(id: a.id)
+        XCTAssertEqual(store.playlists.map(\.id), [b.id])
+    }
+
+    @MainActor
+    func testStoreRename() {
+        let store = SmartPlaylistStore(fileURL: nil, load: false)
+        let pl = SmartPlaylist(name: "Before")
+        store.add(pl)
+        store.rename(id: pl.id, to: "After")
+        XCTAssertEqual(store.playlist(id: pl.id)?.name, "After")
+    }
+
+    /// A store pointed at a non-existent file loads to an empty list rather
+    /// than crashing the launch.
+    @MainActor
+    func testStoreMissingFileLoadsEmpty() {
+        let store = SmartPlaylistStore(fileURL: tempFileURL(), load: true)
+        XCTAssertTrue(store.playlists.isEmpty)
+    }
+
+    /// A store pointed at a corrupt file degrades to empty rather than
+    /// throwing out of `init`.
+    @MainActor
+    func testStoreCorruptFileLoadsEmpty() throws {
+        let url = tempFileURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{ corrupt".utf8).write(to: url)
+
+        let store = SmartPlaylistStore(fileURL: url, load: true)
+        XCTAssertTrue(store.playlists.isEmpty)
+    }
+}


### PR DESCRIPTION
Deferred-feature Wave A. Built green: build + 858 Swift tests.

- **Smart Playlists (client-side)** — rule model (genre/artist/album/year/playCount/isFavorite/dateAdded × is/isNot/contains/>/</inLast), pure evaluator over the library snapshot, disk-backed store, iTunes/Marvis-style builder with live result count, sidebar section + detail view. No core change. Closes #77, #238.
- **Pluralization** — 9 xcstrings plural-variation keys + a CountStrings helper; migrated 18 hand-rolled `count==1` ternary sites. Closes #350.
- **Locale-correct durations** — consolidated ~7 duplicated mm:ss formatters into one tested `DurationFormatter` + spelled-out VoiceOver values. Closes #349.
- **Localized InfoPlist** — display name + copyright via InfoPlist.xcstrings. Closes #359.