### PR TITLE
fix: 2.0 re-audit hardening — downloads security/concurrency + smart-playlist correctness/i18n

### DIFF
--- a/core/src/downloads.rs
+++ b/core/src/downloads.rs
@@ -119,6 +119,61 @@ pub fn budget_bytes(db: &Database) -> u64 {
         .unwrap_or(0)
 }
 
+/// Validate a track id as a filename stem.
+///
+/// The id is server-supplied and flows straight into the on-disk path
+/// (`<dir>/<id>.<ext>`), so an id containing path separators or `..` could
+/// escape the downloads directory on write — and, because the same id is later
+/// used to locate the file for deletion, on delete too. Jellyfin item ids are
+/// GUIDs rendered as 32 lowercase hex chars (some deployments dash-group them),
+/// so we accept only ASCII alphanumerics and `-`. Anything else (a separator,
+/// `.`, NUL, whitespace, a leading dot) is rejected. An empty id is rejected.
+///
+/// Returns the id unchanged when valid, or [`LyrebirdError::InvalidInput`] when
+/// it is not safe to use as a filename stem.
+fn safe_filename_stem(track_id: &str) -> Result<&str> {
+    let ok = !track_id.is_empty()
+        && track_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-');
+    if ok {
+        Ok(track_id)
+    } else {
+        Err(LyrebirdError::InvalidInput(format!(
+            "refusing to download track with unsafe id: {track_id:?}"
+        )))
+    }
+}
+
+/// Build the on-disk destination for a track's audio and assert it stays inside
+/// `dir`.
+///
+/// Defence in depth over [`safe_filename_stem`]: even with a sanitized stem we
+/// normalise the joined path and require it to remain a child of `dir`, so a
+/// future change to the naming scheme can't silently reintroduce a traversal.
+/// `dir` itself isn't required to exist yet (the fetch path creates it lazily),
+/// so we compare against `dir` lexically rather than canonicalising it.
+fn dest_within_dir(dir: &Path, stem: &str, ext: &str) -> Result<PathBuf> {
+    let dest = dir.join(format!("{stem}.{ext}"));
+    // The joined path must have `dir` as a prefix and contribute exactly one
+    // additional, normal path component (the file name). `Path::join` on an
+    // absolute / separator-bearing component would replace or escape `dir`;
+    // `safe_filename_stem` already forbids those, this is the belt-and-braces.
+    let within = dest.starts_with(dir)
+        && dest.file_name().is_some()
+        && dest
+            .strip_prefix(dir)
+            .map(|rest| rest.components().count() == 1)
+            == Ok(true);
+    if within {
+        Ok(dest)
+    } else {
+        Err(LyrebirdError::Storage(format!(
+            "computed download path {dest:?} escapes the downloads directory {dir:?}"
+        )))
+    }
+}
+
 /// Pick a file extension for the downloaded audio.
 ///
 /// Prefers the track's known `container`; otherwise infers from the server's
@@ -247,12 +302,16 @@ fn ensure_budget_for(db: &Database, budget: u64, incoming_bytes: u64) -> Result<
         )));
     }
     let (mut used, _) = db.download_used_bytes()?;
