### PR TITLE
feat(macos): Tab cycles keyboard focus between regions

### DIFF
--- a/macos/Sources/Lyrebird/Components/ThemedFocusRing.swift
+++ b/macos/Sources/Lyrebird/Components/ThemedFocusRing.swift
@@ -31,3 +31,43 @@ extension View {
         modifier(ThemedFocusRing())
     }
 }
+
+/// Region-level focus indicator for the Tab / Shift+Tab region cycle.
+///
+/// Unlike `ThemedFocusRing`, which owns its own `@FocusState`, this ring is
+/// driven by an explicit `isActive` flag because *region* focus is owned by
+/// `MainShell`'s single `@FocusState<FocusRegion?>` — each region container is
+/// told whether it is the focused one rather than tracking focus itself. The
+/// ring sits just inside the region's bounds and reuses the same
+/// contrast-adaptive tokens as `ThemedFocusRing`, so the visible focus ring on
+/// each region transition reads as one design language.
+struct RegionFocusRing: ViewModifier {
+    @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Whether this region currently holds the region-level keyboard focus.
+    let isActive: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        contrast == .increased ? Theme.focusRingHighContrast : Theme.focusRing,
+                        lineWidth: isActive ? 2 : 0
+                    )
+                    // Inset so the 2pt stroke lands inside the region edge
+                    // rather than straddling the divider between regions.
+                    .padding(1)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.12), value: isActive)
+            )
+    }
+}
+
+extension View {
+    /// Apply the region-level focus ring used by the Tab region cycle.
+    /// Pass whether this region currently owns the shell's region focus.
+    func regionFocusRing(isActive: Bool) -> some View {
+        modifier(RegionFocusRing(isActive: isActive))
+    }
+}

