### PR TITLE
feat: offline downloads engine + offline playback (#819) — dormant behind supportsDownloads

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2672,6 +2672,81 @@ impl JellyfinClient {
         Ok((bytes.to_vec(), content_type))
     }
 
+    /// Download a track's audio payload to `dest`, streaming the response body
+    /// to disk in chunks rather than buffering the whole file in memory.
+    ///
+    /// Used by the offline-downloads engine (#819). Writes to a sibling
+    /// `<dest>.part` temp file first and atomically renames it into place only
+    /// on a fully-successful transfer, so an interrupted download never leaves
+    /// a truncated file that offline playback would treat as complete. Returns
+    /// `(bytes_written, content_type)` on success; `content_type` is the
+    /// server-reported MIME so the caller can pick the right file extension.
+    ///
+    /// On any error the partial temp file is removed. The destination's parent
+    /// directory is created if missing.
+    pub async fn download_to_file(
+        &self,
+        track_id: &str,
+        dest: &std::path::Path,
+    ) -> Result<(u64, Option<String>)> {
+        use futures::StreamExt;
+        use tokio::io::AsyncWriteExt;
+
+        let url = self.stream_url(track_id, None, None)?;
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        if let Some(parent) = dest.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| LyrebirdError::Storage(e.to_string()))?;
+        }
+
+        // Stream to a `.part` sibling, then atomically rename on success. The
+        // helper closure scopes the file handle so it's flushed + dropped
+        // before the rename, and lets us unlink the partial on any failure.
+        let tmp = dest.with_extension("part");
+        let result = async {
+            let mut file = tokio::fs::File::create(&tmp)
+                .await
+                .map_err(|e| LyrebirdError::Storage(e.to_string()))?;
+            let mut written: u64 = 0;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?; // reqwest::Error -> Network
+                file.write_all(&chunk)
+                    .await
+                    .map_err(|e| LyrebirdError::Storage(e.to_string()))?;
+                written += chunk.len() as u64;
+            }
+            file.flush()
+                .await
+                .map_err(|e| LyrebirdError::Storage(e.to_string()))?;
+            // Drop the handle before the rename so all bytes are on disk.
+            drop(file);
+            tokio::fs::rename(&tmp, dest)
+                .await
+                .map_err(|e| LyrebirdError::Storage(e.to_string()))?;
+            Ok(written)
+        }
+        .await;
+
+        match result {
+            Ok(written) => Ok((written, content_type)),
+            Err(e) => {
+                // Best-effort cleanup of the partial file; ignore unlink errors.
+                let _ = tokio::fs::remove_file(&tmp).await;
+                Err(e)
+            }
+        }
+    }
+
     /// Build the URL to stream a given track.
     ///
     /// `media_source_id` should come from `MediaSourceInfo::id` returned by

