### PR TITLE
ci: bump MSRV to 1.90 and drop the cargo-audit CVSS-4.0 workaround

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,10 @@ updates:
           - serde_*
     ignore:
       # The 0.22 line of glib-rs (gio, glib, glib-build-tools, glib-macros,
-      # glib-sys, gio-sys, gobject-sys) raises rust-version metadata to 1.92.
-      # Workspace MSRV is 1.86 (intentional pin — Rust 1.92 doesn't exist as
-      # a stable release). Cargo's MSRV-aware resolver rejects every workspace
-      # `cargo` invocation when these are bumped. Held to 0.20 in #751 (#750).
-      # Re-enable when the wider Rust-toolchain bump is on the table.
+      # glib-sys, gio-sys, gobject-sys) raises rust-version metadata to 1.92,
+      # above the workspace MSRV of 1.90. Cargo's MSRV-aware resolver rejects
+      # every workspace `cargo` invocation when these are bumped. Held to 0.20
+      # in #751 (#750). Re-enable when the workspace MSRV reaches >= 1.92.
       - dependency-name: gio
       - dependency-name: glib
       - dependency-name: glib-build-tools
@@ -37,9 +36,6 @@ updates:
       - dependency-name: glib-sys
       - dependency-name: gio-sys
       - dependency-name: gobject-sys
-      # wiremock 0.6.5 introduced unstable `let` expressions that don't
-      # compile under workspace MSRV (Rust 1.86). Held at 0.6.4 in #751.
-      - dependency-name: wiremock
 
   - package-ecosystem: github-actions
     directory: /
@@ -57,8 +53,8 @@ updates:
           - minor
     ignore:
       # dtolnay/rust-toolchain tags follow Rust release versions
-      # (`@1.86` → 1.86 stable). Dependabot can't reason about those —
-      # it tried to bump 1.86 → 1.92 → 1.100, both of which are not
+      # (`@1.90` → 1.90 stable). Dependabot can't reason about those —
+      # it tried to bump the pinned tag to tags like 1.100 that aren't
       # real Rust releases. The MSRV reference must stay pinned to the
       # workspace's `rust-version`, and other call sites use `@stable`,
       # so version bumps on this dependency are always wrong.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,11 @@ jobs:
       - run: cargo doc --workspace --all-features --no-deps
 
   msrv:
-    name: MSRV (Rust 1.86)
+    name: MSRV (Rust 1.90)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.86
+      - uses: dtolnay/rust-toolchain@1.90
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      # rust-toolchain.toml at the repo root pins to 1.86 and overrides the
+      # rust-toolchain.toml at the repo root pins to 1.90 and overrides the
       # action's `targets:` input — the action installs targets for the
       # *requested* (stable) toolchain, not the one rustup actually selects.
       # So we install Windows targets explicitly under the active toolchain.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,29 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # rustsec/audit-check@v2 unconditionally installs the latest cargo-audit,
-      # and the 0.22.x line bumped transitive MSRVs (home 1.88, smol_str 1.89,
-      # time 1.88) past the workspace's pinned rustc 1.86. Pin to the last
-      # 0.21.x release and install with --locked so transitive resolution
-      # respects the published Cargo.lock instead of pulling fresh majors.
+      # cargo-audit 0.22.x parses RustSec's CVSS 4.0 advisory entries (e.g.
+      # RUSTSEC-2026-0073). Its transitive deps need rustc >= 1.89, satisfied
+      # now that the workspace MSRV and the root rust-toolchain.toml pin are
+      # 1.90. --locked keeps transitive resolution on cargo-audit's published
+      # Cargo.lock rather than pulling fresh majors. `cargo audit` fetches and
+      # parses the full advisory-db itself — no manual clone / CVSS-4.0 prune.
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked --version 0.21.2
-      - name: Prefetch advisory-db and prune CVSS 4.0 entries we can't parse
-        # cargo-audit 0.21.x can't parse RustSec's new CVSS 4.0 advisory
-        # entries (e.g. RUSTSEC-2026-0073) — the DB load fails before any
-        # crate-level check runs. 0.22.x supports CVSS 4.0 but bumps
-        # transitive MSRVs (home 1.88, smol_str 1.89, time 1.88) past the
-        # workspace's pinned rustc 1.86. Workaround: clone the DB ourselves
-        # and remove the unparseable files. Each affected advisory is for a
-        # crate not in our dependency tree, so we're not losing coverage.
-        # Revisit when we bump the workspace MSRV past 1.88.
-        run: |
-          mkdir -p ~/.cargo
-          git clone --depth 1 https://github.com/RustSec/advisory-db.git ~/.cargo/advisory-db
-          grep -rl 'cvss = "CVSS:4\.0/' ~/.cargo/advisory-db/crates/ \
-            | xargs -r rm -f
+        run: cargo install cargo-audit --locked
       - name: Run cargo audit
