### PR TITLE
feat(macos): add Suggested section to Search empty state

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Search.swift
+++ b/macos/Sources/Lyrebird/AppModel+Search.swift
@@ -354,4 +354,39 @@ extension AppModel {
         return s
 
     }
+
+    // MARK: - Suggested searches (#87)
+
+    /// Up to 5 artists surfaced in the Search page's "Suggested" section.
+    ///
+    /// Picks artists with the lowest play count (preferring `userData.playCount
+    /// == 0`, i.e. never played) so the suggestions encourage exploration of
+    /// neglected corners of the library. Falls back to any 5 artists when the
+    /// whole library is uniformly played. The result is seeded by the current
+    /// calendar day (UTC) so suggestions rotate daily without requiring a server
+    /// round-trip — stable within a session, fresh the next morning.
+    ///
+    /// Uses the in-memory `artists` snapshot so no FFI call is needed on the
+    /// search page hot-path. If the library hasn't loaded yet (empty array),
+    /// returns an empty list and the suggestions section hides itself.
+    var suggestedSearchArtists: [Artist] {
+        guard !artists.isEmpty else { return [] }
+        // Derive a stable daily seed from today's UTC date so the set
+        // rotates overnight but stays consistent within one session.
+        let today = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        let daySeed = UInt64((today.year ?? 0) * 10000 + (today.month ?? 0) * 100 + (today.day ?? 0))
+        // Prefer artists that have never been played; fall through to all
+        // artists so the section still renders in fully-played libraries.
+        let unplayed = artists.filter { ($0.userData?.playCount ?? 0) == 0 }
+        let pool = unplayed.isEmpty ? artists : unplayed
+        // Deterministic daily shuffle via a seeded LCG over the pool indices.
+        // Each element is paired with a pseudo-random key, sorted by key, then
+        // stripped — a Fisher-Yates-equivalent that is pure and allocation-light.
+        var state = daySeed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        let shuffled: [Artist] = pool.map { artist -> (UInt64, Artist) in
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return (state, artist)
+        }.sorted { $0.0 < $1.0 }.map(\.1)
+        return Array(shuffled.prefix(5))
+    }
 }

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -223,16 +223,21 @@ struct SearchView: View {
         .padding(.vertical, 48)
     }
 
-    // MARK: - Recent searches (#246)
+    // MARK: - Recent searches (#246) + Suggested (#87)
 
     /// Empty-query panel: a "Recent searches" list capped at 10 items
-    /// with per-row clear × and a footer "Clear history" button.
-    /// Persisted in `UserDefaults` under `recentSearches` as JSON.
+    /// with per-row clear × and a footer "Clear history" button, followed
+    /// by the "Suggested" exploration panel (lightly-played artists, genre
+    /// tiles, and decade tiles). Persisted in `UserDefaults` as JSON.
     @ViewBuilder
     private var recentSearches: some View {
         let items = AppModel.decodeRecentSearches(recentSearchesJSON)
         VStack(alignment: .leading, spacing: 28) {
             recentSearchesList(items)
+            SuggestedSearchesSection { term in
+                model.searchPageQuery = term
+                commitQuery(term)
+            }
             BrowseByGenreSection()
         }
     }
@@ -634,6 +639,121 @@ private struct SectionView: View {
             Spacer()
         }
         .padding(.top, 4)
