### PR TITLE
chore(macos): clean up unwired-UI debt — queue-clear + transcoding-gate fixes, de-stale wiring docs

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Playlists.swift
+++ b/macos/Sources/Lyrebird/AppModel+Playlists.swift
@@ -20,13 +20,14 @@ extension AppModel {
     //
     // Parallels the album actions above. Issue #313.
     //
-    // Playback actions are live now that `playlist_tracks` has landed (#125;
-    // see `loadPlaylistTracks`). Mutation actions (favorite, download,
-    // rename, delete) remain TODO stubs pending follow-up FFI work:
-    // favorites (#133), download engine (#819), `update_playlist` (#130),
-    // `delete_playlist` (#131). The UI is wired up now so that when each
-    // backing endpoint lands the action just needs its stub swapped for a
-    // real call.
+    // Playback (#125, `playlist_tracks`), favorite (#133, `set_favorite` /
+    // `unset_favorite`), rename (`rename_playlist`), delete (#131,
+    // `delete_playlist`), and reorder (`reorder_playlist_track`) are all
+    // live now that their FFI has landed. The two remaining unbacked
+    // actions are the download engine (#819, fully gated behind
+    // `supportsDownloads`) and description persistence — the latter has no
+    // `update_playlist` FFI yet (#130), so `updatePlaylistDescription` only
+    // mutates the in-memory `playlistDescriptions` map.
 
     /// Fetch a playlist's tracks and start playback from the top.
     func play(playlist: Playlist) {
@@ -289,14 +290,19 @@ extension AppModel {
         renamePlaylist(id: playlist.id, newName: newName)
     }
 
-    /// Update the description (Jellyfin `Overview`) for a playlist from the
-    /// hero's click-to-edit description editor (#234). The core `Playlist`
-    /// record doesn't expose `Overview` yet, so the new text lives in the
-    /// in-memory `playlistDescriptions` map keyed by playlist id.
+    /// Update the in-memory description (Jellyfin `Overview`) for a playlist.
+    ///
+    /// Currently UNCALLED: there is no `update_playlist` FFI (#130), so this
+    /// can't persist, and the playlist hero (`PlaylistView`) therefore renders
+    /// the description read-only rather than wiring a click-to-edit editor to
+    /// it. The method only logs and stashes the text in the in-memory
+    /// `playlistDescriptions` map keyed by playlist id; it is held in place
+    /// for when the backing FFI lands. Do not wire it to the UI before then.
     ///
     /// TODO: #130 — switch this to `core.updatePlaylist(playlistId:, overview:)`
-    /// once the FFI lands, and drop `playlistDescriptions` entirely in favour
-    /// of a `description: Option<String>` field on `Playlist` in
+    /// once the FFI lands, then surface a real editor in the hero and drop
+    /// `playlistDescriptions` entirely in favour of a
+    /// `description: Option<String>` field on `Playlist` in
     /// `core/src/models.rs`.
     func updatePlaylistDescription(_ playlist: Playlist, newDescription: String) {
         let trimmed = newDescription.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/macos/Sources/Lyrebird/AppModel+Queue.swift
+++ b/macos/Sources/Lyrebird/AppModel+Queue.swift
@@ -106,28 +106,20 @@ extension AppModel {
     /// dialog so an accidental click can't wipe a long queue. Does not
     /// touch the currently-playing track — only what comes after. See #284.
     ///
-    /// The core queue itself still holds the original list (no primitive
-    /// for truncation yet, tracked as TODO(core-#282)); clearing here means
-    /// the inspector goes empty but the engine can continue auto-advancing
-    /// through the underlying album/playlist. We don't reach into
-    /// `core.setQueue` because truncating on remove would also cancel the
-    /// currently-playing track on most engines.
+    /// After clearing the Swift overlays we truncate the engine queue via
+    /// `core.clearQueue()`, which drops every entry except the currently
+    /// playing track (leaving it as a single-item queue). The current track
+    /// keeps playing while everything queued after it stops auto-advancing,
+    /// matching the confirmation dialog's promise. Mirrors the command
+    /// palette's "Clear Queue" verb (#282).
     func clearQueue() {
         upNextUserAdded.removeAll()
         upNextAutoQueue.removeAll()
-        // Pause playback immediately so no phantom track continues (#567).
-        // AVPlayer still has the current item loaded after the queue arrays
-        // are cleared — pausing is the robust fix since stop() tears down
-        // the player item and would break resumption.
-        //
-        // We intentionally do *not* reach into the core's queue here: the
-        // only primitive available is `set_queue`, which rejects an empty
-        // vec with `InvalidIndex` (see `Player::set_queue` in player.rs).
-        // The earlier `try? core.setQueue(tracks: [], startIndex: 0)` was
-        // a silent no-op and is removed. Core-side queue truncation is
-        // tracked as TODO(core-#282); until then, any auto-advance is
-        // gated by the paused AVPlayer above.
-        audio.pause()
+        // #282: truncate the engine queue to the currently playing track so
+        // playback continues but nothing auto-advances after it. Re-read
+        // status so the inspector reflects the now single-item queue.
+        core.clearQueue()
+        status = core.status()
     }
 
     /// Serialize the current queue (currently-playing + user-added + auto

--- a/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/AlbumContextMenu.swift
@@ -21,8 +21,11 @@ import SwiftUI
 /// album page" qualifier. Defaults to `true` so call sites like the library
 /// grid don't need to think about it.
 ///
-/// Many of the backing actions are TODO stubs pending follow-up FFI work
-/// (see individual `AppModel` methods for issue refs).
+/// All backing actions call through to `AppModel` and are wired: Play /
+/// Shuffle / Play Next / Add to Queue, Start Album Radio (`instantMix`),
+/// Add to Playlist, the Go-to navigation, Favorite, Mark All as Played
+/// (`setPlayed`), and Copy Link. Only Download is gated — it shows solely
+/// when `supportsDownloads` is on.
 struct AlbumContextMenu: View {
     @Environment(AppModel.self) private var model
     let album: Album

--- a/macos/Sources/Lyrebird/Components/ArtistCard.swift
+++ b/macos/Sources/Lyrebird/Components/ArtistCard.swift
@@ -7,9 +7,11 @@ import SwiftUI
 /// `model.navPath` via `Route.artist(artist.id)`.
 ///
 /// Issue: #213 (Library → Artists grid). The overlay play button calls
-/// `AppModel.playAll(artist:)`, which is a logging stub today pending
-/// `artist_tracks` FFI (#156 / #465). The visual affordance matches the
-/// album card so users have a consistent hover model across the grid.
+/// `AppModel.playAll(artist:)`, which is fully wired: it loads the artist's
+/// catalog via `loadTracks(forArtist:)` → `core.tracksByArtist(artistId:offset:limit:)`
+/// off the main actor, then plays the returned tracks (#156). The visual
+/// affordance matches the album card so users have a consistent hover model
+/// across the grid.
 ///
 /// Hover state is lifted to the parent (`LibraryView`) through the
 /// `.libraryHoverID` environment, so a 5k-artist grid doesn't accumulate

--- a/macos/Sources/Lyrebird/Components/ArtistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/ArtistContextMenu.swift
@@ -19,8 +19,11 @@ import SwiftUI
 /// Defaults to `true` so call sites like grid rows don't need to think
 /// about it.
 ///
-/// Many of the backing actions are TODO stubs pending follow-up FFI work
-/// (see individual `AppModel` methods for issue refs).
+/// All backing actions call through to `AppModel` and are wired: Play All /
+/// Shuffle All (`tracksByArtist`), Play Next (`playNext`), Start Artist
+/// Radio (`instantMix`), Favorite (`setFavorite`), Go to Artist Page, and
+/// Copy Link. None are gated behind `supportsDownloads` — this menu has no
+/// download action.
 struct ArtistContextMenu: View {
     @Environment(AppModel.self) private var model
     let artist: Artist

--- a/macos/Sources/Lyrebird/Components/ArtistRadioTile.swift
+++ b/macos/Sources/Lyrebird/Components/ArtistRadioTile.swift
@@ -4,9 +4,10 @@ import SwiftUI
 /// Circular artist tile used on the Home screen to launch an Instant Mix
 /// ("artist radio") seeded by that artist. Art-forward: a round artwork
 /// thumbnail with a "<Artist> Radio" label beneath it. Tapping the tile
-/// calls `AppModel.startArtistRadio(artist:)` — which is a stub today
-/// (#144) but will route through the core once the FFI lands, at which
-/// point no UI change is required.
+/// calls `AppModel.startArtistRadio(artist:)`, which is fully wired: it
+/// routes through `playInstantMix(seedId:)` → `core.instantMix(itemId:limit:)`
+/// off the main actor, plays the returned tracks, and surfaces failures via
+/// `errorMessage`.
 ///
 /// Issue: #254.
 struct ArtistRadioTile: View {

--- a/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
@@ -23,7 +23,9 @@ import SwiftUI
 ///     menu item is disabled to prevent a double-fire.
 ///   - **Delete** opens a `.confirmationDialog` presented by `MainShell`
 ///     via `AppModel.playlistPendingDelete`; on confirm we call through to
-///     `deletePlaylist` which carries the `TODO(core-#131)` stub.
+///     `deletePlaylist`, which optimistically removes the playlist and then
+///     persists the deletion via `core.deletePlaylist`, rolling back and
+///     surfacing `errorMessage` on failure.
 struct PlaylistContextMenu: View {
     @Environment(AppModel.self) private var model
     let playlist: Playlist

--- a/macos/Sources/Lyrebird/Components/PlaylistReorderHandle.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistReorderHandle.swift
@@ -30,9 +30,11 @@ import UniformTypeIdentifiers
 ///     routes both through `AppModel.moveTrackInPlaylist(playlistId:,
 ///     from:, to:)`.
 ///
-/// Persistence happens inside `moveTrackInPlaylist`, which today is a
-/// local-only reorder plus a `TODO(core-#129)` stub. When
-/// `move_playlist_item` lands on the core the modifier needs no change.
+/// Persistence happens inside `moveTrackInPlaylist`, which applies the
+/// reorder to the local cache optimistically and then calls
+/// `core.reorderPlaylistTrack` to persist the new position on the server,
+/// surfacing `errorMessage` on failure. (The move stays local-only only as
+/// a fallback when the moved track lacks a `playlistItemId`.)
 
 /// Identifier used for the `NSItemProvider` payload so drops from anywhere
 /// outside the playlist-reorder affordance can be rejected cleanly.

--- a/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/TrackContextMenu.swift
@@ -26,9 +26,12 @@ import SwiftUI
 /// appears when `playlistScope` is non-nil (invoked from a playlist
 /// detail view).
 ///
-/// Backing actions call through to `AppModel`. Several are TODO stubs
-/// pending FFI work (song radio, track info, download engine,
-/// mark-played). Disabled states follow suit per spec.
+/// Backing actions call through to `AppModel` and are all wired: Play /
+/// Play Next / Add to Queue, Start Song Radio (`instantMix`), Add to
+/// Playlist, the Go-to navigation, Show Track Info (sheet), Favorite,
+/// and Mark as Played (`setPlayed`). Only Download is gated — it shows
+/// solely when `supportsDownloads` is on. Disabled states (multi-select
+/// Song Radio / Copy Link, missing album/artist ids) follow the spec.
 struct TrackContextMenu: View {
     @Environment(AppModel.self) private var model
     /// The selection this menu acts on. Single-track call sites pass

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -17,10 +17,14 @@ import SwiftUI
 ///    artwork / play-count UI is already tuned there; we just render the
 ///    section around it.
 /// 4. **Discography** — split by release type (Albums, Singles & EPs,
-///    Compilations, Live, Appears On). Because the core doesn't surface
-///    `AlbumType` yet, we lean on a name/track-count heuristic; sections
-///    with zero matches collapse silently.
-/// 5. **Similar Artists** — stubbed row (data dependency tracked below).
+///    Compilations, Live). Because the core doesn't surface `AlbumType`
+///    yet, we lean on a name/track-count heuristic; sections with zero
+///    matches collapse silently. ("Appears On" is deferred — no
+///    album-artist-vs-track-artist join in the core; see TODO(core-#60)
+///    on `discographyGroups`.)
+/// 5. **Similar Artists** — backed by `model.loadSimilarArtists` →
+///    `core.similarArtists` (Jellyfin `/Artists/{id}/Similar`); the row
+///    collapses silently when the server returns none.
 /// 6. **About / bio** — biography from the artist `Overview`, HTML-stripped,
 ///    clamped to 4 lines with a keyboard-accessible "Read more" popover.
 ///    Hidden entirely when the artist has no overview.
@@ -392,9 +396,10 @@ struct ArtistDetailView: View {
     // MARK: - Transport (#228)
 
     /// Play / Shuffle / Follow / Radio row. Matches the album detail transport
-    /// so the two detail screens share a transport mental model. Most actions
-    /// delegate to stubs on `AppModel` pending core work — the UI is live, the
-    /// wiring lights up when each FFI lands.
+    /// so the two detail screens share a transport mental model. All actions
+    /// are wired: Play/Shuffle load the catalog via `core.tracksByArtist`,
+    /// Follow toggles `core.setFavorite` / `unsetFavorite`, and Radio seeds
+    /// `core.instantMix`.
     @ViewBuilder
     private func transportBar(_ artist: Artist?) -> some View {
         if let artist = artist {

--- a/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
+++ b/macos/Sources/Lyrebird/Screens/NowPlayingView.swift
@@ -378,9 +378,10 @@ struct NowPlayingView: View {
     /// Lyrics drawer. Delegates all rendering to `LyricsView`, which
     /// handles the LRC parse + auto-scroll + reduce-motion fallback.
     /// While `currentLyrics` is nil (pre-fetch / between tracks) we
-    /// show a minimal loading row; an empty array — the stub state
-    /// until the core lyrics FFI lands — renders the view's empty
-    /// state.
+    /// show a minimal loading row; an empty array — the live no-lyrics
+    /// state `fetchCurrentTrackLyrics()` sets when the `core.lyrics`
+    /// FFI returns no lyrics for the track (or the fetch fails) —
+    /// renders the view's "No Lyrics" empty state.
     @ViewBuilder
     private var lyricsPanel: some View {
         if let lines = model.currentLyrics {

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -11,11 +11,12 @@ import SwiftUI
 /// tracked as follow-ups. For now this view lands:
 ///   - the 2×2 collage hero (falls back to the playlist's own primary
 ///     image, and finally a gradient placeholder, when track art is thin);
-///   - the click-to-edit title (uses `model.renamePlaylist`, which today
-///     is an in-memory stub pending the `update_playlist` FFI — see #130);
+///   - the click-to-edit title (uses `model.renamePlaylist`, which
+///     persists to the server via `core.renamePlaylist` — optimistic
+///     update with rollback + `errorMessage` on failure);
 ///   - the click-to-edit description, backed by
 ///     `model.playlistDescriptions` since the core's `Playlist` record
-///     doesn't yet expose `Overview`;
+///     doesn't yet expose `Overview` — see #130;
 ///   - a minimal ordered tracks list using `TrackRow`, wired to play
 ///     through `model.play(tracks:startIndex:)`.
 struct PlaylistView: View {

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
@@ -62,9 +62,9 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     }
 }
 
-/// Row density. Wired to the UI-only selector here; `LibraryView` / track
-/// lists consume the same `@AppStorage("appearance.density")` value once the
-/// density work in #162 lands.
+/// Row density. Wired end-to-end: `LibraryView` reads the same
+/// `@AppStorage("appearance.density")` value and passes it to `TrackListRow`,
+/// which sizes each row off `trackRowHeight` / `trackArtworkSize`.
 enum AppearanceDensity: String, CaseIterable, Identifiable {
     case roomy, compact
 
@@ -98,8 +98,10 @@ enum AppearanceDensity: String, CaseIterable, Identifiable {
     }
 }
 
-/// Sidebar visibility. UI-only today; the sidebar chrome lives in
-/// `Components/Sidebar.swift` and will read this key when auto-hide lands.
+/// Sidebar visibility. Wired end-to-end: `WindowStateStore` resolves a window's
+/// initial column visibility from this key on first launch, and
+/// `MainShell.applySidebarAutoHide` enables width-driven auto-hide only when
+/// `.autoHide` is selected.
 enum AppearanceSidebar: String, CaseIterable, Identifiable {
     case visible, hidden, autoHide = "auto_hide"
 
@@ -237,7 +239,7 @@ struct AppearancePane: View {
 
             AppearanceSection(
                 title: "Density",
-                hint: "Row heights hook in once #162 lands — selection persists now."
+                hint: "Sets track-list row height — Roomy gives taller rows with larger artwork, Compact tightens them so more tracks fit on screen."
             ) {
                 SegmentedPicker(
                     options: AppearanceDensity.allCases,

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
@@ -14,9 +14,13 @@ import SwiftUI
 ///
 /// Also houses the **Transcoding preference** — a two-option toggle between
 /// Direct Play (the server decides, prefers passthrough) and Always Transcode
-/// (the server re-encodes even when a direct stream would work). This is the
+/// (the server re-encodes even when a direct stream would work), meant as the
 /// escape hatch for users hitting compatibility issues with a specific codec
-/// or container on their output device.
+/// or container on their output device. It's gated behind the same
+/// `model.supportsStreamQualitySelection` flag and shown disabled until the
+/// core threads a `DeviceProfile` into the `PlaybackInfo` request (#117/#260):
+/// no playback path reads `audio.transcodingPreference` today, so honouring it
+/// needs that absent core primitive rather than just persisting the key.
 ///
 /// Preference keys (user-facing `@AppStorage`):
 /// - `playback.streamingQuality`     — `PlaybackQuality`
@@ -187,11 +191,13 @@ struct PreferencesAudio: View {
 
             PreferenceSection(
                 title: "Transcoding",
-                footnote: "Direct Play passes the original file through untouched when your device supports the codec — fastest and highest quality. Always Transcode forces the server to re-encode, which helps when a specific file won't play cleanly."
+                footnote: qualityAvailable
+                    ? "Direct Play passes the original file through untouched when your device supports the codec — fastest and highest quality. Always Transcode forces the server to re-encode, which helps when a specific file won't play cleanly."
+                    : "Transcoding control is planned. It needs the same server-side transcoding support that isn't available in this build yet."
             ) {
                 PreferenceRow(
                     label: "Preference",
-                    help: transcoding.wrappedValue.subtitle
+                    help: qualityAvailable ? transcoding.wrappedValue.subtitle : "Coming soon."
                 ) {
                     Picker("", selection: transcoding) {
                         ForEach(TranscodingPreference.allCases) { option in
@@ -201,9 +207,11 @@ struct PreferencesAudio: View {
                     .labelsHidden()
                     .pickerStyle(.segmented)
                     .frame(width: 260)
+                    .disabled(!qualityAvailable)
                     .accessibilityLabel("Transcoding preference")
                 }
             }
+            .opacity(qualityAvailable ? 1 : 0.55)
 
             Spacer(minLength: 0)
         }

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLibrary.swift
@@ -10,8 +10,9 @@ import SwiftUI
 /// count appears on hover. These write the `LibraryDefaults.*` keys that
 /// `LibraryView`, `Sidebar`, `TrackRow`, and `TrackListRow` read, so a change
 /// here reflects in the list views immediately. The default-library picker is
-/// surfaced but inert until the core grows a `libraries()` FFI — see the row's
-/// footnote and `AppModel.playlistLibraryId`'s note on the same gap.
+/// surfaced but holds a single option because the server currently exposes one
+/// music library; it populates (and becomes selectable) once more than one
+/// exists — see the row's footnote.
 ///
 /// **Sidebar sections.** Toggles for each optional "Your Library" row
 /// (Favorites / Albums / Artists / Playlists). All default on, so the sidebar

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -719,10 +719,11 @@ private struct SearchPageTrackRow: View {
 }
 
 /// Simple row for a genre result. Rendered as a clickable chip-row-ish
-/// surface; routes through `AppModel.browseGenre` which is a logging
-/// stub today until the genre browse FFI lands (#823). The context menu
-/// exposes the full genre actions so pin / radio / shuffle work from
-/// here.
+/// surface; routes through `AppModel.browseGenre`, which resolves the
+/// genre name to its Jellyfin UUID via `core.genres` and navigates to
+/// `GenreDetailView` (backed by `core.itemsByGenre` / `core.tracksByGenre`,
+/// shipped in #823). The context menu exposes the full genre actions so
+/// pin / radio / shuffle work from here.
 private struct GenreResultRow: View {
     @Environment(AppModel.self) private var model
     let name: String


### PR DESCRIPTION
## What

Audited **all 163 Swift files** for UI elements that look live but aren't wired up. The landscape turned out to be overwhelmingly **stale documentation** — comments labeling fully-wired controls as "stubs pending FFI" — plus **two real behavior bugs**. This PR fixes both bugs and corrects the misleading docs.

## Behavior fixes (2)

| Area | Before | After |
|---|---|---|
| **Queue Inspector → Clear** | Called `audio.pause()` and left the engine queue intact (it kept auto-advancing), contradicting the confirmation dialog | Truncates the engine queue via `core.clearQueue()` so the current track keeps playing and nothing auto-advances after it. Mirrors the command-palette "Clear Queue" path |
| **Audio prefs → Transcoding picker** | Fully interactive, but no playback path reads `audio.transcodingPreference` — a silent no-op | Gated behind `supportsStreamQualitySelection` ("Coming soon"), matching its sibling Quality/Codec pickers, until the core threads a `DeviceProfile` into `PlaybackInfo` |

## Documentation corrections (no behavior change)

De-staled comments that falsely described **live, fully-wired** controls as TODO stubs pending FFI:

- Artist radio tiles, artist cards, the artist transport bar, similar-artists row (`core.instantMix` / `core.tracksByArtist` / `core.similarArtists`)
- Track / Album / Artist context menus (all actions wired; only Download is capability-gated)
- Playlist rename / delete / drag-reorder handles (`core.renamePlaylist` / `deletePlaylist` / `reorderPlaylistTrack`)
- The genre browse search row (`core.itemsByGenre`), the lyrics panel (`core.lyrics`)
- Appearance Density/Sidebar enums + the Density hint string, and the audio/library preference rationales

## Verification

- `swift build` — clean
- `swift test` — **889/889 pass**
- Each unit independently adversarially reviewed for correctness + scope

## Deferred (out of scope — need separate decisions)

- **Now Playing menu-bar item** ignores the "Show in menu bar" toggle (no `isInserted:` binding) and double-renders alongside the `MenuBarController` `NSStatusItem`. The clean fix consolidates two competing menu-bar implementations and needs interactive QA — filed separately.
- **`PlaylistDetailView`** (rich remove/undo/drag-reorder/multiselect/drop-to-add screen from the merged #540) is built but never routed — `MainShell` shows the simpler `PlaylistView`. Wire-it-up vs. remove-it is a product call — filed separately.
- `supportsDownloads` stays a deliberate QA hold (full stack is tested but gated pending an interactive download/offline-playback pass).