--- a/macos/Sources/Lyrebird/FocusRegion.swift
+++ b/macos/Sources/Lyrebird/FocusRegion.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// The top-level keyboard-focus regions that Tab / Shift+Tab cycle between,
+/// in forward-cycle order:
+///
+///   Sidebar → Content → Up Next inspector → Player bar → Search → (wrap)
+///
+/// This is the region-level counterpart to `SwitchControlGroup` (which labels
+/// the accessibility-tree groups for Switch Control's "Group items" scan). The
+/// two intentionally overlap on Sidebar / Content / Player Bar but `FocusRegion`
+/// also models the two regions that are reachable by Tab but aren't permanent
+/// shell containers — the conditionally-mounted Up Next inspector and the
+/// toolbar Search field — so the Tab cycle and the region focus ring read from
+/// one ordered source of truth.
+///
+/// macOS Full Keyboard Access already moves focus *within* a focusable subtree
+/// with Tab; what it does not do is hop between these named regions with a
+/// region-level focus ring. `MainShell` drives that hop explicitly off this
+/// enum so the behaviour is identical whether or not the user has Full Keyboard
+/// Access enabled (the acceptance criterion).
+enum FocusRegion: String, CaseIterable, Hashable {
+    case sidebar = "Sidebar"
+    case content = "Content"
+    case upNext = "Up Next"
+    case playerBar = "Player Bar"
+    case search = "Search"
+}
+
+/// Pure, view-free cycling logic for the Tab / Shift+Tab region traversal.
+/// Factored out of `MainShell` so the ordering — and, critically, the
+/// rule that the Up Next inspector is skipped when it isn't mounted — is
+/// unit-testable without booting a SwiftUI scene.
+enum FocusRegionCycle {
+    /// Traversal direction. `.forward` is Tab; `.backward` is Shift+Tab.
+    enum Direction {
+        case forward
+        case backward
+    }
+
+    /// The regions that are actually reachable right now, in cycle order. The
+    /// Up Next inspector only participates when it is mounted
+    /// (`inspectorPresent`); every other region is always present.
+    ///
+    /// Kept as a single ordered array so `next(...)` and the focus-ring wiring
+    /// can't drift out of sync — both derive from this one list.
+    static func order(inspectorPresent: Bool) -> [FocusRegion] {
+        FocusRegion.allCases.filter { region in
+            region != .upNext || inspectorPresent
+        }
+    }
+
+    /// The region Tab / Shift+Tab should move to from `current`.
+    ///
+    /// - Wraps cyclically (Search → Sidebar on Tab; Sidebar → Search on
+    ///   Shift+Tab) so traversal never dead-ends, matching macOS's
+    ///   region-cycle convention.
+    /// - Skips the Up Next inspector entirely when `inspectorPresent` is
+    ///   `false`, so closing the inspector mid-traversal can't strand focus on
+    ///   a region that no longer exists.
+    /// - When `current` is `nil` (nothing focused yet) or is the now-absent
+    ///   `.upNext`, a forward Tab enters at the first region (Sidebar) and a
+    ///   backward Shift+Tab enters at the last (Search), so the very first Tab
+    ///   press always lands somewhere sensible.
+    static func next(
+        from current: FocusRegion?,
+        direction: Direction,
+        inspectorPresent: Bool
+    ) -> FocusRegion {
+        let regions = order(inspectorPresent: inspectorPresent)
+        // `order` always contains at least Sidebar/Content/PlayerBar/Search, so
+        // `first`/`last` are non-nil; the fallback satisfies the compiler.
+        guard let first = regions.first, let last = regions.last else {
+            return .sidebar
+        }
+
+        guard let current, let idx = regions.firstIndex(of: current) else {
+            // No current focus (or focus was on the now-unmounted inspector):
+            // enter at the natural end for the direction.
+            return direction == .forward ? first : last
+        }
+
+        switch direction {
+        case .forward:
+            let nextIdx = regions.index(after: idx)
+            return nextIdx == regions.endIndex ? first : regions[nextIdx]
+        case .backward:
+            return idx == regions.startIndex ? last : regions[regions.index(before: idx)]
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -59,6 +59,26 @@ struct MainShell: View {
     /// post-connect *teaching* overlay.
     @AppStorage(FeatureTourSeenStore.seenKey) private var hasSeenFeatureTour: Bool = false
 
+    /// Which top-level region currently owns keyboard focus for the Tab /
+    /// Shift+Tab region cycle. One `@FocusState` for the whole shell:
+    /// each region container binds `.focused($focusedRegion, equals: .x)` so
+    /// SwiftUI keeps exactly one region focused and the region focus ring
+    /// reads off the same source of truth. `nil` until the first Tab press (or
+    /// when focus is inside an inner control rather than parked on a region
+    /// container). Cycling between regions is driven by `cycleRegion(_:)`,
+    /// invoked from the `.onKeyPress(.tab)` handler so the hop works with or
+    /// without macOS Full Keyboard Access enabled — FKA only traverses *within*
+    /// a focusable subtree, never between these named regions.
+    @FocusState private var focusedRegion: FocusRegion?
+
+    /// Mirrors region focus onto the toolbar Search field. The Search "region"
+    /// in the region cycle is that text field; binding its own `@FocusState`
+    /// lets the region cycle land the cursor in it (and lets the field report
+    /// back so Shift+Tab out of Search is observable). Kept distinct from
+    /// `model.isSearchFieldFocused` (the global ⌘⇧F path, which targets the
+    /// full Search *page*, not this toolbar field).
+    @FocusState private var searchFieldFocused: Bool
+
     var body: some View {
         @Bindable var model = model
         VStack(spacing: 0) {
@@ -92,6 +112,14 @@ struct MainShell: View {
                     // floor (brand mark + nav rows stay legible) and a 360pt
                     // ceiling (so the rail can't swallow the detail column).
                     .navigationSplitViewColumnWidth(min: 200, ideal: 252, max: 360)
+                    // Tab region cycle: the sidebar is the first region.
+                    // `.focusable` makes the whole rail a Tab stop the shell can
+                    // park focus on; `.focused` binds it to the shared region
+                    // state; the region ring is the visible focus indicator on
+                    // each transition.
+                    .focusable()
+                    .focused($focusedRegion, equals: .sidebar)
+                    .regionFocusRing(isActive: focusedRegion == .sidebar)
             } detail: {
                 HStack(spacing: 0) {
                     NavigationStack(path: $model.navPath) {
@@ -130,6 +158,13 @@ struct MainShell: View {
                                             .font(Theme.font(13, weight: .medium))
                                             .foregroundStyle(Theme.ink)
                                             .frame(maxWidth: 280)
+                                            // Tab region cycle: this
+                                            // toolbar field is the Search
+                                            // region. Binding its own focus
+                                            // state lets `cycleRegion(_:)` land
+                                            // the cursor here and lets a
+                                            // Shift+Tab out of it be observed.
+                                            .focused($searchFieldFocused)
                                             .onSubmit {
                                                 // Hand off to the Search page so
                                                 // `runFullSearch` and the existing
@@ -163,6 +198,12 @@ struct MainShell: View {
                     // container so it lands on the container, keeping the
                     // #334 tab order (content second, after the sidebar).
                     .accessibilitySortPriority(90)
+                    // Tab region cycle: the content pane is the second
+                    // region. Same focusable + focused + ring trio as the
+                    // sidebar so Tab can park focus on the whole pane.
+                    .focusable()
+                    .focused($focusedRegion, equals: .content)
+                    .regionFocusRing(isActive: focusedRegion == .content)
 
                     // Right-side Queue Inspector (#79). Hidden by default;
                     // toggled by Cmd+Opt+Q or a future PlayerBar button
@@ -177,6 +218,14 @@ struct MainShell: View {
                             .frame(width: 320)
                             .transition(.move(edge: .trailing).combined(with: .opacity))
                             .accessibilitySortPriority(70)
+                            // Tab region cycle: the Up Next inspector is
+                            // the third region — but only while it's mounted.
+                            // `FocusRegionCycle` skips `.upNext` when the
+                            // inspector is closed, so Tab never strands focus on
+                            // a region that isn't on screen.
+                            .focusable()
+                            .focused($focusedRegion, equals: .upNext)
+                            .regionFocusRing(isActive: focusedRegion == .upNext)
                     }
                 }
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: model.isQueueInspectorOpen)
@@ -199,8 +248,39 @@ struct MainShell: View {
                 // sort priority is the only thing the shell needs to set,
                 // pinning the player bar last in the #334 tab order.
                 .accessibilitySortPriority(50)
+                // Tab region cycle: the player bar is the fourth region
+                // (Search, the toolbar field, is the fifth and wraps back to
+                // the sidebar). Same focusable + focused + ring trio.
+                .focusable()
+                .focused($focusedRegion, equals: .playerBar)
+                .regionFocusRing(isActive: focusedRegion == .playerBar)
         }
         .background(Theme.bg)
+        // Tab / Shift+Tab region cycle. One `onKeyPress` keyed on Tab
+        // for the `.down` phase; the `.shift` modifier on the `KeyPress` picks
+        // the direction (Tab forward, Shift+Tab backward). Handling it here —
+        // rather than relying on macOS Full Keyboard Access — is what makes the
+        // region hop work whether or not FKA is enabled (the acceptance
+        // criterion): FKA only moves focus *within* a focusable subtree, never
+        // between these named regions. The handler always returns `.handled`,
+        // consuming the press so the same Tab doesn't *also* step focus inside
+        // the current region — Tab is the app-level "move between regions"
+        // gesture. This ancestor modifier only sees the event when no focused
+        // descendant claimed it first, so a control that genuinely needs Tab
+        // (none today) would still take precedence.
+        .onKeyPress(keys: [.tab], phases: .down) { press in
+            handleTabKey(shift: press.modifiers.contains(.shift))
+        }
+        // Keep region state and the Search field's own focus in sync. When the
+        // user clicks straight into the toolbar Search field (bypassing the Tab
+        // cycle), clear the parked region so a subsequent Shift+Tab steps
+        // backward from Search (computed via `currentRegion`) rather than from a
+        // stale region container.
+        .onChange(of: searchFieldFocused) { _, isFocused in
+            if isFocused {
+                focusedRegion = nil
+            }
+        }
         // Width-driven sidebar auto-hide (#318). A zero-cost GeometryReader in
         // the background reports the shell's width; `onChange` runs the pure
         // `SidebarAutoHide` reducer to collapse the rail on narrow windows and
@@ -343,6 +423,51 @@ struct MainShell: View {
     /// which records the seen flag when it closes.
     private var shouldShowFeatureTour: Bool {
         !hasSeenFeatureTour || model.isFeatureTourPresented
+    }
+
+    // MARK: - Tab region cycle
+
+    /// The region keyboard focus is effectively on right now. The toolbar
+    /// Search field tracks its own `@FocusState` (`searchFieldFocused`) rather
+    /// than the shared region state, so when it's focused the effective region
+    /// is `.search`; otherwise it's whatever container is parked in
+    /// `focusedRegion` (possibly `nil` before the first Tab).
+    private var currentRegion: FocusRegion? {
+        searchFieldFocused ? .search : focusedRegion
+    }
+
+    /// Handles a Tab (`shift == false`) or Shift+Tab (`shift == true`) press by
+    /// advancing the region focus one step through `FocusRegionCycle` and
+    /// returning `.handled` so the press is consumed (preventing the OS from
+    /// *also* stepping focus inside the current region on the same keystroke).
+    ///
+    /// The cycle's order — Sidebar → Content → Up Next → Player Bar → Search →
+    /// (wrap) — and its skip-the-inspector-when-closed rule live in the pure,
+    /// unit-tested `FocusRegionCycle`; this method only applies the result.
+    private func handleTabKey(shift: Bool) -> KeyPress.Result {
+        cycleRegion(shift ? .backward : .forward)
+        return .handled
+    }
+
+    /// Moves region focus one step in `direction`, mapping the chosen
+    /// `FocusRegion` onto the two backing focus states. Search is special: it's
+    /// the toolbar text field, so landing on `.search` drives
+    /// `searchFieldFocused` (and clears the parked region) to put the cursor in
+    /// the field; every other region drives `focusedRegion` (and clears the
+    /// search field) so exactly one region container shows the focus ring.
+    private func cycleRegion(_ direction: FocusRegionCycle.Direction) {
+        let target = FocusRegionCycle.next(
+            from: currentRegion,
+            direction: direction,
+            inspectorPresent: model.isQueueInspectorOpen
+        )
+        if target == .search {
+            focusedRegion = nil
+            searchFieldFocused = true
+        } else {
+            searchFieldFocused = false
+            focusedRegion = target
+        }
     }
 
     /// Toolbar `Toggle Sidebar` handler (#318). Flips `columnVisibility` and

--- a/macos/Tests/LyrebirdTests/FocusRegionCycleTests.swift
+++ b/macos/Tests/LyrebirdTests/FocusRegionCycleTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import Lyrebird
+
+/// Guards the Tab / Shift+Tab region-cycle ordering wired into `MainShell`.
+/// The view-level `@FocusState` wiring can't be introspected without
+/// booting a scene, so these tests pin the part that carries the behaviour: the
+/// pure `FocusRegionCycle` ordering (Sidebar → Content → Up Next → Player Bar →
+/// Search → wrap) and its rule that the Up Next inspector is skipped when it
+/// isn't mounted. Each assertion is falsifiable — reorder the regions, drop the
+/// wrap-around, or stop skipping the closed inspector and one of these fails.
+final class FocusRegionCycleTests: XCTestCase {
+
+    // MARK: - Enum constants
+
+    /// The five regions must keep their stable order + spoken labels so the
+    /// cycle and the region focus ring read off one source of truth.
+    func testFocusRegionOrderAndLabels() {
+        XCTAssertEqual(
+            FocusRegion.allCases,
+            [.sidebar, .content, .upNext, .playerBar, .search]
+        )
+        XCTAssertEqual(FocusRegion.sidebar.rawValue, "Sidebar")
+        XCTAssertEqual(FocusRegion.content.rawValue, "Content")
+        XCTAssertEqual(FocusRegion.upNext.rawValue, "Up Next")
+        XCTAssertEqual(FocusRegion.playerBar.rawValue, "Player Bar")
+        XCTAssertEqual(FocusRegion.search.rawValue, "Search")
+    }
+
+    // MARK: - Reachable order
+
+    /// With the inspector open, all five regions participate in the cycle.
+    func testOrderIncludesInspectorWhenOpen() {
+        XCTAssertEqual(
+            FocusRegionCycle.order(inspectorPresent: true),
+            [.sidebar, .content, .upNext, .playerBar, .search]
+        )
+    }
+
+    /// With the inspector closed, Up Next drops out — the other four stay in
+    /// order.
+    func testOrderSkipsInspectorWhenClosed() {
+        XCTAssertEqual(
+            FocusRegionCycle.order(inspectorPresent: false),
+            [.sidebar, .content, .playerBar, .search]
+        )
+    }
+
+    // MARK: - Forward cycle (Tab), inspector open
+
+    func testForwardCycleWithInspector() {
+        func fwd(_ r: FocusRegion?) -> FocusRegion {
+            FocusRegionCycle.next(from: r, direction: .forward, inspectorPresent: true)
+        }
+        XCTAssertEqual(fwd(.sidebar), .content)
+        XCTAssertEqual(fwd(.content), .upNext)
+        XCTAssertEqual(fwd(.upNext), .playerBar)
+        XCTAssertEqual(fwd(.playerBar), .search)
+        // Wrap-around: Search → Sidebar.
+        XCTAssertEqual(fwd(.search), .sidebar)
+    }
+
+    // MARK: - Forward cycle (Tab), inspector closed
+
+    /// Content must skip straight to Player Bar (not Up Next) when the inspector
+    /// is closed, and the wrap still lands on Sidebar.
+    func testForwardCycleSkipsClosedInspector() {
+        func fwd(_ r: FocusRegion?) -> FocusRegion {
+            FocusRegionCycle.next(from: r, direction: .forward, inspectorPresent: false)
+        }
+        XCTAssertEqual(fwd(.sidebar), .content)
+        XCTAssertEqual(fwd(.content), .playerBar)
+        XCTAssertEqual(fwd(.playerBar), .search)
+        XCTAssertEqual(fwd(.search), .sidebar)
+    }
+
+    // MARK: - Backward cycle (Shift+Tab)
+
+    func testBackwardCycleWithInspector() {
+        func back(_ r: FocusRegion?) -> FocusRegion {
+            FocusRegionCycle.next(from: r, direction: .backward, inspectorPresent: true)
+        }
+        // Wrap-around: Sidebar → Search.
+        XCTAssertEqual(back(.sidebar), .search)
+        XCTAssertEqual(back(.content), .sidebar)
+        XCTAssertEqual(back(.upNext), .content)
+        XCTAssertEqual(back(.playerBar), .upNext)
+        XCTAssertEqual(back(.search), .playerBar)
+    }
+
+    func testBackwardCycleSkipsClosedInspector() {
+        func back(_ r: FocusRegion?) -> FocusRegion {
+            FocusRegionCycle.next(from: r, direction: .backward, inspectorPresent: false)
+        }
+        // Player Bar steps back over the absent Up Next to Content.
+        XCTAssertEqual(back(.playerBar), .content)
+        XCTAssertEqual(back(.sidebar), .search)
+        XCTAssertEqual(back(.content), .sidebar)
+        XCTAssertEqual(back(.search), .playerBar)
+    }
+
+    // MARK: - Entry from no / stale focus
+
+    /// The very first Tab (nothing focused yet) enters at Sidebar; the very
+    /// first Shift+Tab enters at Search — so the cycle never dead-ends on a
+    /// fresh window.
+    func testEntryFromNilFocus() {
+        XCTAssertEqual(
+            FocusRegionCycle.next(from: nil, direction: .forward, inspectorPresent: true),
+            .sidebar
+        )
+        XCTAssertEqual(
+            FocusRegionCycle.next(from: nil, direction: .backward, inspectorPresent: true),
+            .search
+        )
+    }
+
+    /// If focus was parked on the inspector and it then closed, the next Tab
+    /// treats the stale region as "no current region" and re-enters at the
+    /// natural end rather than getting stuck.
+    func testEntryFromStaleInspectorRegion() {
+        XCTAssertEqual(
+            FocusRegionCycle.next(from: .upNext, direction: .forward, inspectorPresent: false),
+            .sidebar
+        )
+        XCTAssertEqual(
+            FocusRegionCycle.next(from: .upNext, direction: .backward, inspectorPresent: false),
+            .search
+        )
+    }
+}


### PR DESCRIPTION
Adds Tab / Shift+Tab keyboard traversal between the app's top-level regions so a keyboard-only user can move around the shell the way macOS's Full Keyboard Access convention leads them to expect.

Tab / Shift+Tab cycle Sidebar → Content → Up Next inspector → Player bar → Search → (wrap), with a themed focus ring drawn on whichever region is active. The hop is driven explicitly from `onKeyPress(.tab)` in `MainShell` rather than relying on Full Keyboard Access, so it behaves identically with or without FKA enabled — FKA only moves focus *within* a focusable subtree, never between these named regions. The Up Next inspector participates only while it's mounted; the closed-inspector skip and the wrap-around ordering live in a pure, unit-tested `FocusRegionCycle` enum so the behaviour is locked without booting a scene. The shell binds one shared `FocusState<FocusRegion?>` across the four in-shell region containers plus the toolbar Search field's own `FocusState`, and renders a new region-level `regionFocusRing(isActive:)` (contrast-adaptive, Reduce-Motion-aware) so each transition is visible.

Closes #107

pipeline:
- builder-session: wave-2 feature builder (isolated worktree)
- slice: scaffold
- hotspot: lyrebirdapp (MainShell view, not AppModel/LyrebirdApp class)
- build-gate: PASS — `swift build` clean; `swift test --filter FocusRegionCycleTests` 9/9; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets --all-features -D warnings` clean; `cargo test --workspace --exclude lyrebird-desktop` 290 passed / 0 failed / 1 ignored
- diff-stat: 4 files, +385 (new FocusRegion.swift + FocusRegionCycleTests.swift; ThemedFocusRing.swift +RegionFocusRing; MainShell.swift region wiring)