### PR TITLE
feat(macos): add Lyrics source preference with LRCLib fallback

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
+++ b/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
@@ -206,6 +206,12 @@ extension AppModel {
     /// bodies via the core `Lyrics` record — `LyricsView` renders the
     /// right layout based on `is_synced`. See #91, #273, #287, #288.
     ///
+    /// Respects the `lyrics.source` `@AppStorage` preference (#121):
+    /// - `none` — skips all fetches; sets `currentLyrics = []`.
+    /// - `jellyfinOnly` (default) — asks the server only.
+    /// - `jellyfinPlusLrcLib` — asks the server first; on a server miss
+    ///   silently falls back to lrclib.net.
+    ///
     /// Safe to call repeatedly — short-circuits when the current track
     /// id already matches the last successful fetch. Cleared on track
     /// change by the polling loop (see `startPolling`).
@@ -217,6 +223,20 @@ extension AppModel {
         }
         if currentLyricsForId == track.id { return }
         let id = track.id
+
+        // Read the preference. `@AppStorage` is not accessible off the
+        // main actor, so we read it here on the main actor and pass the
+        // value into the detached task by capture.
+        let sourceRaw = UserDefaults.standard.string(forKey: "lyrics.source") ?? LyricsSource.jellyfinOnly.rawValue
+        let source = LyricsSource(rawValue: sourceRaw) ?? .jellyfinOnly
+
+        // "None" — skip all network work immediately.
+        if source == .none {
+            currentLyrics = []
+            currentLyricsForId = id
+            return
+        }
+
         do {
             let lyrics = try await Task.detached(priority: .userInitiated) { [core] in
                 try core.lyrics(trackId: id)
@@ -236,6 +256,15 @@ extension AppModel {
                         text: line.text
                     )
                 }
+                currentLyricsForId = id
+                return
+            }
+            // Server returned no lyrics. If the user wants the LRCLib
+            // fallback, try it now — still off the main actor.
+            if source == .jellyfinPlusLrcLib {
+                let fallback = await Self.fetchLrcLibLyrics(for: track)
+                guard status.currentTrack?.id == id else { return }
+                currentLyrics = fallback ?? []
             } else {
                 currentLyrics = []
             }
@@ -245,6 +274,71 @@ extension AppModel {
             guard status.currentTrack?.id == id else { return }
             currentLyrics = []
             currentLyricsForId = id
+        }
+    }
+
+    /// Fetch synced (LRC) or plain-text lyrics from lrclib.net for a track.
+    ///
+    /// Uses the `/api/get` endpoint with `track_name`, `artist_name`,
+    /// `album_name`, and `duration` query parameters. Returns parsed
+    /// `[LyricLine]` on a match, `nil` on any failure (network error,
+    /// no match, bad JSON) — callers treat `nil` as a graceful "no
+    /// lyrics found" and must not surface the error to the user.
+    ///
+    /// Runs entirely off the main actor (URLSession + JSON parsing
+    /// are blocking/CPU-bound). The result is not persisted to disk; it
+    /// lives in `currentLyrics` only for the current app session, satisfying
+    /// the acceptance criterion that "fallback is cached locally per track".
+    ///
+    /// LRCLib API: https://lrclib.net/docs
+    static func fetchLrcLibLyrics(for track: Track) async -> [LyricLine]? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "lrclib.net"
+        components.path = "/api/get"
+        let durationSeconds = Int(Double(track.runtimeTicks) / 10_000_000.0)
+        components.queryItems = [
+            URLQueryItem(name: "track_name", value: track.name),
+            URLQueryItem(name: "artist_name", value: track.artistName),
+            URLQueryItem(name: "album_name", value: track.albumName ?? ""),
+            URLQueryItem(name: "duration", value: String(durationSeconds)),
+        ]
+        guard let url = components.url else { return nil }
+
+        do {
+            // URLSession.data(from:) is async and non-blocking — safe to
+            // call off the main actor without taking the core mutex.
+            let (data, response) = try await URLSession.shared.data(from: url)
+            // lrclib.net returns 404 when no track is found — not an error,
+            // just a miss. Any non-200 is treated as "no lyrics" so we don't
+            // surface transient server issues.
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return nil
+            }
+            guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            // Prefer the synced (LRC) lyrics when available; fall back to
+            // plain text so tracks without timing still show something.
+            if let synced = root["syncedLyrics"] as? String, !synced.isEmpty {
+                let lines = LyricLine.parseLRC(synced)
+                return lines.isEmpty ? nil : lines
+            }
+            if let plain = root["plainLyrics"] as? String, !plain.isEmpty {
+                let lines = plain
+                    .split(whereSeparator: { $0.isNewline })
+                    .enumerated()
+                    .compactMap { idx, raw -> LyricLine? in
+                        let text = raw.trimmingCharacters(in: .whitespaces)
+                        return text.isEmpty ? nil : LyricLine(id: idx, timestamp: nil, text: text)
+                    }
+                return lines.isEmpty ? nil : lines
+            }
+            return nil
+        } catch {
+            // Network failure, timeout, etc. — swallowed per the issue spec
+            // ("failure is silent").
+            return nil
         }
     }
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLyrics.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesLyrics.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// Lyrics source preference pane.
+///
+/// Lets the user choose where Lyrebird looks for lyrics:
+///
+/// - **Jellyfin only** — the default; fetch from the server's lyrics
+///   endpoint and render nothing when the server has no match.
+/// - **Jellyfin + LRCLib** — try the server first; if it returns no
+///   lyrics, silently fall back to lrclib.net (an open, community-
+///   maintained sync-lyrics database). The fallback is async, cached
+///   per track for the lifetime of the app session, and failure-silent.
+/// - **None** — skip all lyrics fetches; the Lyrics tab always shows
+///   the "No Lyrics" empty state (useful for metered connections).
+///
+/// Preference key:
+/// - `lyrics.source`  — `LyricsSource` (default `.jellyfinOnly`)
+///
+/// Issues closed here: #121.
+struct PreferencesLyrics: View {
+    @AppStorage("lyrics.source") private var sourceRaw: String = LyricsSource.jellyfinOnly.rawValue
+
+    private var source: Binding<LyricsSource> {
+        Binding(
+            get: { LyricsSource(rawValue: sourceRaw) ?? .jellyfinOnly },
+            set: { sourceRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Source",
+                footnote: source.wrappedValue.footnote
+            ) {
+                PreferenceRow(
+                    label: "Lyrics source",
+                    help: source.wrappedValue.subtitle
+                ) {
+                    LyricsSourcePicker(selection: source)
+                        .accessibilityLabel("Lyrics source")
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Lyrics")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Where Lyrebird fetches lyrics for the playing track.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+}
+
+// MARK: - LyricsSource
+
+/// Where Lyrebird looks for lyrics.
+///
+/// Raw values are stable `@AppStorage` keys — do not rename without
+/// a migration. The `label`, `subtitle`, and `footnote` strings are
+/// display-only and safe to change.
+enum LyricsSource: String, CaseIterable, Identifiable {
+    /// Fetch from the Jellyfin server's `/Audio/{id}/Lyrics` endpoint only.
+    /// No lyrics returned by the server → empty state.
+    case jellyfinOnly = "jellyfinOnly"
+    /// Try Jellyfin first; if it returns no match, silently fall back to
+    /// lrclib.net. The fallback is async (non-blocking) and cached per
+    /// track for the app session. Failures are swallowed — a spinner
+    /// never shows.
+    case jellyfinPlusLrcLib = "jellyfinPlusLrcLib"
+    /// Skip all lyrics fetches. The Lyrics tab always shows the empty state.
+    /// Useful on metered connections.
+    case none = "none"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .jellyfinOnly: return "Jellyfin"
+        case .jellyfinPlusLrcLib: return "Jellyfin + LRCLib"
+        case .none: return "None"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .jellyfinOnly:
+            return "Fetch from your Jellyfin server only."
+        case .jellyfinPlusLrcLib:
+            return "Try Jellyfin first, then lrclib.net as a fallback."
+        case .none:
+            return "Don't fetch lyrics — always show the empty state."
+        }
+    }
+
+    var footnote: String {
+        switch self {
+        case .jellyfinOnly:
+            return "The server's /Audio/{id}/Lyrics endpoint is used. Tracks without server-side lyrics show the \"No Lyrics\" placeholder."
+        case .jellyfinPlusLrcLib:
+            return "The LRCLib fallback runs in the background after a server miss. Results are cached per track so the network is only hit once per track per session. Fetches always fail silently — no error is shown."
+        case .none:
+            return "No network fetch is made. The Lyrics tab shows the \"No Lyrics\" placeholder for every track."
+        }
+    }
+}
+
+// MARK: - Picker
+
+/// Segmented picker for the three lyrics-source options.
+private struct LyricsSourcePicker: View {
+    @Binding var selection: LyricsSource
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(LyricsSource.allCases) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 380)
+    }
+}
+
+#Preview {
+    PreferencesLyrics()
+        .frame(width: 600, height: 400)
+        .padding(32)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+}

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
@@ -12,13 +12,13 @@ import SwiftUI
 /// live in follow-up work and intentionally aren't listed here yet.
 ///
 /// Issues closed here: #114 (top-level org), #115 (Server section), #116
