### PR TITLE
feat(macos): wire Streaming Quality (#260) — bitrate cap threads to the stream URL

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2758,18 +2758,44 @@ impl JellyfinClient {
     /// Advertises all containers AVFoundation / MediaPlayer handle natively,
     /// so Jellyfin direct-streams whenever the source matches. Exotic source
     /// formats fall back to a transcoded MP3 stream.
+    /// Default transcode ceiling for internal stream fetches and for playback
+    /// when the caller doesn't specify one. 320 kbps matches the long-standing
+    /// hardcoded value, so existing call sites stay byte-for-byte unchanged.
+    pub const DEFAULT_MAX_STREAMING_BITRATE: u32 = 320_000;
+
     pub fn stream_url(
         &self,
         track_id: &str,
         media_source_id: Option<&str>,
         play_session_id: Option<&str>,
     ) -> Result<Url> {
+        self.stream_url_with_bitrate(
+            track_id,
+            media_source_id,
+            play_session_id,
+            Some(Self::DEFAULT_MAX_STREAMING_BITRATE),
+        )
+    }
+
+    /// Like `stream_url`, but lets the caller cap the transcode bitrate (#260).
+    /// `Some(kbps)` sets Jellyfin's `MaxStreamingBitrate` ceiling (the server
+    /// transcodes down to fit); `None` omits the parameter to request the
+    /// original with no transcode cap — the "Original" quality tier.
+    pub fn stream_url_with_bitrate(
+        &self,
+        track_id: &str,
+        media_source_id: Option<&str>,
+        play_session_id: Option<&str>,
+        max_streaming_bitrate: Option<u32>,
+    ) -> Result<Url> {
         let mut url = self.endpoint(&format!("Audio/{track_id}/universal"))?;
         {
             let mut q = url.query_pairs_mut();
             q.append_pair("UserId", self.user_id.as_deref().unwrap_or(""));
             q.append_pair("DeviceId", &self.device_id);
-            q.append_pair("MaxStreamingBitrate", "320000");
+            if let Some(bitrate) = max_streaming_bitrate {
+                q.append_pair("MaxStreamingBitrate", &bitrate.to_string());
+            }
             q.append_pair("Container", "mp3,aac,m4a,flac,alac,wav,ogg,opus");
             q.append_pair("AudioCodec", "mp3,aac,flac,alac,pcm,vorbis,opus");
             q.append_pair("TranscodingContainer", "mp3");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -898,17 +898,24 @@ impl LyrebirdCore {
     /// item has multiple audio versions (fixes #593). `play_session_id` should
     /// be the `PlaySessionId` returned by `PlaybackInfo` and is embedded in the
     /// URL so the server can correlate the stream with its transcode job.
+    ///
+    /// `max_streaming_bitrate` caps the transcode bitrate (#260): `Some(kbps)`
+    /// sets Jellyfin's `MaxStreamingBitrate` ceiling; `None` omits it to request
+    /// the original (no transcode cap). Callers that don't expose a quality
+    /// control should pass `Some(320_000)` to preserve the historical default.
     pub fn stream_url(
         &self,
         track_id: String,
         media_source_id: Option<String>,
         play_session_id: Option<String>,
+        max_streaming_bitrate: Option<u32>,
     ) -> std::result::Result<String, LyrebirdError> {
         self.with_client(|c| {
-            Ok(c.stream_url(
+            Ok(c.stream_url_with_bitrate(
                 &track_id,
                 media_source_id.as_deref(),
                 play_session_id.as_deref(),
+                max_streaming_bitrate,
             )?
             .to_string())
         })

--- a/core/src/tests/playback.rs
+++ b/core/src/tests/playback.rs
@@ -747,6 +747,56 @@ fn stream_url_includes_both_media_source_id_and_play_session_id() {
 }
 
 // ---------------------------------------------------------------------------
+// stream_url — quality / MaxStreamingBitrate cap (#260)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stream_url_defaults_to_320kbps_cap() {
+    // The convenience `stream_url` preserves the long-standing 320 kbps ceiling
+    // so existing internal callers are byte-for-byte unchanged.
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client.stream_url("track-abc", None, None).unwrap();
+    assert!(
+        url.as_str().contains("MaxStreamingBitrate=320000"),
+        "default cap should be 320000: {url}"
+    );
+}
+
+#[test]
+fn stream_url_with_bitrate_sets_requested_cap() {
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client
+        .stream_url_with_bitrate("track-abc", None, None, Some(96_000))
+        .unwrap();
+    let s = url.as_str();
+    assert!(
+        s.contains("MaxStreamingBitrate=96000"),
+        "expected the requested 96k cap: {s}"
+    );
+    assert!(s.contains("/Audio/track-abc/universal"), "url: {s}");
+}
+
+#[test]
+fn stream_url_with_bitrate_none_omits_cap_for_original() {
+    // The "Original" tier passes None, which must omit MaxStreamingBitrate so
+    // the server returns the source unbounded rather than capping at a default.
+    let mut client =
+        JellyfinClient::new("https://example.com", "dev".into(), "Dev".into()).unwrap();
+    client.set_session("tok".into(), "u1".into());
+    let url = client
+        .stream_url_with_bitrate("track-abc", None, None, None)
+        .unwrap();
+    assert!(
+        !url.as_str().contains("MaxStreamingBitrate"),
+        "Original (None) must omit the bitrate cap entirely: {url}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Player — play_session_id threading (#569)
 // ---------------------------------------------------------------------------
 

--- a/examples/cli/src/main.rs
+++ b/examples/cli/src/main.rs
@@ -90,7 +90,8 @@ fn main() -> Result<()> {
 
     if let Some(first) = tracks.first() {
         let url = core
-            .stream_url(first.id.clone(), None, None)
+            // 320 kbps cap matches the historical default (#260).
+            .stream_url(first.id.clone(), None, None, Some(320_000))
             .map_err(|e| anyhow!("stream_url: {e}"))?;
         println!("\nStream URL for {}:\n  {}", first.name, url);
     }

--- a/macos/Sources/Lyrebird/AppModel+Playback.swift
+++ b/macos/Sources/Lyrebird/AppModel+Playback.swift
@@ -11,11 +11,29 @@ import LyrebirdAudio
 extension AppModel {
     // MARK: - Playback
 
+    /// The transcode-bitrate ceiling (bits/s) the engine should apply to new
+    /// streams, resolved from the persisted Streaming Quality preference (#260).
+    /// `nil` = uncapped (the Lossless / Original tiers). When the feature is
+    /// gated off, returns the historical 320 kbps default so playback is
+    /// byte-for-byte unchanged. Seeded at audio-config time and refreshed at the
+    /// start of each `play(tracks:)`, so a quality change applies the next time
+    /// playback starts.
+    var resolvedStreamingBitrate: UInt32? {
+        guard supportsStreamingBitrate else { return 320_000 }
+        let raw = UserDefaults.standard.string(forKey: "playback.streamingQuality")
+        let quality = raw.flatMap(PlaybackQuality.init(rawValue:)) ?? .automatic
+        return quality.maxStreamingBitrate
+    }
+
     func play(tracks: [Track], startIndex: Int = 0) {
         // Starting a fresh queue disarms any leftover "Stop after current
         // track" one-shot — "Resets to off the next time you start
         // playback" (#116).
         AppModel.resetStopAfterCurrent()
+        // Refresh the engine's transcode ceiling from the Streaming Quality
+        // preference so a change picked in Settings takes effect on this fresh
+        // playback session (#260).
+        audio.maxStreamingBitrate = resolvedStreamingBitrate
         do {
             _ = try core.setQueue(tracks: tracks, startIndex: UInt32(startIndex))
             guard let first = tracks[safe: startIndex] else { return }

--- a/macos/Sources/Lyrebird/AppModel+Playlists.swift
+++ b/macos/Sources/Lyrebird/AppModel+Playlists.swift
@@ -205,7 +205,9 @@ extension AppModel {
         let urlString: String?
         do {
             urlString = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.streamUrl(trackId: sampleTrackId, mediaSourceId: nil, playSessionId: nil)
+                // Only the api_key query item is read out of this URL, so the
+                // bitrate cap is irrelevant — pass nil (no cap).
+                try core.streamUrl(trackId: sampleTrackId, mediaSourceId: nil, playSessionId: nil, maxStreamingBitrate: nil)
             }.value
         } catch {
             return nil

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -822,6 +822,11 @@ final class AppModel {
         // stays false, so `AudioEngine.play` never queries the core for a local
         // path and the streaming path is byte-for-byte unchanged.
         self.audio.offlinePlaybackEnabled = supportsDownloads
+        // Streaming quality (#260): seed the engine's transcode ceiling from the
+        // persisted Streaming Quality preference so the first track honours it
+        // without waiting for a `play(tracks:)`. Defaults to 320 kbps when the
+        // feature is gated off, leaving the streaming path unchanged.
+        self.audio.maxStreamingBitrate = resolvedStreamingBitrate
     }
 
     /// Internal guard for `attemptRestoreSession` — the restore pass should

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -53,14 +53,19 @@ extension AppModel {
     /// pattern.
     var supportsGenreActions: Bool { true }
 
-    /// Streaming / download quality + preferred-codec selection (#260).
-    /// Gates the quality and codec pickers in the Audio pane. These need
-    /// the core to thread `MaxStreamingBitrate` + a `DeviceProfile`
-    /// (audio codec / container) into the Jellyfin `PlaybackInfo`
-    /// request; `core/src/client.rs` has no such parameter yet, so the
-    /// pickers would write a preference nothing reads. Disabled until the
-    /// core FFI lands rather than presenting controls that don't affect
-    /// playback.
+    /// Streaming **bitrate** selection (#260). Gates the Audio pane's Streaming
+    /// Quality picker only. Wired end-to-end: `PlaybackQuality.maxStreamingBitrate`
+    /// feeds `AudioEngine.maxStreamingBitrate`, which threads through the
+    /// `core.streamUrl(..., maxStreamingBitrate:)` FFI onto Jellyfin's
+    /// `MaxStreamingBitrate` ceiling. Enabled; kept as a kill-switch.
+    var supportsStreamingBitrate: Bool { true }
+
+    /// Download-quality + preferred-codec + transcoding selection (#260). Gates
+    /// those Audio-pane pickers, which still have no backing path: download
+    /// quality rides the (gated) downloads engine, and codec/transcoding need
+    /// the core to thread a `DeviceProfile` (or a transcode-aware stream URL)
+    /// into the request — `streamUrl` only caps bitrate today. Stays disabled
+    /// until that lands, rather than persisting a preference nothing reads.
     var supportsStreamQualitySelection: Bool { false }
 
     /// Crossfade between tracks (#116). Gates the crossfade slider in the

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAudio.swift
@@ -88,12 +88,16 @@ struct PreferencesAudio: View {
         !outputDeviceUID.isEmpty && !devices.contains { $0.uid == outputDeviceUID }
     }
 
-    /// Whether the quality / codec pickers are wired into playback. Gated on
-    /// the capability flag (#260) — the core has no `MaxStreamingBitrate` /
-    /// `DeviceProfile` parameter on its `PlaybackInfo` request yet, so until it
-    /// does the pickers are shown disabled rather than persisting a preference
-    /// nothing reads.
+    /// Whether the download-quality / codec / transcoding pickers are wired.
+    /// Gated on `supportsStreamQualitySelection` (#260) — those still need a
+    /// `DeviceProfile` (or transcode-aware stream URL) the core doesn't thread
+    /// yet, so they're shown disabled rather than persisting a dead preference.
     private var qualityAvailable: Bool { model.supportsStreamQualitySelection }
+
+    /// Whether the Streaming Quality (bitrate) picker is wired. This one IS
+    /// live (#260): the chosen tier's `maxStreamingBitrate` flows through
+    /// `AudioEngine` into the `core.streamUrl(maxStreamingBitrate:)` cap.
+    private var bitrateAvailable: Bool { model.supportsStreamingBitrate }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -137,20 +141,20 @@ struct PreferencesAudio: View {
 
             PreferenceSection(
                 title: "Streaming Quality",
-                footnote: qualityAvailable
-                    ? "Applied when playing over the network. Higher tiers use more bandwidth; Lossless and Original require your server (and your connection) to sustain them."
-                    : "Quality and codec selection is planned. It needs server-side transcoding support that isn't available in this build yet."
+                footnote: bitrateAvailable
+                    ? "Applied when playing over the network. Higher tiers use more bandwidth; Lossless and Original ask the server for the source uncapped, so they require it (and your connection) to sustain them. Takes effect on the next track."
+                    : "Streaming quality selection is planned but not available in this build yet."
             ) {
                 PreferenceRow(
                     label: "Quality",
-                    help: qualityAvailable ? streamingQuality.subtitle : "Coming soon."
+                    help: bitrateAvailable ? streamingQuality.subtitle : "Coming soon."
                 ) {
                     AudioQualityPicker(selection: $streamingQuality)
-                        .disabled(!qualityAvailable)
+                        .disabled(!bitrateAvailable)
                         .accessibilityLabel("Streaming quality")
                 }
             }
-            .opacity(qualityAvailable ? 1 : 0.55)
+            .opacity(bitrateAvailable ? 1 : 0.55)
 
             PreferenceSection(
                 title: "Download Quality",

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -249,6 +249,20 @@ enum PlaybackQuality: String, CaseIterable, Identifiable {
         case .original: return "Direct stream — no transcoding"
         }
     }
+
+    /// The Jellyfin `MaxStreamingBitrate` ceiling (bits/s) this tier maps to
+    /// when building a stream URL (#260). `nil` means "no cap" — the lossless
+    /// and original tiers ask the server for the source without a transcode
+    /// ceiling. `automatic` keeps the historical 320 kbps default so existing
+    /// users see no change. The bitrate tiers mirror `subtitle`.
+    var maxStreamingBitrate: UInt32? {
+        switch self {
+        case .low: return 96_000
+        case .normal: return 192_000
+        case .high, .automatic: return 320_000
+        case .lossless, .original: return nil
+        }
+    }
 }
 
 /// ReplayGain-style loudness normalization. `off` applies no correction,

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -226,6 +226,14 @@ public final class AudioEngine: NSObject {
     /// pre-#819 behaviour. The offline branch is purely additive.
     public var offlinePlaybackEnabled: Bool = false
 
+    /// Transcode bitrate ceiling (bits/s) applied when building stream URLs,
+    /// from the user's Streaming Quality preference (#260). `nil` requests the
+    /// source uncapped (the "Original"/"Lossless" tiers). Defaults to 320 kbps —
+    /// the historical hardcoded value — so the streaming path is unchanged until
+    /// the app sets a different tier. `AppModel` refreshes this from the
+    /// persisted preference at each playback start.
+    public var maxStreamingBitrate: UInt32? = 320_000
+
     public init(core: LyrebirdCore) {
         self.core = core
         super.init()
@@ -580,7 +588,8 @@ public final class AudioEngine: NSObject {
             let urlString = try core.streamUrl(
                 trackId: track.id,
                 mediaSourceId: mediaSourceId,
-                playSessionId: playSessionId
+                playSessionId: playSessionId,
+                maxStreamingBitrate: maxStreamingBitrate
             )
             guard let streamURL = URL(string: urlString) else {
                 throw AudioEngineError.invalidURL(urlString)
@@ -798,6 +807,9 @@ public final class AudioEngine: NSObject {
         // task never queries the download FFI — gapless preload is byte-for-byte
         // the streaming path (#819).
         let offlineEnabled = offlinePlaybackEnabled
+        // Capture the transcode ceiling on the actor too, so the detached
+        // preload builds the same stream URL `play(track:)` would (#260).
+        let bitrateCap = maxStreamingBitrate
         // `[weak self]` so an engine torn down mid-resolve (track change,
         // stop) doesn't get pinned alive for the duration of the network FFI —
         // matches `applyReplayGain`. The network work below only touches the
@@ -820,7 +832,8 @@ public final class AudioEngine: NSObject {
                     let urlString = try core.streamUrl(
                         trackId: track.id,
                         mediaSourceId: mediaSourceId,
-                        playSessionId: playSessionId
+                        playSessionId: playSessionId,
+                        maxStreamingBitrate: bitrateCap
                     )
                     let authHeader = try core.authHeader()
                     guard let streamURL = URL(string: urlString) else {

--- a/macos/Tests/LyrebirdTests/AudioQualityPreferencesTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioQualityPreferencesTests.swift
@@ -83,4 +83,24 @@ final class AudioQualityPreferencesTests: XCTestCase {
             "the streaming default must be one of the picker's segments"
         )
     }
+
+    /// The Streaming Quality picker feeds `MaxStreamingBitrate` (#260). Pin the
+    /// tier → bitrate mapping so a regression that silently changes the cap (or
+    /// drops the uncapped Lossless/Original semantics) is caught. `automatic`
+    /// must stay 320 kbps — the historical default that keeps playback unchanged
+    /// for users who never touch the picker.
+    func testQualityMaxStreamingBitrateMapping() {
+        XCTAssertEqual(PlaybackQuality.low.maxStreamingBitrate, 96_000)
+        XCTAssertEqual(PlaybackQuality.normal.maxStreamingBitrate, 192_000)
+        XCTAssertEqual(PlaybackQuality.high.maxStreamingBitrate, 320_000)
+        XCTAssertEqual(PlaybackQuality.automatic.maxStreamingBitrate, 320_000)
+        XCTAssertNil(
+            PlaybackQuality.lossless.maxStreamingBitrate,
+            "Lossless must be uncapped so the server sends the lossless source"
+        )
+        XCTAssertNil(
+            PlaybackQuality.original.maxStreamingBitrate,
+            "Original must omit the cap so the server returns the source untouched"
+        )
+    }
 }

--- a/macos/Tests/LyrebirdTests/CapabilityGatedControlsTests.swift
+++ b/macos/Tests/LyrebirdTests/CapabilityGatedControlsTests.swift
@@ -51,6 +51,30 @@ final class CapabilityGatedControlsTests: XCTestCase {
         XCTAssertEqual(Theme.currentPreset, .purple, "legacy/unknown theme falls back to purple")
     }
 
+    /// Streaming bitrate selection is wired (#260): the Streaming Quality picker
+    /// is live and `resolvedStreamingBitrate` maps the persisted tier to the
+    /// stream-URL `MaxStreamingBitrate` cap. Codec / transcoding / download
+    /// quality stay gated behind `supportsStreamQualitySelection`.
+    func testStreamingBitrateWired() throws {
+        let model = try AppModel()
+        XCTAssertTrue(model.supportsStreamingBitrate, "Streaming Quality picker should be live")
+        XCTAssertFalse(model.supportsStreamQualitySelection, "codec/transcoding/download-quality stay gated")
+
+        let key = "playback.streamingQuality"
+        let defaults = UserDefaults.standard
+        let original = defaults.string(forKey: key)
+        defer {
+            if let original { defaults.set(original, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        defaults.set(PlaybackQuality.low.rawValue, forKey: key)
+        XCTAssertEqual(model.resolvedStreamingBitrate, 96_000, "Low tier caps at 96 kbps")
+        defaults.set(PlaybackQuality.original.rawValue, forKey: key)
+        XCTAssertNil(model.resolvedStreamingBitrate, "Original resolves to an uncapped stream")
+        defaults.removeObject(forKey: key)
+        XCTAssertEqual(model.resolvedStreamingBitrate, 320_000, "default (automatic) keeps the historical cap")
+    }
+
     /// Language selection stays gated off until in-app localization (#345) is
     /// wired — nothing reads `general.language` back to re-render the UI, so the
     /// General Language picker is hidden rather than shown as an inert control.


### PR DESCRIPTION
## What

The Audio ▸ **Streaming Quality** picker (Auto / Low / Normal / High / Lossless / Original) persisted a `PlaybackQuality` but **nothing read it** — `stream_url` hardcoded `MaxStreamingBitrate=320000`. This threads the chosen tier's bitrate through to the stream URL so the picker actually caps network quality.

## Core (Rust)

- `client.stream_url` gains a bitrate-aware sibling `stream_url_with_bitrate`: `Some(kbps)` sets `MaxStreamingBitrate`, `None` omits it (Original/Lossless = uncapped). `stream_url` keeps delegating at the 320 kbps default, so the two internal callers (`stream_bytes`, `download_to_file`) and all existing tests are byte-for-byte unchanged.
- The `stream_url` **FFI** gains a `max_streaming_bitrate: Option<u32>` parameter.

## Swift

- `PlaybackQuality.maxStreamingBitrate` maps each tier — Low 96 / Normal 192 / High & Auto 320 kbps; Lossless & Original uncapped.
- `AudioEngine.maxStreamingBitrate` (default 320 kbps) threads into **both** stream-URL builds (playback + gapless preload; captured on-actor for the detached preload).
- `AppModel.resolvedStreamingBitrate` reads the persisted tier, seeds the engine at audio-config, and refreshes it at each `play(tracks:)`, so a change applies on the next playback session.
- New **`supportsStreamingBitrate`** flag gates **only** the Streaming Quality picker. Download-quality / codec / transcoding stay gated behind `supportsStreamQualitySelection` — they still need a `DeviceProfile` (or transcode-aware URL) the core doesn't thread yet.

## Safety — zero regression

`Automatic` (the default for everyone who never touches the picker) resolves to **320 kbps — byte-identical to the old hardcoded URL**, so only a non-default pick changes anything.

## Verification

- **3 new Rust URL tests**: 96k cap present, 320k default, `None` omits the param (Original).
- **891 Swift tests** green (incl. the tier→bitrate mapping + the flag/resolver test).
- **Live server** (`music.skalthoff.com`): a 320 kbps cap streamed ~40% more data than a 96 kbps cap over the same window — the server honors the parameter.

> ⚠️ FFI change: `lyrebird_core.swift` + the xcframework are gitignored and **regenerate in CI**. Verified locally with `build-core.sh`.

Part of the "complete stubbed-but-unconnected features" drive (after Theme #986).