### PR TITLE
fix(workflow): harden reviewPR accounting + close-PR shell safety

### DIFF
--- a/.claude/workflows/drive-lyrebird-desktop.js
+++ b/.claude/workflows/drive-lyrebird-desktop.js
@@ -416,7 +416,11 @@ async function reviewPR(pr, w) {
 			label: `dispute:#${pr}`,
 		})
 	}
-	return rev || { pr, outcome: 'error', notes: 'reviewer returned null' }
+	if (!rev) return { pr, outcome: 'error', notes: 'reviewer returned null' }
+	// REVIEW_SCHEMA doesn't require `pr`, so the agent's object often omits it.
+	// Always stamp the known pr so downstream accounting (run.merged / run.unresolvedPRs)
+	// never pushes `undefined`.
+	return { ...rev, pr: rev.pr ?? pr }
 }
 
 // Newly-built item: review, then up to refixRounds in-wave retries on request-changes.
@@ -463,7 +467,7 @@ async function resolveOpenPR(pr, w) {
 		review = await reviewPR(pr.number, w)
 	}
 	if (review && review.outcome === 'close') {
-		await agent(`Close PR #${pr.number} as not-mergeable (no-op/duplicate/superseded). Run \`gh pr close ${pr.number} --comment "Closing: superseded or no-op per adversarial review — ${(review.notes || '').replace(/"/g, "'")}"\`. Do not delete the linked issue.`, {
+		await agent(`Close PR #${pr.number} as not-mergeable (no-op / duplicate of already-merged work / superseded). Run exactly: \`gh pr close ${pr.number} --comment "Closing: superseded or no-op per adversarial review; the linked issue stays open to be rebuilt clean."\` Do NOT interpolate any other text into that shell command. Do not delete the linked issue.`, {
 			phase: 'Review',
 			label: `close:#${pr.number}`,
 		})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,20 +356,22 @@ buildCeiling, backlogBatch}})`. Lessons from the first campaign (8 PRs merged:
   on green CI; nothing red merged across the whole campaign. This is the load-
   bearing safety property — rely on it rather than reasoning about each merge.
 
-- **`.wave-start` / `wave-budget.sh` is broken for these runs.** The preflight
-  agent writes `.wave-start` as `key=value` lines; `wave-budget.sh remaining`
-  parses two space-separated ints (`awk '{print $2}'`) → returns 0 → reads as
-  "expired" → `area-fixer` (≤1800s) and `problem-triager` (≤600s) abort. Both
-  workflows now tell downstream agents to **ignore the wave-budget gate** (the
-  JS wave-cap + token budget govern). If you invoke those agents outside these
-  workflows, run `Scripts/wave-budget.sh start 14400` first or tell them to
-  ignore it.
+- **`wave-budget.sh` is a no-op gate under the JS workflows.** `Scripts/wave-budget.sh
+  start` writes two space-separated ints (`<start> <deadline>`) to `.wave-start`, and
+  `remaining` reads `awk '{print $2}'`. The drive/finalize workflows never call `start`,
+  so `.wave-start` is absent → `remaining` returns `0` → reads as "expired" → `area-fixer`
+  (≤1800s) and `problem-triager` (≤600s) would abort. (An earlier preflight step also
+  wrote a `key=value` form `awk` couldn't parse — same zero result.) Either way both
+  workflows now tell downstream agents to **ignore the wave-budget gate** (the JS wave-cap
+  + token budget govern). If you invoke those agents OUTSIDE these workflows, run
+  `Scripts/wave-budget.sh start 14400` first or tell them to ignore it.
 
 - **Background runs die mid-flight** (turn end, user interrupt, multi-hour
   runtime). Recovery is cheap: relaunch `drive` — its wave-1 *resolve-open-PRs*
   phase re-reviews/refixes/merges whatever was left in flight, and it re-reads
-  the live backlog, so nothing is lost. `finalize` also supports
-  `resumeFromRunId` (cached prefix replays instantly, no duplicate issue filing).
+  the live backlog, so nothing is lost. The `Workflow` tool's `resumeFromRunId`
+  also works for any script (drive or finalize) — it replays the cached agent
+  prefix instantly; neither workflow needs special script-level resume support.
 
 - **Builder quality failures to guard:** agents have leaked internal monologue
   into PR titles (e.g. #872 "wait. these aren't matching…") and opened


### PR DESCRIPTION
Addresses the 4 Copilot review comments on #950, which squash-merged before these fixes were pushed.

- **reviewPR accounting** — `reviewPR` now stamps the known `pr` on its return (`{ ...rev, pr: rev.pr ?? pr }`). `REVIEW_SCHEMA` doesn't require `pr`, so the agent often omitted it, and the drain-ceiling path pushed `undefined` into `run.merged`/`run.unresolvedPRs`. (#950 comment 3341674108)
- **close-PR shell safety** — the close-PR agent prompt no longer interpolates reviewer `notes` into the `gh pr close --comment` shell string; it uses a fixed comment, so `$()`/backticks/newlines can't break or inject. (#950 comment 3341674062)
- **docs: wave-budget note** — corrected to the accurate failure mode (the JS workflows never call `wave-budget.sh start`, so `.wave-start` is absent → `remaining` returns 0). (#950 comment 3341674139)
- **docs: finalize resume** — removed the implication that `finalize` has script-level resume; `resumeFromRunId` is a Workflow-tool feature that works for any script. (#950 comment 3341674160)

Docs + workflow-script only; no app code.