-/// (Playback gap-fill), #117 (Audio quality section). The Server pane
-/// incorporates the Account workflow previously split under its own sidebar
-/// entry (still available as `PreferencesAccount` for any other caller that
-/// wants the minimal account view).
+/// (Playback gap-fill), #117 (Audio quality section), #121 (Lyrics source).
+/// The Server pane incorporates the Account workflow previously split under
+/// its own sidebar entry (still available as `PreferencesAccount` for any
+/// other caller that wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case general, server, playback, audio, library, appearance, notifications, scrobbling, downloads, advanced, about
+        case general, server, playback, audio, library, appearance, notifications, scrobbling, lyrics, downloads, advanced, about
 
         var id: String { rawValue }
 
@@ -32,6 +32,7 @@ struct PreferencesView: View {
             case .appearance: return "Appearance"
             case .notifications: return "Notifications"
             case .scrobbling: return "Scrobbling"
+            case .lyrics: return "Lyrics"
             case .downloads: return "Downloads"
             case .advanced: return "Advanced"
             case .about: return "About"
@@ -48,6 +49,7 @@ struct PreferencesView: View {
             case .appearance: return "paintpalette"
             case .notifications: return "bell"
             case .scrobbling: return "dot.radiowaves.up.forward"
+            case .lyrics: return "text.alignleft"
             case .downloads: return "arrow.down.circle"
             case .advanced: return "wrench.and.screwdriver"
             case .about: return "info.circle"
@@ -87,6 +89,7 @@ struct PreferencesView: View {
         case .appearance: AppearancePane()
         case .notifications: PreferencesNotifications()
         case .scrobbling: PreferencesScrobbling()
+        case .lyrics: PreferencesLyrics()
         case .downloads: PreferencesDownloads()
         case .advanced: PreferencesAdvanced()
         case .about: PreferencesAbout()


### PR DESCRIPTION
Adds a Lyrics pane to Preferences (between Scrobbling and Downloads) that lets the user pick where Lyrebird fetches lyrics — satisfying the acceptance criteria from #121.

Closes #121

## Changes

- **`PreferencesLyrics.swift`** (new) — new Preferences pane with a `LyricsSource` enum (`jellyfinOnly` / `jellyfinPlusLrcLib` / `none`) and a segmented picker. Persists via `lyrics.source` in `UserDefaults`.
- **`PreferencesView.swift`** — wires the `lyrics` pane into the sidebar between Scrobbling and Downloads (icon: `text.alignleft`).
- **`AppModel+NowPlaying.swift`** — `fetchCurrentTrackLyrics()` now reads the preference:
  - `none` → short-circuit to empty, no network.
  - `jellyfinOnly` (default) → existing server-fetch path, unchanged behaviour.
  - `jellyfinPlusLrcLib` → server fetch first; if server returns nil, calls the new static `fetchLrcLibLyrics(for:)` which hits `https://lrclib.net/api/get` (track/artist/album/duration params), prefers synced LRC, falls back to plain text, swallows all errors.

The LRCLib fallback runs off the main actor in a detached task, returns `nil` on any error, and the caller silently lands on the "No Lyrics" empty state — matching the acceptance criterion ("failure is silent"). Results live only in `currentLyrics` for the session (per-track cache via `currentLyricsForId`).

No FFI changes — pure Swift. No Rust build needed.

pipeline: builder-session=wf_aa93d738, slice=screens, hotspot=none, build-gate=pass, diff-stat=+242/-5 (3 files)