### PR TITLE
feat(macos): Appears On rail on the artist page (#224)

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -755,6 +755,53 @@ impl JellyfinClient {
             .await
     }
 
+    /// Albums where the artist is credited at the track level but is **not**
+    /// the album-artist — i.e. guest features, collaborations, and
+    /// "Various Artists" compilations the artist plays on. The conventional
+    /// "Appears On" rail of a music player's artist page (#224), the
+    /// complement of [`Self::albums_by_artist`]'s Discography.
+    ///
+    /// Scoped via `ArtistIds` (the broad "any credited artist" filter, in
+    /// contrast to `albums_by_artist`'s narrow `AlbumArtistIds`), then the
+    /// artist's *own* releases are subtracted client-side by dropping any
+    /// album whose primary `artist_id` is this artist. The server has no
+    /// single "credited but not album-artist" filter, so the broad fetch +
+    /// local subtraction is the cheapest correct expression of that set.
+    ///
+    /// Sorted by `ProductionYear` descending so the rail leads with the most
+    /// recent guest spots. `total_count` reports the count *after* the local
+    /// subtraction so callers see the size of the rail they will render, not
+    /// the pre-filter fetch window.
+    pub async fn appears_on_albums(
+        &self,
+        artist_id: &str,
+        paging: Paging,
+    ) -> Result<PaginatedAlbums> {
+        let page = ItemsQuery::new()
+            .recursive()
+            .artist(artist_id)
+            .item_types(vec![ItemKind::MusicAlbum])
+            .limit(paging.limit)
+            .offset(paging.offset)
+            .sort(ItemSortBy::ProductionYear, SortOrder::Descending)
+            .fields(vec![
+                ItemField::Genres,
+                ItemField::ProductionYear,
+                ItemField::ChildCount,
+                ItemField::PrimaryImageAspectRatio,
+            ])
+            .enable_user_data()
+            .fetch_albums(self)
+            .await?;
+        let items: Vec<Album> = page
+            .items
+            .into_iter()
+            .filter(|album| album.artist_id.as_deref() != Some(artist_id))
+            .collect();
+        let total_count = items.len() as u32;
+        Ok(PaginatedAlbums { items, total_count })
+    }
+
     /// Fetch the most recently added albums in a library, respecting the
     /// authenticated user's parental controls (enforced server-side via
     /// `userId`). Backed by `GET /Items/Latest`.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -424,6 +424,23 @@ impl LyrebirdCore {
         })
     }
 
+    /// Albums the artist guests on — credited at the track level but not the
+    /// album-artist (guest features, collaborations, "Various Artists"
+    /// compilations). Powers the artist page "Appears On" rail (#224); the
+    /// complement of [`Self::albums_by_artist`]'s Discography. Scopes by
+    /// `ArtistIds` on the server, then subtracts the artist's own releases.
+    pub fn appears_on_albums(
+        &self,
+        artist_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> std::result::Result<PaginatedAlbums, LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.appears_on_albums(&artist_id, Paging::new(offset, limit)))
+        })
+    }
+
     pub fn album_tracks(&self, album_id: String) -> std::result::Result<Vec<Track>, LyrebirdError> {
         self.with_client(|c| self.runtime.block_on(c.album_tracks(&album_id)))
     }

--- a/core/src/tests/client.rs
+++ b/core/src/tests/client.rs
@@ -1427,6 +1427,117 @@ async fn albums_by_artist_clamps_zero_limit_to_one() {
 }
 
 // ============================================================================
