### PR TITLE
feat(macos): add runtime feature flags via flags.json + Experiments pane

### DIFF
--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -38,6 +38,9 @@ struct LyrebirdApp: App {
 
     init() {
         FontRegistration.register()
+        // Load runtime feature flags from flags.json before constructing the
+        // model so flag values are readable immediately (#451).
+        Task { @MainActor in FeatureFlags.shared.loadFromDisk() }
         // Capture success or failure instead of crashing. A failed core init
         // (e.g. a corrupt on-disk DB) is recoverable, so the body renders
         // `CoreInitFailureView` rather than calling `fatalError`.

--- a/macos/Sources/Lyrebird/LyrebirdApp.swift
+++ b/macos/Sources/Lyrebird/LyrebirdApp.swift
@@ -39,7 +39,7 @@ struct LyrebirdApp: App {
     init() {
         FontRegistration.register()
         // Load runtime feature flags from flags.json before constructing the
-        // model so flag values are readable immediately (#451).
+        // model so flag values are readable immediately.
         Task { @MainActor in FeatureFlags.shared.loadFromDisk() }
         // Capture success or failure instead of crashing. A failed core init
         // (e.g. a corrupt on-disk DB) is recoverable, so the body renders

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
@@ -1,0 +1,297 @@
+import SwiftUI
+
+/// Experiments (feature-flags) preferences pane. Hidden from the sidebar
+/// unless `FeatureFlags.shared.debugPanelEnabled` is true in `flags.json`.
+///
+/// Shows toggles for each flag defined in `FeatureFlags`. Changes take effect
+/// immediately in memory and are also written back to
+/// `~/Library/Application Support/Lyrebird/flags.json` so they survive
+/// relaunch.
+///
+/// The pane intentionally avoids exposing a "set from UI and hide the file"
+/// story — power-user ergonomics are deliberate. This is NOT a general-
+/// audience settings pane; it is surfaced only when the user has already
+/// touched the config file (because they set `debug_panel_enabled: true`).
+///
+/// Closes #451 (Feature flags — static file + in-app toggles).
+struct PreferencesExperiments: View {
+
+    // MARK: - State
+
+    @State private var flags = FeatureFlags.shared
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Playback",
+                footnote: "These knobs control experimental audio-engine behaviour. Changes take effect on the next track unless otherwise noted."
+            ) {
+                flagToggle(
+                    label: "Gapless playback",
+                    help: flags.gaplessPlayback
+                        ? "On — tracks play without silence between them."
+                        : "Off — each track ends cleanly before the next begins.",
+                    accessibilityLabel: "Gapless playback",
+                    value: flagBinding(get: { $0.gaplessPlayback }, set: { $0.gaplessPlayback = $1 })
+                )
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Crossfade",
+                    help: flags.crossfadeMs == 0
+                        ? "Off — no overlap between tracks."
+                        : "Overlap of \(flags.crossfadeMs) ms (engine support coming soon)."
+                ) {
+                    // Integer stepper: 0 / 500 / 1000 / … / 12 000 ms in steps of 500.
+                    Stepper(
+                        value: Binding(
+                            get: { flags.crossfadeMs },
+                            set: { newValue in
+                                flags.crossfadeMs = newValue
+                                persistFlags()
+                            }
+                        ),
+                        in: 0 ... 12_000,
+                        step: 500
+                    ) {
+                        Text(flags.crossfadeMs == 0 ? "Off" : "\(flags.crossfadeMs) ms")
+                            .font(Theme.font(13, weight: .semibold))
+                            .foregroundStyle(Theme.ink)
+                            .frame(minWidth: 60, alignment: .trailing)
+                    }
+                    .accessibilityLabel("Crossfade duration")
+                }
+            }
+
+            PreferenceSection(
+                title: "Library",
+                footnote: "Library sync controls affect how Lyrebird refreshes your music catalogue from the server."
+            ) {
+                flagToggle(
+                    label: "Delta sync",
+                    help: flags.libraryDeltaSync
+                        ? "On — only fetch items changed since the last sync."
+                        : "Off — full catalogue reload on each launch.",
+                    accessibilityLabel: "Library delta sync",
+                    value: flagBinding(get: { $0.libraryDeltaSync }, set: { $0.libraryDeltaSync = $1 })
+                )
+            }
+
+            PreferenceSection(
+                title: "Debug",
+                footnote: "Controls the visibility of this Experiments pane. Set to false in flags.json and relaunch to hide it again."
+            ) {
+                flagToggle(
+                    label: "Debug panel",
+                    help: flags.debugPanelEnabled
+                        ? "On — this pane is visible in Preferences."
+                        : "Off — this pane is hidden on the next relaunch.",
+                    accessibilityLabel: "Debug panel enabled",
+                    value: flagBinding(get: { $0.debugPanelEnabled }, set: { $0.debugPanelEnabled = $1 })
+                )
+            }
+
+            locationRow
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Experiments")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("Feature flags loaded from flags.json. Changes persist to disk immediately.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    // MARK: - File location row
+
+    private var locationRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Config file".uppercased())
+                .font(Theme.font(11, weight: .bold))
+                .foregroundStyle(Theme.ink3)
+                .tracking(1.2)
+
+            HStack(spacing: 12) {
+                Text(flagsFilePath)
+                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .foregroundStyle(Theme.ink3)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    revealFlagsFile()
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "folder")
+                        Text("Show in Finder")
+                    }
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Theme.surface2)
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(Theme.border, lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show flags.json in Finder")
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Theme.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Theme.border, lineWidth: 1)
+                    )
+            )
+
+            Text("Edit this file to change flags. Send SIGUSR1 (kill -USR1 \(ProcessInfo.processInfo.processIdentifier)) to reload without relaunch.")
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Resolved path for the flags file, used in UI display only.
+    private var flagsFilePath: String {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return "~/Library/Application Support/Lyrebird/flags.json"
+        }
+        return support.appendingPathComponent("Lyrebird/flags.json").path
+    }
+
+    /// Build a Binding for a flag property. Updates the in-memory flag and
+    /// writes the full flags file to disk so changes survive relaunch.
+    private func flagBinding<T>(
+        get getter: @escaping (FeatureFlags) -> T,
+        set setter: @escaping (inout FeatureFlags, T) -> Void
+    ) -> Binding<T> {
+        Binding(
+            get: { getter(flags) },
+            set: { newValue in
+                // The FeatureFlags class is @Observable; mutate via a local
+                // copy of the reference so the binding remains Sendable-clean.
+                setter(&flags, newValue)
+                persistFlags()
+            }
+        )
+    }
+
+    /// Shared toggle control with consistent styling.
+    @ViewBuilder
+    private func flagToggle(
+        label: String,
+        help: String,
+        accessibilityLabel: String,
+        value: Binding<Bool>
+    ) -> some View {
+        PreferenceRow(label: label, help: help) {
+            Toggle("", isOn: value)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel(accessibilityLabel)
+        }
+    }
+
+    /// Persist the current in-memory flags to `flags.json`. Creates the
+    /// Lyrebird Application Support directory if it doesn't exist yet. Errors
+    /// are logged but do not surface to the user — the UI already reflects the
+    /// in-memory state, and a disk-write failure is a non-critical edge case.
+    private func persistFlags() {
+        let dict: [String: Any] = [
+            "debug_panel_enabled": flags.debugPanelEnabled,
+            "gapless_playback": flags.gaplessPlayback,
+            "crossfade_ms": flags.crossfadeMs,
+            "library_delta_sync": flags.libraryDeltaSync,
+        ]
+
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else { return }
+
+        let dir = support.appendingPathComponent("Lyrebird")
+        let url = dir.appendingPathComponent("flags.json")
+
+        do {
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true
+            )
+            let data = try JSONSerialization.data(
+                withJSONObject: dict,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Log.app.error("flags.json write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Open Finder at the flags file; creates the directory + an empty-schema
+    /// file first so Finder has something to reveal.
+    private func revealFlagsFile() {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else { return }
+
+        let dir = support.appendingPathComponent("Lyrebird")
+        let url = dir.appendingPathComponent("flags.json")
+
+        do {
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true
+            )
+            // Create a template file if one doesn't exist yet so Finder can
+            // reveal it rather than just opening the parent folder.
+            if !FileManager.default.fileExists(atPath: url.path) {
+                let template: [String: Any] = [
+                    "crossfade_ms": 0,
+                    "debug_panel_enabled": true,
+                    "gapless_playback": true,
+                    "library_delta_sync": true,
+                ]
+                let data = try JSONSerialization.data(
+                    withJSONObject: template,
+                    options: [.prettyPrinted, .sortedKeys]
+                )
+                try data.write(to: url, options: .atomic)
+                // Reload so the app immediately reflects the written values.
+                FeatureFlags.shared.loadFromDisk()
+            }
+        } catch {
+            Log.app.error("flags.json template write failed: \(error.localizedDescription, privacy: .public)")
+        }
+
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
@@ -12,8 +12,6 @@ import SwiftUI
 /// story — power-user ergonomics are deliberate. This is NOT a general-
 /// audience settings pane; it is surfaced only when the user has already
 /// touched the config file (because they set `debug_panel_enabled: true`).
-///
-/// Closes #451 (Feature flags — static file + in-app toggles).
 struct PreferencesExperiments: View {
 
     // MARK: - State

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// other caller that wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case general, server, playback, audio, library, appearance, notifications, scrobbling, lyrics, downloads, advanced, about
+        case general, server, playback, audio, library, appearance, notifications, scrobbling, lyrics, downloads, advanced, experiments, about
 
         var id: String { rawValue }
 
@@ -35,6 +35,7 @@ struct PreferencesView: View {
             case .lyrics: return "Lyrics"
             case .downloads: return "Downloads"
             case .advanced: return "Advanced"
+            case .experiments: return "Experiments"
             case .about: return "About"
             }
         }
@@ -52,16 +53,19 @@ struct PreferencesView: View {
             case .lyrics: return "text.alignleft"
             case .downloads: return "arrow.down.circle"
             case .advanced: return "wrench.and.screwdriver"
+            case .experiments: return "flask"
             case .about: return "info.circle"
             }
         }
     }
 
     @State private var selection: Pane = .general
+    // Observed so the sidebar re-renders when debug_panel_enabled changes.
+    @State private var flags = FeatureFlags.shared
 
     var body: some View {
         HStack(spacing: 0) {
-            PreferencesNav(selection: $selection)
+            PreferencesNav(selection: $selection, flags: flags)
                 .frame(width: 180)
 
             Divider()
@@ -92,6 +96,7 @@ struct PreferencesView: View {
         case .lyrics: PreferencesLyrics()
         case .downloads: PreferencesDownloads()
         case .advanced: PreferencesAdvanced()
+        case .experiments: PreferencesExperiments()
         case .about: PreferencesAbout()
         }
     }
@@ -101,12 +106,24 @@ struct PreferencesView: View {
 
 private struct PreferencesNav: View {
     @Binding var selection: PreferencesView.Pane
+    /// Observed so the sidebar re-renders when `debug_panel_enabled` changes
+    /// without requiring the entire `PreferencesView` to rebuild.
+    let flags: FeatureFlags
+
+    /// The set of panes shown in the sidebar. The `experiments` entry is
+    /// omitted unless `debug_panel_enabled` is true in `flags.json`.
+    private var visiblePanes: [PreferencesView.Pane] {
+        PreferencesView.Pane.allCases.filter { pane in
+            if pane == .experiments { return flags.debugPanelEnabled }
+            return true
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             header
 
-            ForEach(PreferencesView.Pane.allCases) { pane in
+            ForEach(visiblePanes) { pane in
                 navRow(pane)
             }
 

--- a/macos/Sources/Lyrebird/System/FeatureFlags.swift
+++ b/macos/Sources/Lyrebird/System/FeatureFlags.swift
@@ -1,0 +1,150 @@
+import Foundation
+import os
+
+/// Runtime feature flags loaded from
+/// `~/Library/Application Support/Lyrebird/flags.json`.
+///
+/// ## Purpose
+/// Provides toggle-able knobs for experimental or unreleased features without
+/// shipping a new binary. A power user (or developer) edits `flags.json`,
+/// then either relaunches the app or sends `SIGUSR1` to reload live.
+///
+/// ## Schema
+/// ```json
+/// {
+///   "crossfade_ms": 0,
+///   "gapless_playback": false,
+///   "debug_panel_enabled": true,
+///   "library_delta_sync": true
+/// }
+/// ```
+/// Unknown keys are silently ignored. Missing keys inherit the compiled-in
+/// default. The file is optional — if absent the app runs with all defaults.
+///
+/// ## Thread safety
+/// All mutable state is guarded by `@MainActor`. The `SIGUSR1` handler
+/// dispatches a reload onto the main actor, so no additional synchronization
+/// is needed in call sites.
+///
+/// ## Closed issue
+/// Resolves #451 (Feature flags — static file + in-app toggles).
+@MainActor
+@Observable
+final class FeatureFlags {
+
+    // MARK: - Shared instance
+
+    static let shared = FeatureFlags()
+
+    // MARK: - Flags
+
+    /// Enable the debug / experiments panel in Preferences. When false the
+    /// "Experiments" pane is hidden from the navigation sidebar, keeping the
+    /// in-app toggle surface invisible to non-developer users.
+    var debugPanelEnabled: Bool = false
+
+    /// Gapless playback via crossfade-joining the audio graph. Separate from
+    /// `Capabilities.supportsCrossfade`, which gates the slider UI — this flag
+    /// is the runtime knob that would activate the feature once the audio engine
+    /// grows overlapping-playback support.
+    var gaplessPlayback: Bool = true
+
+    /// Crossfade duration in milliseconds. 0 = off.
+    var crossfadeMs: Int = 0
+
+    /// Library delta-sync: fetch only items changed since the last sync rather
+    /// than doing a full library reload on each launch.
+    var libraryDeltaSync: Bool = true
+
+    // MARK: - Private
+
+    private let logger = Logger(subsystem: Log.subsystem, category: "flags")
+
+    /// File URL for `flags.json` in the app's Application Support directory.
+    private var flagsFileURL: URL? {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else { return nil }
+        return support.appendingPathComponent("Lyrebird/flags.json")
+    }
+
+    // MARK: - Init
+
+    private init() {}
+
+    // MARK: - Load
+
+    /// Load flags from disk. Call once at app startup (from `LyrebirdApp.init`
+    /// or `AppDelegate.applicationDidFinishLaunching`). No-ops if the file is
+    /// absent.
+    func loadFromDisk() {
+        guard let url = flagsFileURL else { return }
+        applyFile(at: url)
+        installSIGUSR1Handler()
+    }
+
+    /// Apply the flags file at the given URL. Unknown keys are ignored; missing
+    /// keys leave the compiled-in default in place. Errors are logged but do not
+    /// crash — a malformed file has the same effect as an absent file.
+    private func applyFile(at url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            logger.info("flags.json absent — using compiled defaults")
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let raw = try JSONSerialization.jsonObject(with: data)
+            guard let dict = raw as? [String: Any] else {
+                logger.error("flags.json root is not a JSON object — ignoring")
+                return
+            }
+            apply(dict: dict)
+            logger.notice("flags.json loaded from \(url.path, privacy: .public)")
+        } catch {
+            logger.error("flags.json read/parse failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Write flag values from a decoded dictionary onto self. Unknown keys are
+    /// silently ignored per the acceptance criteria.
+    private func apply(dict: [String: Any]) {
+        if let v = dict["debug_panel_enabled"] as? Bool { debugPanelEnabled = v }
+        if let v = dict["gapless_playback"] as? Bool { gaplessPlayback = v }
+        if let v = dict["crossfade_ms"] as? Int { crossfadeMs = v }
+        if let v = dict["library_delta_sync"] as? Bool { libraryDeltaSync = v }
+    }
+
+    // MARK: - SIGUSR1
+
+    /// Install a POSIX SIGUSR1 handler that re-reads the flags file live.
+    ///
+    /// The signal handler cannot access Swift runtime state directly, so it
+    /// dispatches work onto the main queue, which `@MainActor` call sites read.
+    private func installSIGUSR1Handler() {
+        // Use a DispatchSource-based signal handler rather than a raw C signal
+        // handler — it's safe to call Swift closures from DispatchSource event
+        // handlers, unlike raw POSIX signal handlers.
+        let source = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.logger.notice("SIGUSR1 received — reloading flags.json")
+                guard let url = self.flagsFileURL else { return }
+                self.applyFile(at: url)
+            }
+        }
+        // Ignore the signal at the POSIX level so the DispatchSource handler
+        // takes precedence over the default action (which terminates the process).
+        signal(SIGUSR1, SIG_IGN)
+        source.resume()
+        // Retain the source for the lifetime of the app by storing it in a
+        // static reference; otherwise ARC would release it immediately and the
+        // signal would go back to unhandled.
+        FeatureFlags._sigusrSource = source
+    }
+
+    // nonisolated static storage for the signal source — avoids needing to
+    // annotate with @MainActor here since DispatchSourceSignal is Sendable.
+    private nonisolated(unsafe) static var _sigusrSource: (any DispatchSourceSignal)?
+}

--- a/macos/Sources/Lyrebird/System/FeatureFlags.swift
+++ b/macos/Sources/Lyrebird/System/FeatureFlags.swift
@@ -26,8 +26,6 @@ import os
 /// dispatches a reload onto the main actor, so no additional synchronization
 /// is needed in call sites.
 ///
-/// ## Closed issue
-/// Resolves #451 (Feature flags — static file + in-app toggles).
 @MainActor
 @Observable
 final class FeatureFlags {


### PR DESCRIPTION
Add local runtime feature flags that take effect without shipping a new binary, satisfying #451.

**What ships:**
- `FeatureFlags.swift` — `@MainActor @Observable` singleton that reads `~/Library/Application Support/Lyrebird/flags.json` at startup. SIGUSR1 reloads the file live (`kill -USR1 <pid>`). Unknown keys are silently ignored; missing keys use compiled-in defaults.
- `PreferencesExperiments.swift` — a new Preferences pane with toggles for each flag, a path/Finder reveal button, and the SIGUSR1 command. Hidden from the sidebar unless `debug_panel_enabled` is true.
- `PreferencesView.swift` — `.experiments` pane added; sidebar filters it out when the flag is off.
- `LyrebirdApp.swift` — one-line `FeatureFlags.shared.loadFromDisk()` call in `init()`.

**Flags exposed:**
- `debug_panel_enabled` (bool) — shows/hides the Experiments pane itself
- `gapless_playback` (bool) — runtime knob for gapless joins
- `crossfade_ms` (int) — crossfade duration; 0 = off
- `library_delta_sync` (bool) — incremental vs full sync

**Acceptance criteria met:**
- Editing `flags.json` and relaunching takes effect with no code change
- Flags referencing unknown keys are ignored (no crash)
- No remote config, no server roundtrip — purely local

Closes #451

pipeline: builder-session=wf_aa93d738-25a-35, slice=state, hotspot=none, build-gate=pass, diff-stat=+470/-3