### PR TITLE
refactor(macos): extract the last two stray methods from AppModel (selectTab, ambientPalette)

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+ImageURLs.swift
+++ b/macos/Sources/Lyrebird/AppModel+ImageURLs.swift
@@ -75,4 +75,35 @@ extension AppModel {
         }
         return resolved
     }
+
+    /// Resolve the ambient palette for a now-playing item — cache-first, then
+    /// a single off-main Nuke decode + Core Image average (`PaletteSampler`).
+    ///
+    /// Returns `nil` when there's no artwork URL or extraction fails; callers
+    /// (`NowPlayingView`) treat that as "no palette" and `AmbientWash` falls
+    /// back to the theme wash, so the player is never bare. The decode itself
+    /// runs off the MainActor inside `PaletteSampler.sample` (it `await`s
+    /// Nuke's pipeline), so this never blocks the main thread.
+    func ambientPalette(forItemId itemId: String, imageTag: String?) async -> AmbientPalette? {
+        if let encoded = ambientPaletteCache[itemId] {
+            return AmbientPalette(encoded: encoded)
+        }
+        if let existing = ambientPaletteTasks[itemId] {
+            return await existing.value
+        }
+        guard let url = imageURL(for: itemId, tag: imageTag, maxWidth: 512) else {
+            return nil
+        }
+
+        let task = Task<AmbientPalette?, Never> {
+            await PaletteSampler.sample(from: url)
+        }
+        ambientPaletteTasks[itemId] = task
+        let palette = await task.value
+        ambientPaletteTasks[itemId] = nil
+        if let palette {
+            ambientPaletteCache[itemId] = palette.encoded
+        }
+        return palette
+    }
 }

--- a/macos/Sources/Lyrebird/AppModel+Navigation.swift
+++ b/macos/Sources/Lyrebird/AppModel+Navigation.swift
@@ -96,4 +96,12 @@ extension AppModel {
     func goToDiscover() {
         selectTab(.discover)
     }
+
+    /// Switch to a root tab and clear the drill stack. Use this from every
+    /// sidebar / menu tab handler so drill state doesn't survive a tab
+    /// change.
+    func selectTab(_ tab: Screen) {
+        screen = tab
+        navPath = []
+    }
 }

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -65,14 +65,6 @@ final class AppModel {
     /// Playing" menu command and similar reversible drills. See #1 / #4.
     var navPath: [Route] = []
 
-    /// Switch to a root tab and clear the drill stack. Use this from every
-    /// sidebar / menu tab handler so drill state doesn't survive a tab
-    /// change.
-    func selectTab(_ tab: Screen) {
-        screen = tab
-        navPath = []
-    }
-
     /// True when the full Now Playing view is the top of the drill stack.
     /// Used by the ⌘L menu toggle (see `LyrebirdApp.toggleNowPlaying`) so
     /// the second press pops back rather than stacking another copy.
@@ -878,37 +870,6 @@ final class AppModel {
     /// the same id (e.g. a fast tab toggle) coalesce onto one Nuke decode +
     /// CIAreaAverage pass instead of racing two.
     var ambientPaletteTasks: [String: Task<AmbientPalette?, Never>] = [:]
-
-    /// Resolve the ambient palette for a now-playing item — cache-first, then
-    /// a single off-main Nuke decode + Core Image average (`PaletteSampler`).
-    ///
-    /// Returns `nil` when there's no artwork URL or extraction fails; callers
-    /// (`NowPlayingView`) treat that as "no palette" and `AmbientWash` falls
-    /// back to the theme wash, so the player is never bare. The decode itself
-    /// runs off the MainActor inside `PaletteSampler.sample` (it `await`s
-    /// Nuke's pipeline), so this never blocks the main thread.
-    func ambientPalette(forItemId itemId: String, imageTag: String?) async -> AmbientPalette? {
-        if let encoded = ambientPaletteCache[itemId] {
-            return AmbientPalette(encoded: encoded)
-        }
-        if let existing = ambientPaletteTasks[itemId] {
-            return await existing.value
-        }
-        guard let url = imageURL(for: itemId, tag: imageTag, maxWidth: 512) else {
-            return nil
-        }
-
-        let task = Task<AmbientPalette?, Never> {
-            await PaletteSampler.sample(from: url)
-        }
-        ambientPaletteTasks[itemId] = task
-        let palette = await task.value
-        ambientPaletteTasks[itemId] = nil
-        if let palette {
-            ambientPaletteCache[itemId] = palette.encoded
-        }
-        return palette
-    }
 
     // MARK: - Favorite cache
 


### PR DESCRIPTION
## Summary

Follow-up to #981 that extracts the **last two stray methods** from the AppModel
class body, completing the god-object unwrap.

- `selectTab(_:)` → `AppModel+Navigation.swift` — resets `navPath` on a tab change; pure navigation.
- `ambientPalette(forItemId:imageTag:)` → `AppModel+ImageURLs.swift` — its natural home, since it derives the palette from `imageURL(for:tag:maxWidth:)` which already lives there.

The ambient-palette caches (`ambientPaletteCache`, `ambientPaletteTasks`) stay in
AppModel.swift per the `@Observable` contract. **No promotions** — both methods
reference only already-internal members.

After this, the AppModel class body holds only stored `@Observable` state, `init`,
computed projections, and the one-line `requestSidebarToggle` (kept resident — it
mutates a `private(set)` counter, so moving it would weaken that encapsulation for
no benefit). AppModel.swift: **1,390 → 1,351 lines** (the original god-object was 7,106).

## Verification
- Clean rebuild (`rm -rf macos/.build && swift build`): **green**.
- `swift test`: **889 tests pass**, 0 failures.
