### PR TITLE
feat(macos): Home section customization — reorder, show/hide, reset

### DIFF
--- a/macos/Sources/Lyrebird/Components/HomeSectionLayout.swift
+++ b/macos/Sources/Lyrebird/Components/HomeSectionLayout.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// The catalog of customizable Home shelves and the pure ordering / visibility
+/// logic behind "Customize Home" (#56).
+///
+/// Home customization is deliberately **client-only**, mirroring the
+/// `PlaylistSidebarOrder` pattern (#317): the user's chosen order and the set
+/// of hidden shelves are persisted as two `@AppStorage` strings, and the Home
+/// view *renders its sections by sorting this catalog* on every paint. That
+/// makes the feature impossible to desync — the stored layout is just a view
+/// preference layered over whatever shelves the app ships.
+///
+/// The hard parts are all set-reconciliation, not UI:
+///   * the shipped catalog drifts between app versions (a release adds a new
+///     shelf), so the stored order must be reconciled against the current
+///     `HomeSection.allCases` on every read — unknown sections append in
+///     their declared order, retired ids prune;
+///   * the hidden set must likewise drop ids that no longer exist;
+///   * a `.onMove` from SwiftUI hands the sheet an `IndexSet` + destination
+///     against the *displayed* (already-sorted) order, folded back into a
+///     fresh id list to persist.
+///
+/// All of this is expressed as side-effect-free functions over CSV strings (the
+/// `@AppStorage` values) so the contract is unit-testable without booting a
+/// SwiftUI scene or touching `UserDefaults`.
+
+// MARK: - Catalog
+
+/// A customizable Home shelf. The raw value is the **stable persistence key** —
+/// never rename one without a migration, since it's written into the user's
+/// stored layout. Declaration order here *is* the default Home order, matching
+/// `HomeView.body`'s shipped stack.
+///
+/// Only shelves backed by real data sources today are listed. Speculative
+/// shelves from the issue's catalog (For [Decade], Top [Genre], Unplayed Gems,
+/// High-Rated, Most-Played This Year) join this enum when their loaders land —
+/// reconciliation makes them appear at the bottom of an existing user's layout
+/// automatically.
+enum HomeSection: String, CaseIterable, Identifiable, Codable {
+    case recentlyPlayed
+    case artistsYouLove
+    case recentlyDiscoveredArtists
+    case jumpBackIn
+    case recentTracks
+    case yourPlaylists
+    case recentlyAdded
+    case rediscover
+    case quickPicks
+    case suggestions
+    case favorites
+    case pinnedStations
+    case artistRadio
+
+    var id: String { rawValue }
+
+    /// Human-facing title shown in the Customize Home list. Kept in sync with
+    /// the section header titles in `HomeView` so the sheet reads like the page.
+    var title: String {
+        switch self {
+        case .recentlyPlayed: return "Recently Played"
+        case .artistsYouLove: return "Artists You Love"
+        case .recentlyDiscoveredArtists: return "Recently Discovered Artists"
+        case .jumpBackIn: return "Jump Back In"
+        case .recentTracks: return "Recent Tracks"
+        case .yourPlaylists: return "Your Playlists"
+        case .recentlyAdded: return "Recently Added"
+        case .rediscover: return "Rediscover"
+        case .quickPicks: return "Quick Picks"
+        case .suggestions: return "You Might Like"
+        case .favorites: return "Favorites"
+        case .pinnedStations: return "Pinned Stations"
+        case .artistRadio: return "Artist Radio"
+        }
+    }
+
+    /// SF Symbol mirrored from each shelf's header icon, so the sheet row and
+    /// the live shelf share a glyph.
+    var systemImage: String {
+        switch self {
+        case .recentlyPlayed: return "clock"
+        case .artistsYouLove: return "heart.circle.fill"
+        case .recentlyDiscoveredArtists: return "person.crop.circle.badge.plus"
+        case .jumpBackIn: return "arrow.uturn.backward"
+        case .recentTracks: return "clock.arrow.circlepath"
+        case .yourPlaylists: return "music.note.list"
+        case .recentlyAdded: return "sparkle"
+        case .rediscover: return "binoculars.fill"
+        case .quickPicks: return "flame.fill"
+        case .suggestions: return "wand.and.sparkles"
+        case .favorites: return "heart.fill"
+        case .pinnedStations: return "pin.fill"
+        case .artistRadio: return "dot.radiowaves.left.and.right"
+        }
+    }
+
+    /// The default order: the catalog's declaration order. Used as the reset
+    /// target and as the reconciliation tail for unknown stored ids.
+    static var defaultOrder: [HomeSection] { allCases }
+}
+
+// MARK: - Layout codec + reconciliation
+
+/// Pure ordering + visibility logic for the customizable Home stack (#56).
+/// Stateless; the view owns the two `@AppStorage` CSV strings and feeds them
+/// through here.
+enum HomeSectionLayout {
+
+    // MARK: CSV codec
+
+    /// Decode a stored `@AppStorage` CSV into a section list, dropping unknown
+    /// raw values (a retired shelf id from a newer→older downgrade) and blank
+    /// entries (a stray comma or a freshly-initialised `""`). Section raw values
+    /// are bare identifiers and never contain commas, so a plain split is
+    /// unambiguous.
+    static func decode(_ raw: String) -> [HomeSection] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .compactMap { HomeSection(rawValue: $0) }
+    }
+
+    /// Encode a section list back into the `@AppStorage` CSV value.
+    static func encode(_ sections: [HomeSection]) -> String {
+        sections.map(\.rawValue).joined(separator: ",")
+    }
+
+    /// Decode a stored hidden-set CSV into a `Set<HomeSection>`. Same tolerance
+    /// for unknown / blank entries as `decode`.
+    static func decodeHidden(_ raw: String) -> Set<HomeSection> {
+        Set(decode(raw))
+    }
+
+    /// Encode a hidden set back into a CSV. Emitted in catalog order so the
+    /// stored string is stable across writes (set iteration order isn't).
+    static func encodeHidden(_ hidden: Set<HomeSection>) -> String {
+        encode(HomeSection.allCases.filter { hidden.contains($0) })
+    }
+
+    // MARK: Reconciliation
+
+    /// Reconcile a stored order against the shipped catalog
+    /// (`HomeSection.allCases`):
+    ///   * sections in both keep their stored relative order;
+    ///   * sections shipped but not stored (a new shelf in this app version)
+    ///     append in catalog order, so an upgrade lands new shelves at the
+    ///     bottom of the user's arrangement rather than reshuffling it;
+    ///   * stored ids no longer shipped are pruned;
+    ///   * the result is a duplicate-free permutation of the catalog, so
+    ///     sorting by it is total.
+    static func reconciled(stored: [HomeSection]) -> [HomeSection] {
+        let catalog = HomeSection.allCases
+        let catalogSet = Set(catalog)
+        var seen = Set<HomeSection>()
+        var result: [HomeSection] = []
+        for section in stored where catalogSet.contains(section) && seen.insert(section).inserted {
+            result.append(section)
+        }
+        for section in catalog where seen.insert(section).inserted {
+            result.append(section)
+        }
+        return result
+    }
+
+    /// The fully-resolved order to render: the stored CSV reconciled against the
+    /// live catalog. An empty / corrupt stored value yields the default order.
+    static func order(stored raw: String) -> [HomeSection] {
+        reconciled(stored: decode(raw))
+    }
+
+    /// The set of sections the user has hidden, intersected with the live
+    /// catalog so a retired id can't strand a phantom hide.
+    static func hidden(stored raw: String) -> Set<HomeSection> {
+        decodeHidden(raw).intersection(HomeSection.allCases)
+    }
+
+    /// The sections to actually render, in order, with hidden ones removed.
+    /// The single call `HomeView` makes to lay out its stack.
+    static func visibleOrder(order rawOrder: String, hidden rawHidden: String) -> [HomeSection] {
+        let hide = hidden(stored: rawHidden)
+        return order(stored: rawOrder).filter { !hide.contains($0) }
+    }
+
+    // MARK: Move
+
+    /// Fold a SwiftUI `.onMove(source:destination:)` into a fresh stored order.
+    /// `displayed` is the list currently shown in the sheet (already reconciled
+    /// + sorted); `source` / `destination` are exactly what `.onMove` hands the
+    /// view. We persist the *entire* arrangement so the next reconcile is a
+    /// straight pass-through.
+    static func applyingMove(
+        displayed: [HomeSection],
+        source: IndexSet,
+        destination: Int
+    ) -> [HomeSection] {
+        var sections = displayed
+        sections.move(fromOffsets: source, toOffset: destination)
+        return sections
+    }
+
+    /// Toggle a section's hidden state, returning the new hidden set.
+    static func togglingHidden(
+        _ section: HomeSection,
+        in hidden: Set<HomeSection>
+    ) -> Set<HomeSection> {
+        var next = hidden
+        if next.contains(section) {
+            next.remove(section)
+        } else {
+            next.insert(section)
+        }
+        return next
+    }
+}
+
+// MARK: - AppStorage keys
+
+/// `@AppStorage` keys for the Home customization layout (#56). Grouped in one
+/// enum so the sheet and the Home view read/write the same keys without sharing
+/// a view, matching `LibraryDefaults` / `PinnedStationsStore`.
+enum HomeLayoutDefaults {
+    /// CSV of `HomeSection` raw values in the user's chosen order.
+    static let sectionOrderKey = "home_section_order"
+    /// CSV of `HomeSection` raw values the user has hidden.
+    static let sectionHiddenKey = "home_section_hidden"
+}