+    }
+}
+
+// MARK: - Suggested searches (#87)
+
+/// The "Suggested" section shown beneath "Recent Searches" when the search
+/// field is empty. Surfaces up to 5 lightly-played (never or rarely played)
+/// artists so the user can discover neglected corners of their library — the
+/// artists rotate daily via a seeded shuffle in `AppModel.suggestedSearchArtists`.
+///
+/// Hidden entirely when the artist library hasn't loaded yet (empty model), so
+/// a cold-launch first paint is never cluttered with placeholder rows.
+///
+/// Each row taps into the parent's `onSelect` closure which prefills the
+/// search field and commits the query — the same flow as a recent-search tap.
+private struct SuggestedSearchesSection: View {
+    @Environment(AppModel.self) private var model
+    /// Called with the artist name when the user taps a suggestion row.
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        let artists = model.suggestedSearchArtists
+        if !artists.isEmpty {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 8) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Theme.accent)
+                    Text("Suggested")
+                        .font(Theme.font(18, weight: .bold))
+                        .foregroundStyle(Theme.ink)
+                }
+                .padding(.top, 4)
+
+                VStack(spacing: 2) {
+                    ForEach(artists, id: \.id) { artist in
+                        SuggestedArtistRow(artist: artist) {
+                            onSelect(artist.name)
+                        }
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Suggested searches")
+        }
+    }
+}
+
+/// One row in the "Suggested" section. Renders the artist name with a
+/// "sparkle" icon in place of the recents clock, and a chevron to hint that
+/// tapping runs a search. Hovering highlights the row like a recent-search row.
+private struct SuggestedArtistRow: View {
+    @Environment(AppModel.self) private var model
+    let artist: Artist
+    let onTap: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Small circular artwork fallback — matches the Home Artists
+            // carousel aesthetic at a compact size.
+            Artwork(
+                url: model.imageURL(for: artist.id, tag: artist.imageTag, maxWidth: 60),
+                seed: artist.name,
+                size: 32,
+                radius: 16,
+                targetPixelSize: CGSize(width: 96, height: 96)
+            )
+            .frame(width: 32, height: 32)
+            .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(artist.name)
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(1)
+                Text(artistSubtitle)
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "arrow.up.left")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .opacity(isHovering ? 1 : 0.4)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovering ? Theme.rowHover : .clear)
+        )
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture { onTap() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Search for \(artist.name)")
+        .accessibilityHint("Never played — \(artist.albumCount) album\(artist.albumCount == 1 ? "" : "s")")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Short descriptor shown below the artist name. Prefers "Never played"
+    /// when play count is 0 or missing; falls back to a "N album(s)" count
+    /// for artists in the played fallback pool.
+    private var artistSubtitle: String {
+        let playCount = artist.userData?.playCount ?? 0
+        if playCount == 0 {
+            let n = artist.albumCount
+            return "Never played · \(n) album\(n == 1 ? "" : "s")"
+        }
+        return "\(artist.albumCount) album\(artist.albumCount == 1 ? "" : "s")"
     }
 }
 

--- a/macos/Tests/LyrebirdTests/SearchPagePaginationTests.swift
+++ b/macos/Tests/LyrebirdTests/SearchPagePaginationTests.swift
@@ -185,4 +185,85 @@ final class SearchPagePaginationTests: XCTestCase {
         XCTAssertEqual(model.searchPageLoaded, 0)
         XCTAssertFalse(model.searchPageExhausted, "exhaustion resets on a fresh (empty) query")
     }