--- a/core/src/downloads.rs
+++ b/core/src/downloads.rs
@@ -1,0 +1,396 @@
+//! Offline downloads engine (#819).
+//!
+//! Keeps tracks available for offline playback by streaming their audio bytes
+//! to disk and indexing them in the `downloads` table. The on-disk layout is a
+//! flat `downloads/` directory under the configured root, one file per track:
+//!
+//! ```text
+//! <root>/downloads/<track_id>.<ext>
+//! ```
+//!
+//! The engine is deliberately stateless beyond what's in SQLite + on disk: it
+//! is a set of free functions over an [`Arc<Database>`] and (for the fetch
+//! path) a [`JellyfinClient`]. That mirrors the rest of the core — `lib.rs`
+//! clones the `Arc`s under the `Inner` mutex, drops the guard, then calls these
+//! on the tokio runtime so a long download never holds the FFI lock.
+//!
+//! ## Budget
+//!
+//! A configurable storage budget (bytes; 0 = unlimited) caps total disk used by
+//! *completed* downloads. Before a fetch, the budget planner evicts the
+//! oldest-completed downloads (LRU on `completed_at`) to make room; if even an
+//! empty store can't fit the incoming track the enqueue is refused with
+//! [`LyrebirdError::Storage`]. This is the "evict/refuse past budget" contract.
+
+use crate::client::JellyfinClient;
+use crate::error::{LyrebirdError, Result};
+use crate::models::{DownloadEntry, DownloadState, DownloadStats, Track};
+use crate::storage::{Database, DownloadRow};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Settings-table key under which the download root override is persisted.
+/// Empty / absent means "use `<data_dir>/downloads`".
+pub const DOWNLOAD_DIR_KEY: &str = "downloads_dir";
+
+/// Settings-table key for the storage budget in bytes. Absent / "0" means
+/// unlimited.
+pub const DOWNLOAD_BUDGET_KEY: &str = "downloads_budget_bytes";
+
+/// Map a raw `state` column string to the typed [`DownloadState`]. Unknown
+/// values (only reachable via a hand-edited DB) degrade to `Failed` so the row
+/// is never mistaken for a playable `Done`.
+fn parse_state(raw: &str) -> DownloadState {
+    match raw {
+        "queued" => DownloadState::Queued,
+        "downloading" => DownloadState::Downloading,
+        "done" => DownloadState::Done,
+        _ => DownloadState::Failed,
+    }
+}
+
+/// Convert a stored [`DownloadRow`] into the FFI-facing [`DownloadEntry`].
+///
+/// The `track_json` snapshot is deserialized back into a [`Track`]; if that
+/// fails (an upgrade changed the `Track` shape, say) the row is reported as
+/// `Failed` with a decode error rather than being dropped, so the UI can still
+/// offer a delete affordance.
+fn row_to_entry(row: DownloadRow) -> DownloadEntry {
+    match serde_json::from_str::<Track>(&row.track_json) {
+        Ok(track) => DownloadEntry {
+            track,
+            state: parse_state(&row.state),
+            local_path: row.local_path,
+            size_bytes: row.size_bytes,
+            error: row.error,
+            created_at: row.created_at,
+            completed_at: row.completed_at,
+        },
+        Err(e) => DownloadEntry {
+            // A minimal placeholder track so the row is still addressable.
+            track: Track {
+                id: row.track_id,
+                name: String::new(),
+                album_id: None,
+                album_name: None,
+                artist_name: String::new(),
+                artist_id: None,
+                index_number: None,
+                disc_number: None,
+                year: None,
+                runtime_ticks: 0,
+                is_favorite: false,
+                play_count: 0,
+                container: row.container,
+                bitrate: None,
+                image_tag: None,
+                playlist_item_id: None,
+                user_data: None,
+            },
+            state: DownloadState::Failed,
+            local_path: None,
+            size_bytes: 0,
+            error: Some(format!("corrupt download record: {e}")),
+            created_at: row.created_at,
+            completed_at: row.completed_at,
+        },
+    }
+}
+
+/// Resolve the directory offline audio files live in.
+///
+/// Prefers the persisted [`DOWNLOAD_DIR_KEY`] override; otherwise falls back to
+/// `<data_dir>/downloads`. The directory is **not** created here — the fetch
+/// path creates it lazily so a read-only query (list / stats) never has a side
+/// effect.
+pub fn download_dir(db: &Database, data_dir: &Path) -> PathBuf {
+    match db.get_setting(DOWNLOAD_DIR_KEY).ok().flatten() {
+        Some(custom) if !custom.trim().is_empty() => PathBuf::from(custom),
+        _ => data_dir.join("downloads"),
+    }
+}
+
+/// Read the configured storage budget in bytes. `0` means unlimited.
+pub fn budget_bytes(db: &Database) -> u64 {
+    db.get_setting(DOWNLOAD_BUDGET_KEY)
+        .ok()
+        .flatten()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+/// Pick a file extension for the downloaded audio.
+///
+/// Prefers the track's known `container`; otherwise infers from the server's
+/// `Content-Type`. Falls back to `bin` so a file is always written with *some*
+/// extension. The extension is cosmetic for AVFoundation (which sniffs the
+/// bytes), but a faithful one keeps the cache directory legible.
+fn extension_for(container: Option<&str>, content_type: Option<&str>) -> String {
+    if let Some(c) = container {
+        let c = c.trim().trim_start_matches('.').to_ascii_lowercase();
+        if !c.is_empty() {
+            // `container` can be a comma list (e.g. "mp3,aac"); take the first.
+            if let Some(first) = c.split(',').next() {
+                if !first.is_empty() {
+                    return first.to_string();
+                }
+            }
+        }
+    }
+    match content_type.map(|s| {
+        s.split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase()
+    }) {
+        Some(mime) => match mime.as_str() {
+            "audio/mpeg" | "audio/mp3" => "mp3",
+            "audio/aac" => "aac",
+            "audio/mp4" | "audio/m4a" | "audio/x-m4a" => "m4a",
+            "audio/flac" | "audio/x-flac" => "flac",
+            "audio/ogg" | "application/ogg" => "ogg",
+            "audio/opus" => "opus",
+            "audio/wav" | "audio/x-wav" | "audio/wave" => "wav",
+            _ => "bin",
+        },
+        None => "bin",
+    }
+    .to_string()
+}
+
+/// Current `(used_bytes, item_count)` for completed downloads.
+pub fn stats(db: &Database) -> Result<DownloadStats> {
+    let (used_bytes, item_count) = db.download_used_bytes()?;
+    Ok(DownloadStats {
+        used_bytes,
+        budget_bytes: budget_bytes(db),
+        item_count,
+    })
+}
+
+/// The typed download state for a single track (`None` when the track has no
+/// download row at all). The hot per-track query the UI consults.
+pub fn state_for(db: &Database, track_id: &str) -> Result<Option<DownloadState>> {
+    Ok(db
+        .download_get(track_id)?
+        .map(|row| parse_state(&row.state)))
+}
+
+/// The absolute on-disk path of a track's completed download, or `None` when
+/// the track isn't downloaded, isn't yet `done`, or the file has gone missing.
+///
+/// The file-existence check is what makes offline playback safe: a stale `done`
+/// row whose backing file was deleted out from under us (manual cleanup, macOS
+/// cache eviction) reports `None`, so the player falls back to streaming
+/// instead of handing AVFoundation a dead path.
+pub fn local_path_for(db: &Database, track_id: &str) -> Result<Option<String>> {
+    let row = match db.download_get(track_id)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    if parse_state(&row.state) != DownloadState::Done {
+        return Ok(None);
+    }
+    match row.local_path {
+        Some(p) if Path::new(&p).exists() => Ok(Some(p)),
+        _ => Ok(None),
+    }
+}
+
+/// Every download row as FFI entries, newest-enqueued first.
+pub fn list(db: &Database) -> Result<Vec<DownloadEntry>> {
+    Ok(db.download_list()?.into_iter().map(row_to_entry).collect())
+}
+
+/// Delete a download: remove the DB row and unlink its on-disk file.
+///
+/// Idempotent — deleting a track that was never downloaded is a successful
+/// no-op. The file unlink is best-effort; a missing file (already gone) is not
+/// an error.
+pub fn delete(db: &Database, track_id: &str) -> Result<()> {
+    if let Some(path) = db.download_delete(track_id)? {
+        let _ = std::fs::remove_file(&path);
+        // Also clean up any leftover `.part` from an interrupted fetch.
+        let _ = std::fs::remove_file(Path::new(&path).with_extension("part"));
+    }
+    Ok(())
+}
+
+/// Record an enqueue: snapshot the track into the `downloads` table in the
+/// `queued` state. Does not fetch bytes — [`fetch`] does that. Separated so the
+/// UI can optimistically show a queued badge the instant the user taps,
+/// independent of the network round trip.
+pub fn enqueue(db: &Database, track: &Track, now: i64) -> Result<()> {
+    let json = serde_json::to_string(track)?;
+    db.download_upsert_queued(&track.id, &json, now)
+}
+
+/// Evict completed downloads (oldest-first) until `incoming_bytes` would fit
+/// within `budget` alongside what remains.
+///
+/// Returns `Err(Storage)` when `incoming_bytes` alone exceeds a non-zero budget
+/// — no amount of eviction can make room, so the caller must refuse the
+/// download. A `budget` of 0 (unlimited) short-circuits to `Ok(())`.
+///
+/// `incoming_bytes` is an *estimate* available before the fetch (from the
+/// track's bitrate × duration); the post-fetch true size is reconciled by the
+/// caller. Over-eviction from a high estimate is acceptable — it errs toward
+/// staying under budget.
+fn ensure_budget_for(db: &Database, budget: u64, incoming_bytes: u64) -> Result<()> {
+    if budget == 0 {
+        return Ok(());
+    }
+    if incoming_bytes > budget {
+        return Err(LyrebirdError::Storage(format!(
+            "track ({incoming_bytes} bytes) exceeds the entire download budget ({budget} bytes)"
+        )));
+    }
+    let (mut used, _) = db.download_used_bytes()?;
+    if used + incoming_bytes <= budget {
+        return Ok(());
+    }
+    // Evict LRU completed downloads until the incoming track fits.
+    for (track_id, path, size) in db.download_completed_lru()? {
+        if used + incoming_bytes <= budget {
+            break;
+        }
+        // Remove the row + file; subtract its size from the running total.
+        if db.download_delete(&track_id)?.is_some() {
+            let _ = std::fs::remove_file(&path);
+        }
+        used = used.saturating_sub(size);
+    }
+    Ok(())
+}
+
+/// Estimate a track's on-disk size from its bitrate and duration. Used only for
+/// pre-fetch budget planning; falls back to a conservative 0 (which makes the
+/// budget check a no-op until the true size is known post-fetch) when the track
+/// carries no bitrate.
+fn estimate_bytes(track: &Track) -> u64 {
+    match track.bitrate {
+        Some(bps) if bps > 0 => {
+            let secs = track.duration_seconds();
+            if secs.is_finite() && secs > 0.0 {
+                ((bps as f64) * secs / 8.0) as u64
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Download a queued track's audio to disk and mark it `done`.
+///
+/// The full pipeline for one track:
+/// 1. Enforce the budget (evict LRU / refuse) using a pre-fetch size estimate.
+/// 2. Mark the row `downloading`.
+/// 3. Stream bytes to `<dir>/<track_id>.<ext>` via [`JellyfinClient::download_to_file`].
+/// 4. Re-check the budget against the *true* byte size; if the real file blew
+///    past the budget, evict to make room (keeping this download).
+/// 5. Mark the row `done` with its path + size.
+///
+/// On any failure the row is flipped to `failed` with the error recorded, and
+/// the error is returned so the caller (UI) can surface it. The partial file is
+/// cleaned up by `download_to_file` itself.
+///
+/// `now` is the completion timestamp the caller passes (Unix seconds) so tests
+/// can pin it.
+pub async fn fetch(
+    db: &Arc<Database>,
+    client: &JellyfinClient,
+    data_dir: &Path,
+    track: &Track,
+    now: i64,
+) -> Result<DownloadEntry> {
+    let dir = download_dir(db, data_dir);
+    let budget = budget_bytes(db);
+
+    // 1. Pre-fetch budget planning against an estimate.
+    if let Err(e) = ensure_budget_for(db, budget, estimate_bytes(track)) {
+        let _ = db.download_mark_failed(&track.id, &e.to_string());
+        return Err(e);
+    }
+
+    // 2. In-progress marker so the UI shows a spinner.
+    db.download_mark_downloading(&track.id)?;
+
+    // 3. Stream to disk. We don't yet know the real extension until the
+    //    response arrives, but the destination path must be fixed up front; use
+    //    the track's container hint, then settle the file's final name after we
+    //    learn the content-type. To keep it simple and avoid a rename dance, we
+    //    pick the extension from the container hint when present, else `bin`,
+    //    download, then (if the content-type disagrees) the file already plays
+    //    via byte-sniffing regardless. Most Jellyfin music carries a container.
+    let provisional_ext = extension_for(track.container.as_deref(), None);
+    let dest = dir.join(format!("{}.{provisional_ext}", track.id));
+
+    let (size, content_type) = match client.download_to_file(&track.id, &dest).await {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = db.download_mark_failed(&track.id, &e.to_string());
+            return Err(e);
+        }
+    };
+
+    // 4. Reconcile against the true size. If the real file pushed us over a
+    //    non-zero budget, evict *other* completed downloads to make room;
+    //    never delete the file we just fetched.
+    if budget > 0 {
+        let (used, _) = db.download_used_bytes()?;
+        if used + size > budget {
+            // Evict LRU (excluding this track, which isn't `done` yet) until it
+            // fits. If it still can't fit even an otherwise-empty store, fail
+            // the download and remove the file.
+            if let Err(e) = ensure_budget_for(db, budget, size) {
+                let _ = std::fs::remove_file(&dest);
+                let _ = db.download_mark_failed(&track.id, &e.to_string());
+                return Err(e);
+            }
+        }
+    }
+
+    // 5. Commit.
+    let final_container = track
+        .container
+        .clone()
+        .or_else(|| Some(extension_for(None, content_type.as_deref())));
+    let path_str = dest.to_string_lossy().to_string();
+    db.download_mark_done(&track.id, &path_str, size, final_container.as_deref(), now)?;
+
+    match db.download_get(&track.id)? {
+        Some(row) => Ok(row_to_entry(row)),
+        // Shouldn't happen — we just wrote it — but don't panic across FFI.
+        None => Err(LyrebirdError::Storage(
+            "download row vanished after completion".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod unit {
+    use super::*;
+
+    #[test]
+    fn extension_prefers_container_then_content_type() {
+        assert_eq!(extension_for(Some("flac"), None), "flac");
+        assert_eq!(extension_for(Some(".MP3"), None), "mp3");
+        assert_eq!(extension_for(Some("mp3,aac"), None), "mp3");
+        assert_eq!(extension_for(None, Some("audio/mpeg")), "mp3");
+        assert_eq!(
+            extension_for(None, Some("audio/flac; charset=binary")),
+            "flac"
+        );
+        assert_eq!(extension_for(None, None), "bin");
+        assert_eq!(extension_for(Some(""), Some("audio/aac")), "aac");
+    }
+
+    #[test]
+    fn parse_state_unknown_is_failed() {
+        assert_eq!(parse_state("queued"), DownloadState::Queued);
+        assert_eq!(parse_state("done"), DownloadState::Done);
+        assert_eq!(parse_state("garbage"), DownloadState::Failed);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@
 //! play them and calls back with status updates.
 
 pub mod client;
+pub mod downloads;
 pub mod enums;
 pub mod error;
 pub mod models;
@@ -85,6 +86,10 @@ struct Inner {
     db: Arc<Database>,
     device_id: String,
     device_name: String,
+    /// Resolved root data directory (the parent of `lyrebird.db`). Held so the
+    /// downloads engine can locate the default offline-audio directory
+    /// (`<data_dir>/downloads`) without recomputing it. See `downloads.rs`.
+    data_dir: PathBuf,
 }
 
 #[derive(Clone, Debug, uniffi::Record)]
@@ -132,6 +137,7 @@ impl LyrebirdCore {
                 db,
                 device_id,
                 device_name: config.device_name,
+                data_dir,
             })),
             player,
             runtime,
@@ -1355,6 +1361,147 @@ impl LyrebirdCore {
 
     pub fn status(&self) -> PlayerStatus {
         self.player.status()
+    }
+
+    // ======================================================================
+    // Offline downloads (#819).
+    //
+    // All of these serialize through the same `Inner` mutex as every other
+    // FFI, but the long-running one (`download_track`) clones the `Arc`s
+    // under the lock and drops the guard before the network stream, exactly
+    // like `with_client`. The cheap query methods (`download_state`,
+    // `is_track_downloaded`, `download_local_path`, `list_downloads`,
+    // `downloads_used_bytes`, `download_stats`) only touch SQLite, so they're
+    // safe for the platform layer to call off the main thread and cache.
+    // ======================================================================
+
+    /// Enqueue and synchronously download a track's audio for offline
+    /// playback. Records a `queued` row first (so a concurrent `download_state`
+    /// query reflects the intent immediately), then streams the bytes to disk
+    /// and flips the row to `done`.
+    ///
+    /// Enforces the configured storage budget: evicts least-recently-completed
+    /// downloads to make room, or refuses with [`LyrebirdError::Storage`] when
+    /// the track can't fit even an empty store. On any failure the row is
+    /// marked `failed` with the reason and the error is returned.
+    ///
+    /// Blocking: this drives the full HTTP transfer on the tokio runtime, so
+    /// the platform layer MUST call it off the main thread (e.g. inside a
+    /// `Task.detached`).
+    pub fn download_track(
+        &self,
+        track: Track,
+    ) -> std::result::Result<DownloadEntry, LyrebirdError> {
+        let (client, db, data_dir) = {
+            let inner = self.inner.lock();
+            (
+                inner
+                    .client
+                    .as_ref()
+                    .ok_or(LyrebirdError::NoSession)?
+                    .clone(),
+                inner.db.clone(),
+                inner.data_dir.clone(),
+            )
+        };
+        let now = chrono::Utc::now().timestamp();
+        // Record the queued intent up front, off the network path.
+        downloads::enqueue(&db, &track, now)?;
+        self.runtime
+            .block_on(downloads::fetch(&db, &client, &data_dir, &track, now))
+    }
+
+    /// Cancel / remove a download: deletes the on-disk file and the index row.
+    /// Idempotent — removing a track that was never downloaded succeeds.
+    ///
+    /// Note: this does not abort an in-flight `download_track` mid-stream (that
+    /// call owns the transfer synchronously); it removes a completed or queued
+    /// entry. The platform layer surfaces it as "Remove Download".
+    pub fn delete_download(&self, track_id: String) -> std::result::Result<(), LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        downloads::delete(&db, &track_id)
+    }
+
+    /// The download state of a single track, or `None` when it has no download
+    /// record. Cheap (one indexed SQLite read) and side-effect free.
+    pub fn download_state(
+        &self,
+        track_id: String,
+    ) -> std::result::Result<Option<DownloadState>, LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        downloads::state_for(&db, &track_id)
+    }
+
+    /// `true` when the track is fully downloaded *and* its backing file still
+    /// exists on disk. The existence check makes this the safe predicate for
+    /// the offline-playback branch — a stale `done` row whose file was evicted
+    /// reports `false`, so playback falls back to streaming.
+    pub fn is_track_downloaded(&self, track_id: String) -> bool {
+        let db = self.inner.lock().db.clone();
+        downloads::local_path_for(&db, &track_id)
+            .ok()
+            .flatten()
+            .is_some()
+    }
+
+    /// Absolute on-disk path of a track's completed download, or `None` when it
+    /// isn't downloaded / not yet done / the file is gone. The platform audio
+    /// engine turns this into a `file://` URL for offline playback.
+    pub fn download_local_path(&self, track_id: String) -> Option<String> {
+        let db = self.inner.lock().db.clone();
+        downloads::local_path_for(&db, &track_id).ok().flatten()
+    }
+
+    /// Every download record (any state), newest-enqueued first. Drives the
+    /// Downloads screen.
+    pub fn list_downloads(&self) -> std::result::Result<Vec<DownloadEntry>, LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        downloads::list(&db)
+    }
+
+    /// Total bytes used by completed downloads.
+    pub fn downloads_used_bytes(&self) -> std::result::Result<u64, LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        Ok(db.download_used_bytes()?.0)
+    }
+
+    /// Aggregate offline-storage stats (used bytes, configured budget, item
+    /// count) for the Downloads preferences pane.
+    pub fn download_stats(&self) -> std::result::Result<DownloadStats, LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        downloads::stats(&db)
+    }
+
+    /// Set the storage budget in bytes (`0` = unlimited). Persisted to the
+    /// settings table; consulted on the next `download_track`.
+    pub fn set_download_budget_bytes(&self, bytes: u64) -> std::result::Result<(), LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        db.set_setting(downloads::DOWNLOAD_BUDGET_KEY, &bytes.to_string())
+    }
+
+    /// Override the directory offline audio files are written to. Pass an empty
+    /// string to clear the override and fall back to `<data_dir>/downloads`.
+    /// Existing files are not migrated — this only affects subsequent
+    /// downloads (the UI warns accordingly).
+    pub fn set_download_dir(&self, dir: String) -> std::result::Result<(), LyrebirdError> {
+        let db = self.inner.lock().db.clone();
+        if dir.trim().is_empty() {
+            db.delete_setting(downloads::DOWNLOAD_DIR_KEY)
+        } else {
+            db.set_setting(downloads::DOWNLOAD_DIR_KEY, &dir)
+        }
+    }
+
+    /// The directory offline audio files are written to (the resolved path,
+    /// honouring any override). Shown read-only in the Downloads pane.
+    pub fn download_dir_path(&self) -> String {
+        let (db, data_dir) = {
+            let inner = self.inner.lock();
+            (inner.db.clone(), inner.data_dir.clone())
+        };
+        downloads::download_dir(&db, &data_dir)
+            .to_string_lossy()
+            .to_string()
     }
 }
 

--- a/core/src/migrations/002_downloads.sql
+++ b/core/src/migrations/002_downloads.sql
@@ -1,0 +1,32 @@
+-- Offline downloads (#819).
+--
+-- One row per track the user has asked to keep available offline. The audio
+-- bytes themselves live on disk under the configurable downloads directory
+-- (see `downloads.rs`); this table is the index the UI and the offline-playback
+-- path consult. `track_json` snapshots the full `Track` record at enqueue time
+-- so the Downloads screen can render rows (title / artist / artwork tag) and
+-- offline playback can reconstruct a queue without a live server.
+--
+-- `state` is the lifecycle marker: 'queued' | 'downloading' | 'done' |
+-- 'failed'. Only a 'done' row with a present `local_path` + non-zero
+-- `size_bytes` counts toward the storage budget and is eligible for offline
+-- playback. `created_at` / `completed_at` are Unix seconds; `completed_at` is
+-- NULL until the download finishes (used as the LRU key for budget eviction —
+-- oldest completed download evicts first).
+CREATE TABLE IF NOT EXISTS downloads (
+    track_id TEXT PRIMARY KEY,
+    track_json TEXT NOT NULL,
+    local_path TEXT,
+    container TEXT,
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    state TEXT NOT NULL DEFAULT 'queued',
+    error TEXT,
+    created_at INTEGER NOT NULL,
+    completed_at INTEGER
+);
+
+-- Budget eviction scans completed rows oldest-first; index the LRU key so that
+-- scan stays cheap as the offline library grows.
+CREATE INDEX IF NOT EXISTS idx_downloads_completed_at
+    ON downloads (completed_at)
+    WHERE state = 'done';

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -686,6 +686,60 @@ pub struct PlaybackStopInfo {
     pub session_id: Option<String>,
 }
 
+// ============================================================================
+// Offline downloads (#819).
+// ============================================================================
+
+/// Lifecycle of a single offline download. Surfaced across the FFI so the UI
+/// can render the right per-track affordance (queued spinner, progress, a
+/// solid "downloaded" check, or a retry on failure).
+///
+/// Only [`DownloadState::Done`] entries are eligible for offline playback and
+/// count toward the storage budget. `Queued` and `Downloading` are transient;
+/// `Failed` is terminal until the user re-enqueues.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+pub enum DownloadState {
+    /// Enqueued, bytes not yet being fetched.
+    Queued,
+    /// Audio bytes are actively streaming to disk.
+    Downloading,
+    /// Fully on disk and playable offline.
+    Done,
+    /// The download failed (network, disk, or budget). Terminal until retried.
+    Failed,
+}
+
+/// One row of the offline-downloads index. Mirrors a row of the `downloads`
+/// table. `track` is the snapshot captured at enqueue time so the Downloads
+/// screen and offline queue can render without a live server.
+///
+/// `local_path` is the absolute on-disk path of the audio file; it is `Some`
+/// only once `state == Done`. `size_bytes` is the byte length of that file (0
+/// until completion). `completed_at` is the Unix timestamp (seconds) the
+/// download finished, used as the LRU key for budget eviction.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct DownloadEntry {
+    pub track: Track,
+    pub state: DownloadState,
+    pub local_path: Option<String>,
+    pub size_bytes: u64,
+    pub error: Option<String>,
+    pub created_at: i64,
+    pub completed_at: Option<i64>,
+}
+
+/// Aggregate offline-storage figures for the Downloads preferences pane.
+///
+/// `used_bytes` is the sum of `size_bytes` across all completed downloads;
+/// `budget_bytes` is the user's configured cap (0 means "unlimited");
+/// `item_count` is the number of completed (playable) downloads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
+pub struct DownloadStats {
+    pub used_bytes: u64,
+    pub budget_bytes: u64,
+    pub item_count: u32,
+}
+
 // `ImageType` now lives in `crate::enums` alongside the other typed query
 // enums (`ItemKind`, `ItemSortBy`, `SortOrder`, `ItemField`). It is
 // re-exported from the crate root for backwards-compatible imports.

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -4,7 +4,7 @@ use parking_lot::Mutex;
 use rusqlite::{params, Connection};
 use std::path::{Path, PathBuf};
 
-const SCHEMA_VERSION: i32 = 1;
+const SCHEMA_VERSION: i32 = 2;
 
 pub struct Database {
     conn: Mutex<Connection>,
@@ -61,6 +61,16 @@ impl Database {
             tx.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
                 params![1],
+            )?;
+        }
+
+        if current < 2 {
+            // Offline downloads index (#819). Additive: adds the `downloads`
+            // table + its LRU index, leaving every v1 table untouched.
+            tx.execute_batch(include_str!("migrations/002_downloads.sql"))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
+                params![2],
             )?;
         }
 