+// appears_on_albums — #224, ArtistDetailView "Appears On" rail
+// ============================================================================
+
+/// Covers the "Appears On" rail endpoint. Unlike `albums_by_artist` (which
+/// scopes by `AlbumArtistIds`), this scopes by the broad `ArtistIds` filter so
+/// guest features are captured, then subtracts the artist's *own* releases
+/// (albums whose primary `artist_id` is this artist) client-side. Asserts the
+/// query shape and that the own-release is filtered out while the guest spot
+/// remains.
+#[tokio::test]
+async fn appears_on_albums_uses_artist_ids_and_subtracts_own_releases() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u1/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                // Own release — album-artist IS the target artist. Must be
+                // subtracted (it belongs in Discography, not Appears On).
+                {
+                    "Id": "own1", "Name": "My Own Record", "Type": "MusicAlbum",
+                    "AlbumArtist": "Guest",
+                    "AlbumArtistId": "artist-guest",
+                    "AlbumArtists": [{"Id": "artist-guest", "Name": "Guest"}],
+                    "ArtistItems": [{"Id": "artist-guest", "Name": "Guest"}],
+                    "ProductionYear": 2021, "RunTimeTicks": 1800000000000u64,
+                    "ChildCount": 10, "Genres": ["Rock"],
+                    "ImageTags": { "Primary": "imgOwn" }
+                },
+                // Guest spot — album-artist is someone else; the target artist
+                // is only a track-level credit. Must remain in the rail.
+                {
+                    "Id": "feat1", "Name": "Someone Else's LP", "Type": "MusicAlbum",
+                    "AlbumArtist": "Headliner",
+                    "AlbumArtistId": "artist-headliner",
+                    "AlbumArtists": [{"Id": "artist-headliner", "Name": "Headliner"}],
+                    "ArtistItems": [
+                        {"Id": "artist-headliner", "Name": "Headliner"},
+                        {"Id": "artist-guest", "Name": "Guest"}
+                    ],
+                    "ProductionYear": 2023, "RunTimeTicks": 2400000000000u64,
+                    "ChildCount": 12, "Genres": ["Rock"],
+                    "ImageTags": { "Primary": "imgFeat" }
+                },
+                // Compilation — "Various Artists" headlines; target artist is a
+                // track credit. Must remain in the rail.
+                {
+                    "Id": "comp1", "Name": "Summer Hits", "Type": "MusicAlbum",
+                    "AlbumArtist": "Various Artists",
+                    "AlbumArtistId": "artist-va",
+                    "AlbumArtists": [{"Id": "artist-va", "Name": "Various Artists"}],
+                    "ArtistItems": [{"Id": "artist-guest", "Name": "Guest"}],
+                    "ProductionYear": 2019, "RunTimeTicks": 3600000000000u64,
+                    "ChildCount": 18, "Genres": ["Pop"],
+                    "ImageTags": { "Primary": "imgComp" }
+                }
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    let page = client
+        .appears_on_albums("artist-guest", crate::Paging::new(0, 60))
+        .await
+        .unwrap();
+
+    // The own release is subtracted; the guest spot + compilation remain.
+    assert_eq!(page.items.len(), 2, "own release should be filtered out");
+    assert_eq!(
+        page.total_count, 2,
+        "total_count reports the post-filter rail size"
+    );
+    let ids: Vec<&str> = page.items.iter().map(|a| a.id.as_str()).collect();
+    assert!(ids.contains(&"feat1"), "guest spot should remain: {ids:?}");
+    assert!(ids.contains(&"comp1"), "compilation should remain: {ids:?}");
+    assert!(
+        !ids.contains(&"own1"),
+        "own release must be subtracted: {ids:?}"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let get = requests
+        .iter()
+        .find(|r| r.method.as_str() == "GET")
+        .expect("expected a GET request");
+    let q = get.url.query().expect("expected a query string");
+    // Scopes by the broad ArtistIds filter (captures guest credits), NOT the
+    // narrow AlbumArtistIds (which would exclude the guest spots entirely).
+    assert!(
+        q.starts_with("ArtistIds=") || q.contains("&ArtistIds="),
+        "should scope by the broad ArtistIds filter, got: {q}"
+    );
+    assert!(
+        !q.contains("AlbumArtistIds="),
+        "should NOT use AlbumArtistIds (that's the Discography scope), got: {q}"
+    );
+    assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
+    assert!(q.contains("Recursive=true"), "query: {q}");
+}
+
+// ============================================================================
 // artists endpoint — MusicArtist filter regression (UX fix)
 // ============================================================================
 

--- a/macos/Sources/Lyrebird/AppModel+Resolvers.swift
+++ b/macos/Sources/Lyrebird/AppModel+Resolvers.swift
@@ -355,6 +355,37 @@ extension AppModel {
         }
     }
 
