### PR TITLE
chore(macos): de-stale coming-soon copy for shipped Theme + playlist-create

### DIFF
--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -818,13 +818,13 @@
       }
     },
     "login.placeholder.not_wired" : {
-      "comment" : "Placeholder banner when a menu action hasn't been wired to the core yet.",
+      "comment" : "Placeholder banner when a menu action is temporarily unavailable.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Creating playlists isn't wired yet \u2014 see #131."
+            "value" : "This action is not available yet."
           }
         }
       }

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesAppearance.swift
@@ -191,17 +191,16 @@ struct AppearancePane: View {
         )
     }
 
-    /// Theme-section helper text. While theme selection is gated off
-    /// (`!supportsThemeSelection`) the picker is a disabled preview, so the copy
-    /// says so plainly rather than implying the swatch is actionable. Once the
-    /// theme engine (#405) lands and the picker is live, the copy steers users
-    /// who have asked the system to convey meaning without relying on colour
-    /// alone (System Settings → Accessibility → Display → "Differentiate without
-    /// color") toward the Ocean preset, whose primary/accent pair stays
-    /// distinguishable for every colour-blind type.
+    /// Theme-section helper text. Steers users who have asked the system to
+    /// convey meaning without relying on colour alone (System Settings →
+    /// Accessibility → Display → "Differentiate without color") toward the
+    /// Ocean preset, whose primary/accent pair stays distinguishable for every
+    /// colour-blind type. If the kill-switch (`supportsThemeSelection`) is ever
+    /// toggled off, the fallback copy explains the picker is temporarily
+    /// disabled rather than implying the swatches are inert by design.
     private var themeHint: String {
         guard model.supportsThemeSelection else {
-            return "Theme colours are coming soon — the picker previews the palettes; the rest of the app still uses the Purple theme for now."
+            return "Theme selection is temporarily disabled — the picker previews the palettes but picks are not applied yet."
         }
         if ThemePreset.suggestedForAccessibility() == .ocean,
            (AppearanceTheme(rawValue: themeRaw) ?? .purple) != .ocean {
@@ -311,12 +310,11 @@ private struct AppearanceSection<Content: View>: View {
 /// Horizontal row of colored swatches. The active swatch draws a ring in
 /// `Theme.accent` and inks the label.
 ///
-/// When `isEnabled` is false the row is a disabled "coming soon" preview: the
-/// swatches still show the palettes (and the ring marks the persisted choice),
-/// but taps are inert and the row dims, so the picker never masquerades as a
-/// working selector while the theme engine (#405) that would consume the
-/// selection is still unwired. Once `isEnabled` flips true, tapping a swatch
-/// updates the binding.
+/// When `isEnabled` is false the row is a disabled preview: the swatches
+/// still show the palettes (and the ring marks the persisted choice), but taps
+/// are inert and the row dims. `supportsThemeSelection` acts as a kill-switch
+/// and is currently `true`; if it is ever toggled off, this disabled state
+/// prevents the picker from masquerading as a working selector.
 private struct ThemePicker: View {
     @Binding var selection: AppearanceTheme
     var isEnabled: Bool = true
@@ -338,11 +336,11 @@ private struct ThemePicker: View {
         // Surface the disabled state to assistive tech so VoiceOver announces
         // the picker as unavailable rather than reading the swatches as
         // tappable selectors.
-        .accessibilityValue(isEnabled ? "" : "Coming soon")
+        .accessibilityValue(isEnabled ? "" : "Temporarily disabled")
     }
 
     private var comingSoonBadge: some View {
-        Text("SOON")
+        Text("OFF")
             .font(Theme.font(9, weight: .bold))
             .tracking(1)
             .foregroundStyle(Theme.ink3)


### PR DESCRIPTION
Theme selection shipped in commit 2e896c5 (#986) but several hint strings in the Appearance pane and one Localizable.xcstrings key still described the picker as a \"coming soon\" preview.

**Strings changed:**
- `PreferencesAppearance.swift` — `themeHint` dead-branch text: was `"Theme colours are coming soon …"`, now `"Theme selection is temporarily disabled …"` (accurate kill-switch language)
- `PreferencesAppearance.swift` — `ThemePicker.accessibilityValue`: was `"Coming soon"`, now `"Temporarily disabled"`
- `PreferencesAppearance.swift` — `ThemePicker.comingSoonBadge` badge label: was `"SOON"`, now `"OFF"`
- `Localizable.xcstrings` key `login.placeholder.not_wired`: was `"Creating playlists isn't wired yet — see #131."` (unused key, #131 closed), now `"This action is not available yet."`

**Intentionally left unchanged (features still genuinely gated):**
- `PreferencesAudio.swift` — Download quality / codec / transcoding `"Coming soon."` (gated on `supportsStreamQualitySelection == false`)
- `PreferencesScrobbling.swift` — Last.fm `"Coming soon."` (Last.fm not wired)
- `PreferencesPlayback.swift` — Crossfade `"Coming soon."` (gated on `supportsCrossfade == false`)
- `HomeView.swift:245` — developer comment about radio personalization signals (#133/#229), not user-visible

pipeline:
  fixer-session: wf_aa93d738-25a-7
  slice: slice:components
  hotspots-claimed: []
  build-gate: pass
  diff-stat: 2 files changed, +17/-19