-        run: cargo audit --no-fetch
+        run: cargo audit
 
   deny:
     name: cargo-deny (${{ matrix.checks }})

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,11 +34,13 @@ jobs:
       # cargo-audit 0.22.x parses RustSec's CVSS 4.0 advisory entries (e.g.
       # RUSTSEC-2026-0073). Its transitive deps need rustc >= 1.89, satisfied
       # now that the workspace MSRV and the root rust-toolchain.toml pin are
-      # 1.90. --locked keeps transitive resolution on cargo-audit's published
-      # Cargo.lock rather than pulling fresh majors. `cargo audit` fetches and
-      # parses the full advisory-db itself — no manual clone / CVSS-4.0 prune.
+      # 1.90. Constrain to ^0.22 so CI still picks up 0.22.x patches but a
+      # future 0.23 that raises cargo-audit's own build-MSRV can't silently
+      # break the install; --locked keeps transitive resolution on the
+      # published Cargo.lock. `cargo audit` then fetches and parses the full
+      # advisory-db itself — no manual clone / CVSS-4.0 prune.
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --locked --version "^0.22"
       - name: Run cargo audit
         run: cargo audit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Thanks for your interest. This project is early — shapes and conventions are s
 
 ## Toolchain
 
-- **Rust**: 1.88 or newer.
-  - Floor: `core/` itself compiles on Rust 1.75 (the workspace MSRV), but
-    the Windows port's `uniffi-bindgen-cs` requires 1.88 — so any
-    contributor regenerating bindings (any platform) needs 1.88+ on
-    PATH.
+- **Rust**: 1.90 or newer.
+  - Floor: the workspace MSRV is 1.90 (`rust-version` in `Cargo.toml`,
+    matched by the root `rust-toolchain.toml` pin and the CI MSRV job).
+    The Windows port's `uniffi-bindgen-cs` needs 1.88, which 1.90 already
+    covers — so a single 1.90+ toolchain works for every platform.
   - Workspace pins `uniffi = "0.29"`. Regenerated bindings (Swift
     xcframework, C#) must be produced by a matching bindgen build:
     macOS uses the in-tree `uniffi-bindgen` binary; Windows uses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,12 +396,12 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deadpool"
-version = "0.10.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
  "tokio",
 ]
@@ -442,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1539,7 +1539,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1938,7 +1938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2192,7 +2192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2291,7 +2291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,12 +3194,11 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "async-trait",
  "base64",
  "deadpool",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [workspace.package]
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.90"
 license = "GPL-3.0-only"
 repository = "https://github.com/skalthoff/lyrebird-desktop"
 
@@ -48,13 +48,7 @@ parking_lot = "0.12"
 uniffi = { version = "0.29", features = ["cli"] }
 
 # Testing
-# NOTE: pinned below 0.6.5 — that release uses unstable `let` expressions
-# that fail under workspace MSRV (Rust 1.86):
-#   error[E0658]: `let` expressions in this position are unstable
-#   error: could not compile `wiremock` (lib) due to 2 previous errors
-# 0.6.4 compiles cleanly. Lockstep upgrade with the rest of the dev deps
-# happens when MSRV moves; tracked in #750.
-wiremock = ">=0.6, <0.6.5"
+wiremock = "0.6"
 tempfile = "3"
 insta = { version = "1", features = ["yaml"] }
 

--- a/linux/Cargo.toml
+++ b/linux/Cargo.toml
@@ -33,11 +33,10 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-# NOTE: pinned to 0.20.x to keep workspace MSRV at 1.86. The 0.22.x line
-# of every glib-rs crate (gio, glib, glib-macros, glib-build-tools, etc.)
+# NOTE: pinned to 0.20.x to stay within the workspace MSRV (1.90). The 0.22.x
+# line of every glib-rs crate (gio, glib, glib-macros, glib-build-tools, etc.)
 # raises rust-version metadata to 1.92 — Cargo's MSRV-aware resolver then