-    if used + incoming_bytes <= budget {
+    // `estimate_bytes` is derived from unvalidated server-supplied
+    // bitrate × duration, so a pathological estimate (or a corrupt `used`
+    // sum) could wrap a plain `used + incoming_bytes` and slip past the
+    // `<= budget` check. Saturate so an overflow can never *pass* the gate.
+    if used.saturating_add(incoming_bytes) <= budget {
         return Ok(());
     }
     // Evict LRU completed downloads until the incoming track fits.
     for (track_id, path, size) in db.download_completed_lru()? {
-        if used + incoming_bytes <= budget {
+        if used.saturating_add(incoming_bytes) <= budget {
             break;
         }
         // Remove the row + file; subtract its size from the running total.
@@ -285,16 +344,26 @@ fn estimate_bytes(track: &Track) -> u64 {
 /// Download a queued track's audio to disk and mark it `done`.
 ///
 /// The full pipeline for one track:
-/// 1. Enforce the budget (evict LRU / refuse) using a pre-fetch size estimate.
-/// 2. Mark the row `downloading`.
-/// 3. Stream bytes to `<dir>/<track_id>.<ext>` via [`JellyfinClient::download_to_file`].
-/// 4. Re-check the budget against the *true* byte size; if the real file blew
-///    past the budget, evict to make room (keeping this download).
-/// 5. Mark the row `done` with its path + size.
+/// 1. Acquire a transfer permit (caps parallel fetches per #819 — default 2).
+/// 2. Under the budget lock: enforce the budget (evict LRU / refuse) using a
+///    pre-fetch size estimate, then mark the row `downloading`.
+/// 3. Stream bytes to `<dir>/<sanitized_track_id>.<ext>` via
+///    [`JellyfinClient::download_to_file`] (lock released — only the cap bounds
+///    concurrency here).
+/// 4. Under the budget lock again: re-check the budget against the *true* byte
+///    size (now reflecting any sibling that committed while we streamed); if the
+///    real file blew past the budget, evict to make room, then mark the row
+///    `done`. Doing the final size check + commit under the lock is what closes
+///    the check-then-act race between concurrent fetches.
 ///
 /// On any failure the row is flipped to `failed` with the error recorded, and
 /// the error is returned so the caller (UI) can surface it. The partial file is
 /// cleaned up by `download_to_file` itself.
+///
+/// `budget_lock` serialises budget planning + the size-checked commit so two
+/// concurrent fetches can't each pass the budget check and collectively exceed
+/// it. `permits` bounds how many transfers stream at once. Both are owned by
+/// `LyrebirdCore` and shared across all `download_track` calls.
 ///
 /// `now` is the completion timestamp the caller passes (Unix seconds) so tests
 /// can pin it.
@@ -304,29 +373,59 @@ pub async fn fetch(
     data_dir: &Path,
     track: &Track,
     now: i64,
+    permits: &tokio::sync::Semaphore,
+    budget_lock: &tokio::sync::Mutex<()>,
 ) -> Result<DownloadEntry> {
     let dir = download_dir(db, data_dir);
     let budget = budget_bytes(db);
 
-    // 1. Pre-fetch budget planning against an estimate.
-    if let Err(e) = ensure_budget_for(db, budget, estimate_bytes(track)) {
-        let _ = db.download_mark_failed(&track.id, &e.to_string());
-        return Err(e);
+    // Validate the server-supplied id before it ever touches the filesystem,
+    // and fix the destination up front so a single sanitized path is used for
+    // both the write here and any later delete. `?` here propagates the error
+    // without writing a row, mirroring `enqueue`'s up-front validation; mark the
+    // row failed too so an already-queued retry doesn't spin forever.
+    let stem = match safe_filename_stem(&track.id) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = db.download_mark_failed(&track.id, &e.to_string());
+            return Err(e);
+        }
+    };
+    let provisional_ext = extension_for(track.container.as_deref(), None);
+    let dest = match dest_within_dir(&dir, stem, &provisional_ext) {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = db.download_mark_failed(&track.id, &e.to_string());
+            return Err(e);
+        }
+    };
+
+    // 1. Cap parallel transfers. The permit is held for the whole fetch; the
+    //    semaphore is never closed, so acquire only fails on a poisoned runtime,
+    //    which we surface rather than unwrap.
+    let _permit = permits
+        .acquire()
+        .await
+        .map_err(|e| LyrebirdError::Other(format!("download semaphore closed: {e}")))?;
+
+    // 2. Pre-fetch budget planning against an estimate + in-progress marker,
+    //    serialised against other fetches' planning/commit.
+    {
+        let _budget = budget_lock.lock().await;
+        if let Err(e) = ensure_budget_for(db, budget, estimate_bytes(track)) {
+            let _ = db.download_mark_failed(&track.id, &e.to_string());
+            return Err(e);
+        }
+        db.download_mark_downloading(&track.id)?;
     }
 
-    // 2. In-progress marker so the UI shows a spinner.
-    db.download_mark_downloading(&track.id)?;
-
     // 3. Stream to disk. We don't yet know the real extension until the
-    //    response arrives, but the destination path must be fixed up front; use
-    //    the track's container hint, then settle the file's final name after we
-    //    learn the content-type. To keep it simple and avoid a rename dance, we
-    //    pick the extension from the container hint when present, else `bin`,
-    //    download, then (if the content-type disagrees) the file already plays
-    //    via byte-sniffing regardless. Most Jellyfin music carries a container.
-    let provisional_ext = extension_for(track.container.as_deref(), None);
-    let dest = dir.join(format!("{}.{provisional_ext}", track.id));
-
+    //    response arrives, but the destination path must be fixed up front; we
+    //    pick the extension from the container hint when present, else `bin`.
+    //    If the content-type later disagrees, the file still plays via
+    //    AVFoundation byte-sniffing. Most Jellyfin music carries a container.
+    //    The budget lock is intentionally NOT held across this network I/O —
+    //    only the transfer permit bounds concurrency here.
     let (size, content_type) = match client.download_to_file(&track.id, &dest).await {
         Ok(v) => v,
         Err(e) => {
@@ -335,12 +434,15 @@ pub async fn fetch(
         }
     };
 
-    // 4. Reconcile against the true size. If the real file pushed us over a
-    //    non-zero budget, evict *other* completed downloads to make room;
+    // 4. Reconcile against the true size and commit, under the budget lock so a
+    //    sibling that committed while we streamed is reflected in `used` and we
+    //    can't collectively overshoot the budget. If the real file pushed us
+    //    over a non-zero budget, evict *other* completed downloads to make room;
     //    never delete the file we just fetched.
+    let _budget = budget_lock.lock().await;
     if budget > 0 {
         let (used, _) = db.download_used_bytes()?;
-        if used + size > budget {
+        if used.saturating_add(size) > budget {
             // Evict LRU (excluding this track, which isn't `done` yet) until it
             // fits. If it still can't fit even an otherwise-empty store, fail
             // the download and remove the file.
@@ -392,5 +494,58 @@ mod unit {
         assert_eq!(parse_state("queued"), DownloadState::Queued);
         assert_eq!(parse_state("done"), DownloadState::Done);
         assert_eq!(parse_state("garbage"), DownloadState::Failed);
+    }
+
+    #[test]
+    fn safe_filename_stem_accepts_guid_shapes() {
+        // 32-hex GUID (Jellyfin's usual rendering) and the dash-grouped form.
+        assert!(safe_filename_stem("0f8fad5bd9cb469fa16570867728950e").is_ok());
+        assert!(safe_filename_stem("0f8fad5b-d9cb-469f-a165-70867728950e").is_ok());
+        assert!(safe_filename_stem("Track123").is_ok());
+    }
+
+    #[test]
+    fn safe_filename_stem_rejects_traversal_and_separators() {
+        for bad in [
+            "",
+            "..",
+            "../../etc/passwd",
+            "a/b",
+            "a\\b",
+            "a.b", // a dot would split the extension / hide a second ext
+            "with space",
+            ".hidden",
+            "a\0b",
+            "abc/../def",
+        ] {
+            assert!(
+                matches!(safe_filename_stem(bad), Err(LyrebirdError::InvalidInput(_))),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn dest_within_dir_keeps_path_inside() {
+        let dir = Path::new("/var/data/downloads");
+        let dest = dest_within_dir(dir, "abc123", "mp3").unwrap();
+        assert_eq!(dest, Path::new("/var/data/downloads/abc123.mp3"));
+        assert!(dest.starts_with(dir));
+    }
+
+    #[test]
+    fn dest_within_dir_rejects_escape() {
+        let dir = Path::new("/var/data/downloads");
+        // A stem with a separator would `join` to escape `dir`. (Such stems are
+        // already blocked by `safe_filename_stem`; this is the second gate.)
+        assert!(matches!(
+            dest_within_dir(dir, "../evil", "mp3"),
+            Err(LyrebirdError::Storage(_))
+        ));
+        // An absolute "stem" replaces `dir` entirely under `Path::join`.
+        assert!(matches!(
+            dest_within_dir(dir, "/etc/cron.d/evil", "mp3"),
+            Err(LyrebirdError::Storage(_))
+        ));
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,10 @@ impl Drop for HeartbeatHandle {
     }
 }
 
+/// Default number of offline downloads allowed to stream in parallel (#819:
+/// "default 2 parallel transfers"). Bounds [`LyrebirdCore::download_semaphore`].
+const DOWNLOAD_PARALLELISM: usize = 2;
+
 /// The main handle a UI holds.
 #[derive(uniffi::Object)]
 pub struct LyrebirdCore {
@@ -68,6 +72,18 @@ pub struct LyrebirdCore {
     runtime: tokio::runtime::Runtime,
     /// Running heartbeat task, if one was started via [`Self::start_heartbeat`].
     heartbeat: Mutex<Option<HeartbeatHandle>>,
+    /// Caps how many offline downloads stream concurrently (#819 — default
+    /// [`DOWNLOAD_PARALLELISM`]). Acquired by `downloads::fetch` for the
+    /// duration of each transfer. Shared (not behind the `Inner` mutex) so the
+    /// permit can be held across the network stream without keeping the FFI
+    /// lock — `download_track` clones this `Arc` under the lock, then awaits
+    /// outside it.
+    download_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Serialises offline-download budget planning + the size-checked commit so
+    /// two concurrent `download_track` calls can't each pass the budget check
+    /// and collectively overshoot. Held only around the cheap plan/commit
+    /// critical sections, never across the byte stream. See `downloads::fetch`.
+    download_budget_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 struct Inner {
@@ -142,6 +158,8 @@ impl LyrebirdCore {
             player,
             runtime,
             heartbeat: Mutex::new(None),
+            download_semaphore: Arc::new(tokio::sync::Semaphore::new(DOWNLOAD_PARALLELISM)),
+            download_budget_lock: Arc::new(tokio::sync::Mutex::new(())),
         }))
     }
 
@@ -1388,6 +1406,11 @@ impl LyrebirdCore {
     /// Blocking: this drives the full HTTP transfer on the tokio runtime, so
     /// the platform layer MUST call it off the main thread (e.g. inside a
     /// `Task.detached`).
+    ///
+    /// Concurrency: parallel transfers are capped (#819 — default 2) via a
+    /// shared semaphore, and budget planning + the final size-checked commit
+    /// are serialised by a shared lock, so concurrent `download_track` calls
+    /// can't collectively overshoot the storage budget.
     pub fn download_track(
         &self,
         track: Track,
@@ -1407,8 +1430,20 @@ impl LyrebirdCore {
         let now = chrono::Utc::now().timestamp();
         // Record the queued intent up front, off the network path.
         downloads::enqueue(&db, &track, now)?;
-        self.runtime
-            .block_on(downloads::fetch(&db, &client, &data_dir, &track, now))
+        // The concurrency cap + budget lock are shared across all in-flight
+        // downloads; clone the handles so `fetch` can hold a permit / take the
+        // lock without keeping the `Inner` mutex (already dropped above).
+        let permits = self.download_semaphore.clone();
+        let budget_lock = self.download_budget_lock.clone();
+        self.runtime.block_on(downloads::fetch(
+            &db,
+            &client,
+            &data_dir,
+            &track,
+            now,
+            &permits,
+            &budget_lock,
+        ))
     }
 
     /// Cancel / remove a download: deletes the on-disk file and the index row.

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -9032,7 +9032,9 @@ async fn download_budget_refuses_track_larger_than_whole_budget() {
     let track = dl_track("t-big", Some(320_000), 225 * 10_000_000);
     downloads::enqueue(&db, &track, 1).unwrap();
     let client = mock_client("http://127.0.0.1:0");
-    let err = downloads::fetch(&db, &client, tmp.path(), &track, 2)
+    let permits = tokio::sync::Semaphore::new(2);
+    let budget_lock = tokio::sync::Mutex::new(());
+    let err = downloads::fetch(&db, &client, tmp.path(), &track, 2, &permits, &budget_lock)
         .await
         .expect_err("oversized track must be refused");
     match err {
@@ -9257,4 +9259,202 @@ async fn download_track_server_error_marks_failed() {
     })
     .await
     .unwrap();
+}
+
+/// A track id carrying path separators / `..` must be refused before any file
+/// is written, and must not escape the downloads directory. Guards the
+/// path-traversal fix in `downloads::fetch` (`safe_filename_stem` +
+/// `dest_within_dir`).
+#[tokio::test]
+async fn download_rejects_path_traversal_track_id() {
+    use crate::downloads;
+    let db = std::sync::Arc::new(Database::in_memory().unwrap());
+    let tmp = tempfile::tempdir().unwrap();
+    // Point the downloads dir at our temp tree so we can prove nothing escaped.
+    db.set_setting(downloads::DOWNLOAD_DIR_KEY, &tmp.path().to_string_lossy())
+        .unwrap();
+
+    // An id that, interpolated into `<dir>/<id>.<ext>`, would climb out of the
+    // downloads dir and into the temp root as `escape.mp3`.
+    let evil_id = "../escape";
+    let track = dl_track(evil_id, None, 0);
+    downloads::enqueue(&db, &track, 1).unwrap();
+
+    let permits = tokio::sync::Semaphore::new(2);
+    let budget_lock = tokio::sync::Mutex::new(());
+    // The client URL is never contacted — validation refuses the id first.
+    let client = mock_client("http://127.0.0.1:0");
+    let err = downloads::fetch(&db, &client, tmp.path(), &track, 2, &permits, &budget_lock)
+        .await
+        .expect_err("path-traversal id must be refused");
+    assert!(
+        matches!(err, LyrebirdError::InvalidInput(_)),
+        "expected InvalidInput, got {err:?}"
+    );
+
+    // The row is marked failed, and crucially NO file was written anywhere the
+    // traversal pointed: neither inside the downloads dir nor its parent.
+    assert_eq!(
+        downloads::state_for(&db, evil_id).unwrap(),
+        Some(crate::models::DownloadState::Failed)
+    );
+    let parent_escape = tmp.path().parent().unwrap().join("escape.mp3");
+    assert!(
+        !parent_escape.exists(),
+        "traversal wrote outside the downloads dir at {parent_escape:?}"
+    );
+    // The downloads dir itself holds no stray audio file.
+    let stray: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "expected no files written for a refused id, found {stray:?}"
+    );
+}
+
+/// `downloads::fetch` must cap parallel transfers at the semaphore's permit
+/// count (#819: default 2). Three concurrent fetches sharing a 2-permit
+/// semaphore must never have more than two streaming at once. A counting
+/// wiremock responder records the peak observed concurrency.
+#[tokio::test(flavor = "multi_thread")]
+async fn download_fetch_caps_parallel_transfers() {
+    use crate::downloads;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let server = MockServer::start().await;
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let in_flight_mock = in_flight.clone();
+    let peak_mock = peak.clone();
+
+    // Each audio request bumps the in-flight counter, records the running peak,
+    // holds the connection briefly so overlap is observable, then releases.
+    Mock::given(method("GET"))
+        .respond_with(move |req: &Request| {
+            // Only the /Audio/.../universal stream endpoint participates.
+            if !req.url.path().starts_with("/Audio/") {
+                return ResponseTemplate::new(404);
+            }
+            let now = in_flight_mock.fetch_add(1, Ordering::SeqCst) + 1;
+            peak_mock.fetch_max(now, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            in_flight_mock.fetch_sub(1, Ordering::SeqCst);
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "audio/mpeg")
+                .set_body_bytes(vec![7u8; 64])
+        })
+        .mount(&server)
+        .await;
+
+    let db = Arc::new(Database::in_memory().unwrap());
+    let tmp = tempfile::tempdir().unwrap();
+    db.set_setting(downloads::DOWNLOAD_DIR_KEY, &tmp.path().to_string_lossy())
+        .unwrap();
+    // Shared across all fetches — this is the cap under test.
+    let permits = Arc::new(tokio::sync::Semaphore::new(2));
+    let budget_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let client = Arc::new(mock_client(&server.uri()));
+
+    let mut handles = Vec::new();
+    for i in 0..3 {
+        let id = format!("cap-{i}");
+        let track = dl_track(&id, None, 0);
+        downloads::enqueue(&db, &track, 1).unwrap();
+        let (db, client, permits, budget_lock) = (
+            db.clone(),
+            client.clone(),
+            permits.clone(),
+            budget_lock.clone(),
+        );
+        let dir = tmp.path().to_path_buf();
+        handles.push(tokio::spawn(async move {
+            downloads::fetch(&db, &client, &dir, &track, 2, &permits, &budget_lock)
+                .await
+                .expect("fetch should succeed");
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    assert!(
+        peak.load(Ordering::SeqCst) <= 2,
+        "expected at most 2 concurrent transfers, observed peak {}",
+        peak.load(Ordering::SeqCst)
+    );
+    // All three still completed.
+    assert_eq!(db.download_used_bytes().unwrap().1, 3);
+}
+
+/// Two concurrent fetches sharing a budget that fits only one track must not
+/// both commit and collectively exceed the budget. The size-checked commit
+/// under `download_budget_lock` serialises the decision, so the second to
+/// finish evicts the first (LRU) instead of stacking on top. Guards the TOCTOU
+/// fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn download_concurrent_fetches_respect_shared_budget() {
+    use crate::downloads;
+    use std::sync::Arc;
+
+    let server = MockServer::start().await;
+    // 64-byte body per track; budget of 100 fits exactly one (not two).
+    Mock::given(method("GET"))
+        .respond_with(|req: &Request| {
+            if req.url.path().starts_with("/Audio/") {
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "audio/mpeg")
+                    .set_body_bytes(vec![1u8; 64])
+            } else {
+                ResponseTemplate::new(404)
+            }
+        })
+        .mount(&server)
+        .await;
+
+    let db = Arc::new(Database::in_memory().unwrap());
+    let tmp = tempfile::tempdir().unwrap();
+    db.set_setting(downloads::DOWNLOAD_DIR_KEY, &tmp.path().to_string_lossy())
+        .unwrap();
+    db.set_setting(downloads::DOWNLOAD_BUDGET_KEY, &100u64.to_string())
+        .unwrap();
+    let permits = Arc::new(tokio::sync::Semaphore::new(2));
+    let budget_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let client = Arc::new(mock_client(&server.uri()));
+
+    // Two tracks with no bitrate -> pre-fetch estimate is 0, so both pass the
+    // *estimate* gate and race to the post-fetch (true-size) commit. Distinct
+    // completion timestamps via `now` so the LRU victim is deterministic.
+    let mut handles = Vec::new();
+    for (i, now) in [("budget-a", 10i64), ("budget-b", 20i64)] {
+        let track = dl_track(i, None, 0);
+        downloads::enqueue(&db, &track, now).unwrap();
+        let (db, client, permits, budget_lock) = (
+            db.clone(),
+            client.clone(),
+            permits.clone(),
+            budget_lock.clone(),
+        );
+        let dir = tmp.path().to_path_buf();
+        handles.push(tokio::spawn(async move {
+            // A fetch may legitimately fail here only if it can't fit at all,
+            // which it can (64 <= 100), so both should succeed; the loser just
+            // evicts the winner.
+            downloads::fetch(&db, &client, &dir, &track, now, &permits, &budget_lock)
+                .await
+                .expect("fetch should succeed (track fits an empty store)");
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    // The invariant: completed usage never exceeds the budget, even though both
+    // ran concurrently. Exactly one survives as `done`.
+    let (used, count) = db.download_used_bytes().unwrap();
+    assert!(used <= 100, "used {used} exceeded budget 100");
+    assert_eq!(count, 1, "exactly one download should remain within budget");
 }

--- a/macos/Sources/Lyrebird/AppModel+Downloads.swift
+++ b/macos/Sources/Lyrebird/AppModel+Downloads.swift
@@ -70,6 +70,12 @@ extension AppModel {
             } catch {
                 if handleAuthError(error) {
                     downloadsInFlight.remove(track.id)
+                    // Auth expired mid-batch: clear the optimistic `.queued`
+                    // badge so the row doesn't show a permanent spinner with
+                    // nothing in flight (markAuthExpired() doesn't touch the
+                    // download maps). `.failed` mirrors the core, which marks
+                    // the DB row failed on the same auth error.
+                    downloadStateById[track.id] = .failed
                     continue
                 }
                 // Mark failed locally and surface the reason. We deliberately
@@ -80,9 +86,12 @@ extension AppModel {
                 Log.tracks.error("download failed track=\(track.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
             downloadsInFlight.remove(track.id)
-            // Keep aggregate stats fresh after each completion.
-            await refreshDownloadStats()
         }
+        // Refresh aggregate stats once after the batch rather than per track:
+        // the per-track `downloadStateById` updates already drive row badges,
+        // and the stats aggregate (SQLite sum) only feeds the preferences pane,
+        // so one read at the end avoids O(n) serialized FFI hops.
+        await refreshDownloadStats()
     }
 
     /// Remove the offline copies of a batch of tracks: deletes the files + index

--- a/macos/Sources/Lyrebird/Components/SmartPlaylistBuilderView.swift
+++ b/macos/Sources/Lyrebird/Components/SmartPlaylistBuilderView.swift
@@ -21,6 +21,14 @@ struct SmartPlaylistBuilderView: View {
     /// Local working copy. Edits mutate this; nothing persists until `onSave`.
     @State private var draft: SmartPlaylist
 
+    /// Live count of matching tracks over the current snapshot, recomputed
+    /// off the main thread and debounced (see `recomputeLiveCount`). `nil`
+    /// until the first evaluation completes so the footer can show a neutral
+    /// placeholder rather than a misleading "0 match" before the sweep runs.
+    /// The in-flight sweep is owned by `.task(id: draft)`, which cancels and
+    /// restarts it on every edit, so no manual task handle is needed.
+    @State private var liveCount: Int?
+
     /// Called with the finished playlist when the user taps Save. The caller
     /// owns persistence (`SmartPlaylistStore.save`).
     private let onSave: (SmartPlaylist) -> Void
@@ -37,19 +45,40 @@ struct SmartPlaylistBuilderView: View {
         self.onCancel = onCancel
     }
 
-    /// Live count of matching tracks over the current snapshot. Recomputed
-    /// each render; the evaluator is a single linear pass so this is cheap
-    /// even for the largest in-memory snapshot.
-    private var liveCount: Int {
-        SmartPlaylistEvaluator.matchCount(
-            draft,
-            tracks: model.tracks,
-            albums: model.albums
-        )
-    }
-
     private var trimmedName: String {
         draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Recompute the live match count without blocking the main thread.
+    ///
+    /// The old code read `matchCount` from a computed property in `body`, so
+    /// every keystroke in the name field or any rule editor re-ran the whole
+    /// O(albums + tracks) sweep synchronously on the MainActor (CLAUDE.md gap
+    /// pattern #2). Instead we debounce (~250 ms) and run the evaluation in a
+    /// detached task, building the album→genre index once and passing it to
+    /// the `genresByAlbumId:` evaluator overload, then marshal just the `Int`
+    /// back to `@State` on the main actor. The task is keyed to `draft` via
+    /// `.task(id:)` so SwiftUI cancels the prior sweep on each edit.
+    private func recomputeLiveCount() async {
+        // Debounce: if the draft changes again within the window, `.task(id:)`
+        // cancels this task before the sleep returns and starts a fresh one.
+        do {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        } catch {
+            return // cancelled — a newer edit superseded this one
+        }
+        let snapshotTracks = model.tracks
+        let snapshotAlbums = model.albums
+        let playlist = draft
+        let count = await Task.detached(priority: .userInitiated) {
+            SmartPlaylistEvaluator.matchCount(
+                playlist,
+                tracks: snapshotTracks,
+                genresByAlbumId: SmartPlaylistEvaluator.albumGenreIndex(snapshotAlbums)
+            )
+        }.value
+        if Task.isCancelled { return }
+        liveCount = count
     }
 
     var body: some View {
@@ -69,6 +98,11 @@ struct SmartPlaylistBuilderView: View {
         }
         .frame(width: 560, height: 520)
         .background(Theme.bg)
+        // Recompute the live count off-main whenever the draft changes;
+        // `.task(id:)` cancels the prior (debounced) sweep on each edit.
+        .task(id: draft) {
+            await recomputeLiveCount()
+        }
     }
 
     // MARK: - Header
@@ -79,7 +113,7 @@ struct SmartPlaylistBuilderView: View {
             Image(systemName: "gearshape.2.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(Theme.primary)
-            Text("Smart Playlist")
+            Text("smart_playlist.builder.title")
                 .font(Theme.font(16, weight: .bold))
                 .foregroundStyle(Theme.ink)
             Spacer()
@@ -93,11 +127,11 @@ struct SmartPlaylistBuilderView: View {
     @ViewBuilder
     private var nameField: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("NAME")
+            Text("smart_playlist.builder.name_label")
                 .font(Theme.font(10, weight: .bold))
                 .foregroundStyle(Theme.ink3)
                 .tracking(1.5)
-            TextField("Smart Playlist Name", text: $draft.name)
+            TextField(String(localized: "smart_playlist.builder.name_placeholder"), text: $draft.name)
                 .textFieldStyle(.plain)
                 .font(Theme.font(15, weight: .semibold))
                 .foregroundStyle(Theme.ink)
@@ -106,7 +140,7 @@ struct SmartPlaylistBuilderView: View {
                 .background(Theme.surface)
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.border, lineWidth: 1))
                 .cornerRadius(8)
-                .accessibilityLabel("Smart playlist name")
+                .accessibilityLabel(Text("smart_playlist.builder.a11y.name"))
         }
     }
 
@@ -115,10 +149,10 @@ struct SmartPlaylistBuilderView: View {
     @ViewBuilder
     private var matchModeRow: some View {
         HStack(spacing: 8) {
-            Text("Match")
+            Text("smart_playlist.builder.match_prefix")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink2)
-            Picker("Match mode", selection: $draft.matchMode) {
+            Picker(String(localized: "smart_playlist.builder.a11y.match_mode"), selection: $draft.matchMode) {
                 ForEach(SmartPlaylistMatchMode.allCases, id: \.self) { mode in
                     Text(mode.displayName).tag(mode)
                 }
@@ -126,8 +160,8 @@ struct SmartPlaylistBuilderView: View {
             .pickerStyle(.menu)
             .labelsHidden()
             .frame(width: 90)
-            .accessibilityLabel("Match mode")
-            Text("of the following rules:")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.match_mode"))
+            Text("smart_playlist.builder.match_suffix")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink2)
             Spacer()
@@ -149,14 +183,14 @@ struct SmartPlaylistBuilderView: View {
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "plus.circle.fill")
-                    Text("Add Rule")
+                    Text("smart_playlist.builder.add_rule")
                 }
                 .font(Theme.font(13, weight: .semibold))
                 .foregroundStyle(Theme.primary)
             }
             .buttonStyle(.plain)
             .padding(.top, 2)
-            .accessibilityLabel("Add rule")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.add_rule"))
         }
     }
 
@@ -165,14 +199,14 @@ struct SmartPlaylistBuilderView: View {
     @ViewBuilder
     private func ruleRow(_ rule: Binding<SmartPlaylistRule>) -> some View {
         HStack(spacing: 8) {
-            // Field picker — changing the field repairs the operator/value so
-            // an impossible pairing (e.g. Favorite + greater-than) can't form.
-            Picker("Field", selection: Binding(
+            // Field picker — changing the field normalizes the operator *and*
+            // the value for the new field's kind so an impossible pairing
+            // (e.g. Favorite + greater-than) or a stale value (e.g. a text
+            // value left behind on a boolean field) can't form.
+            Picker(String(localized: "smart_playlist.builder.a11y.field"), selection: Binding(
                 get: { rule.wrappedValue.field },
                 set: { newField in
-                    var next = rule.wrappedValue
-                    next.field = newField
-                    rule.wrappedValue = next.repaired()
+                    rule.wrappedValue = rule.wrappedValue.changingField(to: newField)
                 }
             )) {
                 ForEach(SmartPlaylistField.allCases, id: \.self) { field in
@@ -181,17 +215,17 @@ struct SmartPlaylistBuilderView: View {
             }
             .labelsHidden()
             .frame(width: 110)
-            .accessibilityLabel("Rule field")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.field"))
 
             // Operator picker — scoped to operators valid for the field kind.
-            Picker("Operator", selection: rule.op) {
+            Picker(String(localized: "smart_playlist.builder.a11y.operator"), selection: rule.op) {
                 ForEach(SmartPlaylistOperator.applicable(to: rule.wrappedValue.field.valueKind), id: \.self) { op in
                     Text(op.displayName).tag(op)
                 }
             }
             .labelsHidden()
             .frame(width: 150)
-            .accessibilityLabel("Rule operator")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.operator"))
 
             valueEditor(rule)
 
@@ -207,7 +241,7 @@ struct SmartPlaylistBuilderView: View {
                     .foregroundStyle(Theme.ink3)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Remove rule")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.remove_rule"))
         }
     }
 
@@ -218,7 +252,7 @@ struct SmartPlaylistBuilderView: View {
     private func valueEditor(_ rule: Binding<SmartPlaylistRule>) -> some View {
         switch rule.wrappedValue.field.valueKind {
         case .text:
-            TextField("value", text: rule.value)
+            TextField(String(localized: "smart_playlist.builder.value_placeholder"), text: rule.value)
                 .textFieldStyle(.plain)
                 .font(Theme.font(13))
                 .foregroundStyle(Theme.ink)
@@ -227,7 +261,7 @@ struct SmartPlaylistBuilderView: View {
                 .background(Theme.surface)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
                 .cornerRadius(6)
-                .accessibilityLabel("Rule value")
+                .accessibilityLabel(Text("smart_playlist.builder.a11y.value"))
         case .number:
             TextField("0", text: rule.value)
                 .textFieldStyle(.plain)
@@ -239,18 +273,29 @@ struct SmartPlaylistBuilderView: View {
                 .background(Theme.surface)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
                 .cornerRadius(6)
-                .accessibilityLabel("Rule value")
+                .accessibilityLabel(Text("smart_playlist.builder.a11y.value"))
         case .boolean:
-            Picker("value", selection: Binding(
+            // The picker's `get` defaults an unparseable stored value to
+            // `true`; normalize that back into the binding on appear so the
+            // displayed state and the stored/evaluated state agree (otherwise
+            // a stale non-boolean value would show "yes" but evaluate to
+            // no-match). The `changingField` repair already seeds a valid
+            // default on a field switch; this also covers hand-edited files.
+            Picker(String(localized: "smart_playlist.builder.a11y.value"), selection: Binding(
                 get: { SmartPlaylistEvaluator.parseBool(rule.wrappedValue.value) ?? true },
                 set: { rule.wrappedValue.value = $0 ? "true" : "false" }
             )) {
-                Text("yes").tag(true)
-                Text("no").tag(false)
+                Text("smart_playlist.builder.bool_yes").tag(true)
+                Text("smart_playlist.builder.bool_no").tag(false)
             }
             .labelsHidden()
             .frame(width: 80)
-            .accessibilityLabel("Rule value")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.value"))
+            .onAppear {
+                if SmartPlaylistEvaluator.parseBool(rule.wrappedValue.value) == nil {
+                    rule.wrappedValue.value = "true"
+                }
+            }
         case .date:
             HStack(spacing: 4) {
                 TextField("30", text: rule.value)
@@ -263,8 +308,8 @@ struct SmartPlaylistBuilderView: View {
                     .background(Theme.surface)
                     .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.border, lineWidth: 1))
                     .cornerRadius(6)
-                    .accessibilityLabel("Rule value in days")
-                Text("days")
+                    .accessibilityLabel(Text("smart_playlist.builder.a11y.value_days"))
+                Text("smart_playlist.builder.days_suffix")
                     .font(Theme.font(12, weight: .medium))
                     .foregroundStyle(Theme.ink3)
             }
@@ -276,12 +321,25 @@ struct SmartPlaylistBuilderView: View {
     @ViewBuilder
     private var footer: some View {
         HStack {
-            // Live result count over the loaded snapshot.
-            Label(SmartPlaylistDetailView.countSummary(liveCount) + " match", systemImage: "music.note")
-                .font(Theme.font(12, weight: .semibold))
-                .foregroundStyle(Theme.ink2)
+            // Live result count over the loaded snapshot. A single localized,
+            // plural-aware format string carries the count (no English-glued
+            // " match" suffix, which both broke localization and read wrong in
+            // the singular). `nil` while the first off-main sweep is in flight.
+            Label {
+                if let liveCount {
+                    Text("smart_playlist.builder.match_count \(liveCount)")
+                } else {
+                    Text("smart_playlist.builder.counting")
+                }
+            } icon: {
+                Image(systemName: "music.note")
+            }
+            .font(Theme.font(12, weight: .semibold))
+            .foregroundStyle(Theme.ink2)
             Spacer()
-            Button("Cancel") { onCancel() }
+            Button { onCancel() } label: {
+                Text("smart_playlist.builder.cancel")
+            }
                 .buttonStyle(.plain)
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink2)
@@ -291,15 +349,17 @@ struct SmartPlaylistBuilderView: View {
                 .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
                 .keyboardShortcut(.cancelAction)
 
-            Button("Save") {
+            Button {
                 var finished = draft
                 // Never persist a blank name — fall back to a sensible default.
                 if trimmedName.isEmpty {
-                    finished.name = "Smart Playlist"
+                    finished.name = String(localized: "smart_playlist.builder.default_name")
                 } else {
                     finished.name = trimmedName
                 }
                 onSave(finished)
+            } label: {
+                Text("smart_playlist.builder.save")
             }
             .buttonStyle(.plain)
             .font(Theme.font(13, weight: .bold))
@@ -308,7 +368,7 @@ struct SmartPlaylistBuilderView: View {
             .frame(height: 32)
             .background(Capsule().fill(Theme.accent))
             .keyboardShortcut(.defaultAction)
-            .accessibilityLabel("Save smart playlist")
+            .accessibilityLabel(Text("smart_playlist.builder.a11y.save"))
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 14)

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1693,6 +1693,642 @@
         }
       }
     },
+    "smart_playlist.a11y.edit_rules" : {
+      "comment" : "Accessibility label for the Edit Rules button on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit smart playlist rules"
+          }
+        }
+      }
+    },
+    "smart_playlist.a11y.play" : {
+      "comment" : "Accessibility label for the Play button on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play smart playlist"
+          }
+        }
+      }
+    },
+    "smart_playlist.a11y.shuffle" : {
+      "comment" : "Accessibility label for the Shuffle button on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuffle smart playlist"
+          }
+        }
+      }
+    },
+    "smart_playlist.badge" : {
+      "comment" : "Small uppercase badge above the title on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SMART PLAYLIST"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.add_rule" : {
+      "comment" : "Accessibility label for the Add Rule button in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add rule"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.field" : {
+      "comment" : "Accessibility label for a rule's field picker in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rule field"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.match_mode" : {
+      "comment" : "Accessibility label for the match-mode (all/any) picker in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Match mode"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.name" : {
+      "comment" : "Accessibility label for the name field in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart playlist name"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.operator" : {
+      "comment" : "Accessibility label for a rule's operator picker in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rule operator"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.remove_rule" : {
+      "comment" : "Accessibility label for the per-row Remove Rule button in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove rule"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.save" : {
+      "comment" : "Accessibility label for the Save button in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save smart playlist"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.value" : {
+      "comment" : "Accessibility label for a rule's value editor in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rule value"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.a11y.value_days" : {
+      "comment" : "Accessibility label for a date rule's day-count value editor in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rule value in days"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.add_rule" : {
+      "comment" : "Button that appends a new rule row in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Rule"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.bool_no" : {
+      "comment" : "The \"no\" / false option in a boolean (Favorite) rule's value picker.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.bool_yes" : {
+      "comment" : "The \"yes\" / true option in a boolean (Favorite) rule's value picker.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yes"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.cancel" : {
+      "comment" : "Cancel button in the smart playlist builder footer.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.counting" : {
+      "comment" : "Placeholder shown in the builder footer while the live match count is still being computed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Counting…"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.days_suffix" : {
+      "comment" : "Unit label after a date rule's day-count field, e.g. \"30 days\".",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "days"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.default_name" : {
+      "comment" : "Fallback name applied when a smart playlist is saved with a blank name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart Playlist"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.match_count %lld" : {
+      "comment" : "Live result count in the builder footer, e.g. \"12 match\". %lld is the count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld match"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld match"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.match_prefix" : {
+      "comment" : "Leading word of the \"Match [all/any] of the following rules:\" sentence in the builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Match"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.match_suffix" : {
+      "comment" : "Trailing clause of the \"Match [all/any] of the following rules:\" sentence in the builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "of the following rules:"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.name_label" : {
+      "comment" : "Uppercase field label above the name input in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NAME"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.name_placeholder" : {
+      "comment" : "Placeholder text for the name input in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart Playlist Name"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.save" : {
+      "comment" : "Save button in the smart playlist builder footer.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.title" : {
+      "comment" : "Header title of the smart playlist builder sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart Playlist"
+          }
+        }
+      }
+    },
+    "smart_playlist.builder.value_placeholder" : {
+      "comment" : "Placeholder for a text rule's value field in the smart playlist builder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "value"
+          }
+        }
+      }
+    },
+    "smart_playlist.edit_rules" : {
+      "comment" : "Edit Rules button label on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Rules"
+          }
+        }
+      }
+    },
+    "smart_playlist.empty.detail %lld" : {
+      "comment" : "Body of the empty-result state on the smart playlist detail screen. %lld is the number of tracks loaded so far.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loaded %lld tracks so far. Try loosening the rules, or open the Library so more tracks are in memory."
+          }
+        }
+      }
+    },
+    "smart_playlist.empty.title" : {
+      "comment" : "Headline of the empty-result state on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tracks match these rules"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.album" : {
+      "comment" : "Smart playlist rule field: Album.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.artist" : {
+      "comment" : "Smart playlist rule field: Artist.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artist"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.favorite" : {
+      "comment" : "Smart playlist rule field: Favorite (boolean).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorite"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.genre" : {
+      "comment" : "Smart playlist rule field: Genre.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.last_played" : {
+      "comment" : "Smart playlist rule field: Last Played. Sourced from Jellyfin's per-track lastPlayedAt (the server projection exposes last-played, not date-added), so the label reflects last-played semantics.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Played"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.play_count" : {
+      "comment" : "Smart playlist rule field: Play Count.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play Count"
+          }
+        }
+      }
+    },
+    "smart_playlist.field.year" : {
+      "comment" : "Smart playlist rule field: Year.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
+          }
+        }
+      }
+    },
+    "smart_playlist.filter_placeholder" : {
+      "comment" : "Placeholder for the scoped filter field on the smart playlist detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter tracks"
+          }
+        }
+      }
+    },
+    "smart_playlist.match_mode.all" : {
+      "comment" : "Smart playlist match mode: all (every rule must match). Lowercase; reads inline as \"Match all of the following rules\".",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "all"
+          }
+        }
+      }
+    },
+    "smart_playlist.match_mode.any" : {
+      "comment" : "Smart playlist match mode: any (at least one rule must match). Lowercase; reads inline as \"Match any of the following rules\".",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "any"
+          }
+        }
+      }
+    },
+    "smart_playlist.no_filter_match %@" : {
+      "comment" : "Shown when the scoped filter matches no tracks on the smart playlist detail screen. %@ is the filter query.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tracks match “%@”"
+          }
+        }
+      }
+    },
+    "smart_playlist.not_found" : {
+      "comment" : "Shown when a smart playlist can't be resolved by id on the detail screen.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart playlist not found"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.contains" : {
+      "comment" : "Smart playlist rule operator: contains (text).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "contains"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.greater_than" : {
+      "comment" : "Smart playlist rule operator: greater than (number/date).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "greater than"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.in_last" : {
+      "comment" : "Smart playlist rule operator: in the last N days (date).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "in the last (days)"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.is" : {
+      "comment" : "Smart playlist rule operator: is (equality).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "is"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.is_not" : {
+      "comment" : "Smart playlist rule operator: is not (inequality).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "is not"
+          }
+        }
+      }
+    },
+    "smart_playlist.op.less_than" : {
+      "comment" : "Smart playlist rule operator: less than (number/date).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "less than"
+          }
+        }
+      }
+    },
+    "smart_playlist.rules.clause_separator" : {
+      "comment" : "Separator joining individual rule clauses in the detail screen's rule summary. Default \", \".",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", "
+          }
+        }
+      }
+    },
+    "smart_playlist.rules.matches %@ %@" : {
+      "comment" : "Rule summary frame on the detail screen, e.g. \"Matches all of: Artist is Radiohead\". First %@ is the match mode (all/any); second %@ is the joined rule clauses.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Matches %1$@ of: %2$@"
+          }
+        }
+      }
+    },
+    "smart_playlist.rules.matches_all_tracks" : {
+      "comment" : "Rule summary shown when a smart playlist has no rules (matches every track).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Matches every track."
+          }
+        }
+      }
+    },
     "stream.error.retry.a11y" : {
       "comment" : "Accessibility label on the Retry button inside StreamErrorToast.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/Screens/SmartPlaylistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/SmartPlaylistDetailView.swift
@@ -33,30 +33,34 @@ struct SmartPlaylistDetailView: View {
     }
 
     /// The live evaluated track set. Pure function of the playlist's rules
-    /// and the current snapshot — recomputed each render (cheap: a single
-    /// linear pass with an O(1) genre lookup).
-    private var matchedTracks: [Track] {
-        guard let playlist else { return [] }
-        return SmartPlaylistEvaluator.evaluate(
+    /// and the current snapshot.
+    ///
+    /// SwiftUI does not memoize computed properties, so reading this once per
+    /// visible row (as the old code did via `matchedTracks`) re-ran the whole
+    /// O(albums + tracks) predicate N times per render. `body` instead
+    /// evaluates **once** into a local and threads the result down to every
+    /// subview, building the album→genre index a single time per render with
+    /// the `genresByAlbumId:` evaluator overload rather than rebuilding it
+    /// per access.
+    private func evaluate(_ playlist: SmartPlaylist) -> [Track] {
+        SmartPlaylistEvaluator.evaluate(
             playlist,
             tracks: model.tracks,
-            albums: model.albums
+            genresByAlbumId: SmartPlaylistEvaluator.albumGenreIndex(model.albums)
         )
-    }
-
-    /// `matchedTracks` filtered by the scoped query, paired with the index
-    /// into `matchedTracks` so playback starts from the right row.
-    private var filteredTracks: [(index: Int, track: Track)] {
-        PlaylistView.filterTracks(matchedTracks, query: scopedQuery)
     }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 if let playlist {
-                    hero(playlist)
-                    transportBar
-                    trackList
+                    // Evaluate once per render; pass the result to every
+                    // subview so the predicate isn't re-run per row / per
+                    // property access.
+                    let matched = evaluate(playlist)
+                    hero(playlist, matched: matched)
+                    transportBar(playlist, matched: matched)
+                    trackList(matched: matched)
                 } else {
                     notFound
                 }
@@ -82,7 +86,7 @@ struct SmartPlaylistDetailView: View {
     // MARK: - Hero
 
     @ViewBuilder
-    private func hero(_ playlist: SmartPlaylist) -> some View {
+    private func hero(_ playlist: SmartPlaylist, matched: [Track]) -> some View {
         HStack(alignment: .top, spacing: 24) {
             // Gradient artwork tile with the smart-playlist glyph, so the
             // detail page reads as "rule-driven" rather than a normal
@@ -103,7 +107,7 @@ struct SmartPlaylistDetailView: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 10) {
-                Text("SMART PLAYLIST")
+                Text("smart_playlist.badge")
                     .font(Theme.font(10, weight: .bold))
                     .foregroundStyle(Theme.ink3)
                     .tracking(2)
@@ -121,7 +125,7 @@ struct SmartPlaylistDetailView: View {
                     .lineLimit(3)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Text(SmartPlaylistDetailView.countSummary(matchedTracks.count))
+                Text(CountStrings.label(matched.count, .songs))
                     .font(Theme.font(12, weight: .semibold))
                     .foregroundStyle(Theme.ink3)
             }
@@ -134,11 +138,10 @@ struct SmartPlaylistDetailView: View {
     // MARK: - Transport bar
 
     @ViewBuilder
-    private var transportBar: some View {
+    private func transportBar(_ playlist: SmartPlaylist, matched: [Track]) -> some View {
         HStack(spacing: 14) {
             Button {
-                let t = matchedTracks
-                if !t.isEmpty { model.play(tracks: t, startIndex: 0) }
+                if !matched.isEmpty { model.play(tracks: matched, startIndex: 0) }
             } label: {
                 Image(systemName: "play.fill")
                     .font(.system(size: 22))
@@ -148,12 +151,11 @@ struct SmartPlaylistDetailView: View {
                     .shadow(color: Theme.accent.opacity(0.35), radius: 12, y: 8)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Play smart playlist")
-            .disabled(matchedTracks.isEmpty)
+            .accessibilityLabel(Text("smart_playlist.a11y.play"))
+            .disabled(matched.isEmpty)
 
             Button {
-                let t = matchedTracks
-                if !t.isEmpty { model.play(tracks: t.shuffled(), startIndex: 0) }
+                if !matched.isEmpty { model.play(tracks: matched.shuffled(), startIndex: 0) }
             } label: {
                 Image(systemName: "shuffle")
                     .font(.system(size: 20))
@@ -161,15 +163,15 @@ struct SmartPlaylistDetailView: View {
                     .frame(width: 36, height: 36)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Shuffle smart playlist")
-            .disabled(matchedTracks.isEmpty)
+            .accessibilityLabel(Text("smart_playlist.a11y.shuffle"))
+            .disabled(matched.isEmpty)
 
             Button {
                 editing = playlist
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "slider.horizontal.3")
-                    Text("Edit Rules")
+                    Text("smart_playlist.edit_rules")
                 }
                 .font(Theme.font(13, weight: .semibold))
                 .foregroundStyle(Theme.ink2)
@@ -179,7 +181,7 @@ struct SmartPlaylistDetailView: View {
                 .overlay(Capsule().stroke(Theme.border, lineWidth: 1))
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Edit smart playlist rules")
+            .accessibilityLabel(Text("smart_playlist.a11y.edit_rules"))
 
             Spacer()
         }
@@ -191,36 +193,39 @@ struct SmartPlaylistDetailView: View {
     // MARK: - Track list
 
     @ViewBuilder
-    private var trackList: some View {
+    private func trackList(matched: [Track]) -> some View {
+        // Filter the (already-evaluated) set by the scoped query once, paired
+        // with the index into `matched` so playback starts from the right row.
+        let filtered = PlaylistView.filterTracks(matched, query: scopedQuery)
         VStack(alignment: .leading, spacing: 0) {
-            if !matchedTracks.isEmpty {
+            if !matched.isEmpty {
                 HStack {
                     Spacer()
                     ScopedSearchBar(
                         query: $scopedQuery,
                         isFocused: $scopedSearchFocused,
-                        placeholder: "Filter tracks"
+                        placeholder: String(localized: "smart_playlist.filter_placeholder")
                     )
                 }
                 .padding(.bottom, 8)
             }
 
-            if matchedTracks.isEmpty {
+            if matched.isEmpty {
                 emptyResult
-            } else if filteredTracks.isEmpty {
-                Text("No tracks match \u{201C}\(scopedQuery)\u{201D}")
+            } else if filtered.isEmpty {
+                Text("smart_playlist.no_filter_match \(scopedQuery)")
                     .font(Theme.font(13, weight: .medium))
                     .foregroundStyle(Theme.ink3)
                     .padding(.vertical, 40)
                     .frame(maxWidth: .infinity)
             } else {
-                ForEach(filteredTracks, id: \.track.id) { entry in
+                ForEach(filtered, id: \.track.id) { entry in
                     let idx = entry.index
                     TrackRow(
                         track: entry.track,
                         number: idx + 1,
-                        onPlay: { model.play(tracks: matchedTracks, startIndex: idx) },
-                        tracks: matchedTracks,
+                        onPlay: { model.play(tracks: matched, startIndex: idx) },
+                        tracks: matched,
                         index: idx
                     )
                 }
@@ -238,15 +243,17 @@ struct SmartPlaylistDetailView: View {
             Image(systemName: "line.3.horizontal.decrease.circle")
                 .font(.system(size: 34))
                 .foregroundStyle(Theme.ink3)
-            Text("No tracks match these rules")
+            Text("smart_playlist.empty.title")
                 .font(Theme.font(14, weight: .semibold))
                 .foregroundStyle(Theme.ink2)
-            Text("Loaded \(model.tracks.count) tracks so far. Try loosening the rules, or open the Library so more tracks are in memory.")
+            Text("smart_playlist.empty.detail \(model.tracks.count)")
                 .font(Theme.font(12, weight: .medium))
                 .foregroundStyle(Theme.ink3)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 360)
-            Button("Edit Rules") { editing = playlist }
+            Button { editing = playlist } label: {
+                Text("smart_playlist.edit_rules")
+            }
                 .buttonStyle(.plain)
                 .font(Theme.font(13, weight: .semibold))
                 .foregroundStyle(Theme.primary)
@@ -262,7 +269,7 @@ struct SmartPlaylistDetailView: View {
             Image(systemName: "questionmark.folder")
                 .font(.system(size: 34))
                 .foregroundStyle(Theme.ink3)
-            Text("Smart playlist not found")
+            Text("smart_playlist.not_found")
                 .font(Theme.font(15, weight: .semibold))
                 .foregroundStyle(Theme.ink2)
         }
@@ -272,20 +279,29 @@ struct SmartPlaylistDetailView: View {
 
     // MARK: - Pure summary helpers (unit-tested)
 
-    /// One-line plain-English description of a playlist's rules, e.g.
+    /// One-line localized description of a playlist's rules, e.g. (en)
     /// "Matches all of: Artist is Radiohead, Year greater than 2000". An
-    /// empty rule set reads as "Matches every track". Pure so it's tested
-    /// without a view.
+    /// empty rule set reads as "Matches every track."
+    ///
+    /// Built from localized format strings rather than English-glued clauses:
+    /// the empty case and the "Matches {mode} of: {clauses}" frame are catalog
+    /// keys, the per-clause `field`/`op` labels are already localized via the
+    /// model's `displayName`, and the clause separator is itself a catalog key
+    /// so locales that don't list-join with ", " can override it. Pure (no
+    /// view state) so it stays unit-testable; in the test bundle the catalog
+    /// is stripped, so lookups return the raw keys — the *structure* is what's
+    /// pinned there, the rendered copy is verified in the running app.
     static func ruleSummary(_ playlist: SmartPlaylist) -> String {
-        guard !playlist.rules.isEmpty else { return "Matches every track." }
-        let clauses = playlist.rules.map { rule -> String in
-            "\(rule.field.displayName) \(rule.op.displayName) \(rule.value)"
+        guard !playlist.rules.isEmpty else {
+            return String(localized: "smart_playlist.rules.matches_all_tracks", bundle: .main)
         }
-        return "Matches \(playlist.matchMode.displayName) of: " + clauses.joined(separator: ", ")
-    }
-
-    /// Pluralized "N song(s)" readout. Pure.
-    static func countSummary(_ count: Int) -> String {
-        count == 1 ? "1 song" : "\(count) songs"
+        let separator = String(localized: "smart_playlist.rules.clause_separator", bundle: .main)
+        let clauses = playlist.rules
+            .map { rule in "\(rule.field.displayName) \(rule.op.displayName) \(rule.value)" }
+            .joined(separator: separator)
+        return String(
+            localized: "smart_playlist.rules.matches \(playlist.matchMode.displayName) \(clauses)",
+            bundle: .main
+        )
     }
 }

--- a/macos/Sources/Lyrebird/System/SmartPlaylist.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylist.swift
@@ -33,10 +33,13 @@ import Foundation
 /// | `.isFavorite` | `userData?.isFavorite ?? isFavorite`               |
 /// | `.dateAdded`  | `userData?.lastPlayedAt` (ISO-8601). Jellyfin's    |
 /// |               | per-track projection exposes *last played*, not    |
-/// |               | `DateCreated`; the desktop client treats "Date     |
-/// |               | added" as last activity until core surfaces a real |
-/// |               | creation date. The seam is the single `dateAdded`  |
-/// |               | assignment in `TrackFacts.init`.                   |
+/// |               | `DateCreated`, so this field is surfaced to the     |
+/// |               | user as **"Last Played"** — the case raw value is  |
+/// |               | the pre-existing `dateAdded` storage key (kept for |
+/// |               | persistence compatibility), but `displayName`      |
+/// |               | reflects what the data actually means. The seam is |
+/// |               | the single `dateAdded` assignment in               |
+/// |               | `TrackFacts.init`.                                 |
 
 // MARK: - Field
 
@@ -63,18 +66,25 @@ enum SmartPlaylistField: String, Codable, CaseIterable, Hashable, Sendable {
         }
     }
 
-    /// Short, human-facing label. Not localized through the String Catalog
-    /// yet (the catalog work is #560); kept as plain English so the builder
-    /// is legible until that lands.
+    /// Short, human-facing label shown in the builder's field picker and the
+    /// detail view's rule summary. Routed through the String Catalog so it is
+    /// localized like the rest of the smart-playlist UI.
+    ///
+    /// `.dateAdded` is labelled **"Last Played"** rather than "Date Added":
+    /// Jellyfin's `Track` projection exposes only `UserData.lastPlayedAt`,
+    /// not `DateCreated`, so the rule actually filters on last-played date.
+    /// The case raw value stays `dateAdded` (a stable persisted storage key
+    /// that must not be renamed); only the user-facing label is honest about
+    /// the semantics. See `TrackFacts.dateAdded`.
     var displayName: String {
         switch self {
-        case .genre: return "Genre"
-        case .artist: return "Artist"
-        case .album: return "Album"
-        case .year: return "Year"
-        case .playCount: return "Play Count"
-        case .isFavorite: return "Favorite"
-        case .dateAdded: return "Date Added"
+        case .genre: return String(localized: "smart_playlist.field.genre", bundle: .main)
+        case .artist: return String(localized: "smart_playlist.field.artist", bundle: .main)
+        case .album: return String(localized: "smart_playlist.field.album", bundle: .main)
+        case .year: return String(localized: "smart_playlist.field.year", bundle: .main)
+        case .playCount: return String(localized: "smart_playlist.field.play_count", bundle: .main)
+        case .isFavorite: return String(localized: "smart_playlist.field.favorite", bundle: .main)
+        case .dateAdded: return String(localized: "smart_playlist.field.last_played", bundle: .main)
         }
     }
 }
@@ -104,12 +114,12 @@ enum SmartPlaylistOperator: String, Codable, CaseIterable, Hashable, Sendable {
 
     var displayName: String {
         switch self {
-        case .is: return "is"
-        case .isNot: return "is not"
-        case .contains: return "contains"
-        case .greaterThan: return "greater than"
-        case .lessThan: return "less than"
-        case .inLast: return "in the last (days)"
+        case .is: return String(localized: "smart_playlist.op.is", bundle: .main)
+        case .isNot: return String(localized: "smart_playlist.op.is_not", bundle: .main)
+        case .contains: return String(localized: "smart_playlist.op.contains", bundle: .main)
+        case .greaterThan: return String(localized: "smart_playlist.op.greater_than", bundle: .main)
+        case .lessThan: return String(localized: "smart_playlist.op.less_than", bundle: .main)
+        case .inLast: return String(localized: "smart_playlist.op.in_last", bundle: .main)
         }
     }
 
@@ -137,8 +147,8 @@ enum SmartPlaylistMatchMode: String, Codable, CaseIterable, Hashable, Sendable {
 
     var displayName: String {
         switch self {
-        case .all: return "all"
-        case .any: return "any"
+        case .all: return String(localized: "smart_playlist.match_mode.all", bundle: .main)
+        case .any: return String(localized: "smart_playlist.match_mode.any", bundle: .main)
         }
     }
 }
@@ -209,6 +219,37 @@ struct SmartPlaylistRule: Codable, Identifiable, Hashable, Sendable {
         var fixed = SmartPlaylistRule.defaultRule(for: field)
         fixed.id = id
         return fixed
+    }
+
+    /// Return this rule with its `field` changed to `newField`, normalizing
+    /// the operator **and the value** for the new field's value kind.
+    ///
+    /// Unlike `repaired()` (which only fixes an *illegal* operator and so
+    /// preserves the old value when the operator happens to stay legal), this
+    /// resets the value to the new kind's default whenever the **value kind**
+    /// changes — even if the operator survives. Without that reset, switching
+    /// e.g. a text rule (`Artist is "Pink Floyd"`) to `Favorite` keeps the
+    /// stale `"Pink Floyd"` value: `.is` is legal for booleans, so the
+    /// operator-only repair leaves it, the boolean editor *displays* "yes",
+    /// but `booleanMatch` can't parse `"Pink Floyd"` and the saved playlist
+    /// silently matches nothing. Resetting on a kind change keeps the
+    /// displayed state and the stored/evaluated state in agreement.
+    ///
+    /// When the value kind is unchanged (e.g. Artist → Album, both text) the
+    /// user's typed value is preserved and only the operator is repaired.
+    func changingField(to newField: SmartPlaylistField) -> SmartPlaylistRule {
+        guard newField != field else { return repaired() }
+        var next = self
+        next.field = newField
+        if newField.valueKind != field.valueKind {
+            // Value kind changed → the stored value is meaningless for the new
+            // kind; seed the kind's default (and a legal operator with it).
+            var fresh = SmartPlaylistRule.defaultRule(for: newField)
+            fresh.id = id
+            return fresh
+        }
+        // Same kind → keep the value, just fix the operator if needed.
+        return next.repaired()
     }
 }
 

--- a/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
@@ -5,7 +5,7 @@ import Foundation
 /// `SmartPlaylistEvaluator` tests rules against. Decoupling the rule logic
 /// from the `Track` FFI struct keeps the evaluator unit-testable with tiny
 /// hand-built fixtures (no UniFFI buffer round-trips) and gives the
-/// `dateAdded` semantics a single documented seam.
+/// last-played-date semantics a single documented seam.
 ///
 /// All text comparisons the evaluator performs are case- and
 /// diacritic-insensitive; the raw values are stored verbatim here and the
@@ -25,11 +25,15 @@ struct TrackFacts: Hashable, Sendable {
     var year: Int?
     var playCount: Int
     var isFavorite: Bool
-    /// Best per-track date the snapshot exposes. Jellyfin's track projection
-    /// carries `lastPlayedAt`, not `DateCreated`, so "Date Added" rules test
-    /// against last-played for now. `nil` when the track has no user data /
-    /// has never been played, in which case `.inLast` / date comparisons
-    /// never match (a never-played track isn't "added in the last N days").
+    /// Best per-track date the snapshot exposes: Jellyfin's `Track`
+    /// projection carries `UserData.lastPlayedAt`, not `DateCreated`, so the
+    /// date field tests **last-played** and is surfaced to the user as "Last
+    /// Played" (see `SmartPlaylistField.displayName`). `nil` when the track
+    /// has no user data / has never been played, in which case `.inLast` /
+    /// date comparisons never match (a never-played track has no last-played
+    /// date to fall inside any window). The case raw value is still
+    /// `dateAdded` — a stable persisted storage key that predates the
+    /// honest label and must not be renamed (see `SmartPlaylistField`).
     var dateAdded: Date?
 
     init(
@@ -73,8 +77,12 @@ extension TrackFacts {
         // mirror so a snapshot fetched without `Fields=UserData` still reads.
         self.playCount = Int(track.userData?.playCount ?? track.playCount)
         self.isFavorite = track.userData?.isFavorite ?? track.isFavorite
-        // The single documented "Date Added" seam — swap `lastPlayedAt` for a
-        // real `DateCreated` here if core ever surfaces one.
+        // The single documented last-played-date seam. The field is labelled
+        // "Last Played" because Jellyfin's `Track` projection exposes only
+        // `lastPlayedAt`, not `DateCreated`; if core ever surfaces a real
+        // per-track creation date, add it to the `Track` FFI model and a new
+        // `SmartPlaylistField.dateAdded`-style case rather than overloading
+        // this one (the label would otherwise lie again).
         self.dateAdded = track.userData?.lastPlayedAt.flatMap(SmartPlaylistEvaluator.parseDate)
     }
 }
@@ -107,36 +115,77 @@ enum SmartPlaylistEvaluator {
     /// Convenience over the FFI `Track` type: builds the per-track genre
     /// lookup from `albums`, adapts each track, and filters. This is the
     /// entry point `AppModel` / the detail view call with the live snapshot.
+    ///
+    /// On a large library (the canonical real server holds ~20,060 albums)
+    /// building `albumGenreIndex(albums)` is an O(albums) allocation. When a
+    /// call site re-evaluates repeatedly against the *same* albums snapshot
+    /// (a SwiftUI body that renders per keystroke / per visible row), build
+    /// the index once with `albumGenreIndex(_:)` and call the
+    /// `genresByAlbumId:` overload below so the index is reused rather than
+    /// rebuilt on every pass.
     static func evaluate(
         _ playlist: SmartPlaylist,
         tracks: [Track],
         albums: [Album],
         now: Date = Date()
     ) -> [Track] {
+        evaluate(playlist, tracks: tracks, genresByAlbumId: albumGenreIndex(albums), now: now)
+    }
+
+    /// As `evaluate(_:tracks:albums:now:)` but takes a *prebuilt*
+    /// `[albumId: [genre]]` index instead of rebuilding it from `albums` on
+    /// every call. Hot-path entry point: the detail/builder views build the
+    /// index once per albums-snapshot and pass it in so a per-render
+    /// re-evaluation is a single O(tracks) pass with no per-call O(albums)
+    /// dictionary allocation.
+    static func evaluate(
+        _ playlist: SmartPlaylist,
+        tracks: [Track],
+        genresByAlbumId: [String: [String]],
+        now: Date = Date()
+    ) -> [Track] {
         guard !playlist.rules.isEmpty else { return tracks }
-        let genresByAlbumId = albumGenreIndex(albums)
         return tracks.filter { track in
-            let genres = track.albumId.flatMap { genresByAlbumId[$0] } ?? []
-            let facts = TrackFacts(track: track, genres: genres)
-            return matches(facts, playlist: playlist, now: now)
+            matches(facts(for: track, genresByAlbumId: genresByAlbumId), playlist: playlist, now: now)
         }
     }
 
     /// The count of matching tracks — used for the builder's live "N songs"
     /// readout without materializing the filtered array at every call site.
+    /// Builds the genre index from `albums`; prefer the `genresByAlbumId:`
+    /// overload from a per-interaction path so the index isn't rebuilt on
+    /// every keystroke.
     static func matchCount(
         _ playlist: SmartPlaylist,
         tracks: [Track],
         albums: [Album],
         now: Date = Date()
     ) -> Int {
+        matchCount(playlist, tracks: tracks, genresByAlbumId: albumGenreIndex(albums), now: now)
+    }
+
+    /// As `matchCount(_:tracks:albums:now:)` but takes a prebuilt genre
+    /// index. See `evaluate(_:tracks:genresByAlbumId:now:)`.
+    static func matchCount(
+        _ playlist: SmartPlaylist,
+        tracks: [Track],
+        genresByAlbumId: [String: [String]],
+        now: Date = Date()
+    ) -> Int {
         guard !playlist.rules.isEmpty else { return tracks.count }
-        let genresByAlbumId = albumGenreIndex(albums)
         return tracks.reduce(into: 0) { count, track in
-            let genres = track.albumId.flatMap { genresByAlbumId[$0] } ?? []
-            let facts = TrackFacts(track: track, genres: genres)
-            if matches(facts, playlist: playlist, now: now) { count += 1 }
+            if matches(facts(for: track, genresByAlbumId: genresByAlbumId), playlist: playlist, now: now) {
+                count += 1
+            }
         }
+    }
+
+    /// Adapt a `Track` to `TrackFacts`, projecting its album's genres via the
+    /// prebuilt index. Shared by the filter + count paths so the projection
+    /// rule lives in one place.
+    private static func facts(for track: Track, genresByAlbumId: [String: [String]]) -> TrackFacts {
+        let genres = track.albumId.flatMap { genresByAlbumId[$0] } ?? []
+        return TrackFacts(track: track, genres: genres)
     }
 
     // MARK: - Matching
@@ -269,10 +318,19 @@ enum SmartPlaylistEvaluator {
     /// Parse a numeric rule value with the POSIX locale so "1,5" never reads
     /// as fifteen on a comma-decimal system. Returns `nil` for blank /
     /// non-numeric input.
+    ///
+    /// Non-finite values are rejected. `Double("inf")` / `Double("nan")`
+    /// parse successfully but make a date rule's day count `±inf`/`NaN`
+    /// (`threshold = now - inf*86400` is a `-inf` Date that matches or
+    /// excludes *every* track) and a numeric `is`/`<`/`>` comparison
+    /// silently degenerate — so a finite check keeps a hand-typed "inf" /
+    /// "nan" from forming a silently-broken filter rather than an empty
+    /// (no-match) one the user can at least see is wrong.
     static func parseNumber(_ s: String) -> Double? {
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return Double(trimmed)
+        guard let value = Double(trimmed), value.isFinite else { return nil }
+        return value
     }
 
     /// Parse a boolean rule value. Accepts the JSON-ish `true`/`false` the

--- a/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
@@ -394,6 +394,94 @@ final class SmartPlaylistEvaluatorTests: XCTestCase {
         XCTAssertNil(SmartPlaylistEvaluator.parseNumber("twelve"))
     }
 
+    /// Non-finite values (`inf` / `nan`, which `Double.init` *does* accept)
+    /// are rejected. `Double("inf")` would otherwise make a date rule's day
+    /// count infinite (`threshold = now - inf*86400` is a `-inf` Date that
+    /// matches or excludes every track) and `nan` poisons numeric
+    /// comparisons; a finite check degrades both to "no value" (a visible
+    /// empty result) instead of a silently-wrong filter.
+    func testParseNumberRejectsNonFinite() {
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("inf"))
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("Infinity"))
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("-inf"))
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("nan"))
+        XCTAssertNil(SmartPlaylistEvaluator.parseNumber("NaN"))
+    }
+
+    /// A date rule with an "inf" day count must not match every track. Before
+    /// the finite guard, `parseNumber("inf")` → `.infinity`, which passed the
+    /// `days > 0` check and produced a `-inf` threshold so `.inLast` matched
+    /// everything (and `.lessThan` excluded everything). Now it's unparseable
+    /// → no-match.
+    func testDateRuleWithInfiniteDaysNeverMatches() {
+        let now = date("2026-06-04T12:00:00Z")
+        let recent = facts(dateAdded: date("2026-06-03T12:00:00Z"))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(recent, rule: rule(.dateAdded, .inLast, "inf"), now: now))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(recent, rule: rule(.dateAdded, .lessThan, "inf"), now: now))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(recent, rule: rule(.dateAdded, .greaterThan, "inf"), now: now))
+    }
+
+    /// A numeric rule with a NaN value never matches (NaN comparisons are all
+    /// false), and the finite guard makes that explicit rather than relying on
+    /// IEEE comparison semantics.
+    func testNumberRuleWithNaNNeverMatches() {
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 2020), rule: rule(.year, .greaterThan, "nan")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(facts(year: 2020), rule: rule(.year, .is, "nan")))
+    }
+
+    // MARK: - Prebuilt-index overloads (perf hot path)
+
+    /// The `genresByAlbumId:` overload of `evaluate` produces the same result
+    /// as the `albums:` overload — it just reuses a prebuilt index instead of
+    /// rebuilding it per call, so a per-render re-evaluation skips the
+    /// O(albums) allocation.
+    func testEvaluateWithPrebuiltIndexMatchesAlbumsOverload() {
+        let albums = [
+            makeAlbum(id: "alb-rock", genres: ["Rock"]),
+            makeAlbum(id: "alb-jazz", genres: ["Jazz"]),
+        ]
+        let tracks = [
+            makeTrack(id: "t1", albumId: "alb-rock"),
+            makeTrack(id: "t2", albumId: "alb-jazz"),
+            makeTrack(id: "t3", albumId: "alb-rock"),
+        ]
+        let p = playlist(.all, [rule(.genre, .is, "Rock")])
+        let index = SmartPlaylistEvaluator.albumGenreIndex(albums)
+
+        let viaAlbums = SmartPlaylistEvaluator.evaluate(p, tracks: tracks, albums: albums)
+        let viaIndex = SmartPlaylistEvaluator.evaluate(p, tracks: tracks, genresByAlbumId: index)
+        XCTAssertEqual(viaAlbums.map(\.id), viaIndex.map(\.id))
+        XCTAssertEqual(viaIndex.map(\.id), ["t1", "t3"])
+    }
+
+    /// `matchCount`'s prebuilt-index overload agrees with both the `albums:`
+    /// overload and the materialized filter.
+    func testMatchCountWithPrebuiltIndexMatchesAlbumsOverload() {
+        let albums = [makeAlbum(id: "alb", genres: ["Pop"])]
+        let tracks = [
+            makeTrack(id: "t1", albumId: "alb", isFavorite: true),
+            makeTrack(id: "t2", albumId: "alb", isFavorite: false),
+            makeTrack(id: "t3", albumId: "alb", isFavorite: true),
+        ]
+        let p = playlist(.all, [rule(.isFavorite, .is, "true")])
+        let index = SmartPlaylistEvaluator.albumGenreIndex(albums)
+
+        let viaAlbums = SmartPlaylistEvaluator.matchCount(p, tracks: tracks, albums: albums)
+        let viaIndex = SmartPlaylistEvaluator.matchCount(p, tracks: tracks, genresByAlbumId: index)
+        XCTAssertEqual(viaAlbums, viaIndex)
+        XCTAssertEqual(viaIndex, 2)
+    }
+
+    /// An empty prebuilt index means no track gets album genres — a genre
+    /// rule then matches nothing, proving the projection truly comes from the
+    /// passed-in index (not some hidden rebuild).
+    func testEvaluateWithEmptyIndexProjectsNoGenres() {
+        let tracks = [makeTrack(id: "t1", albumId: "alb-rock")]
+        let p = playlist(.all, [rule(.genre, .is, "Rock")])
+        let result = SmartPlaylistEvaluator.evaluate(p, tracks: tracks, genresByAlbumId: [:])
+        XCTAssertTrue(result.isEmpty)
+    }
+
     func testParseDateAcceptsBothISOForms() {
         XCTAssertNotNil(SmartPlaylistEvaluator.parseDate("2026-05-01T08:30:00.0000000Z"))
         XCTAssertNotNil(SmartPlaylistEvaluator.parseDate("2026-05-01T08:30:00Z"))

--- a/macos/Tests/LyrebirdTests/SmartPlaylistLocalizationTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistLocalizationTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import Lyrebird
+
+/// Localization coverage for the smart-playlist views (#77 / #238 re-audit).
+///
+/// The three smart-playlist screens (detail, builder) were shipped with
+/// hard-coded English literals while the rest of the app routes through the
+/// String Catalog. This pins two things:
+///
+/// 1. **Pure summary structure.** `SmartPlaylistDetailView.ruleSummary` is a
+///    pure helper; it now builds from localized format strings. In the unit
+///    test binary the `.xcstrings` catalog is stripped (SwiftPM copies
+///    resources only into the `.app`), so `String(localized:)` returns the raw
+///    key — which is precisely what lets us assert the *structure* (which key,
+///    which interpolation order) deterministically here, with the rendered
+///    English copy verified by the catalog-sync test below + the running app.
+///
+/// 2. **Catalog sync.** Same `#filePath`-relative loader idiom as
+///    `CountStringsTests`: every `smart_playlist.*` key the code references is
+///    read off disk and asserted present, so a typo'd key (which would
+///    silently render as the raw key in the UI) fails the build instead.
+final class SmartPlaylistLocalizationTests: XCTestCase {
+
+    // MARK: - ruleSummary structure
+
+    /// An empty rule set resolves to the dedicated "matches every track" key.
+    func testRuleSummaryEmptyUsesMatchesAllTracksKey() {
+        let p = SmartPlaylist(name: "All", matchMode: .all, rules: [])
+        XCTAssertEqual(SmartPlaylistDetailView.ruleSummary(p), "smart_playlist.rules.matches_all_tracks")
+    }
+
+    /// A non-empty rule set is built from the localized "matches %@ of: %@"
+    /// frame. In the test bundle (catalog stripped) `String(localized:)`
+    /// returns the raw key with the interpolated arguments appended, so we can
+    /// pin that the match mode and the joined clauses are both threaded in.
+    func testRuleSummaryNonEmptyThreadsModeAndClauses() {
+        let p = SmartPlaylist(
+            name: "Test",
+            matchMode: .all,
+            rules: [
+                SmartPlaylistRule(field: .artist, op: .is, value: "Radiohead"),
+                SmartPlaylistRule(field: .year, op: .greaterThan, value: "2000"),
+            ]
+        )
+        let summary = SmartPlaylistDetailView.ruleSummary(p)
+        // The frame key is present…
+        XCTAssertTrue(
+            summary.contains("smart_playlist.rules.matches"),
+            "rule summary should be built from the localized frame key"
+        )
+        // …the match mode label is threaded in (its own localized key)…
+        XCTAssertTrue(summary.contains(SmartPlaylistMatchMode.all.displayName))
+        // …and each clause's raw value appears (values aren't localized).
+        XCTAssertTrue(summary.contains("Radiohead"))
+        XCTAssertTrue(summary.contains("2000"))
+    }
+
+    /// The clause separator is itself a catalog key (so locales that don't
+    /// join with ", " can override it) — joining two clauses must place that
+    /// separator between them.
+    func testRuleSummaryJoinsClausesWithLocalizedSeparator() {
+        let p = SmartPlaylist(
+            name: "Test",
+            matchMode: .any,
+            rules: [
+                SmartPlaylistRule(field: .artist, op: .is, value: "A"),
+                SmartPlaylistRule(field: .album, op: .is, value: "B"),
+            ]
+        )
+        let summary = SmartPlaylistDetailView.ruleSummary(p)
+        let separator = String(localized: "smart_playlist.rules.clause_separator", bundle: .main)
+        XCTAssertTrue(
+            summary.contains(separator),
+            "joined clauses should be separated by the localized clause separator"
+        )
+    }
+
+    // MARK: - Field / operator / mode displayName routing
+
+    /// `.dateAdded` is surfaced to the user as "Last Played" — the honest
+    /// label for a field sourced from `UserData.lastPlayedAt` (Jellyfin's
+    /// `Track` projection has no `DateCreated`). The catalog key encodes that.
+    func testDateFieldDisplayNameRoutesToLastPlayedKey() {
+        XCTAssertEqual(SmartPlaylistField.dateAdded.displayName, "smart_playlist.field.last_played")
+    }
+
+    /// Every field's `displayName` routes through a `smart_playlist.field.*`
+    /// catalog key (raw key returned in the stripped test bundle).
+    func testEveryFieldDisplayNameRoutesThroughCatalog() {
+        for field in SmartPlaylistField.allCases {
+            XCTAssertTrue(
+                field.displayName.hasPrefix("smart_playlist.field."),
+                "\(field) displayName should route through the catalog, got \(field.displayName)"
+            )
+        }
+    }
+
+    /// Every operator's `displayName` routes through a `smart_playlist.op.*`
+    /// key, and every match mode through `smart_playlist.match_mode.*`.
+    func testOperatorAndModeDisplayNamesRouteThroughCatalog() {
+        for op in SmartPlaylistOperator.allCases {
+            XCTAssertTrue(
+                op.displayName.hasPrefix("smart_playlist.op."),
+                "\(op) displayName should route through the catalog, got \(op.displayName)"
+            )
+        }
+        for mode in SmartPlaylistMatchMode.allCases {
+            XCTAssertTrue(
+                mode.displayName.hasPrefix("smart_playlist.match_mode."),
+                "\(mode) displayName should route through the catalog, got \(mode.displayName)"
+            )
+        }
+    }
+
+    // MARK: - Catalog sync
+
+    /// Every `smart_playlist.*` key the views and model reference exists in the
+    /// catalog with an English localization. A missing key would silently
+    /// render as the raw key string in the UI; this turns that into a test
+    /// failure. The list mirrors the literals routed through the catalog in
+    /// `SmartPlaylistDetailView`, `SmartPlaylistBuilderView`, and
+    /// `SmartPlaylist` (field/op/mode displayNames).
+    func testAllReferencedKeysExistInCatalog() throws {
+        let catalog = try loadCatalog()
+        let keys = [
+            // Detail view
+            "smart_playlist.badge",
+            "smart_playlist.edit_rules",
+            "smart_playlist.a11y.play",
+            "smart_playlist.a11y.shuffle",
+            "smart_playlist.a11y.edit_rules",
+            "smart_playlist.filter_placeholder",
+            "smart_playlist.no_filter_match %@",
+            "smart_playlist.empty.title",
+            "smart_playlist.empty.detail %lld",
+            "smart_playlist.not_found",
+            "smart_playlist.rules.matches_all_tracks",
+            "smart_playlist.rules.matches %@ %@",
+            "smart_playlist.rules.clause_separator",
+            // Builder view
+            "smart_playlist.builder.title",
+            "smart_playlist.builder.name_label",
+            "smart_playlist.builder.name_placeholder",
+            "smart_playlist.builder.a11y.name",
+            "smart_playlist.builder.match_prefix",
+            "smart_playlist.builder.match_suffix",
+            "smart_playlist.builder.a11y.match_mode",
+            "smart_playlist.builder.add_rule",
+            "smart_playlist.builder.a11y.add_rule",
+            "smart_playlist.builder.a11y.field",
+            "smart_playlist.builder.a11y.operator",
+            "smart_playlist.builder.a11y.remove_rule",
+            "smart_playlist.builder.value_placeholder",
+            "smart_playlist.builder.a11y.value",
+            "smart_playlist.builder.a11y.value_days",
+            "smart_playlist.builder.bool_yes",
+            "smart_playlist.builder.bool_no",
+            "smart_playlist.builder.days_suffix",
+            "smart_playlist.builder.counting",
+            "smart_playlist.builder.match_count %lld",
+            "smart_playlist.builder.cancel",
+            "smart_playlist.builder.save",
+            "smart_playlist.builder.a11y.save",
+            "smart_playlist.builder.default_name",
+            // Field labels
+            "smart_playlist.field.genre",
+            "smart_playlist.field.artist",
+            "smart_playlist.field.album",
+            "smart_playlist.field.year",
+            "smart_playlist.field.play_count",
+            "smart_playlist.field.favorite",
+            "smart_playlist.field.last_played",
+            // Operator labels
+            "smart_playlist.op.is",
+            "smart_playlist.op.is_not",
+            "smart_playlist.op.contains",
+            "smart_playlist.op.greater_than",
+            "smart_playlist.op.less_than",
+            "smart_playlist.op.in_last",
+            // Match mode labels
+            "smart_playlist.match_mode.all",
+            "smart_playlist.match_mode.any",
+        ]
+        for key in keys {
+            guard let entry = catalog[key] as? [String: Any],
+                  let locs = entry["localizations"] as? [String: Any],
+                  locs["en"] != nil else {
+                XCTFail("Catalog key \(key) is missing or has no `en` localization")
+                continue
+            }
+        }
+    }
+
+    /// The plural-aware footer count key carries `one`/`other` English
+    /// variations that both keep the `%lld` placeholder.
+    func testMatchCountKeyHasPluralVariations() throws {
+        let catalog = try loadCatalog()
+        let key = "smart_playlist.builder.match_count %lld"
+        guard let entry = catalog[key] as? [String: Any],
+              let locs = entry["localizations"] as? [String: Any],
+              let en = locs["en"] as? [String: Any],
+              let variations = en["variations"] as? [String: Any],
+              let plural = variations["plural"] as? [String: Any] else {
+            return XCTFail("\(key) is missing its en plural variations")
+        }
+        let one = stringUnitValue(plural["one"])
+        let other = stringUnitValue(plural["other"])
+        XCTAssertEqual(one?.contains("%lld"), true, "`one` variation lost its %lld placeholder")
+        XCTAssertEqual(other?.contains("%lld"), true, "`other` variation lost its %lld placeholder")
+    }
+
+    // MARK: - Catalog loading helpers (mirrors CountStringsTests)
+
+    private func loadCatalog(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let target = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Resources/Localizable.xcstrings")
+        let data = try Data(contentsOf: target)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let strings = json?["strings"] as? [String: Any] else {
+            XCTFail("Could not parse strings table from \(target.path)", file: file, line: line)
+            return [:]
+        }
+        return strings
+    }
+
+    private func stringUnitValue(_ variation: Any?) -> String? {
+        (variation as? [String: Any])?["stringUnit"]
+            .flatMap { ($0 as? [String: Any])?["value"] as? String }
+    }
+}

--- a/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
@@ -84,6 +84,69 @@ final class SmartPlaylistModelTests: XCTestCase {
         XCTAssertEqual(rule.repaired().value, "1999")
     }
 
+    // MARK: - changingField value normalization
+
+    /// Switching a text rule to a boolean field resets the value to the
+    /// boolean default even though `.is` is legal for both kinds. This is the
+    /// bug `repaired()` alone missed: the operator survives the switch, so the
+    /// operator-only repair left the stale text value (`"Pink Floyd"`) behind,
+    /// the boolean editor displayed "yes", but `booleanMatch` couldn't parse
+    /// it and the playlist silently matched nothing. `changingField` resets on
+    /// a value-kind change so displayed state == stored/evaluated state.
+    func testChangingFieldToBooleanResetsStaleTextValue() {
+        let textRule = SmartPlaylistRule(field: .artist, op: .is, value: "Pink Floyd")
+        let changed = textRule.changingField(to: .isFavorite)
+        XCTAssertEqual(changed.field, .isFavorite)
+        XCTAssertEqual(changed.op, .is, "`.is` is legal for booleans and is the default")
+        XCTAssertEqual(changed.value, "true", "stale text value must be reset to the boolean default")
+        XCTAssertEqual(changed.id, textRule.id, "row identity preserved")
+        // And the reset value is actually parseable — proving the silent
+        // no-match bug is gone.
+        XCTAssertNotNil(SmartPlaylistEvaluator.parseBool(changed.value))
+    }
+
+    /// Switching a boolean rule to a number field resets the value to the
+    /// numeric default (another value-kind change where an operator might
+    /// otherwise survive).
+    func testChangingFieldToNumberResetsValue() {
+        let boolRule = SmartPlaylistRule(field: .isFavorite, op: .is, value: "true")
+        let changed = boolRule.changingField(to: .year)
+        XCTAssertEqual(changed.field, .year)
+        XCTAssertEqual(changed.value, "0", "boolean value reset to numeric default")
+        XCTAssertTrue(SmartPlaylistOperator.applicable(to: .number).contains(changed.op))
+    }
+
+    /// Switching between two fields of the *same* value kind (text → text)
+    /// preserves the user's typed value — only the field changes. Resetting
+    /// here would be needlessly destructive (the value is still meaningful).
+    func testChangingFieldSameKindPreservesValue() {
+        let rule = SmartPlaylistRule(field: .artist, op: .contains, value: "Floyd")
+        let changed = rule.changingField(to: .album)
+        XCTAssertEqual(changed.field, .album)
+        XCTAssertEqual(changed.op, .contains, "operator still legal for text → kept")
+        XCTAssertEqual(changed.value, "Floyd", "same-kind switch keeps the typed value")
+    }
+
+    /// Switching to a field whose kind still matches but whose operator does
+    /// not (number → date keeps numeric-looking value but the operator must
+    /// land on a legal date operator). Here number `.greaterThan` is legal for
+    /// date too, and both are `.number`/`.date`… which differ, so the value is
+    /// reset to the date default.
+    func testChangingFieldNumberToDateResetsToDateDefault() {
+        let numberRule = SmartPlaylistRule(field: .playCount, op: .greaterThan, value: "5")
+        let changed = numberRule.changingField(to: .dateAdded)
+        XCTAssertEqual(changed.field, .dateAdded)
+        XCTAssertEqual(changed.value, "30", "date default day count")
+        XCTAssertTrue(SmartPlaylistOperator.applicable(to: .date).contains(changed.op))
+    }
+
+    /// `changingField(to:)` with the *same* field is equivalent to `repaired()`
+    /// (no field change → just fix an illegal operator, keep the value).
+    func testChangingFieldToSameFieldIsRepair() {
+        let rule = SmartPlaylistRule(field: .year, op: .greaterThan, value: "1999")
+        XCTAssertEqual(rule.changingField(to: .year), rule.repaired())
+    }
+
     // MARK: - Semantic equality
 
     /// Two rules with identical field/op/value compare equal even if their


### PR DESCRIPTION
Fixes the p1/p2 findings from the comment-blind re-audit of the new 2.0 code. Built green: regen + build + 889 Swift tests + 287 core tests + clippy + fmt + rustdoc `-D warnings`.

Downloads (dormant — hardened before any future activation):
- **Path traversal (p1/security):** server-supplied `track.id` is now sanitized to a safe filename stem + a dest-within-dir assertion (write & delete paths).
- **Budget TOCTOU (p1):** a shared async lock serializes budget planning + the size-checked commit; **2-permit concurrency cap** (#819 spec); saturating budget math.
- Stuck optimistic badge on mid-batch auth expiry; per-batch (not per-track) stats refresh.

Smart Playlists:
- **"Date Added" relabeled "Last Played" (p1):** the Track FFI exposes only `lastPlayedAt`, not a created date — honest label rather than promising semantics it can't deliver.
- Evaluator caches the album→genre index (no per-row rebuild); detail view evaluates once; builder live-count debounced off the MainActor; `parseNumber` rejects non-finite; field-change resets stale values; **all new views localized** through the String Catalog.