+
+    // MARK: - suggestedSearchArtists (#87)
+
+    func testSuggestedSearchArtistsEmptyWhenNoArtistsLoaded() throws {
+        let model = try AppModel()
+        // artists defaults to [] — suggestions must be empty so the view
+        // can hide the section without any additional guard.
+        XCTAssertTrue(model.artists.isEmpty)
+        XCTAssertTrue(
+            model.suggestedSearchArtists.isEmpty,
+            "no artists loaded → empty suggestions, not a crash"
+        )
+    }
+
+    func testSuggestedSearchArtistsCappedAtFive() throws {
+        let model = try AppModel()
+        // Populate 10 never-played artists — the property must return at most 5.
+        model.artists = (0..<10).map { i in
+            makeArtist(id: "a\(i)", name: "Artist \(i)")
+        }
+        let suggestions = model.suggestedSearchArtists
+        XCTAssertEqual(suggestions.count, 5, "suggestions are always capped at 5")
+    }
+
+    func testSuggestedSearchArtistsPrefersUnplayed() throws {
+        let model = try AppModel()
+        // Mix of played and unplayed artists. The property must select only
+        // from the unplayed pool when any unplayed artists exist.
+        let playedUserData = UserItemData(
+            isFavorite: false, played: true, playCount: 3,
+            playbackPositionTicks: 0, lastPlayedAt: nil, likes: nil, rating: nil
+        )
+        let playedArtists: [Artist] = (0..<8).map { i in
+            Artist(
+                id: "played-\(i)", name: "Played \(i)", albumCount: 2,
+                songCount: 10, genres: [], imageTag: nil, userData: playedUserData
+            )
+        }
+        let unplayedArtists: [Artist] = (0..<3).map { i in
+            makeArtist(id: "unplayed-\(i)", name: "Unplayed \(i)")
+        }
+        model.artists = playedArtists + unplayedArtists
+
+        let suggestions = model.suggestedSearchArtists
+        // All returned artists must be from the unplayed pool.
+        let suggestedIds = Set(suggestions.map(\.id))
+        let unplayedIds = Set(unplayedArtists.map(\.id))
+        XCTAssertTrue(
+            suggestedIds.isSubset(of: unplayedIds),
+            "suggestions must come exclusively from the unplayed pool when one exists"
+        )
+        XCTAssertEqual(suggestions.count, 3, "pool smaller than cap → all 3 returned")
+    }
+
+    func testSuggestedSearchArtistsFallsBackToAllWhenAllPlayed() throws {
+        let model = try AppModel()
+        // Every artist has been played — suggestions must still return up to 5
+        // rather than an empty list.
+        let playedUserData = UserItemData(
+            isFavorite: false, played: true, playCount: 1,
+            playbackPositionTicks: 0, lastPlayedAt: nil, likes: nil, rating: nil
+        )
+        model.artists = (0..<7).map { i in
+            Artist(
+                id: "p\(i)", name: "Played \(i)", albumCount: 1,
+                songCount: 4, genres: [], imageTag: nil, userData: playedUserData
+            )
+        }
+        let suggestions = model.suggestedSearchArtists
+        XCTAssertEqual(suggestions.count, 5, "falls back to full pool when all artists are played")
+    }
+
+    func testSuggestedSearchArtistsDailyStabilityIsIdempotent() throws {
+        let model = try AppModel()
+        model.artists = (0..<20).map { i in makeArtist(id: "a\(i)", name: "Artist \(i)") }
+        // Calling the property twice within the same process (same day) must
+        // return identical results — no RNG call that isn't seeded by the date.
+        let first = model.suggestedSearchArtists.map(\.id)
+        let second = model.suggestedSearchArtists.map(\.id)
+        XCTAssertEqual(first, second, "seeded daily shuffle must be stable within a session")
+    }
 }


### PR DESCRIPTION
Adds the "Suggested" exploration panel to the Search page's empty-query state, directly below the "Recent Searches" list. Closes #87

## What changed

- `AppModel+Search.swift` — new `suggestedSearchArtists` computed property: picks up to 5 artists with `userData.playCount == 0` (never played) from the in-memory cache, shuffled with a daily LCG seed so the list rotates overnight without a server round-trip. Falls back to any 5 artists when the whole library is played.
- `SearchView.swift` — new `SuggestedSearchesSection` + `SuggestedArtistRow` private structs inserted between the recents list and `BrowseByGenreSection`. Tapping a row prefills the search field and commits the query (same code-path as a recent-search tap). Section is hidden entirely until the artist library loads.
- `SearchPagePaginationTests.swift` — 5 new test cases covering: empty-library guard, 5-item cap, unplayed-pool preference, full-played fallback, and daily-seed idempotency.

No FFI changes; no hotspot files touched.

pipeline:
  builder-session: wf_aa93d738-25a-16
  slice: screens
  hotspot: none
  build-gate: pass (swift build + swift test 894/894 pass, 5 new)
  diff-stat: +239 / -3 across 3 files