--- a/macos/Sources/Lyrebird/Screens/CustomizeHomeSheet.swift
+++ b/macos/Sources/Lyrebird/Screens/CustomizeHomeSheet.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// "Customize Home" modal (#56) — add/remove (show/hide) and reorder the Home
+/// shelves, Marvis-style.
+///
+/// The layout is persisted client-side as two `@AppStorage` CSV strings (the
+/// chosen order + the hidden set), and `HomeView` renders its stack by sorting
+/// the `HomeSection` catalog through `HomeSectionLayout`. This sheet is the
+/// editor over those two strings: a drag-reorderable list with a per-row
+/// show/hide toggle, plus a "Reset to defaults" affordance.
+///
+/// Presentation mirrors `InstantMixSheet` — a fixed-size `VStack` mounted via
+/// `.sheet` on `HomeView`, driven by a parent `isPresented` binding. All the
+/// ordering / visibility math lives in `HomeSectionLayout` (unit-tested), so
+/// this view is a thin editor shell around the two stored strings.
+struct CustomizeHomeSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// The same two keys `HomeView` reads, so an edit here repaints Home live.
+    @AppStorage(HomeLayoutDefaults.sectionOrderKey) private var orderRaw = ""
+    @AppStorage(HomeLayoutDefaults.sectionHiddenKey) private var hiddenRaw = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().background(Theme.border)
+            sectionList
+            footer
+        }
+        .frame(width: 460, height: 560)
+        .background(Theme.bg)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Customize Home")
+                    .font(Theme.font(16, weight: .bold))
+                    .foregroundStyle(Theme.ink)
+                Text("Drag to reorder. Toggle a section to show or hide it.")
+                    .font(Theme.font(11, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.ink2)
+                    .frame(width: 24, height: 24)
+                    .background(Circle().fill(Theme.surface))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Section list
+
+    /// The reconciled, ordered catalog the editor shows. Reconciling against
+    /// the live catalog on every render means a shelf added in a future build
+    /// shows up here automatically (appended at the bottom).
+    private var orderedSections: [HomeSection] {
+        HomeSectionLayout.order(stored: orderRaw)
+    }
+
+    private var hiddenSet: Set<HomeSection> {
+        HomeSectionLayout.hidden(stored: hiddenRaw)
+    }
+
+    private var sectionList: some View {
+        // A `List` (rather than ScrollView+VStack) unlocks SwiftUI's native
+        // `.onMove` drag-reorder — the same pattern the sidebar's playlist
+        // reorder uses (#317). Styled down to match the sheet chrome.
+        List {
+            ForEach(orderedSections) { section in
+                row(for: section)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 3, leading: 12, bottom: 3, trailing: 12))
+            }
+            .onMove(perform: move)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    /// One section row: glyph + title, a "Hidden" caption when off, and a
+    /// trailing toggle that flips the section's visibility. The whole catalog
+    /// is reorderable (including hidden rows) so a user can park a shelf at the
+    /// bottom whether or not it's currently shown.
+    private func row(for section: HomeSection) -> some View {
+        let isHidden = hiddenSet.contains(section)
+        return HStack(spacing: 12) {
+            Image(systemName: section.systemImage)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(isHidden ? Theme.ink3 : Theme.accent)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(section.title)
+                    .font(Theme.font(13, weight: .semibold))
+                    .foregroundStyle(isHidden ? Theme.ink3 : Theme.ink)
+                    .lineLimit(1)
+                if isHidden {
+                    Text("Hidden")
+                        .font(Theme.font(10, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+            }
+            Spacer(minLength: 8)
+            Toggle("", isOn: visibilityBinding(for: section))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(Theme.accent)
+                .controlSize(.small)
+                .accessibilityLabel(section.title)
+                .accessibilityValue(isHidden ? "Hidden" : "Shown")
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Theme.surface.opacity(0.6))
+        )
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            Button(role: .destructive, action: resetToDefaults) {
+                Text("Reset to Defaults")
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(canReset ? Theme.accentHot : Theme.ink3)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canReset)
+            .help("Restore the original section order and show every section")
+            .accessibilityLabel("Reset Home sections to defaults")
+
+            Spacer()
+
+            Button(action: { dismiss() }) {
+                Text("Done")
+                    .font(Theme.font(13, weight: .semibold))
+                    .frame(width: 96, height: 32)
+                    .foregroundStyle(Theme.bg)
+                    .background(Theme.ink)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Done")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 18)
+        .overlay(alignment: .top) {
+            Rectangle().fill(Theme.border).frame(height: 1)
+        }
+    }
+
+    /// Reset is only meaningful when the layout actually diverges from the
+    /// shipped default — both stores empty means "defaults" already.
+    private var canReset: Bool {
+        !orderRaw.isEmpty || !hiddenRaw.isEmpty
+    }
+
+    // MARK: - Mutations
+
+    /// Per-section visibility binding. Reading folds the hidden set; writing
+    /// toggles it and re-encodes in stable catalog order. `isOn == true` means
+    /// "shown", so the stored hidden flag is the inverse.
+    private func visibilityBinding(for section: HomeSection) -> Binding<Bool> {
+        Binding(
+            get: { !hiddenSet.contains(section) },
+            set: { shown in
+                var hidden = hiddenSet
+                if shown {
+                    hidden.remove(section)
+                } else {
+                    hidden.insert(section)
+                }
+                hiddenRaw = HomeSectionLayout.encodeHidden(hidden)
+            }
+        )
+    }
+
+    /// Fold a `.onMove` into the persisted order. `orderedSections` is the
+    /// already-reconciled list the user sees, so the offsets line up; we
+    /// re-encode the whole arrangement. Pure list math — see `HomeSectionLayout`.
+    private func move(from source: IndexSet, to destination: Int) {
+        let next = HomeSectionLayout.applyingMove(
+            displayed: orderedSections,
+            source: source,
+            destination: destination
+        )
+        orderRaw = HomeSectionLayout.encode(next)
+    }
+
+    /// Clear both stores so order falls back to the catalog's declaration order
+    /// and every section is shown — the documented "reset to defaults".
+    private func resetToDefaults() {
+        orderRaw = ""
+        hiddenRaw = ""
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -21,6 +21,15 @@ struct HomeView: View {
     /// pin infrastructure ships. See `PinnedStationTile.swift`.
     @AppStorage(PinnedStationsStore.defaultsKey) private var pinnedStationsData: Data = Data()
 
+    /// User-chosen section order + hidden set (#56). Two CSV strings the
+    /// `CustomizeHomeSheet` edits and `HomeSectionLayout` sorts the shelf stack
+    /// by; an empty value is the shipped default order with every shelf shown.
+    @AppStorage(HomeLayoutDefaults.sectionOrderKey) private var sectionOrderRaw = ""
+    @AppStorage(HomeLayoutDefaults.sectionHiddenKey) private var sectionHiddenRaw = ""
+
+    /// Drives the "Customize Home" sheet.
+    @State private var isCustomizing = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
@@ -29,19 +38,14 @@ struct HomeView: View {
                 // placeholder for "top tracks of the day"; random albums are
                 // not meaningful here. Re-enable once the ranked data sources
                 // land (#206, #209).
-                recentlyPlayedSection
-                artistsYouLoveSection
-                recentlyDiscoveredArtistsSection
-                jumpBackInSection
-                recentlyPlayedTracksSection
-                yourPlaylistsSection
-                recentlyAddedSection
-                rediscoverSection
-                quickPicksSection
-                suggestionsSection
-                favoritesSection
-                pinnedStationsRow
-                artistRadioRow
+                //
+                // Section stack order + visibility is user-customizable (#56):
+                // render the catalog through `HomeSectionLayout`, skipping hidden
+                // shelves. Each shelf still hides itself when its own data is
+                // empty, so this governs order + explicit show/hide only.
+                ForEach(visibleSections, id: \.self) { section in
+                    sectionView(for: section)
+                }
                 Spacer(minLength: 24)
             }
             .padding(.horizontal, 32)
@@ -49,6 +53,9 @@ struct HomeView: View {
             .padding(.bottom, 32)
         }
         .background(backgroundWash)
+        .sheet(isPresented: $isCustomizing) {
+            CustomizeHomeSheet()
+        }
         // Keep the Recently Played carousel fresh as tracks play (#794).
         // `loadHomeData()` only seeds the section on initial library load,
         // so without this hook a user who plays a few songs and returns to
@@ -58,6 +65,38 @@ struct HomeView: View {
         // which is exactly when the server's recently-played list grows.
         .task(id: model.status.currentTrack?.id) {
             await model.refreshRecentlyPlayed()
+        }
+    }
+
+    // MARK: - Section customization (#56)
+
+    /// The shelves to render, in the user's chosen order, with hidden ones
+    /// removed. Reconciled against the live `HomeSection` catalog on every
+    /// paint so a shelf added in a future build appears automatically. See
+    /// `HomeSectionLayout`.
+    private var visibleSections: [HomeSection] {
+        HomeSectionLayout.visibleOrder(order: sectionOrderRaw, hidden: sectionHiddenRaw)
+    }
+
+    /// Map a catalog entry to its shelf view. Each case is the same shelf the
+    /// body used to list inline; the shelves themselves still self-hide when
+    /// their data slice is empty.
+    @ViewBuilder
+    private func sectionView(for section: HomeSection) -> some View {
+        switch section {
+        case .recentlyPlayed: recentlyPlayedSection
+        case .artistsYouLove: artistsYouLoveSection
+        case .recentlyDiscoveredArtists: recentlyDiscoveredArtistsSection
+        case .jumpBackIn: jumpBackInSection
+        case .recentTracks: recentlyPlayedTracksSection
+        case .yourPlaylists: yourPlaylistsSection
+        case .recentlyAdded: recentlyAddedSection
+        case .rediscover: rediscoverSection
+        case .quickPicks: quickPicksSection
+        case .suggestions: suggestionsSection
+        case .favorites: favoritesSection
+        case .pinnedStations: pinnedStationsRow
+        case .artistRadio: artistRadioRow
         }
     }
 
@@ -169,6 +208,23 @@ struct HomeView: View {
             .disabled(model.albums.isEmpty)
             .opacity(model.albums.isEmpty ? 0.5 : 1)
             .accessibilityLabel("Shuffle your entire library")
+
+            // "Customize Home" entry point (#56). Compact icon-only ghost
+            // button so it sits beside the two primary CTAs without competing
+            // with them; opens the reorder / show-hide sheet.
+            Button {
+                isCustomizing = true
+            } label: {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Theme.ink2)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 13)
+                    .background(Capsule().stroke(Theme.borderStrong, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .help("Customize Home — reorder, show, or hide sections")
+            .accessibilityLabel("Customize Home")
         }
     }
 
@@ -876,6 +932,17 @@ struct HomeView: View {
                     .buttonStyle(.plain)
                     .help("Open \(title) in full")
                     .accessibilityLabel("See all \(title)")
+                }
+            }
+            // Right-click (the Mac-native "long-press on a section header")
+            // opens the same Customize Home sheet (#56). `contentShape` makes
+            // the whole header row the hit target, not just the glyphs.
+            .contentShape(Rectangle())
+            .contextMenu {
+                Button {
+                    isCustomizing = true
+                } label: {
+                    Label("Customize Home…", systemImage: "slider.horizontal.3")
                 }
             }
             ScrollView(.horizontal, showsIndicators: false) {

--- a/macos/Tests/LyrebirdTests/HomeSectionLayoutTests.swift
+++ b/macos/Tests/LyrebirdTests/HomeSectionLayoutTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import Lyrebird
+
+/// Coverage for `HomeSectionLayout` — the pure ordering + visibility logic
+/// behind "Customize Home" (#56).
+///
+/// Like the sidebar's playlist reorder (#317), Home customization is
+/// client-only: the Home view sorts the `HomeSection` catalog by two stored
+/// CSV strings (the chosen order + the hidden set), so the contract that
+/// matters is set-reconciliation, not any server round-trip. These tests pin:
+///   * catalog invariants (stable raw values, default order == declaration);
+///   * the CSV codec (`decode` / `encode`) the order `@AppStorage` rides on;
+///   * the hidden-set codec (`decodeHidden` / `encodeHidden`);
+///   * `reconciled` — stored sections keep their order, new shelves append,
+///     retired ids prune, duplicates collapse (the persists-across-launches
+///     contract);
+///   * `visibleOrder` — order minus hidden, the single call the view makes;
+///   * `applyingMove` + `togglingHidden` — folding the sheet's edits back.
+final class HomeSectionLayoutTests: XCTestCase {
+
+    // MARK: - Catalog invariants
+
+    /// `defaultOrder` is exactly the declaration order — the reset target and
+    /// the reconciliation tail both depend on this.
+    func testDefaultOrderIsDeclarationOrder() {
+        XCTAssertEqual(HomeSection.defaultOrder, HomeSection.allCases)
+        XCTAssertEqual(HomeSection.defaultOrder.first, .recentlyPlayed)
+    }
+
+    /// Raw values are the stable persistence keys; assert a representative set
+    /// so an accidental rename (which would silently drop a user's stored
+    /// layout) trips the suite.
+    func testRawValuesAreStablePersistenceKeys() {
+        XCTAssertEqual(HomeSection.jumpBackIn.rawValue, "jumpBackIn")
+        XCTAssertEqual(HomeSection.favorites.rawValue, "favorites")
+        XCTAssertEqual(HomeSection.artistRadio.rawValue, "artistRadio")
+        // Raw values must be comma-free so the CSV split is unambiguous.
+        for section in HomeSection.allCases {
+            XCTAssertFalse(section.rawValue.contains(","), "\(section) raw value has a comma")
+        }
+    }
+
+    /// Every section exposes a non-empty title + glyph so the sheet never
+    /// renders a blank row.
+    func testEverySectionHasTitleAndGlyph() {
+        for section in HomeSection.allCases {
+            XCTAssertFalse(section.title.isEmpty, "\(section) has an empty title")
+            XCTAssertFalse(section.systemImage.isEmpty, "\(section) has an empty glyph")
+        }
+    }
+
+    // MARK: - Order CSV codec
+
+    func testEncodeDecodeRoundTrip() {
+        let sections: [HomeSection] = [.favorites, .jumpBackIn, .quickPicks]
+        XCTAssertEqual(HomeSectionLayout.encode(sections), "favorites,jumpBackIn,quickPicks")
+        XCTAssertEqual(HomeSectionLayout.decode("favorites,jumpBackIn,quickPicks"), sections)
+    }
+
+    /// The empty `@AppStorage` default decodes to an empty list, not a ghost.
+    func testDecodeEmptyStringYieldsEmptyList() {
+        XCTAssertEqual(HomeSectionLayout.decode(""), [])
+        XCTAssertEqual(HomeSectionLayout.encode([]), "")
+    }
+
+    /// Stray / trailing commas and whitespace are dropped; unknown raw values
+    /// (a retired shelf id from a newer→older downgrade) are dropped too.
+    func testDecodeDropsBlankWhitespaceAndUnknownEntries() {
+        XCTAssertEqual(
+            HomeSectionLayout.decode("favorites,, jumpBackIn ,bogus,"),
+            [.favorites, .jumpBackIn]
+        )
+    }
+
+    // MARK: - Reconciliation
+
+    /// Stored sections present in the catalog keep their stored relative order —
+    /// the whole point of persisting a reorder across launches.
+    func testReconcileKeepsStoredOrderForSurvivingSections() {
+        let result = HomeSectionLayout.reconciled(stored: [.favorites, .recentlyPlayed, .jumpBackIn])
+        XCTAssertEqual(Array(result.prefix(3)), [.favorites, .recentlyPlayed, .jumpBackIn])
+    }
+
+    /// Sections shipped but not in the stored order (a shelf added in this app
+    /// version) append at the bottom in catalog order rather than reshuffling
+    /// the user's arrangement.
+    func testReconcileAppendsNewCatalogSectionsAtBottom() {
+        // A stored order from an "older" build that only knew two shelves.
+        let result = HomeSectionLayout.reconciled(stored: [.quickPicks, .favorites])
+        XCTAssertEqual(Array(result.prefix(2)), [.quickPicks, .favorites])
+        // Everything else the catalog ships follows, and the whole catalog is
+        // present exactly once.
+        XCTAssertEqual(Set(result), Set(HomeSection.allCases))
+        XCTAssertEqual(result.count, HomeSection.allCases.count)
+    }
+
+    /// The result is a duplicate-free permutation of the catalog even when the
+    /// stored value is corrupt (a duplicate). Every live section appears once.
+    func testReconcileIsDuplicateFreePermutationOfCatalog() {
+        let result = HomeSectionLayout.reconciled(stored: [.favorites, .favorites, .jumpBackIn])
+        XCTAssertEqual(result.count, Set(result).count, "no duplicates")
+        XCTAssertEqual(Set(result), Set(HomeSection.allCases))
+        XCTAssertEqual(Array(result.prefix(2)), [.favorites, .jumpBackIn])
+    }
+
+    /// An empty stored order yields the shipped default (catalog) order.
+    func testReconcileEmptyStoredYieldsDefaultOrder() {
+        XCTAssertEqual(HomeSectionLayout.reconciled(stored: []), HomeSection.allCases)
+        XCTAssertEqual(HomeSectionLayout.order(stored: ""), HomeSection.allCases)
+    }
+
+    /// A full round trip through the codec + reconcile reproduces exactly the
+    /// order the user dropped — the persists-across-launches guarantee.
+    func testOrderPersistsAsStablePassThrough() {
+        let moved = HomeSectionLayout.applyingMove(
+            displayed: HomeSection.allCases,
+            source: IndexSet(integer: HomeSection.allCases.count - 1),
+            destination: 0
+        )
+        let raw = HomeSectionLayout.encode(moved)
+        XCTAssertEqual(HomeSectionLayout.order(stored: raw), moved)
+    }
+
+    // MARK: - Hidden-set codec
+
+    /// The hidden set encodes in stable catalog order regardless of insertion
+    /// order, so the stored string doesn't churn between writes.
+    func testHiddenSetEncodesInStableCatalogOrder() {
+        let hidden: Set<HomeSection> = [.artistRadio, .recentlyPlayed]
+        // recentlyPlayed precedes artistRadio in the catalog.
+        XCTAssertEqual(HomeSectionLayout.encodeHidden(hidden), "recentlyPlayed,artistRadio")
+    }
+
+    func testHiddenSetRoundTrip() {
+        let hidden: Set<HomeSection> = [.favorites, .quickPicks]
+        let raw = HomeSectionLayout.encodeHidden(hidden)
+        XCTAssertEqual(HomeSectionLayout.decodeHidden(raw), hidden)
+    }
+
+    /// `hidden(stored:)` drops ids no longer in the catalog so a stale hide
+    /// can't strand a phantom.
+    func testHiddenIntersectsLiveCatalog() {
+        XCTAssertEqual(HomeSectionLayout.hidden(stored: "favorites,bogus"), [.favorites])
+        XCTAssertEqual(HomeSectionLayout.hidden(stored: ""), [])
+    }
+
+    // MARK: - visibleOrder
+
+    /// Hidden sections are removed and the rest keep their order — the single
+    /// call the Home view makes to lay out its stack.
+    func testVisibleOrderRemovesHiddenKeepsOrder() {
+        let order = HomeSectionLayout.encode([.recentlyPlayed, .favorites, .jumpBackIn])
+        let hidden = HomeSectionLayout.encodeHidden([.favorites])
+        let visible = HomeSectionLayout.visibleOrder(order: order, hidden: hidden)
+        XCTAssertEqual(Array(visible.prefix(2)), [.recentlyPlayed, .jumpBackIn])
+        XCTAssertFalse(visible.contains(.favorites))
+    }
+
+    /// Defaults (both empty) show every shelf in catalog order.
+    func testVisibleOrderWithDefaultsShowsEverything() {
+        let visible = HomeSectionLayout.visibleOrder(order: "", hidden: "")
+        XCTAssertEqual(visible, HomeSection.allCases)
+    }
+
+    /// Hiding every section yields an empty visible list (a valid, if bare,
+    /// Home — the header CTAs still render).
+    func testVisibleOrderHidingAllYieldsEmpty() {
+        let hidden = HomeSectionLayout.encodeHidden(Set(HomeSection.allCases))
+        XCTAssertTrue(HomeSectionLayout.visibleOrder(order: "", hidden: hidden).isEmpty)
+    }
+
+    // MARK: - Move
+
+    /// Moving the last shelf to the front mirrors SwiftUI's `.onMove` semantics.
+    func testApplyingMoveReordersDisplayed() {
+        let next = HomeSectionLayout.applyingMove(
+            displayed: [.recentlyPlayed, .jumpBackIn, .favorites],
+            source: IndexSet(integer: 2),
+            destination: 0
+        )
+        XCTAssertEqual(next, [.favorites, .recentlyPlayed, .jumpBackIn])
+    }
+
+    // MARK: - togglingHidden
+
+    func testTogglingHiddenAddsThenRemoves() {
+        let added = HomeSectionLayout.togglingHidden(.favorites, in: [])
+        XCTAssertEqual(added, [.favorites])
+        let removed = HomeSectionLayout.togglingHidden(.favorites, in: added)
+        XCTAssertTrue(removed.isEmpty)
+    }
+}


### PR DESCRIPTION
Lets users tailor the Home screen Marvis-style — drag to reorder shelves, toggle each on/off, and reset to defaults — with the layout persisted across launches.

Closes #56

## What

- **`HomeSection` catalog + `HomeSectionLayout`** (new `Components/HomeSectionLayout.swift`): a pure, side-effect-free ordering/visibility helper over two CSV strings (chosen order + hidden set), mirroring the `PlaylistSidebarOrder` (#317) pattern. Reconciles the stored layout against the shipped catalog on every read, so a shelf added in a future build appears automatically at the bottom and a retired id prunes cleanly.
- **`CustomizeHomeSheet`** (new `Screens/CustomizeHomeSheet.swift`): a fixed-size sheet with a drag-reorderable `List` (native `.onMove`), a per-row show/hide switch, and a "Reset to Defaults" button. Presentation mirrors `InstantMixSheet`.
- **`HomeView` wiring**: the shelf stack now renders `ForEach(visibleSections)` through `HomeSectionLayout` instead of a hardcoded list (default order unchanged — the catalog maps 1:1 to the previous inline order). Two entry points per the issue: a "Customize" button in the header CTA cluster, and a right-click "Customize Home…" on any carousel header (the Mac-native equivalent of long-press).
- Persistence is via `@AppStorage` (this is the SwiftUI desktop app; the issue's MMKV/CoreData note is from the cross-platform source doc). Each shelf still self-hides when its own data slice is empty, so this governs order + explicit show/hide only.

## Acceptance criteria

- Reorder persists across launches — stored as `@AppStorage` CSV, reconciled on read. ✅
- Settings stored in app defaults. ✅
- Reset to defaults — clears both keys → catalog order, every shelf shown. ✅

## Tests

`HomeSectionLayoutTests` (19 cases): catalog invariants (stable raw keys, default == declaration order), CSV + hidden-set codecs, reconciliation (keeps stored order, appends new shelves, prunes retired ids, dedupes), `visibleOrder`, `applyingMove`, `togglingHidden`, and the persists-across-launches round-trip.

## pipeline

- builder-session: wf_aa93d738-25a-15
- slice: screens
- hotspot: none (new files + `HomeView`; AppModel untouched)
- build-gate: `swift build` clean; full Swift suite 913/913 pass (incl. 19 new). Swift-only change — no Rust/FFI touched.
- diff-stat: 4 files, +713 / −13