### PR TITLE
feat(macos): drag track rows to Finder as .m3u stream reference

### DIFF
--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -136,6 +136,14 @@ struct TrackListRow: View {
                 }
             }
             .contextMenu { TrackContextMenu(selection: [track]) }
+            // Drag to Finder: materialises a `.m3u` file when the user drops
+            // the row onto Finder or any M3U-accepting app (#14). Mirrors the
+            // same modifier on `TrackRow`.
+            .draggable(TrackM3UDrag(
+                tracks: [track],
+                serverURL: model.serverURL,
+                core: model.core
+            ))
             // A single row should read as one VoiceOver element — the wrapping
             // Button already carries a label, but we override it here to pull
             // in the active state so playing rows announce "Now playing" and

--- a/macos/Sources/Lyrebird/Components/TrackM3UDrag.swift
+++ b/macos/Sources/Lyrebird/Components/TrackM3UDrag.swift
@@ -1,0 +1,122 @@
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+@preconcurrency import LyrebirdCore
+
+/// A drag-source that materialises a `.m3u` playlist file when the user drops
+/// one or more track rows onto Finder (or any other app that accepts file
+/// drops).
+///
+/// **How it works.** SwiftUI's `Transferable + FileRepresentation` pattern is
+/// the recommended replacement for `NSFilePromiseProvider` on macOS 13+: the
+/// exporter closure is called once the user completes the drop, on a background
+/// thread, so the file can be written asynchronously without blocking the drag
+/// gesture. The receiving app gets a real `.m3u` file in a system temp
+/// directory — not a phantom promise — so VLC / IINA / Music all open it
+/// directly.
+///
+/// **Stream URL credential.** Each M3U entry embeds the Jellyfin `api_key` so
+/// the file is playable in an external player without further authentication
+/// (a bare `/universal` path 401s for generic HTTP players — see
+/// `PlaylistExport.streamURL`). The key is extracted from `core.streamUrl` on
+/// a background thread inside the exporter closure so it never touches the
+/// MainActor. When extraction fails the file falls back to auth-free URLs
+/// (valid, but will prompt for credentials in the player).
+///
+/// **File name.** Single-track drags use "<Artist> - <Title>.m3u"; multi-track
+/// drags use "Selection (<N> tracks).m3u".
+struct TrackM3UDrag: Transferable {
+    /// The ordered tracks to include in the exported file.
+    let tracks: [Track]
+    /// The server base URL (no trailing slash), e.g. `https://music.example.com`.
+    let serverURL: String
+    /// The LyrebirdCore instance, captured by reference so the exporter can
+    /// call `core.streamUrl` off the MainActor inside the `FileRepresentation`
+    /// exporter closure. `LyrebirdCore` is a reference-counted FFI object and
+    /// is safe to hold across concurrency domains.
+    let core: LyrebirdCore
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .m3uPlaylist) { drag in
+            // Resolve the api_key from the first track's stream URL.  Runs on
+            // a background thread (the FileRepresentation exporter is always
+            // called off the main actor) so it is safe to cross the UniFFI
+            // boundary here.
+            let apiKey: String? = drag.resolveApiKey()
+
+            let content = PlaylistExport.m3u8(
+                playlistName: drag.suggestedName,
+                tracks: drag.tracks,
+                serverURL: drag.serverURL,
+                apiKey: apiKey
+            )
+
+            let tempDir = FileManager.default.temporaryDirectory
+            let filename = drag.safeFilename
+            let tempURL = tempDir.appendingPathComponent(filename)
+            try content.write(to: tempURL, atomically: true, encoding: .utf8)
+            return SentTransferredFile(tempURL)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// A human-readable name for the exported file, free of characters that
+    /// are illegal in macOS filenames (`/`, `:`, NUL).
+    var safeFilename: String {
+        sanitize(suggestedName) + ".m3u"
+    }
+
+    /// The logical name for the selection — used in the M3U `#PLAYLIST:`
+    /// header and as the base of the filename.
+    var suggestedName: String {
+        if tracks.count == 1, let t = tracks.first {
+            return PlaylistExport.displayTitle(for: t)
+        }
+        return "Selection (\(tracks.count) tracks)"
+    }
+
+    /// Extract the `api_key` query parameter from a `core.streamUrl` call on
+    /// the first track. Returns `nil` on any failure, in which case the caller
+    /// emits auth-free (prompt-on-play) stream URLs.
+    ///
+    /// Called from the `FileRepresentation` exporter closure which runs on a
+    /// background thread — safe to cross the UniFFI boundary directly.
+    private func resolveApiKey() -> String? {
+        guard let first = tracks.first else { return nil }
+        guard let urlString = try? core.streamUrl(
+            trackId: first.id,
+            mediaSourceId: nil,
+            playSessionId: nil,
+            maxStreamingBitrate: nil
+        ) else { return nil }
+        guard let components = URLComponents(string: urlString),
+              let key = components.queryItems?.first(where: { $0.name == "api_key" })?.value,
+              !key.isEmpty
+        else { return nil }
+        return key
+    }
+
+    /// Replace characters that are illegal or problematic in macOS filenames
+    /// with a safe substitute so the temp file can always be created.
+    private func sanitize(_ name: String) -> String {
+        name
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - UTType extension
+
+extension UTType {
+    /// The M3U playlist UTI (`public.m3u-playlist`). Registered by macOS as the
+    /// canonical type for `.m3u` and `.m3u8` files. Declared here so the UTI
+    /// name is centralised and can't be misspelled at the call site.
+    static var m3uPlaylist: UTType {
+        // Prefer the well-known system type when available; fall back to a
+        // declared type so we don't accidentally use a different UTI.
+        UTType(filenameExtension: "m3u") ?? UTType(importedAs: "public.m3u-playlist")
+    }
+}

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -162,6 +162,17 @@ struct TrackRow: View {
         .onHover { isHovering = $0 }
         .onTapGesture(count: 1) { onPlay?() }
         .contextMenu { TrackContextMenu(selection: [track], playlistScope: playlistScope) }
+        // Drag to Finder: materialises a `.m3u` file referencing the Jellyfin
+        // stream URL so the user can drop the row onto VLC/Finder and play it
+        // outside the app (#14). `TrackM3UDrag` is a `Transferable` whose
+        // `FileRepresentation` exporter resolves the api_key and writes the
+        // temp file asynchronously once the user completes the drop — the drag
+        // gesture itself is instantaneous.
+        .draggable(TrackM3UDrag(
+            tracks: [track],
+            serverURL: model.serverURL,
+            core: model.core
+        ))
         // VoiceOver reads the row as a single "<title> by <artist>" line
         // with the button trait + hint so the double-tap play action is
         // discoverable without sighted hover affordances. See #331.


### PR DESCRIPTION
Dragging any track row onto Finder or a media player (VLC, IINA, Music.app) materialises a playable `.m3u` file containing the Jellyfin stream URL with embedded `api_key`, so the track plays in an external app without further authentication.

Closes #14

## Implementation

- **`Components/TrackM3UDrag.swift`** — new `Transferable` struct using SwiftUI's `FileRepresentation(exportedContentType: .m3uPlaylist)`. The exporter closure runs off the MainActor (deferred to drop time), resolves the `api_key` via `core.streamUrl`, then writes a temp `.m3u` using the existing `PlaylistExport.m3u8` + `PlaylistExport.streamURL` infrastructure.
- **`Components/TrackRow.swift`** — `.draggable(TrackM3UDrag(...))` on the disc-grouped AlbumDetailView row.
- **`Components/TrackListRow.swift`** — same modifier on the Library Tracks row.

Single-track drag → `"<Artist> - <Title>.m3u"`. Multi-track drag → `"Selection (<N> tracks).m3u"`. Falls back to auth-free URLs if the api_key can't be resolved.

No core/FFI changes — no xcframework regen needed.

---

pipeline:
- builder-session: wf_aa93d738-25a-19
- slice: components
- hotspot: none
- build-gate: pass (`swift build` — Build complete)
- diff-stat: 3 files changed, 141 insertions(+)