@@ -162,6 +172,206 @@ impl Database {
             )?;
         }
         Ok(())
+    }
+
+    // ------------------------------------------------------------------------
+    // Offline downloads index (#819).
+    //
+    // Thin CRUD over the `downloads` table. The connection lives here, so these
+    // methods are the single writer/reader; the orchestration (streaming bytes
+    // to disk, budget enforcement) lives in `crate::downloads`, which calls
+    // through these. Returned shapes are intentionally primitive tuples / the
+    // `DownloadRow` struct so `storage.rs` stays free of the FFI-facing
+    // `DownloadEntry` mapping (that's `downloads.rs`'s job).
+    // ------------------------------------------------------------------------
+
+    /// Insert (or reset) a download row in the `queued` state. `track_json` is
+    /// the serialized [`crate::models::Track`] snapshot. Re-enqueuing an
+    /// existing row clears any prior `local_path` / `size_bytes` / `error` and
+    /// returns it to `queued` so a failed download can be retried cleanly.
+    pub fn download_upsert_queued(
+        &self,
+        track_id: &str,
+        track_json: &str,
+        created_at: i64,
+    ) -> Result<()> {
+        self.conn.lock().execute(
+            "INSERT INTO downloads (track_id, track_json, state, created_at) \
+             VALUES (?1, ?2, 'queued', ?3) \
+             ON CONFLICT(track_id) DO UPDATE SET \
+                 track_json = excluded.track_json, \
+                 state = 'queued', \
+                 local_path = NULL, \
+                 size_bytes = 0, \
+                 error = NULL, \
+                 completed_at = NULL",
+            params![track_id, track_json, created_at],
+        )?;
+        Ok(())
+    }
+
+    /// Move a row to the `downloading` state. No-op if the row is gone.
+    pub fn download_mark_downloading(&self, track_id: &str) -> Result<()> {
+        self.conn.lock().execute(
+            "UPDATE downloads SET state = 'downloading', error = NULL WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        Ok(())
+    }
+
+    /// Mark a download complete: record its on-disk path, byte size, container,
+    /// and completion timestamp, flipping it to `done`.
+    pub fn download_mark_done(
+        &self,
+        track_id: &str,
+        local_path: &str,
+        size_bytes: u64,
+        container: Option<&str>,
+        completed_at: i64,
+    ) -> Result<()> {
+        self.conn.lock().execute(
+            "UPDATE downloads SET state = 'done', local_path = ?2, size_bytes = ?3, \
+                 container = ?4, error = NULL, completed_at = ?5 WHERE track_id = ?1",
+            params![
+                track_id,
+                local_path,
+                size_bytes as i64,
+                container,
+                completed_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Mark a download failed with a human-readable reason. Leaves any prior
+    /// `local_path` cleared so a half-written file is never treated as playable.
+    pub fn download_mark_failed(&self, track_id: &str, error: &str) -> Result<()> {
+        self.conn.lock().execute(
+            "UPDATE downloads SET state = 'failed', error = ?2, local_path = NULL, \
+                 size_bytes = 0, completed_at = NULL WHERE track_id = ?1",
+            params![track_id, error],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a download row. Returns the `local_path` that was recorded (if
+    /// any) so the caller can unlink the file on disk. Returns `Ok(None)` when
+    /// no such row existed.
+    pub fn download_delete(&self, track_id: &str) -> Result<Option<String>> {
+        let conn = self.conn.lock();
+        let path: Option<String> = match conn.query_row(
+            "SELECT local_path FROM downloads WHERE track_id = ?1",
+            params![track_id],
+            |r| r.get::<_, Option<String>>(0),
+        ) {
+            Ok(p) => p,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        conn.execute(
+            "DELETE FROM downloads WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        Ok(path)
+    }
+
+    /// Fetch a single download row by track id, or `None` when absent.
+    pub fn download_get(&self, track_id: &str) -> Result<Option<DownloadRow>> {
+        let conn = self.conn.lock();
+        match conn.query_row(
+            "SELECT track_id, track_json, local_path, container, size_bytes, state, \
+                    error, created_at, completed_at \
+             FROM downloads WHERE track_id = ?1",
+            params![track_id],
+            DownloadRow::from_sql_row,
+        ) {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// All download rows, newest-enqueued first. Drives the Downloads screen.
+    pub fn download_list(&self) -> Result<Vec<DownloadRow>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT track_id, track_json, local_path, container, size_bytes, state, \
+                    error, created_at, completed_at \
+             FROM downloads ORDER BY created_at DESC",
+        )?;
+        let rows = stmt
+            .query_map([], DownloadRow::from_sql_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Sum of `size_bytes` across completed (`done`) downloads, plus the count
+    /// of such rows. This is the figure compared against the storage budget.
+    pub fn download_used_bytes(&self) -> Result<(u64, u32)> {
+        let conn = self.conn.lock();
+        let (sum, count): (i64, i64) = conn.query_row(
+            "SELECT COALESCE(SUM(size_bytes), 0), COUNT(*) FROM downloads WHERE state = 'done'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )?;
+        Ok((sum.max(0) as u64, count.max(0) as u32))
+    }
+
+    /// Completed downloads ordered oldest-first (LRU). Returns
+    /// `(track_id, local_path, size_bytes)` so the budget-eviction loop can
+    /// pick victims and unlink their files. Rows missing a `local_path` are
+    /// skipped — they can't be evicted by file deletion and don't count toward
+    /// used bytes anyway.
+    pub fn download_completed_lru(&self) -> Result<Vec<(String, String, u64)>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT track_id, local_path, size_bytes FROM downloads \
+             WHERE state = 'done' AND local_path IS NOT NULL \
+             ORDER BY completed_at ASC, created_at ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?.max(0) as u64,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+}
+
+/// A raw row of the `downloads` table, as read from SQLite. Lives in
+/// `storage.rs` (next to the connection that produces it) and is mapped to the
+/// FFI-facing [`crate::models::DownloadEntry`] in `crate::downloads`.
+#[derive(Clone, Debug)]
+pub struct DownloadRow {
+    pub track_id: String,
+    pub track_json: String,
+    pub local_path: Option<String>,
+    pub container: Option<String>,
+    pub size_bytes: u64,
+    /// Raw `state` column: `"queued" | "downloading" | "done" | "failed"`.
+    pub state: String,
+    pub error: Option<String>,
+    pub created_at: i64,
+    pub completed_at: Option<i64>,
+}
+
+impl DownloadRow {
+    fn from_sql_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(DownloadRow {
+            track_id: r.get(0)?,
+            track_json: r.get(1)?,
+            local_path: r.get(2)?,
+            container: r.get(3)?,
+            size_bytes: r.get::<_, i64>(4)?.max(0) as u64,
+            state: r.get(5)?,
+            error: r.get(6)?,
+            created_at: r.get(7)?,
+            completed_at: r.get(8)?,
+        })
     }
 }
 

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -8904,3 +8904,357 @@ fn error_chain_is_cert_failure_false_for_benign_transport_error() {
         "benign transport error must not match cert markers"
     );
 }
+
+// ===========================================================================
+// Offline downloads (#819).
+//
+// The engine in `crate::downloads` is exercised at two layers:
+//   * directly over a temp-backed `Database` + temp dir (enqueue / state /
+//     list / delete / budget evict + refuse / stale-file fallback), which
+//     needs no network, and
+//   * end-to-end through the `LyrebirdCore` FFI against a wiremock Jellyfin
+//     (login -> download_track -> file on disk + `done` state + offline path).
+// ===========================================================================
+
+/// A minimal `Track` for download tests. `bitrate` + `runtime_ticks` drive the
+/// pre-fetch budget estimate, so they're parameterized.
+fn dl_track(id: &str, bitrate: Option<i64>, runtime_ticks: u64) -> crate::models::Track {
+    crate::models::Track {
+        id: id.into(),
+        name: format!("Track {id}"),
+        album_id: Some("album-1".into()),
+        album_name: Some("Album One".into()),
+        artist_name: "Artist".into(),
+        artist_id: Some("artist-1".into()),
+        index_number: Some(1),
+        disc_number: Some(1),
+        year: Some(2020),
+        runtime_ticks,
+        is_favorite: false,
+        play_count: 0,
+        container: Some("mp3".into()),
+        bitrate,
+        image_tag: None,
+        playlist_item_id: None,
+        user_data: None,
+    }
+}
+
+#[test]
+fn download_enqueue_then_state_and_delete() {
+    use crate::downloads;
+    let db = Database::in_memory().unwrap();
+    let track = dl_track("t-enq", None, 0);
+
+    // No record yet.
+    assert!(downloads::state_for(&db, "t-enq").unwrap().is_none());
+
+    downloads::enqueue(&db, &track, 100).unwrap();
+    assert_eq!(
+        downloads::state_for(&db, "t-enq").unwrap(),
+        Some(crate::models::DownloadState::Queued)
+    );
+
+    // It appears in the list with the snapshotted track metadata.
+    let list = downloads::list(&db).unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].track.name, "Track t-enq");
+    assert_eq!(list[0].state, crate::models::DownloadState::Queued);
+
+    // Queued rows are not yet playable offline (no file).
+    assert!(downloads::local_path_for(&db, "t-enq").unwrap().is_none());
+
+    // Delete is idempotent and clears the record.
+    downloads::delete(&db, "t-enq").unwrap();
+    assert!(downloads::state_for(&db, "t-enq").unwrap().is_none());
+    downloads::delete(&db, "t-enq").unwrap(); // second delete: no-op, no error
+}
+
+#[test]
+fn download_mark_done_counts_toward_used_bytes() {
+    let db = Database::in_memory().unwrap();
+    let track = dl_track("t-done", None, 0);
+    let json = serde_json::to_string(&track).unwrap();
+
+    db.download_upsert_queued("t-done", &json, 1).unwrap();
+    // A queued row contributes nothing to used bytes.
+    assert_eq!(db.download_used_bytes().unwrap(), (0, 0));
+
+    db.download_mark_done("t-done", "/tmp/t-done.mp3", 4096, Some("mp3"), 2)
+        .unwrap();
+    assert_eq!(db.download_used_bytes().unwrap(), (4096, 1));
+
+    let stats = crate::downloads::stats(&db).unwrap();
+    assert_eq!(stats.used_bytes, 4096);
+    assert_eq!(stats.item_count, 1);
+    assert_eq!(stats.budget_bytes, 0); // unlimited by default
+}
+
+#[test]
+fn download_local_path_falls_back_when_file_missing() {
+    use crate::downloads;
+    let db = Database::in_memory().unwrap();
+    let track = dl_track("t-stale", None, 0);
+    let json = serde_json::to_string(&track).unwrap();
+    db.download_upsert_queued("t-stale", &json, 1).unwrap();
+    // Point at a path that does not exist on disk.
+    db.download_mark_done(
+        "t-stale",
+        "/nonexistent/dir/t-stale.mp3",
+        10,
+        Some("mp3"),
+        2,
+    )
+    .unwrap();
+
+    // State is `done`...
+    assert_eq!(
+        downloads::state_for(&db, "t-stale").unwrap(),
+        Some(crate::models::DownloadState::Done)
+    );
+    // ...but the offline-playback resolver returns None because the file is
+    // gone, so the player streams instead of handing AVFoundation a dead path.
+    assert!(downloads::local_path_for(&db, "t-stale").unwrap().is_none());
+}
+
+#[tokio::test]
+async fn download_budget_refuses_track_larger_than_whole_budget() {
+    use crate::downloads;
+    let db = std::sync::Arc::new(Database::in_memory().unwrap());
+    let tmp = tempfile::tempdir().unwrap();
+
+    // 1 MB budget; a track estimated at ~9 MB (320 kbps for ~225s) can't fit.
+    db.set_setting(downloads::DOWNLOAD_BUDGET_KEY, &(1_000_000u64).to_string())
+        .unwrap();
+
+    // 320 kbps * 225s / 8 ≈ 9 MB. The pre-fetch budget check refuses it before
+    // any network I/O, so the (never-contacted) client URL is irrelevant.
+    let track = dl_track("t-big", Some(320_000), 225 * 10_000_000);
+    downloads::enqueue(&db, &track, 1).unwrap();
+    let client = mock_client("http://127.0.0.1:0");
+    let err = downloads::fetch(&db, &client, tmp.path(), &track, 2)
+        .await
+        .expect_err("oversized track must be refused");
+    match err {
+        LyrebirdError::Storage(_) => {}
+        other => panic!("expected Storage error, got {other:?}"),
+    }
+    // The refused track is recorded as failed, not done, and uses no space.
+    assert_eq!(
+        downloads::state_for(&db, "t-big").unwrap(),
+        Some(crate::models::DownloadState::Failed)
+    );
+    assert_eq!(db.download_used_bytes().unwrap(), (0, 0));
+}
+
+#[test]
+fn download_budget_evicts_oldest_completed_first() {
+    use crate::downloads;
+    let db = Database::in_memory().unwrap();
+
+    // Two completed downloads at 400 bytes each, with distinct completion
+    // timestamps so the LRU order is deterministic.
+    for (id, completed_at) in [("old", 10i64), ("new", 20i64)] {
+        let track = dl_track(id, None, 0);
+        let json = serde_json::to_string(&track).unwrap();
+        db.download_upsert_queued(id, &json, completed_at).unwrap();
+        db.download_mark_done(
+            id,
+            &format!("/tmp/{id}.mp3"),
+            400,
+            Some("mp3"),
+            completed_at,
+        )
+        .unwrap();
+    }
+    assert_eq!(db.download_used_bytes().unwrap(), (800, 2));
+
+    // Budget 1000, incoming 400 -> total would be 1200, over by 200. Evicting
+    // the single oldest (400 bytes) brings used to 400, so 400+400 = 800 fits.
+    // `ensure_budget_for` is private; exercise it via the public planning that
+    // `fetch` would do by calling the crate-internal helper through a thin
+    // re-enqueue + manual check using the LRU list it consults.
+    let lru = db.download_completed_lru().unwrap();
+    assert_eq!(lru.first().map(|(id, _, _)| id.as_str()), Some("old"));
+    assert_eq!(lru.last().map(|(id, _, _)| id.as_str()), Some("new"));
+
+    // Simulate the evict step the budget planner performs: drop the oldest.
+    let _ = downloads::delete(&db, "old");
+    assert_eq!(db.download_used_bytes().unwrap(), (400, 1));
+    // The survivor is the newest one.
+    assert!(downloads::state_for(&db, "new").unwrap().is_some());
+    assert!(downloads::state_for(&db, "old").unwrap().is_none());
+}
+
+#[test]
+fn download_dir_honours_override_then_falls_back() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+
+    // Default: <data_dir>/downloads.
+    let default_dir = core.download_dir_path();
+    assert!(default_dir.ends_with("downloads"), "got {default_dir}");
+
+    // Override to a custom path.
+    core.set_download_dir("/custom/offline/spot".into())
+        .unwrap();
+    assert_eq!(core.download_dir_path(), "/custom/offline/spot");
+
+    // Clearing the override falls back to the default.
+    core.set_download_dir("".into()).unwrap();
+    assert_eq!(core.download_dir_path(), default_dir);
+
+    // Budget round-trips through the FFI.
+    core.set_download_budget_bytes(5_000_000).unwrap();
+    assert_eq!(core.download_stats().unwrap().budget_bytes, 5_000_000);
+}
+
+#[test]
+fn download_track_without_session_is_no_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    let track = dl_track("t-nosession", None, 0);
+    let err = core
+        .download_track(track)
+        .expect_err("download without login must fail");
+    assert!(matches!(err, LyrebirdError::NoSession));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn download_track_end_to_end_writes_file_and_marks_done() {
+    install_mock_keyring();
+    let server = MockServer::start().await;
+
+    // Auth.
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok-dl",
+            "ServerId": "srv-dl",
+            "ServerName": "DL Server",
+            "User": { "Id": "user-dl", "Name": "dl-user", "ServerId": "srv-dl", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+
+    // The audio stream endpoint hit by `download_to_file` -> `stream_url`.
+    let audio_bytes: Vec<u8> = (0..2048u32).map(|i| (i % 251) as u8).collect();
+    Mock::given(method("GET"))
+        .and(path("/Audio/track-dl/universal"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "audio/mpeg")
+                .set_body_bytes(audio_bytes.clone()),
+        )
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().to_string_lossy().into_owned();
+    let server_uri = server.uri();
+    let expected = audio_bytes.clone();
+
+    // The whole `LyrebirdCore` lifecycle runs on a blocking thread: `new` /
+    // `login` / `download_track` all `block_on` the core's owned runtime
+    // (illegal from an async worker), and the core's runtime must also be
+    // *dropped* off the async context — dropping a tokio runtime inside another
+    // runtime panics ("Cannot drop a runtime ..."). Keeping the core local to
+    // this closure guarantees it's dropped here, on the blocking thread.
+    tokio::task::spawn_blocking(move || {
+        let core = LyrebirdCore::new(CoreConfig {
+            data_dir,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_uri, "dl-user".into(), "pw".into())
+            .expect("login");
+        let track = dl_track("track-dl", None, 0);
+        let entry = core.download_track(track).expect("download_track");
+
+        // The returned entry is complete and sized to the payload.
+        assert_eq!(entry.state, crate::models::DownloadState::Done);
+        assert_eq!(entry.size_bytes, expected.len() as u64);
+        let local_path = entry.local_path.clone().expect("local_path");
+
+        // The file exists on disk with exactly the bytes we served.
+        let on_disk = std::fs::read(&local_path).expect("read downloaded file");
+        assert_eq!(on_disk, expected);
+        // It lives under the resolved downloads dir.
+        assert!(
+            local_path.starts_with(&core.download_dir_path()),
+            "got {local_path}"
+        );
+
+        // The cheap query FFIs reflect the completed download.
+        assert!(core.is_track_downloaded("track-dl".into()));
+        assert_eq!(
+            core.download_state("track-dl".into()).unwrap(),
+            Some(crate::models::DownloadState::Done)
+        );
+        assert_eq!(
+            core.download_local_path("track-dl".into()).as_deref(),
+            Some(local_path.as_str())
+        );
+        assert_eq!(core.downloads_used_bytes().unwrap(), expected.len() as u64);
+        assert_eq!(core.list_downloads().unwrap().len(), 1);
+
+        // Deleting removes both the row and the file.
+        core.delete_download("track-dl".into()).unwrap();
+        assert!(!core.is_track_downloaded("track-dl".into()));
+        assert!(!std::path::Path::new(&local_path).exists());
+        assert_eq!(core.downloads_used_bytes().unwrap(), 0);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn download_track_server_error_marks_failed() {
+    install_mock_keyring();
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "tok-fail",
+            "ServerId": "srv-fail",
+            "ServerName": "Fail Server",
+            "User": { "Id": "user-fail", "Name": "fail-user", "ServerId": "srv-fail", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    // The audio endpoint returns 404 — a non-retryable failure.
+    Mock::given(method("GET"))
+        .and(path("/Audio/track-fail/universal"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().to_string_lossy().into_owned();
+    let server_uri = server.uri();
+
+    // See the end-to-end test for why the core lives entirely inside the
+    // blocking closure (block_on + runtime-drop both need a non-async thread).
+    tokio::task::spawn_blocking(move || {
+        let core = LyrebirdCore::new(CoreConfig {
+            data_dir,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_uri, "fail-user".into(), "pw".into())
+            .expect("login");
+        let track = dl_track("track-fail", None, 0);
+        let result = core.download_track(track);
+
+        assert!(result.is_err(), "404 audio fetch must surface an error");
+        // The row is marked failed (not done) and contributes no used bytes.
+        assert_eq!(
+            core.download_state("track-fail".into()).unwrap(),
+            Some(crate::models::DownloadState::Failed)
+        );
+        assert!(!core.is_track_downloaded("track-fail".into()));
+        assert_eq!(core.downloads_used_bytes().unwrap(), 0);
+    })
+    .await
+    .unwrap();
+}

--- a/core/tests/e2e_live.rs
+++ b/core/tests/e2e_live.rs
@@ -97,3 +97,70 @@ fn list_albums_returns_envelope() {
         "items should not exceed total_count"
     );
 }
+
+/// Offline downloads end-to-end against the live server (#819): resolve a real
+/// album track, download its audio to disk, and assert the byte stream landed,
+/// the index flipped to `Done`, the offline-playback path resolves, and that
+/// deleting removes the file. Gated on `LYREBIRD_E2E_URL` like the rest, so it's
+/// a no-op in the default hermetic run.
+#[test]
+fn download_track_to_disk_round_trips() {
+    use lyrebird_core::DownloadState;
+
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with the test account");
+
+    // Find a real track to download: first album with tracks.
+    let albums = core.list_albums(0, 25).expect("list_albums");
+    let mut track = None;
+    for album in albums.items {
+        if let Ok(tracks) = core.album_tracks(album.id.clone()) {
+            if let Some(first) = tracks.into_iter().next() {
+                track = Some(first);
+                break;
+            }
+        }
+    }
+    let track = track.expect("the live library should have at least one album track");
+    let track_id = track.id.clone();
+
+    // Download it.
+    let entry = core
+        .download_track(track)
+        .expect("download_track against the live server");
+    assert_eq!(entry.state, DownloadState::Done);
+    assert!(entry.size_bytes > 0, "downloaded file must be non-empty");
+    let local_path = entry.local_path.clone().expect("local_path set on Done");
+
+    // The bytes are on disk and the size matches what the index recorded.
+    let meta = std::fs::metadata(&local_path).expect("downloaded file exists");
+    assert_eq!(meta.len(), entry.size_bytes, "on-disk size matches index");
+
+    // Query FFIs reflect the completed download.
+    assert!(core.is_track_downloaded(track_id.clone()));
+    assert_eq!(
+        core.download_local_path(track_id.clone()).as_deref(),
+        Some(local_path.as_str())
+    );
+    assert_eq!(
+        core.download_state(track_id.clone())
+            .expect("download_state"),
+        Some(DownloadState::Done)
+    );
+    assert!(core.downloads_used_bytes().expect("used_bytes") >= entry.size_bytes);
+
+    // Cleanup: delete removes the row and the file.
+    core.delete_download(track_id.clone())
+        .expect("delete_download");
+    assert!(!core.is_track_downloaded(track_id));
+    assert!(
+        !std::path::Path::new(&local_path).exists(),
+        "deleting a download removes its file"
+    );
+}

--- a/macos/Sources/Lyrebird/AppModel+Downloads.swift
+++ b/macos/Sources/Lyrebird/AppModel+Downloads.swift
@@ -1,0 +1,198 @@
+import Foundation
+import SwiftUI
+@preconcurrency import LyrebirdCore
+
+/// Offline downloads (#819) — the AppModel surface the UI talks to.
+///
+/// Design notes:
+///
+/// * **No synchronous FFI on a per-cell path.** Row views (`TrackRow`,
+///   `DownloadsView`) read `downloadStateById` / `downloadStats`, which are
+///   plain in-memory `@Observable` state. The Rust core is only touched
+///   off-main: when the user enqueues / deletes a download, when one finishes,
+///   or in `refreshDownloads()`. This honours CLAUDE.md runtime gap #2.
+///
+/// * **Fully gated.** Every public entry checks `supportsDownloads` (the
+///   `Capabilities` flag). While that flag is `false` the maps stay empty,
+///   `downloadState(forTrackId:)` returns `nil`, and offline playback is never
+///   reached — the streaming path is byte-for-byte unchanged.
+///
+/// * **Optimistic + reconciled.** Enqueue stamps a `.queued` badge immediately,
+///   then the off-main `core.downloadTrack` flips it to `.done` (or `.failed`,
+///   surfaced via `errorMessage`). Delete is optimistic too, with the row
+///   removed up front and restored only implicitly by the next refresh on
+///   failure.
+extension AppModel {
+    /// The cached download state for a track id, or `nil` when the track has no
+    /// download record. The single read the UI should use — never calls the
+    /// core. Returns `nil` for everything while `supportsDownloads` is off.
+    func downloadState(forTrackId id: String) -> DownloadState? {
+        downloadStateById[id]
+    }
+
+    /// Convenience: is this track fully downloaded and playable offline?
+    func isDownloaded(_ track: Track) -> Bool {
+        downloadStateById[track.id] == .done
+    }
+
+    /// Convenience: is a download for this track currently queued / running?
+    func isDownloading(_ track: Track) -> Bool {
+        switch downloadStateById[track.id] {
+        case .queued, .downloading: return true
+        default: return downloadsInFlight.contains(track.id)
+        }
+    }
+
+    /// Download a batch of tracks for offline playback. Idempotent per track:
+    /// already-done or in-flight tracks are skipped. Each track is fetched on
+    /// its own detached task so one failure (or a budget refusal) doesn't sink
+    /// the rest of the batch — mirroring the favorite/played multi-select
+    /// convention.
+    ///
+    /// No-op while `supportsDownloads` is false.
+    func downloadTracks(_ tracks: [Track]) async {
+        guard supportsDownloads else { return }
+        for track in tracks {
+            // Skip ones already done or in flight.
+            if downloadStateById[track.id] == .done { continue }
+            if downloadsInFlight.contains(track.id) { continue }
+
+            // Optimistic queued badge + in-flight guard on the main actor.
+            downloadsInFlight.insert(track.id)
+            downloadStateById[track.id] = .queued
+
+            do {
+                let entry = try await Task.detached(priority: .utility) { [core] in
+                    try core.downloadTrack(track: track)
+                }.value
+                // Reconcile from the authoritative entry the core returned.
+                applyDownloadEntry(entry)
+            } catch {
+                if handleAuthError(error) {
+                    downloadsInFlight.remove(track.id)
+                    continue
+                }
+                // Mark failed locally and surface the reason. We deliberately
+                // keep a `.failed` badge (rather than clearing the row) so the
+                // user can see the attempt and retry.
+                downloadStateById[track.id] = .failed
+                errorMessage = LyrebirdErrorPresenter.message(for: error, context: .download)
+                Log.tracks.error("download failed track=\(track.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+            downloadsInFlight.remove(track.id)
+            // Keep aggregate stats fresh after each completion.
+            await refreshDownloadStats()
+        }
+    }
+
+    /// Remove the offline copies of a batch of tracks: deletes the files + index
+    /// rows in the core and clears the local snapshot. Optimistic — the badges
+    /// clear immediately. No-op while `supportsDownloads` is false.
+    func removeDownloads(_ tracks: [Track]) async {
+        guard supportsDownloads else { return }
+        let ids = tracks.map { $0.id }
+        // Optimistic local clear.
+        for id in ids {
+            downloadStateById.removeValue(forKey: id)
+            downloadsInFlight.remove(id)
+        }
+        downloads.removeAll { ids.contains($0.track.id) }
+
+        do {
+            try await Task.detached(priority: .utility) { [core] in
+                for id in ids {
+                    try core.deleteDownload(trackId: id)
+                }
+            }.value
+        } catch {
+            if handleAuthError(error) { return }
+            errorMessage = LyrebirdErrorPresenter.message(for: error, context: .download)
+            Log.tracks.error("delete download failed: \(error.localizedDescription, privacy: .public)")
+            // Re-sync so the snapshot reflects whatever actually got deleted.
+            await refreshDownloads()
+            return
+        }
+        await refreshDownloadStats()
+    }
+
+    /// Remove a single track's offline copy. Thin wrapper over
+    /// `removeDownloads` for call sites that have one track.
+    func removeDownload(_ track: Track) async {
+        await removeDownloads([track])
+    }
+
+    /// Rehydrate the full download snapshot from the core: the list, the
+    /// per-track state map, and the aggregate stats. Called after login /
+    /// session-restore and whenever the Downloads screen wants a fresh read.
+    /// No-op while `supportsDownloads` is false.
+    func refreshDownloads() async {
+        guard supportsDownloads else { return }
+        do {
+            let list = try await Task.detached(priority: .utility) { [core] in
+                try core.listDownloads()
+            }.value
+            downloads = list
+            // Rebuild the per-track map from the authoritative list. Preserve
+            // any in-flight `.queued` badges for tracks not yet in the list.
+            var map: [String: DownloadState] = [:]
+            for entry in list {
+                map[entry.track.id] = entry.state
+            }
+            for id in downloadsInFlight where map[id] == nil {
+                map[id] = .queued
+            }
+            downloadStateById = map
+            await refreshDownloadStats()
+        } catch {
+            if handleAuthError(error) { return }
+            Log.tracks.error("refreshDownloads failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Refresh just the aggregate stats (used / budget / count). Cheap; called
+    /// after each completion and on demand by the preferences pane.
+    func refreshDownloadStats() async {
+        guard supportsDownloads else { return }
+        let stats = try? await Task.detached(priority: .utility) { [core] in
+            try core.downloadStats()
+        }.value
+        if let stats { downloadStats = stats }
+    }
+
+    /// Persist the storage budget (in gigabytes from the slider) to the core,
+    /// then refresh stats so the usage readout reflects the new cap.
+    func setDownloadBudget(gigabytes: Double) {
+        guard supportsDownloads else { return }
+        let bytes = UInt64(max(0, gigabytes) * 1_000_000_000)
+        Task {
+            do {
+                try await Task.detached(priority: .utility) { [core] in
+                    try core.setDownloadBudgetBytes(bytes: bytes)
+                }.value
+                await refreshDownloadStats()
+            } catch {
+                Log.tracks.error("setDownloadBudget failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// The resolved on-disk directory offline audio lives in. Shown read-only in
+    /// the Downloads pane. Safe to call on the main thread (one cheap settings
+    /// read in the core).
+    func downloadDirectoryPath() -> String {
+        core.downloadDirPath()
+    }
+
+    // MARK: - Internal
+
+    /// Fold a single authoritative `DownloadEntry` (from the core) into the
+    /// local snapshot: update the per-track state and upsert it into the list.
+    private func applyDownloadEntry(_ entry: DownloadEntry) {
+        downloadStateById[entry.track.id] = entry.state
+        if let idx = downloads.firstIndex(where: { $0.track.id == entry.track.id }) {
+            downloads[idx] = entry
+        } else {
+            downloads.insert(entry, at: 0)
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1027,9 +1027,8 @@ final class AppModel {
                 searchTitle: "Download Current",
                 symbol: "arrow.down.circle",
                 run: { [weak self] in
-                    guard self?.status.currentTrack != nil else { return }
-                    // TODO(#819): wire to the download engine once it lands.
-                    Log.app.notice("Download Current — not yet wired (see #819)")
+                    guard let self, let track = self.status.currentTrack else { return }
+                    Task { await self.downloadTracks([track]) }
                 }
             ))
         }
@@ -1208,6 +1207,11 @@ final class AppModel {
         // Seed the scrobble-connected flag from the core's persisted token so
         // the Preferences pane shows the right state on first open.
         self.scrobbleConnected = core.isScrobbleConfigured()
+        // Offline playback (#819): only let the engine prefer a local copy when
+        // the downloads feature is live. With `supportsDownloads == false` this
+        // stays false, so `AudioEngine.play` never queries the core for a local
+        // path and the streaming path is byte-for-byte unchanged.
+        self.audio.offlinePlaybackEnabled = supportsDownloads
     }
 
     // MARK: - Network
@@ -1246,6 +1250,7 @@ final class AppModel {
             self.errorMessage = nil
             startPolling()
             await refreshLibrary()
+            await refreshDownloads()
         } catch {
             self.errorMessage = LyrebirdErrorPresenter.message(for: error, context: .login)
         }
@@ -1284,6 +1289,7 @@ final class AppModel {
             self.errorMessage = nil
             startPolling()
             await refreshLibrary()
+            await refreshDownloads()
         } catch {
             // Best-effort: leave `session == nil` so RootView renders LoginView.
             // No banner — the user sees the login form, which is already the
@@ -1363,6 +1369,13 @@ final class AppModel {
         currentLyrics = nil
         currentLyricsForId = nil
         sessionPlayHistory = []
+        // Clear the in-memory download snapshot. On-disk files are intentionally
+        // NOT removed — they're keyed by track id and rehydrate via
+        // `refreshDownloads()` on the next sign-in. See #819.
+        downloadStateById = [:]
+        downloads = []
+        downloadStats = nil
+        downloadsInFlight = []
         resetPaginationState()
         stopPolling()
     }
@@ -1480,7 +1493,11 @@ final class AppModel {
     /// Call-sites that do NOT match auth go on to call
     /// `LyrebirdErrorPresenter.message(for:context:)` (see #351) to turn the
     /// raw Display string into localized banner copy.
-    private func handleAuthError(_ error: Error) -> Bool {
+    ///
+    /// `internal` (not `private`) so AppModel extension files in other source
+    /// files (e.g. `AppModel+Downloads.swift`) can route their FFI failures
+    /// through the same auth-expiry interception.
+    func handleAuthError(_ error: Error) -> Bool {
         guard let err = error as? LyrebirdError else { return false }
         switch err {
         case .NotAuthenticated, .Auth, .AuthExpired:
@@ -4179,6 +4196,38 @@ final class AppModel {
     /// without polling.
     var favoriteChangeToken: UInt64 = 0
 
+    // MARK: - Offline downloads (#819)
+    //
+    // The download state of every track the user has interacted with, mirrored
+    // into an in-memory snapshot so per-cell row views (`TrackRow`) can read a
+    // downloading / done badge WITHOUT a synchronous core FFI on the main
+    // thread (CLAUDE.md runtime gap #2). The dictionary is the single source the
+    // UI reads; the FFI is consulted only off-main when a download is enqueued,
+    // finishes, is deleted, or when `refreshDownloadSnapshot()` rehydrates it.
+    //
+    // Keyed by track id. Absence means "no download record" (the common case),
+    // which `downloadState(forTrackId:)` reports as `nil`. All of this is inert
+    // while `supportsDownloads` is false — nothing populates the map, so every
+    // lookup returns `nil` and the UI shows no download affordances.
+
+    /// Per-track download lifecycle, keyed by track id. Read by row views; never
+    /// holds the core mutex on the main thread.
+    var downloadStateById: [String: DownloadState] = [:]
+
+    /// The full list of download records (any state), newest-enqueued first.
+    /// Drives the Downloads area. Refreshed from `core.listDownloads()` off-main
+    /// via `refreshDownloads()`.
+    var downloads: [DownloadEntry] = []
+
+    /// Aggregate offline-storage figures (used / budget / count) for the
+    /// Downloads preferences pane. Refreshed alongside `downloads`.
+    var downloadStats: DownloadStats?
+
+    /// Set of track ids with an enqueue/fetch currently in flight, so the UI can
+    /// show an immediate spinner before the core flips the row to `downloading`,
+    /// and so a double-tap doesn't kick a second concurrent fetch.
+    var downloadsInFlight: Set<String> = []
+
     /// In-memory played flag keyed by item id (track / album / playlist).
     /// Mirrors `favoriteById` — populated lazily from
     /// `track.userData?.played` and stamped with the server's authoritative
@@ -4320,12 +4369,17 @@ final class AppModel {
         }
     }
 
-    /// Enqueue a download of every track on the album.
-    /// TODO: #819 — there is no download engine yet; this is a logging
-    /// stub so the UI action has a landing pad.
+    /// Download every track on the album for offline playback (#819).
+    /// Resolves the album's tracks (cache-or-fetch), then hands them to the
+    /// shared `downloadTracks` pipeline. Gated behind `supportsDownloads`; a
+    /// no-op when the feature is dormant.
     func enqueueDownload(album: Album) {
-        // TODO(#819): download engine not yet wired.
-        Log.app.notice("enqueueDownload(album:) not yet wired — see #819")
+        guard supportsDownloads else { return }
+        Task {
+            let tracks = await loadTracks(forAlbum: album.id)
+            guard !tracks.isEmpty else { return }
+            await downloadTracks(tracks)
+        }
     }
 
     /// Append a batch of tracks to an existing playlist via `add_to_playlist`
@@ -4744,12 +4798,15 @@ final class AppModel {
         Task { await setFavorite(itemId: playlist.id, enabled: !isFavorite(playlist: playlist)) }
     }
 
-    /// Enqueue a download of every track in the playlist.
-    /// TODO: #819 — there is no download engine yet; this is a logging
-    /// stub so the UI action has a landing pad.
+    /// Download every track in the playlist for offline playback (#819).
+    /// Mirrors `enqueueDownload(album:)`. Gated behind `supportsDownloads`.
     func enqueueDownload(playlist: Playlist) {
-        // TODO(#819): download engine not yet wired.
-        Log.app.notice("enqueueDownload(playlist:) not yet wired — see #819")
+        guard supportsDownloads else { return }
+        Task {
+            let tracks = await loadPlaylistTracks(playlist: playlist)
+            guard !tracks.isEmpty else { return }
+            await downloadTracks(tracks)
+        }
     }
 
     /// Flip the sidebar's inline TextField onto an existing playlist row so
@@ -5386,12 +5443,24 @@ final class AppModel {
         }
     }
 
-    /// Toggle the download state of every track in the selection.
-    /// TODO(#819): download engine not yet wired.
+    /// Toggle the download state across a multi-select of tracks (#819).
+    ///
+    /// Target direction mirrors the favorite/played multi-select convention:
+    /// when **every** selected track is already downloaded, the action removes
+    /// them all; otherwise it downloads the ones that aren't already done (or
+    /// in flight). Gated behind `supportsDownloads`.
     func toggleDownload(tracks: [Track]) {
-        guard !tracks.isEmpty else { return }
-        // TODO(#819): download engine not yet wired.
-        Log.app.notice("toggleDownload(tracks: \(tracks.count, privacy: .public)) not yet wired — see #819")
+        guard supportsDownloads, !tracks.isEmpty else { return }
+        let allDownloaded = tracks.allSatisfy { downloadStateById[$0.id] == .done }
+        if allDownloaded {
+            Task { await removeDownloads(tracks) }
+        } else {
+            let pending = tracks.filter {
+                downloadStateById[$0.id] != .done && !downloadsInFlight.contains($0.id)
+            }
+            guard !pending.isEmpty else { return }
+            Task { await downloadTracks(pending) }
+        }
     }
 
     /// Toggle the played flag across a multi-select of tracks. Target

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -12,11 +12,21 @@ import Foundation
 /// FFI work that enables it can flip a single flag rather than re-wiring
 /// every surface.
 extension AppModel {
-    /// Download engine (#819). Gates "Download Current" in the command
-    /// palette plus per-album / per-playlist / per-track Download
-    /// affordances. The four AppModel stubs (Download Current,
-    /// enqueueDownload(album:), enqueueDownload(playlist:),
-    /// toggleDownload(tracks:)) flip live once the core engine lands.
+    /// Offline downloads (#819). Gates "Download Current" in the command
+    /// palette, the per-album / per-playlist / per-track Download affordances,
+    /// the per-row download badge, the Downloads-pane usage readout, and the
+    /// AudioEngine's offline-playback branch (`offlinePlaybackEnabled`).
+    ///
+    /// The core engine (`core/src/downloads.rs`: stream-to-disk, SQLite index,
+    /// budget evict/refuse, offline-path resolution) and the full Swift wiring
+    /// (`AppModel+Downloads.swift`, AudioEngine local-file branch) are
+    /// implemented and unit/integration-tested (incl. a live-server download
+    /// e2e). The flag stays `false` deliberately until the end-to-end flow is
+    /// validated interactively in the running app — flipping it activates a
+    /// live change to the playback code path, so it gets its own focused QA
+    /// pass rather than riding in with the engine landing. When enabled, a
+    /// track with no local copy still streams byte-for-byte as before, so the
+    /// branch is purely additive. See CLAUDE.md "Deferred / known-open work".
     var supportsDownloads: Bool { false }
 
     /// `mark_played` / `mark_unplayed` FFIs (#133, #222). Gates

--- a/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
@@ -108,7 +108,7 @@ struct TrackContextMenu: View {
         if model.supportsDownloads {
             Button(
                 downloadLabel,
-                systemImage: "arrow.down.circle"
+                systemImage: allDownloaded ? "arrow.down.circle.fill" : "arrow.down.circle"
             ) { model.toggleDownload(tracks: selection) }
         }
         if model.supportsMarkPlayed {
@@ -136,11 +136,15 @@ struct TrackContextMenu: View {
         allFavorited ? "Unfavorite\(countSuffix)" : "Favorite\(countSuffix)"
     }
 
+    /// True when every track in the selection is already downloaded, so the
+    /// action reads as "Remove Download" rather than "Download" (#819). Mirrors
+    /// `allFavorited`.
+    private var allDownloaded: Bool {
+        !selection.isEmpty && selection.allSatisfy { model.downloadState(forTrackId: $0.id) == .done }
+    }
+
     private var downloadLabel: String {
-        // Download state isn't tracked per-track yet (#819 downloads engine),
-        // so the label always reads as "Download" for now. Once state lands
-        // this mirrors favorite's all-on / any-off logic.
-        "Download\(countSuffix)"
+        allDownloaded ? "Remove Download\(countSuffix)" : "Download\(countSuffix)"
     }
 
     private var markPlayedLabel: String {

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -101,6 +101,11 @@ struct TrackRow: View {
                             .foregroundStyle(Theme.warning)
                             .help("Transcoding required. Enable in Preferences → Playback.")
                     }
+                    // Offline-download status (#819). Reads the cached snapshot
+                    // (`model.downloadState`), never the core synchronously, so
+                    // this stays cheap per row. Renders nothing while the
+                    // downloads feature is dormant (state is always nil).
+                    downloadBadge
                 }
                 Text(track.artistName)
                     .font(Theme.font(11, weight: .medium))
@@ -210,6 +215,36 @@ struct TrackRow: View {
         if isFocused { return Theme.rowHover }
         if isHovering { return Theme.rowHover }
         return .clear
+    }
+
+    /// Inline download-status glyph (#819). `.done` shows a solid offline
+    /// check; an in-progress state shows a small spinner. Absent state renders
+    /// nothing, which is the case for every row while the feature is dormant.
+    @ViewBuilder
+    private var downloadBadge: some View {
+        switch model.downloadState(forTrackId: track.id) {
+        case .done:
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(a11yTheme.accent)
+                .help("Available offline")
+                .accessibilityLabel("Downloaded")
+        case .queued, .downloading:
+            ProgressView()
+                .controlSize(.mini)
+                .scaleEffect(0.7)
+                .frame(width: 12, height: 12)
+                .help("Downloading…")
+                .accessibilityLabel("Downloading")
+        case .failed:
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(Theme.warning)
+                .help("Download failed")
+                .accessibilityLabel("Download failed")
+        case .none:
+            EmptyView()
+        }
     }
 
     /// "1 play" / "12 plays" readout shown on hover when the user enables

--- a/macos/Sources/Lyrebird/LyrebirdErrorPresenter.swift
+++ b/macos/Sources/Lyrebird/LyrebirdErrorPresenter.swift
@@ -146,6 +146,7 @@ enum LyrebirdErrorPresenter {
         case favorite
         case markPlayed
         case playlistAdd
+        case download
 
         fileprivate var fallbackKey: String? {
             switch self {
@@ -161,6 +162,7 @@ enum LyrebirdErrorPresenter {
             case .favorite: return "error.favorite"
             case .markPlayed: return "error.markPlayed"
             case .playlistAdd: return "error.playlist.add"
+            case .download: return "error.download"
             }
         }
     }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -589,6 +589,18 @@
         }
       }
     },
+    "error.download" : {
+      "comment" : "Banner copy when downloading a track for offline playback fails.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't download for offline playback."
+          }
+        }
+      }
+    },
     "error.storage" : {
       "comment" : "Banner copy for LyrebirdError.Storage — local SQLite or cache failure.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesDownloads.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesDownloads.swift
@@ -1,28 +1,26 @@
 import SwiftUI
 
-/// Downloads preferences pane.
+/// Downloads preferences pane (#819).
 ///
-/// Minimal shell today — two surfaces users look for first:
+/// Two surfaces, both now wired to the core download engine when
+/// `supportsDownloads` is live:
 ///
-/// 1. **Download location** — read-only display of the path where offline
-///    copies will land. Today this resolves to
-///    `~/Library/Containers/.../Caches/Downloads` via
-///    `FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)`
-///    so the path reads as expected for a sandboxed app. Picking a custom
-///    location lands alongside the broader download manager work
-///    (`TODO(#570)`).
+/// 1. **Download location** — read-only display of the resolved directory
+///    offline copies land in (`core.downloadDirPath()`), falling back to the
+///    sandbox cache path when the feature is dormant.
 ///
-/// 2. **Storage budget slider** — caps total disk space used by offline
-///    downloads. 1 GB — 100 GB with a 500 MB step; the chosen value is
-///    persisted under `downloads.storageBudgetGb` so the download manager
-///    can enforce it once it lands.
+/// 2. **Storage budget slider** — caps total disk used by completed downloads.
+///    1 GB – 100 GB; the chosen value is persisted under
+///    `downloads.storageBudgetGb` *and* pushed to the core via
+///    `setDownloadBudget(gigabytes:)`, which the engine enforces (evict/refuse)
+///    on the next download.
 ///
-/// Both surfaces are here now so users can see the feature exists and set
-/// their preference in advance — the download manager honours both when
-/// `core.download_track` / offline playback ships.
+/// When the feature is live the pane also shows current usage (used of budget,
+/// item count) read from `core.downloadStats()`.
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 66 Downloads bullet.
 struct PreferencesDownloads: View {
+    @Environment(AppModel.self) private var model
     @AppStorage("downloads.storageBudgetGb") private var storageBudgetGb: Double = 10
 
     var body: some View {
@@ -31,11 +29,11 @@ struct PreferencesDownloads: View {
 
             PreferenceSection(
                 title: "Location",
-                footnote: "Offline copies live inside Lyrebird's cache folder so macOS can evict them under disk pressure."
+                footnote: "Offline copies live inside Lyrebird's data folder so they survive relaunches."
             ) {
                 PreferenceRow(
                     label: "Download location",
-                    help: "Cache directory inside Lyrebird's sandbox."
+                    help: "Directory offline audio is written to."
                 ) {
                     Text(downloadLocationText)
                         .font(Theme.font(12, weight: .medium))
@@ -58,7 +56,7 @@ struct PreferencesDownloads: View {
 
             PreferenceSection(
                 title: "Storage",
-                footnote: "Budget for offline downloads. When the cap is reached, the download manager stops queuing new tracks and asks you to free space. Oldest-played downloads evict first when auto-prune lands."
+                footnote: "Budget for offline downloads. When the cap is reached, the oldest-downloaded tracks are evicted to make room; a track larger than the whole budget is refused."
             ) {
                 PreferenceRow(
                     label: "Storage budget",
@@ -69,6 +67,12 @@ struct PreferencesDownloads: View {
                             .frame(width: 220)
                             .accessibilityLabel("Storage budget")
                             .accessibilityValue("\(Int(storageBudgetGb)) gigabytes")
+                            .onChange(of: storageBudgetGb) { _, newValue in
+                                // Push the new cap to the engine so it's enforced
+                                // on the next download. No-op while the feature
+                                // is dormant.
+                                model.setDownloadBudget(gigabytes: newValue)
+                            }
                         Text(budgetReadout)
                             .font(Theme.font(12, weight: .semibold))
                             .foregroundStyle(Theme.ink2)
@@ -76,9 +80,29 @@ struct PreferencesDownloads: View {
                             .frame(width: 56, alignment: .trailing)
                     }
                 }
+
+                if model.supportsDownloads {
+                    PreferenceRow(
+                        label: "Used",
+                        help: "Disk space currently used by completed downloads."
+                    ) {
+                        Text(usageText)
+                            .font(Theme.font(12, weight: .semibold))
+                            .foregroundStyle(Theme.ink2)
+                            .monospacedDigit()
+                            .accessibilityLabel("Storage used: \(usageText)")
+                    }
+                }
             }
 
             Spacer(minLength: 0)
+        }
+        .task {
+            // Seed the core's budget from the persisted slider value and pull
+            // current usage so the pane shows real numbers on open. Both no-op
+            // while `supportsDownloads` is false.
+            model.setDownloadBudget(gigabytes: storageBudgetGb)
+            await model.refreshDownloadStats()
         }
     }
 
@@ -93,11 +117,14 @@ struct PreferencesDownloads: View {
         }
     }
 
-    /// Path where offline tracks live. Resolves against the user's cache
-    /// directory so the value matches macOS's sandbox expectations. When the
-    /// resolver fails (extremely unusual) we show a dash rather than an
-    /// empty string so the row stays readable.
+    /// Path where offline tracks live. When the downloads feature is live this
+    /// is the engine's resolved directory; otherwise it falls back to the
+    /// sandbox cache path so the row stays meaningful before the feature ships.
     private var downloadLocationText: String {
+        if model.supportsDownloads {
+            let resolved = model.downloadDirectoryPath()
+            if !resolved.isEmpty { return resolved }
+        }
         let fm = FileManager.default
         guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             return "—"
@@ -113,12 +140,17 @@ struct PreferencesDownloads: View {
         let gb = Int(storageBudgetGb.rounded())
         return "Up to \(gb) GB of disk space reserved for offline music."
     }
-}
 
-#Preview {
-    PreferencesDownloads()
-        .frame(width: 560, height: 520)
-        .padding(32)
-        .background(Theme.bg)
-        .preferredColorScheme(.dark)
+    /// "1.2 GB of 10 GB · 14 tracks" style usage readout, formatted from the
+    /// core's `DownloadStats`. Falls back to a zero readout before the first
+    /// stats refresh.
+    private var usageText: String {
+        let stats = model.downloadStats
+        let used = stats?.usedBytes ?? 0
+        let count = Int(stats?.itemCount ?? 0)
+        let usedStr = ByteCountFormatter.string(fromByteCount: Int64(used), countStyle: .file)
+        let budgetStr = "\(Int(storageBudgetGb.rounded())) GB"
+        let trackWord = count == 1 ? "track" : "tracks"
+        return "\(usedStr) of \(budgetStr) · \(count) \(trackWord)"
+    }
 }

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -215,6 +215,17 @@ public final class AudioEngine: NSObject {
     /// flip) has superseded it.
     private var replayGainGeneration: Int = 0
 
+    /// Offline playback gate (#819). When `true`, `play(track:)` and
+    /// `preloadNextTrack(_:)` first ask the core whether the track has a
+    /// completed local download and, if so, play the `file://` copy instead of
+    /// streaming. The owner (`AppModel`) sets this from `supportsDownloads`.
+    ///
+    /// CRITICAL: while this is `false` (the default, and what ships until the
+    /// downloads feature is proven), neither method ever calls the core's
+    /// download FFI, so the streaming path is byte-for-byte identical to the
+    /// pre-#819 behaviour. The offline branch is purely additive.
+    public var offlinePlaybackEnabled: Bool = false
+
     public init(core: LyrebirdCore) {
         self.core = core
         super.init()
@@ -278,6 +289,15 @@ public final class AudioEngine: NSObject {
     /// Test seam: whether a stall watchdog is currently armed. Lets a test
     /// confirm the give-up path actually cancels it.
     var hasPendingStallWatchdogForTesting: Bool { stallWorkItem != nil }
+
+    /// Test seam: drive the offline asset resolver directly (#819). Returns the
+    /// `file://` URL for a downloaded track, or nil when offline playback is
+    /// disabled / the track isn't downloaded. Lets a test assert that the
+    /// streaming path is unperturbed (nil result, no FFI) while
+    /// `offlinePlaybackEnabled` is false, without a live `play(_:)`.
+    func resolveLocalAssetURLForTesting(_ trackId: String) async -> URL? {
+        await resolveLocalAssetURL(for: trackId)
+    }
     #endif
 
     // MARK: - Private helpers
@@ -309,6 +329,26 @@ public final class AudioEngine: NSObject {
             }
             return (info.mediaSources.first?.id, info.playSessionId)
         }.value
+    }
+
+    /// Resolve the local `file://` URL for a track that has a completed offline
+    /// download, or `nil` when offline playback is disabled or no usable local
+    /// copy exists (#819).
+    ///
+    /// Returns `nil` immediately — without any FFI — when
+    /// `offlinePlaybackEnabled` is `false`, so the streaming path is never
+    /// perturbed while the downloads feature is dormant. When enabled, the
+    /// core's `downloadLocalPath` already verifies the file exists on disk, so a
+    /// non-nil result is safe to hand straight to AVFoundation. The FFI blocks
+    /// on a SQLite read, so it runs off the main actor.
+    private func resolveLocalAssetURL(for trackId: String) async -> URL? {
+        guard offlinePlaybackEnabled else { return nil }
+        let core = self.core
+        let path: String? = await Task.detached {
+            core.downloadLocalPath(trackId: trackId)
+        }.value
+        guard let path, !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path)
     }
 
     /// The currently-reporting session, captured at the last
@@ -510,30 +550,55 @@ public final class AudioEngine: NSObject {
         // not touch the pending `stallWorkItem`, so cancel it explicitly here.
         cancelStallWatchdog()
 
-        // Resolve media source + play session id via PlaybackInfo so the
-        // server picks the right source for multi-version items and can
-        // correlate subsequent /Sessions/Playing* reports with the stream.
-        // Falling back to nil is harmless — the server just picks its
-        // default source and correlation stays opportunistic.
-        let (mediaSourceId, playSessionId) = await resolvePlaybackSource(for: track.id)
-        let urlString = try core.streamUrl(
-            trackId: track.id,
-            mediaSourceId: mediaSourceId,
-            playSessionId: playSessionId
-        )
-        guard let url = URL(string: urlString) else {
-            throw AudioEngineError.invalidURL(urlString)
+        // Offline playback (#819): when enabled and a completed local copy
+        // exists, play the file directly — no PlaybackInfo round-trip, no auth
+        // header, no play-session correlation. `resolveLocalAssetURL` returns
+        // nil (with no FFI) whenever `offlinePlaybackEnabled` is false, so the
+        // streaming branch below is reached byte-for-byte as before when the
+        // feature is dormant or the track isn't downloaded.
+        let url: URL
+        let authHeader: String?
+        let mediaSourceId: String?
+        let playSessionId: String?
+        if let localURL = await resolveLocalAssetURL(for: track.id) {
+            url = localURL
+            authHeader = nil
+            mediaSourceId = nil
+            playSessionId = nil
+            // No server play-session for a local file; clear any stale one so a
+            // later progress/stop report doesn't correlate against a dead id.
+            core.setPlaySessionId(playSessionId: nil)
+        } else {
+            // Resolve media source + play session id via PlaybackInfo so the
+            // server picks the right source for multi-version items and can
+            // correlate subsequent /Sessions/Playing* reports with the stream.
+            // Falling back to nil is harmless — the server just picks its
+            // default source and correlation stays opportunistic.
+            let (resolvedSource, resolvedSession) = await resolvePlaybackSource(for: track.id)
+            mediaSourceId = resolvedSource
+            playSessionId = resolvedSession
+            let urlString = try core.streamUrl(
+                trackId: track.id,
+                mediaSourceId: mediaSourceId,
+                playSessionId: playSessionId
+            )
+            guard let streamURL = URL(string: urlString) else {
+                throw AudioEngineError.invalidURL(urlString)
+            }
+            url = streamURL
+            core.setPlaySessionId(playSessionId: playSessionId)
+            authHeader = try core.authHeader()
         }
-        core.setPlaySessionId(playSessionId: playSessionId)
-        let authHeader = try core.authHeader()
-        let asset = AVURLAsset(
-            url: url,
-            options: [
-                "AVURLAssetHTTPHeaderFieldsKey": [
-                    "Authorization": authHeader
-                ]
-            ]
-        )
+        // Build the asset with the auth header only for a streamed URL; a local
+        // file needs no Authorization (and AVFoundation ignores HTTP header
+        // options for `file://` anyway).
+        let assetOptions: [String: Any]
+        if let authHeader {
+            assetOptions = ["AVURLAssetHTTPHeaderFieldsKey": ["Authorization": authHeader]]
+        } else {
+            assetOptions = [:]
+        }
+        let asset = AVURLAsset(url: url, options: assetOptions)
         let item = AVPlayerItem(asset: asset)
 
         // Capture the *outgoing* track's playback position while `self.player`
@@ -728,6 +793,11 @@ public final class AudioEngine: NSObject {
         // preload has superseded this one.
         preloadGeneration &+= 1
         let generation = preloadGeneration
+        // Capture the offline gate on the actor so the detached task makes the
+        // same local-vs-stream decision `play(track:)` does. When false the
+        // task never queries the download FFI — gapless preload is byte-for-byte
+        // the streaming path (#819).
+        let offlineEnabled = offlinePlaybackEnabled
         // `[weak self]` so an engine torn down mid-resolve (track change,
         // stop) doesn't get pinned alive for the duration of the network FFI —
         // matches `applyReplayGain`. The network work below only touches the
@@ -735,27 +805,32 @@ public final class AudioEngine: NSObject {
         // if `self` is gone.
         Task.detached { [weak self] in
             do {
-                let info = try? core.playbackInfo(itemId: track.id, opts: opts)
-                let mediaSourceId = info?.mediaSources.first?.id
-                let playSessionId = info?.playSessionId
-                let urlString = try core.streamUrl(
-                    trackId: track.id,
-                    mediaSourceId: mediaSourceId,
-                    playSessionId: playSessionId
-                )
-                let authHeader = try core.authHeader()
-                guard let url = URL(string: urlString) else {
-                    engineLog.error("preload skipped: invalid stream URL for track \(track.id, privacy: .public)")
-                    return
+                // Offline branch: a completed local copy plays from disk with no
+                // PlaybackInfo round-trip or auth header.
+                let localPath = offlineEnabled ? core.downloadLocalPath(trackId: track.id) : nil
+                let url: URL
+                let assetOptions: [String: Any]
+                if let localPath, !localPath.isEmpty {
+                    url = URL(fileURLWithPath: localPath)
+                    assetOptions = [:]
+                } else {
+                    let info = try? core.playbackInfo(itemId: track.id, opts: opts)
+                    let mediaSourceId = info?.mediaSources.first?.id
+                    let playSessionId = info?.playSessionId
+                    let urlString = try core.streamUrl(
+                        trackId: track.id,
+                        mediaSourceId: mediaSourceId,
+                        playSessionId: playSessionId
+                    )
+                    let authHeader = try core.authHeader()
+                    guard let streamURL = URL(string: urlString) else {
+                        engineLog.error("preload skipped: invalid stream URL for track \(track.id, privacy: .public)")
+                        return
+                    }
+                    url = streamURL
+                    assetOptions = ["AVURLAssetHTTPHeaderFieldsKey": ["Authorization": authHeader]]
                 }
-                let asset = AVURLAsset(
-                    url: url,
-                    options: [
-                        "AVURLAssetHTTPHeaderFieldsKey": [
-                            "Authorization": authHeader
-                        ]
-                    ]
-                )
+                let asset = AVURLAsset(url: url, options: assetOptions)
                 let nextItem = AVPlayerItem(asset: asset)
 
                 await MainActor.run {

--- a/macos/Tests/LyrebirdTests/DownloadsTests.swift
+++ b/macos/Tests/LyrebirdTests/DownloadsTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Offline downloads (#819) — Swift-side coverage.
+///
+/// Two things matter most here and both are about *safety while the feature is
+/// gated off*:
+///   1. With `supportsDownloads == false` (today's shipping default) every
+///      AppModel download entry point is a no-op and the per-track state read
+///      is `nil`, so no UI affordance appears and no work is kicked off.
+///   2. The AudioEngine's offline branch never fires while
+///      `offlinePlaybackEnabled` is false — `resolveLocalAssetURL` returns nil
+///      with no FFI, so the streaming path is byte-for-byte unchanged.
+///
+/// The snapshot-read helpers and the context-menu toggle-direction logic are
+/// also exercised directly against the in-memory `downloadStateById` map (which
+/// is `internal`), so the read path the row views depend on is locked even
+/// while the engine flag is off.
+///
+/// `AppModel` is `@MainActor`; the suite redirects the core's data dir to a
+/// throwaway temp dir via `XDG_DATA_HOME` so it never touches the real DB.
+@MainActor
+final class DownloadsTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-downloads-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: "mp3",
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - Gating (feature dormant)
+
+    /// The downloads capability ships gated off, so the four AppModel entry
+    /// points stay inert. This is the contract the prompt mandates: a
+    /// dormant-but-correct feature.
+    func testDownloadsCapabilityGatedOff() throws {
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.supportsDownloads,
+            "downloads must stay gated until the full flow is proven solid"
+        )
+    }
+
+    /// With the feature gated off, the per-track state read returns nil for any
+    /// track — so `TrackRow.downloadBadge` renders nothing and the context menu
+    /// hides the Download action.
+    func testDownloadStateNilWhileGatedOff() throws {
+        let model = try AppModel()
+        XCTAssertNil(model.downloadState(forTrackId: "anything"))
+        XCTAssertFalse(model.isDownloaded(makeTrack("x")))
+        XCTAssertFalse(model.isDownloading(makeTrack("x")))
+    }
+
+    /// `downloadTracks` / `toggleDownload` are no-ops while gated off: they must
+    /// not mutate the in-memory snapshot or kick a fetch. (If they ran, the
+    /// optimistic path would stamp a `.queued` badge into `downloadStateById`.)
+    func testDownloadEntryPointsAreNoOpsWhileGatedOff() async throws {
+        let model = try AppModel()
+        let track = makeTrack("gated")
+
+        await model.downloadTracks([track])
+        XCTAssertNil(model.downloadStateById[track.id], "downloadTracks must no-op while gated off")
+
+        model.toggleDownload(tracks: [track])
+        // toggleDownload dispatches into a Task; give the main actor a turn.
+        await Task.yield()
+        XCTAssertNil(model.downloadStateById[track.id], "toggleDownload must no-op while gated off")
+
+        await model.refreshDownloads()
+        XCTAssertTrue(model.downloads.isEmpty, "refreshDownloads must no-op while gated off")
+    }
+
+    // MARK: - AudioEngine offline gate (additive)
+
+    /// The engine flag is seeded from `supportsDownloads`, so it stays false in
+    /// the shipping build — guaranteeing `play(track:)` never queries the
+    /// download FFI and the streaming path is unchanged.
+    func testEngineOfflinePlaybackDisabledByDefault() throws {
+        let model = try AppModel()
+        XCTAssertFalse(
+            model.audio.offlinePlaybackEnabled,
+            "offline playback must mirror supportsDownloads (false today)"
+        )
+    }
+
+    /// With offline playback disabled, the local-asset resolver returns nil for
+    /// any track without touching the core — the streaming branch in
+    /// `play(track:)` is reached exactly as before #819.
+    func testResolveLocalAssetReturnsNilWhenOfflineDisabled() async throws {
+        let dir = NSTemporaryDirectory() + "lyrebird-dl-engine-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "dl-test"))
+        let engine = AudioEngine(core: core)
+        XCTAssertFalse(engine.offlinePlaybackEnabled)
+
+        let url = await engine.resolveLocalAssetURLForTesting("any-track")
+        XCTAssertNil(url, "disabled offline playback must resolve no local URL")
+    }
+
+    /// Even when the flag is flipped on, a track with no completed download
+    /// resolves to nil — so playback still streams. This proves the offline
+    /// branch only diverts when an actual local copy exists.
+    func testResolveLocalAssetReturnsNilForUndownloadedTrackWhenEnabled() async throws {
+        let dir = NSTemporaryDirectory() + "lyrebird-dl-engine2-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "dl-test"))
+        let engine = AudioEngine(core: core)
+        engine.offlinePlaybackEnabled = true
+
+        let url = await engine.resolveLocalAssetURLForTesting("never-downloaded")
+        XCTAssertNil(url, "an undownloaded track must resolve to no local URL even when enabled")
+    }
+
+    // MARK: - Snapshot read helpers (independent of the gate)
+
+    /// The read helpers the row views and context menu depend on map the
+    /// in-memory state correctly. Driven directly against `downloadStateById`
+    /// so the mapping is locked regardless of the capability flag.
+    func testSnapshotReadHelpersMapState() throws {
+        let model = try AppModel()
+        let done = makeTrack("done")
+        let queued = makeTrack("queued")
+        let downloading = makeTrack("downloading")
+        let failed = makeTrack("failed")
+
+        model.downloadStateById = [
+            done.id: .done,
+            queued.id: .queued,
+            downloading.id: .downloading,
+            failed.id: .failed,
+        ]
+
+        XCTAssertEqual(model.downloadState(forTrackId: done.id), .done)
+        XCTAssertTrue(model.isDownloaded(done))
+        XCTAssertFalse(model.isDownloaded(failed))
+
+        XCTAssertTrue(model.isDownloading(queued))
+        XCTAssertTrue(model.isDownloading(downloading))
+        XCTAssertFalse(model.isDownloading(done))
+        XCTAssertFalse(model.isDownloading(failed))
+    }
+
+    /// `in-flight` set also counts as "downloading" for the spinner, covering
+    /// the window between an optimistic enqueue and the core flipping the row.
+    func testInFlightCountsAsDownloading() throws {
+        let model = try AppModel()
+        let t = makeTrack("inflight")
+        model.downloadsInFlight = [t.id]
+        XCTAssertTrue(model.isDownloading(t))
+    }
+
+    /// The budget slider value (GB) converts to the byte count the core stores.
+    /// Pin the 1e9-per-GB factor the preferences pane uses so a UI tweak can't
+    /// silently change the persisted budget.
+    func testBudgetGigabytesToBytesFactor() {
+        // 10 GB -> 10_000_000_000 bytes. The conversion lives in
+        // `setDownloadBudget(gigabytes:)`; mirror it here as the contract.
+        let gb = 10.0
+        let bytes = UInt64(max(0, gb) * 1_000_000_000)
+        XCTAssertEqual(bytes, 10_000_000_000)
+    }
+}


### PR DESCRIPTION
Complete offline-downloads MVP, **shipped dormant** (`supportsDownloads` stays `false`) so it cannot affect users until you've done an interactive QA pass and flip the flag. Built green: regen + build + 867 Swift tests + 280 core tests + clippy + fmt + rustdoc `-D warnings`.

- **Core (Rust):** new `downloads.rs` engine (stream-to-disk via a `.part` temp + atomic rename, LRU budget evict/refuse, stale-file fallback), `002_downloads.sql` migration (additive, schema v2), `client.rs` chunked `download_to_file`, 11 FFI methods, `DownloadState/Entry/Stats` types.
- **Swift (all gated):** the 4 stub AppModel methods wired; an in-memory download-state snapshot rows read (no per-cell FFI); an **additive** AudioEngine local-file branch in `play`/`preloadNextTrack` (plays a completed local copy when present, else byte-for-byte the streaming path); per-row download badge + context-menu Download/Remove; PreferencesDownloads wired (location/budget/usage).
- **Tests:** hermetic wiremock end-to-end (login → stream bytes to disk → verify → delete) + budget/stale/failure cases; 9 Swift gating tests.

Reviewer confirmed default (flag-off) playback is provably unchanged. **To activate:** QA the download→offline-play→delete→budget flow, then flip `supportsDownloads` to `true`.