+    /// Albums the artist guests on — credited at the track level but not the
+    /// album-artist (guest features, collaborations, "Various Artists"
+    /// compilations). Drives the artist page "Appears On" rail (#224), the
+    /// complement of `loadArtistAlbums`'s Discography. Backed by
+    /// `core.appearsOnAlbums`, which scopes by `ArtistIds` on the server then
+    /// subtracts the artist's own releases. Detached off the MainActor (gap
+    /// pattern #2), cached per-artist for the session in `artistAppearsOnCache`
+    /// (cleared on logout), and silently falls back to an empty rail on error
+    /// — the rail collapses when empty, so an error reads as "no guest spots"
+    /// rather than a broken section.
+    @discardableResult
+    func loadArtistAppearsOnAlbums(artistId: String, limit: UInt32 = 60) async -> [Album] {
+        if let cached = artistAppearsOnCache[artistId] { return cached }
+        do {
+            let page = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.appearsOnAlbums(artistId: artistId, offset: 0, limit: limit)
+            }.value
+            artistAppearsOnCache[artistId] = page.items
+            serverReachability.noteSuccess()
+            return page.items
+        } catch {
+            // Silent fallback — don't surface errors for a secondary rail.
+            Log.app.notice("loadArtistAppearsOnAlbums failed artist=\(artistId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            if handleAuthError(error) { return [] }
+            if ServerReachability.shouldCount(error: error) {
+                serverReachability.noteFailure()
+            }
+            return []
+        }
+    }
+
     /// Fetch the top 5 most-played tracks for an artist, driving the
     /// "Top Tracks" section on the artist detail screen (#229). Backed by
     /// `/Items?ArtistIds=<id>&SortBy=PlayCount,SortName&SortOrder=Descending,Ascending`

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -117,6 +117,7 @@ extension AppModel {
         artistSimilarCache = [:]
         artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
+        artistAppearsOnCache = [:]
         artistDetailCache = [:]
         resolvedNameCache = [:]
         ambientPaletteCache.removeAll()
@@ -197,6 +198,7 @@ extension AppModel {
         artistSimilarCache = [:]
         artistPlaylistsCache = [:]
         artistAlbumsCache = [:]
+        artistAppearsOnCache = [:]
         artistDetailCache = [:]
         resolvedNameCache = [:]
         ambientPaletteCache.removeAll()

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -857,6 +857,10 @@ final class AppModel {
     /// Per-session cache for `loadArtistAlbums`. Cleared on `logout()`.
     var artistAlbumsCache: [String: [Album]] = [:]
 
+    /// Per-session cache for `loadArtistAppearsOnAlbums` (the "Appears On"
+    /// rail — albums the artist guests on, #224). Cleared on `logout()`.
+    var artistAppearsOnCache: [String: [Album]] = [:]
+
     /// Memoized cache keyed on (itemID, tag, maxWidth). Each grid cell calls
     /// `imageURL` during every scroll-driven body recomputation; without this
     /// cache every cell crosses the UniFFI boundary (Swift → C → Rust) and

--- a/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
+++ b/macos/Sources/Lyrebird/Screens/ArtistDetailView.swift
@@ -19,9 +19,11 @@ import SwiftUI
 /// 4. **Discography** — split by release type (Albums, Singles & EPs,
 ///    Compilations, Live). Because the core doesn't surface `AlbumType`
 ///    yet, we lean on a name/track-count heuristic; sections with zero
-///    matches collapse silently. ("Appears On" is deferred — no
-///    album-artist-vs-track-artist join in the core; see TODO(core-#60)
-///    on `discographyGroups`.)
+///    matches collapse silently.
+/// 4b. **Appears On** (#224) — albums the artist guests on (credited at the
+///    track level but not as the album-artist). Backed by
+///    `core.appearsOnAlbums`, which scopes by `ArtistIds` then subtracts the
+///    artist's own releases; collapses silently when there are none.
 /// 5. **Similar Artists** — backed by `model.loadSimilarArtists` →
 ///    `core.similarArtists` (Jellyfin `/Artists/{id}/Similar`); the row
 ///    collapses silently when the server returns none.
@@ -45,6 +47,11 @@ struct ArtistDetailView: View {
     @State private var topTracks: [Track] = []
     @State private var isLoadingTopTracks = true
     @State private var artistAlbums: [Album] = []
+    /// Albums the artist guests on (credited at the track level but not the
+    /// album-artist). Drives the "Appears On" rail; collapses silently when
+    /// empty. Populated by the `.task(id:)` block via
+    /// `model.loadArtistAppearsOnAlbums`. See #224.
+    @State private var appearsOnAlbums: [Album] = []
     @State private var fetchedArtist: Artist?
     @State private var isBioExpanded = false
     @State private var similarArtistsState: [Artist] = []
@@ -129,6 +136,7 @@ struct ArtistDetailView: View {
                 transportBar(artist)
                 topSongsSection
                 discographySection
+                appearsOnSection(artist)
                 featuringPlaylistsSection(artist)
                 similarArtistsSection
                 aboutSection(artist)
@@ -155,6 +163,7 @@ struct ArtistDetailView: View {
             isBioExpanded = false
             scopedQuery = ""
             featuringPlaylists = []
+            appearsOnAlbums = []
             discographyArtwork = [:]
             isLoadingTopTracks = true
             if model.artists.first(where: { $0.id == artistID }) == nil {
@@ -180,6 +189,22 @@ struct ArtistDetailView: View {
             isLoadingTopTracks = false
             similarArtistsState = await model.loadSimilarArtists(artistId: artistID)
             featuringPlaylists = await model.loadPlaylistsFeaturingArtist(artistId: artistID)
+            // "Appears On" — albums the artist guests on. Loaded after the
+            // primary sections so it never delays the Discography / Top Songs.
+            // Its tiles reuse `ArtistDiscographyTile`, so its artwork is warmed
+            // into the shared `discographyArtwork` map (merged, not replaced)
+            // off the main thread — same gap-pattern-#2 reasoning as above. See
+            // #224.
+            appearsOnAlbums = await model.loadArtistAppearsOnAlbums(artistId: artistID)
+            if !appearsOnAlbums.isEmpty {
+                let appearsArt = await model.resolveImageURLs(
+                    for: appearsOnAlbums.map { (id: $0.id, tag: $0.imageTag) },
+                    maxWidth: 400
+                )
+                for (id, url) in appearsArt where url != nil {
+                    discographyArtwork[id] = url
+                }
+            }
             // Biography is independent of the lists above so a missing or slow
             // detail fetch never blocks the rest of the page. The server
             // overview may carry HTML, so it is stripped to plain text before
@@ -187,7 +212,7 @@ struct ArtistDetailView: View {
             if let detail = await model.artistDetail(artistId: artistID) {
                 bioOverview = Self.plainTextOverview(detail.overview)
             }
-            Log.app.info("ArtistDetailView.task done artist=\(artistID, privacy: .public) albums=\(artistAlbums.count, privacy: .public) topTracks=\(topTracks.count, privacy: .public) similar=\(similarArtistsState.count, privacy: .public) bio=\(bioOverview != nil, privacy: .public)")
+            Log.app.info("ArtistDetailView.task done artist=\(artistID, privacy: .public) albums=\(artistAlbums.count, privacy: .public) appearsOn=\(appearsOnAlbums.count, privacy: .public) topTracks=\(topTracks.count, privacy: .public) similar=\(similarArtistsState.count, privacy: .public) bio=\(bioOverview != nil, privacy: .public)")
         }
     }
 
@@ -574,10 +599,10 @@ struct ArtistDetailView: View {
     ///   standard 4-6 track EP formats).
     /// - **Albums** — everything else.
     ///
-    /// "Appears On" would be albums where the artist is credited at the
-    /// track level but not as the album-artist. We don't have that join in
-    /// the core yet, so the section is surfaced only when we can build it.
-    /// Tracked in TODO(core-#60) along with real `AlbumType` support.
+    /// Albums where the artist is credited only at the track level (not as
+    /// the album-artist) are handled separately by `appearsOnSection` (#224) —
+    /// `albums_by_artist` scopes by `AlbumArtistIds`, so guest spots never
+    /// reach this grouping in the first place.
     ///
     /// Empty sections collapse silently. Each section sorts by year
     /// descending and renders a horizontal carousel of 160pt album tiles.
@@ -640,10 +665,6 @@ struct ArtistDetailView: View {
     /// `AlbumType` field once the core exposes it from Jellyfin's
     /// `Album.AlbumType` (MusicBrainz plugin populates this; otherwise we
     /// keep the heuristic as a reasonable fallback).
-    /// TODO(core-#60): add an "Appears On" group once the core can tell us
-    /// which albums credit this artist only at the track level. Needs either
-    /// an `album_artist_id` vs `track_artist_ids` split on the `Album` record
-    /// or a dedicated `artist_appearances` query.
     private func discographyGroups() -> [DiscographyGroup] {
         var singles: [Album] = []
         var compilations: [Album] = []
@@ -710,6 +731,43 @@ struct ArtistDetailView: View {
     private struct DiscographyGroup {
         let title: String
         let albums: [Album]
+    }
+
+    // MARK: - Appears On (#224)
+
+    /// Horizontal carousel of albums the artist guests on — credited at the
+    /// track level but not as the album-artist (guest features,
+    /// collaborations, "Various Artists" compilations). The complement of the
+    /// Discography above; the core's `appearsOnAlbums` scopes by `ArtistIds`
+    /// then subtracts the artist's own releases, so this rail never duplicates
+    /// a Discography tile. Reuses `ArtistDiscographyTile` for visual
+    /// consistency with the Discography carousels, and hides entirely when the
+    /// artist guests on nothing so it never reads as a broken empty shelf.
+    /// Data comes from `appearsOnAlbums`, populated by the `.task(id:)` block.
+    @ViewBuilder
+    private func appearsOnSection(_ artist: Artist?) -> some View {
+        if !appearsOnAlbums.isEmpty, let artist = artist {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeader(eyebrow: "APPEARS ON", title: "\(artist.name) Guests On")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    // Eager `HStack` (not `LazyHStack`) for the same macOS 26.4
+                    // recycle-UAF reason documented in `discographyGroup`. The
+                    // rail is capped at `loadArtistAppearsOnAlbums`'s limit, so
+                    // eager rendering stays cheap.
+                    HStack(alignment: .top, spacing: 16) {
+                        ForEach(appearsOnAlbums, id: \.id) { album in
+                            ArtistDiscographyTile(
+                                album: album,
+                                artworkURL: discographyArtwork[album.id]
+                            )
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 32)
+        }
     }
 
     // MARK: - Playlists featuring artist


### PR DESCRIPTION
Adds an "Appears On" carousel to the artist detail page so albums where the artist guests (credited at the track level but not as the album-artist — features, collaborations, "Various Artists" compilations) are surfaced as the conventional complement of the Discography, retiring the long-standing `TODO(core-#60)` "Appears On is deferred" note.

Core adds `appears_on_albums(artist_id, paging)`, which scopes by the broad `ArtistIds` server filter (so guest credits are captured, unlike `albums_by_artist`'s narrow `AlbumArtistIds`) and then subtracts the artist's own releases client-side. Swift wires `loadArtistAppearsOnAlbums` (detached FFI off the MainActor, per-session cache cleared on logout, silent fallback) plus an `appearsOnSection` that reuses `ArtistDiscographyTile` and collapses silently when empty; its artwork is warmed off the main thread into the shared discography artwork map so the eager tiles never take the Rust `Inner` mutex on the main thread.

Closes #224

pipeline:
- builder-session: wave-3 single-issue feature builder
- slice: client (artist detail "Appears On" rail)
- hotspot: core (`core/src/client.rs` + `core/src/lib.rs` FFI) — single in-flight item
- build-gate: pass — `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test --workspace --exclude lyrebird-desktop --all-features` 292 passed/0 failed; FFI regen via `build-core.sh` + `rm -rf macos/.build && swift build` clean
- diff-stat: 7 files changed, +282 / -12