-# rejects every workspace `cargo` invocation when the toolchain is 1.86.
-# Bumping back to 0.22 lands together with the wider Rust-toolchain
-# bump tracked in #750.
+# rejects every workspace `cargo` invocation under the 1.90 toolchain.
+# Bumping back to 0.22 needs the workspace MSRV at >= 1.92 (tracked in #750).
 [build-dependencies]
 glib-build-tools = "0.20"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,9 @@
 [toolchain]
-# Pinned to 1.86 to match the MSRV CI job in `.github/workflows/ci.yml`.
-# Anything older breaks `clap v4.6.1` which requires the `edition2024`
-# Cargo feature (stabilized in 1.85). Bump in lockstep with CI's MSRV
-# matrix when it moves.
-channel = "1.86"
+# Pinned to 1.90 to match the MSRV CI job in `.github/workflows/ci.yml`.
+# Floor drivers: `clap v4.6.1` needs the `edition2024` Cargo feature
+# (stabilized 1.85); wiremock >= 0.6.5 needs `let`-chains (stabilized 1.88);
+# cargo-audit 0.22.x's transitive deps (smol_str) need 1.89. Bump in
+# lockstep with CI's MSRV matrix when it moves.
+channel = "1.90"
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
 components = ["rustfmt", "clippy"]

--- a/windows/README.md
+++ b/windows/README.md
@@ -58,16 +58,16 @@ windows/
 - **PowerShell 7+** (`pwsh`). Required by the helper scripts under
   `tools/`. Windows PowerShell 5.1 is missing several cmdlets they rely
   on.
-- **Rust 1.88 or newer** with both MSVC targets installed:
+- **Rust 1.90 or newer** with both MSVC targets installed:
 
   ```pwsh
   rustup target add x86_64-pc-windows-msvc
   rustup target add aarch64-pc-windows-msvc
   ```
 
-  1.88 is the floor required by `uniffi-bindgen-cs` v0.10 (which tracks
-  upstream `uniffi 0.29.x`). The workspace's MSRV is 1.75 for the core
-  itself; the bindgen tool is the binding constraint on Windows.
+  The workspace MSRV is 1.90; `uniffi-bindgen-cs` v0.10 (which tracks
+  upstream `uniffi 0.29.x`) needs 1.88, so the 1.90 toolchain already
+  covers binding regeneration on Windows.
 
 - **uniffi-bindgen-cs**:
 


### PR DESCRIPTION
## Phase 2 of the tech-debt remediation — resolves the #750 MSRV cluster

The workspace MSRV of **1.86** was forcing two workarounds, the more serious of which silently erodes security coverage.

### The security problem
`security.yml` pinned `cargo-audit` to **0.21.2** (0.22.x's transitive deps need rustc ≥ 1.89). But 0.21.x can't parse RustSec's **CVSS 4.0** advisory entries — the DB load fails outright — so the workflow cloned the advisory-db and **deleted every CVSS-4.0 advisory before scanning**:

```bash
grep -rl 'cvss = "CVSS:4\.0/' ~/.cargo/advisory-db/crates/ | xargs -r rm -f
```

The "each affected advisory is for a crate not in our tree" justification is a **manual claim that rots**: the next CVSS-4.0 advisory for a dep we *do* ship gets silently pruned and never reported.

### The fix
Bump MSRV **1.86 → 1.90** (one above the 1.89 floor cargo-audit 0.22.x needs), in lockstep across `Cargo.toml`, the root `rust-toolchain.toml` pin, and the CI MSRV job. Then remove both workarounds the old pin forced:

- **cargo-audit**: unpinned → installs latest (**0.22.2**), parses CVSS 4.0, scans the **full** advisory-db. The prune step is deleted.
- **wiremock**: unpinned `<0.6.5` → **0.6.5** (the let-chains release, stable since 1.88).

### Verification (real 1.90 toolchain, local)
- `cargo test -p lyrebird_core --lib` → **287 passed, 1 ignored, 0 failed**
- `cargo audit` (0.22.2) → loads all **1,120** advisories incl. CVSS 4.0; **337 deps clean, exit 0**
- `cargo-audit` itself builds under 1.90 (validates the CI install step)
- `clippy -D warnings`, `fmt --check`, `cargo check --workspace` (minus the GTK-only linux crate) → all clean

The linux/GTK crate under 1.90 is the one thing only CI can verify (no GTK locally); bumping the compiler *up* from 1.86 is low-risk for it.

### Test plan
- [x] core suite, clippy, fmt, audit verified under Rust 1.90 locally
- [ ] CI MSRV (Rust 1.90) job — full workspace incl. linux crate
- [ ] CI security/audit job — full advisory-db scan
