### PR TITLE
feat(macos): Quick Connect + editable device name on login

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -611,6 +611,77 @@ impl JellyfinClient {
         })
     }
 
+    /// Begin a Quick Connect handshake. `POST /QuickConnect/Initiate` returns
+    /// an opaque `Secret` plus the short numeric `Code` the user enters into an
+    /// already-signed-in Jellyfin client to authorise this device. No auth
+    /// token is required to start the flow — the device is anonymous until the
+    /// pairing is approved server-side.
+    pub async fn quick_connect_initiate(&self) -> Result<QuickConnectInfo> {
+        let url = self.endpoint("QuickConnect/Initiate")?;
+        let resp = self
+            .send_with_retry(|| Ok(self.http.post(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let state: QuickConnectResponse = resp.json().await?;
+        Ok(QuickConnectInfo {
+            secret: state.secret,
+            code: state.code,
+        })
+    }
+
+    /// Poll the state of a pending Quick Connect handshake.
+    /// `GET /QuickConnect/Connect?Secret=…` returns `Authenticated: true` once
+    /// the user has approved the code on another client. Returns the raw
+    /// `Authenticated` flag so the caller can decide when to exchange the
+    /// secret for a session via [`Self::authenticate_with_quick_connect`].
+    pub async fn quick_connect_state(&self, secret: &str) -> Result<bool> {
+        let mut url = self.endpoint("QuickConnect/Connect")?;
+        url.query_pairs_mut().append_pair("Secret", secret);
+        let resp = self
+            .send_with_retry(|| Ok(self.http.get(url.clone()).headers(self.build_headers()?)))
+            .await?;
+        let state: QuickConnectResponse = resp.json().await?;
+        Ok(state.authenticated)
+    }
+
+    /// Exchange an approved Quick Connect secret for a full session.
+    /// `POST /Users/AuthenticateWithQuickConnect` mirrors the response shape of
+    /// [`Self::authenticate_by_name`], so on success the access token + user id
+    /// are stored on the client exactly as a password sign-in would.
+    pub async fn authenticate_with_quick_connect(&mut self, secret: &str) -> Result<Session> {
+        let url = self.endpoint("Users/AuthenticateWithQuickConnect")?;
+        let body = QuickConnectAuthBody {
+            secret: secret.to_string(),
+        };
+        let resp = self
+            .send_with_retry(|| {
+                Ok(self
+                    .http
+                    .post(url.clone())
+                    .headers(self.build_headers()?)
+                    .json(&body))
+            })
+            .await?;
+        let auth: AuthResult = resp.json().await?;
+        *self.token.lock() = Some(auth.access_token.clone());
+        self.user_id = Some(auth.user.id.clone());
+        Ok(Session {
+            server: Server {
+                url: self.base_url.to_string(),
+                name: auth.server_name.unwrap_or_default(),
+                version: None,
+                id: auth.server_id,
+            },
+            user: User {
+                id: auth.user.id,
+                name: auth.user.name,
+                server_id: auth.user.server_id,
+                primary_image_tag: auth.user.primary_image_tag,
+            },
+            access_token: auth.access_token,
+            device_id: self.device_id.clone(),
+        })
+    }
+
     // ----- Library queries -----
 
     pub async fn artists(&self, paging: Paging) -> Result<PaginatedArtists> {
@@ -2965,6 +3036,26 @@ struct AuthByNameBody {
     username: String,
     #[serde(rename = "Pw")]
     pw: String,
+}
+
+#[derive(Serialize)]
+struct QuickConnectAuthBody {
+    #[serde(rename = "Secret")]
+    secret: String,
+}
+
+/// Wire shape of Jellyfin's `QuickConnectResult`, returned by both
+/// `/QuickConnect/Initiate` and `/QuickConnect/Connect`. We only read the three
+/// fields the pairing flow needs; the rest (`DeviceId`, `AppName`, `DateAdded`,
+/// …) are ignored.
+#[derive(Debug, Deserialize)]
+struct QuickConnectResponse {
+    #[serde(rename = "Authenticated", default)]
+    authenticated: bool,
+    #[serde(rename = "Secret", default)]
+    secret: String,
+    #[serde(rename = "Code", default)]
+    code: String,
 }
 
 // PlaybackProgressBody and PlaybackStoppedBody are kept as thin private

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -135,6 +135,15 @@ impl LyrebirdCore {
             }
         };
 
+        // A user-edited device name (set via `set_device_name`, e.g. from the
+        // login gear popover, #202) is persisted in the DB and wins over the
+        // platform-supplied default in `config.device_name`. On first launch
+        // the setting is absent, so the host-derived default is used as-is.
+        let device_name = db
+            .get_setting("device_name")?
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or(config.device_name);
+
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
@@ -152,7 +161,7 @@ impl LyrebirdCore {
                 client: None,
                 db,
                 device_id,
-                device_name: config.device_name,
+                device_name,
                 data_dir,
             })),
             player,
@@ -165,6 +174,32 @@ impl LyrebirdCore {
 
     pub fn device_id(&self) -> String {
         self.inner.lock().device_id.clone()
+    }
+
+    /// The current device name sent to Jellyfin as the `Device="…"` field of
+    /// the auth header. Defaults to the platform-supplied value passed at
+    /// construction (e.g. the host name) unless overridden via
+    /// [`Self::set_device_name`].
+    pub fn device_name(&self) -> String {
+        self.inner.lock().device_name.clone()
+    }
+
+    /// Override the device name. Persisted in the local DB so it survives
+    /// relaunch and sign-out, and applied to every subsequent client build
+    /// (`probe_server`, `login`, `resume_session`, quick-connect). An empty or
+    /// whitespace-only name is rejected so the auth header always carries a
+    /// usable `Device` field (#202).
+    pub fn set_device_name(&self, name: String) -> std::result::Result<(), LyrebirdError> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(LyrebirdError::InvalidInput(
+                "device name must not be empty".to_string(),
+            ));
+        }
+        let mut inner = self.inner.lock();
+        inner.db.set_setting("device_name", trimmed)?;
+        inner.device_name = trimmed.to_string();
+        Ok(())
     }
 
     pub fn probe_server(&self, url: String) -> std::result::Result<Server, LyrebirdError> {
@@ -210,27 +245,66 @@ impl LyrebirdCore {
         let session = self
             .runtime
             .block_on(client.authenticate_by_name(&username, &password))?;
+        self.persist_session(&session, client, &db)?;
+        Ok(session)
+    }
 
-        if let Some(server_id) = &session.server.id {
-            CredentialStore::save_token(server_id, &session.user.name, &session.access_token)
-                .map_err(|e| LyrebirdError::KeyringWrite {
-                    reason: e.to_string(),
-                })?;
-        }
-        {
+    /// Begin a Jellyfin Quick Connect handshake. Returns the short numeric
+    /// `code` the user enters into another already-signed-in client (rendered
+    /// as text + a QR by the UI) plus the opaque `secret` the caller passes
+    /// back to [`Self::quick_connect_poll`] / [`Self::quick_connect_complete`].
+    /// No session is required to start the flow (#202).
+    pub fn quick_connect_initiate(
+        &self,
+        url: String,
+    ) -> std::result::Result<QuickConnectInfo, LyrebirdError> {
+        let (device_id, device_name) = {
             let inner = self.inner.lock();
-            inner
-                .db
-                .set_setting("last_server_url", &session.server.url)?;
-            inner.db.set_setting("last_username", &session.user.name)?;
-            if let Some(server_id) = &session.server.id {
-                inner.db.set_setting("last_server_id", server_id)?;
-            }
-            inner.db.set_setting("last_user_id", &session.user.id)?;
-        }
-        let client = Arc::new(client);
-        Self::install_refresh_callback(&client, &db);
-        self.inner.lock().client = Some(client);
+            (inner.device_id.clone(), inner.device_name.clone())
+        };
+        let client = JellyfinClient::new(&url, device_id, device_name)?;
+        let info = self.runtime.block_on(client.quick_connect_initiate())?;
+        Ok(info)
+    }
+
+    /// Poll whether a pending Quick Connect `secret` has been approved on
+    /// another client. Returns `true` once authorised — the UI should then call
+    /// [`Self::quick_connect_complete`] to exchange the secret for a session.
+    pub fn quick_connect_poll(
+        &self,
+        url: String,
+        secret: String,
+    ) -> std::result::Result<bool, LyrebirdError> {
+        let (device_id, device_name) = {
+            let inner = self.inner.lock();
+            (inner.device_id.clone(), inner.device_name.clone())
+        };
+        let client = JellyfinClient::new(&url, device_id, device_name)?;
+        let authenticated = self.runtime.block_on(client.quick_connect_state(&secret))?;
+        Ok(authenticated)
+    }
+
+    /// Exchange an approved Quick Connect `secret` for a full session. Persists
+    /// the token + last-server identity exactly like a password sign-in, so
+    /// `resume_session` works after a quick-connect login (#202).
+    pub fn quick_connect_complete(
+        &self,
+        url: String,
+        secret: String,
+    ) -> std::result::Result<models::Session, LyrebirdError> {
+        let (device_id, device_name, db) = {
+            let inner = self.inner.lock();
+            (
+                inner.device_id.clone(),
+                inner.device_name.clone(),
+                inner.db.clone(),
+            )
+        };
+        let mut client = JellyfinClient::new(&url, device_id, device_name)?;
+        let session = self
+            .runtime
+            .block_on(client.authenticate_with_quick_connect(&secret))?;
+        self.persist_session(&session, client, &db)?;
         Ok(session)
     }
 
@@ -1624,6 +1698,42 @@ impl LyrebirdCore {
     fn install_refresh_callback(client: &JellyfinClient, db: &Arc<Database>) {
         let db = db.clone();
         client.set_refresh_callback(Arc::new(move || storage::refresh_token_from_keyring(&db)));
+    }
+
+    /// Shared post-auth bookkeeping for password + quick-connect sign-in: save
+    /// the access token to the OS keyring, write the `last_*` identity settings
+    /// so `resume_session` can rehydrate, install the 401 refresh callback, and
+    /// stash the live client on `Inner`.
+    ///
+    /// Deliberately **not** in the `#[uniffi::export]` block — it takes a raw
+    /// [`JellyfinClient`], which is not an FFI-liftable type.
+    fn persist_session(
+        &self,
+        session: &models::Session,
+        client: JellyfinClient,
+        db: &Arc<Database>,
+    ) -> std::result::Result<(), LyrebirdError> {
+        if let Some(server_id) = &session.server.id {
+            CredentialStore::save_token(server_id, &session.user.name, &session.access_token)
+                .map_err(|e| LyrebirdError::KeyringWrite {
+                    reason: e.to_string(),
+                })?;
+        }
+        {
+            let inner = self.inner.lock();
+            inner
+                .db
+                .set_setting("last_server_url", &session.server.url)?;
+            inner.db.set_setting("last_username", &session.user.name)?;
+            if let Some(server_id) = &session.server.id {
+                inner.db.set_setting("last_server_id", server_id)?;
+            }
+            inner.db.set_setting("last_user_id", &session.user.id)?;
+        }
+        let client = Arc::new(client);
+        Self::install_refresh_callback(&client, db);
+        self.inner.lock().client = Some(client);
+        Ok(())
     }
 }
 

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -24,6 +24,18 @@ pub struct Session {
     pub device_id: String,
 }
 
+/// A pending Jellyfin Quick Connect handshake. Returned by
+/// `LyrebirdCore::quick_connect_initiate`: `code` is the short numeric code the
+/// user types into another already-signed-in Jellyfin client (or scans as a
+/// QR), and `secret` is the opaque token the desktop app polls with until the
+/// pairing is approved, then exchanges for a real session. The secret is never
+/// shown to the user — only the code is.
+#[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct QuickConnectInfo {
+    pub secret: String,
+    pub code: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct Artist {
     pub id: String,

--- a/core/src/tests/session_auth.rs
+++ b/core/src/tests/session_auth.rs
@@ -1362,3 +1362,148 @@ async fn login_forwards_whitespace_only_password_as_empty() {
         "whitespace-only Pw must be trimmed to empty"
     );
 }
+
+#[tokio::test]
+async fn quick_connect_initiate_poll_and_complete_persists_session() {
+    // End-to-end Quick Connect (#202): initiate → poll (pending then approved)
+    // → complete, then assert the session is persisted like a password login so
+    // `resume_session` works on the next launch.
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/QuickConnect/Initiate"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Authenticated": false,
+            "Secret": "qc-secret-abc",
+            "Code": "123456"
+        })))
+        .mount(&server)
+        .await;
+    // First poll: still pending. Second poll: approved. `up_to_n_times` lets us
+    // chain two responses against the same GET so the test exercises the
+    // pending→approved transition the UI polls through.
+    Mock::given(method("GET"))
+        .and(path("/QuickConnect/Connect"))
+        .and(query_param("Secret", "qc-secret-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Authenticated": false,
+            "Secret": "qc-secret-abc",
+            "Code": "123456"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/QuickConnect/Connect"))
+        .and(query_param("Secret", "qc-secret-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Authenticated": true,
+            "Secret": "qc-secret-abc",
+            "Code": "123456"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateWithQuickConnect"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "qc-token",
+            "ServerId": "srv-qc",
+            "ServerName": "QC Jellyfin",
+            "User": {
+                "Id": "usr-qc",
+                "Name": "qc-user",
+                "ServerId": "srv-qc",
+                "PrimaryImageTag": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let server_url = server.uri();
+    let tmp_path = tmp.path().to_string_lossy().into_owned();
+    let url = server_url.clone();
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = LyrebirdCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+
+        let info = core
+            .quick_connect_initiate(url.clone())
+            .expect("quick_connect_initiate");
+        assert_eq!(info.code, "123456");
+        assert_eq!(info.secret, "qc-secret-abc");
+        // The code is what the user sees; the secret is the polling token.
+
+        assert!(
+            !core
+                .quick_connect_poll(url.clone(), info.secret.clone())
+                .expect("first poll"),
+            "first poll should report not-yet-approved"
+        );
+        assert!(
+            core.quick_connect_poll(url.clone(), info.secret.clone())
+                .expect("second poll"),
+            "second poll should report approved"
+        );
+
+        let session = core
+            .quick_connect_complete(url, info.secret)
+            .expect("quick_connect_complete");
+        assert_eq!(session.access_token, "qc-token");
+        assert_eq!(session.user.id, "usr-qc");
+
+        // Persisted identically to a password login so resume works.
+        let inner = core.inner.lock();
+        assert_eq!(
+            inner.db.get_setting("last_user_id").unwrap().as_deref(),
+            Some("usr-qc")
+        );
+        assert_eq!(
+            inner.db.get_setting("last_server_id").unwrap().as_deref(),
+            Some("srv-qc")
+        );
+        assert!(
+            inner.client.is_some(),
+            "quick_connect_complete must install a live client"
+        );
+    })
+    .await
+    .expect("join quick-connect task");
+}
+
+#[test]
+fn set_device_name_persists_overrides_default_and_rejects_empty() {
+    // #202: a user-edited device name persists in the DB, wins over the
+    // platform-supplied `CoreConfig.device_name` on the next launch, and an
+    // empty/whitespace name is rejected so the auth header always has a usable
+    // `Device` field.
+    let tmp = tempfile::tempdir().unwrap();
+
+    let core = resume_test_core(&tmp);
+    assert_eq!(core.device_name(), "Test", "starts from the config default");
+
+    // Whitespace-only is rejected and leaves the name untouched.
+    let err = core
+        .set_device_name("   ".into())
+        .expect_err("blank device name must be rejected");
+    assert!(matches!(err, LyrebirdError::InvalidInput(_)));
+    assert_eq!(core.device_name(), "Test");
+
+    // A real edit is trimmed, applied live, and persisted.
+    core.set_device_name("  Soren's MacBook Pro  ".into())
+        .expect("set_device_name");
+    assert_eq!(core.device_name(), "Soren's MacBook Pro");
+
+    // A fresh core over the same data dir reads the persisted name in
+    // preference to the default it was constructed with.
+    let core2 = LyrebirdCore::new(CoreConfig {
+        data_dir: tmp.path().to_string_lossy().into_owned(),
+        device_name: "Different Default".into(),
+    })
+    .expect("core init");
+    assert_eq!(core2.device_name(), "Soren's MacBook Pro");
+}

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -46,6 +46,92 @@ extension AppModel {
         }
     }
 
+    // MARK: - Device name
+
+    /// Host-derived default device name (e.g. "Soren's MacBook Pro"), used the
+    /// first time the app launches before the user has set one. Falls back to a
+    /// generic product name if the host name can't be resolved (#202).
+    static func defaultDeviceName() -> String {
+        let host = Host.current().localizedName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let host, !host.isEmpty {
+            return host
+        }
+        return "Lyrebird macOS"
+    }
+
+    /// Persist a user-edited device name through the core (which trims it,
+    /// stores it in its DB, and applies it to every subsequent auth header) and
+    /// mirror the resolved value back onto the model. A blank name is ignored —
+    /// the core rejects it — so the field can't be cleared into an empty
+    /// `Device` header (#202).
+    func updateDeviceName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != deviceName else { return }
+        do {
+            try core.setDeviceName(name: trimmed)
+            deviceName = core.deviceName()
+        } catch {
+            Log.auth.error("setDeviceName failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Quick Connect
+
+    /// Begin a Quick Connect handshake against `url`. Returns the
+    /// `QuickConnectInfo` (the short code to display + the polling secret) or
+    /// `nil` on failure, surfacing a localized error on the model. Runs the
+    /// blocking FFI off the main actor (#202, gap pattern #2).
+    func quickConnectInitiate(url: String) async -> QuickConnectInfo? {
+        do {
+            return try await Task.detached(priority: .userInitiated) { [core] in
+                try core.quickConnectInitiate(url: url)
+            }.value
+        } catch {
+            errorMessage = LyrebirdErrorPresenter.message(for: error, context: .login)
+            return nil
+        }
+    }
+
+    /// Poll whether a pending Quick Connect `secret` has been approved on
+    /// another client. Returns `true` once authorised. Off-main-actor FFI.
+    func quickConnectPoll(url: String, secret: String) async -> Bool {
+        do {
+            return try await Task.detached(priority: .userInitiated) { [core] in
+                try core.quickConnectPoll(url: url, secret: secret)
+            }.value
+        } catch {
+            // Transient poll failures shouldn't tear down the sheet — the next
+            // tick retries. Surface only at debug level.
+            Log.auth.debug("quickConnectPoll failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Exchange an approved Quick Connect `secret` for a session and finish
+    /// sign-in (load library, start polling) exactly like a password login.
+    /// Returns `true` on success. Off-main-actor FFI.
+    @discardableResult
+    func quickConnectComplete(url: String, secret: String) async -> Bool {
+        isLoggingIn = true
+        defer { isLoggingIn = false }
+        do {
+            let session = try await Task.detached(priority: .userInitiated) { [core] in
+                try core.quickConnectComplete(url: url, secret: secret)
+            }.value
+            self.session = session
+            self.serverURL = session.server.url
+            self.username = session.user.name
+            self.errorMessage = nil
+            startPolling()
+            await refreshLibrary()
+            await refreshDownloads()
+            return true
+        } catch {
+            self.errorMessage = LyrebirdErrorPresenter.message(for: error, context: .login)
+            return false
+        }
+    }
+
     /// Rehydrate the previous session from on-disk settings + the keychain
     /// token. Called once from `RootView.task` on cold start. No-ops when the
     /// core has nothing to restore (first launch, post-logout, etc.); in that

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -601,6 +601,13 @@ final class AppModel {
     var isLoadingLibrary = false
     var errorMessage: String?
 
+    /// The device name Jellyfin sees for this client (the `Device="…"` auth
+    /// header field). Seeded from the core in `init()` — which itself prefers a
+    /// previously user-edited value persisted in the DB over the host-derived
+    /// default — and edited via the login gear popover through
+    /// `updateDeviceName(_:)` (#202).
+    var deviceName: String = ""
+
     /// Set during the one-shot `attemptRestoreSession` pass at launch. `RootView`
     /// renders a minimal loading state while this is true so we don't briefly
     /// flash `LoginView` on cold start even though a valid session is about to
@@ -808,9 +815,13 @@ final class AppModel {
 
     init() throws {
         let core = try LyrebirdCore(
-            config: CoreConfig(dataDir: "", deviceName: "Lyrebird macOS")
+            config: CoreConfig(dataDir: "", deviceName: AppModel.defaultDeviceName())
         )
         self.core = core
+        // The core prefers a previously user-edited name (persisted in its DB)
+        // over the host-derived default we just passed, so read the resolved
+        // value back rather than re-deriving it here (#202).
+        self.deviceName = core.deviceName()
         self.audio = AudioEngine(core: core)
         self.mediaSession = MediaSession()
         self.network = NetworkMonitor()

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -3421,6 +3421,234 @@
           }
         }
       }
+    },
+    "login.device_name.a11y_field" : {
+      "comment" : "Accessibility label for the device-name text field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device name"
+          }
+        }
+      }
+    },
+    "login.device_name.a11y_label %@" : {
+      "comment" : "Accessibility label for the device-name gear; the argument is the current device name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device name: %@"
+          }
+        }
+      }
+    },
+    "login.device_name.cancel" : {
+      "comment" : "Button that dismisses the device-name popover.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "login.device_name.help" : {
+      "comment" : "Tooltip on the device-name gear.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change the name Jellyfin shows for this device."
+          }
+        }
+      }
+    },
+    "login.device_name.placeholder" : {
+      "comment" : "Placeholder for the device-name field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Mac"
+          }
+        }
+      }
+    },
+    "login.device_name.save" : {
+      "comment" : "Button that saves the edited device name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        }
+      }
+    },
+    "login.device_name.subtitle" : {
+      "comment" : "Explains where the device name appears.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shown on this server's Dashboard and in other Jellyfin clients."
+          }
+        }
+      }
+    },
+    "login.device_name.title" : {
+      "comment" : "Title of the device-name editing popover.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device name"
+          }
+        }
+      }
+    },
+    "login.quick_connect.a11y_hint" : {
+      "comment" : "Accessibility hint for the Quick Connect link.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pair this device by entering a code in another signed-in Jellyfin client."
+          }
+        }
+      }
+    },
+    "login.quick_connect.cancel" : {
+      "comment" : "Button to dismiss the Quick Connect sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "login.quick_connect.code_label" : {
+      "comment" : "Label above the numeric Quick Connect code.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CODE"
+          }
+        }
+      }
+    },
+    "login.quick_connect.error" : {
+      "comment" : "Shown when Quick Connect fails to start or complete.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Connect couldn't be completed. Please try again."
+          }
+        }
+      }
+    },
+    "login.quick_connect.link" : {
+      "comment" : "Secondary link under the sign-in button that opens the Quick Connect pairing sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Jellyfin Quick Connect"
+          }
+        }
+      }
+    },
+    "login.quick_connect.needs_server" : {
+      "comment" : "Shown when no server URL has been entered yet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your server address on the login screen first, then try Quick Connect."
+          }
+        }
+      }
+    },
+    "login.quick_connect.retry" : {
+      "comment" : "Button to retry a failed Quick Connect.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        }
+      }
+    },
+    "login.quick_connect.starting" : {
+      "comment" : "Shown while the Quick Connect code is being requested.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starting Quick Connect…"
+          }
+        }
+      }
+    },
+    "login.quick_connect.subtitle" : {
+      "comment" : "Subtitle explaining how Quick Connect works.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter this code in another signed-in Jellyfin app to pair this device."
+          }
+        }
+      }
+    },
+    "login.quick_connect.title" : {
+      "comment" : "Title of the Quick Connect pairing sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Connect"
+          }
+        }
+      }
+    },
+    "login.quick_connect.waiting" : {
+      "comment" : "Shown while waiting for the user to approve the code elsewhere.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for approval…"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/macos/Sources/Lyrebird/Screens/LoginView.swift
+++ b/macos/Sources/Lyrebird/Screens/LoginView.swift
@@ -45,6 +45,12 @@ struct LoginView: View {
     /// failures (#203).
     @State private var hasSeenRepeatedUnreachable: Bool = false
 
+    /// Presents the Quick Connect pairing sheet (#202).
+    @State private var showQuickConnect: Bool = false
+
+    /// Presents the device-name editing popover anchored on the gear (#202).
+    @State private var showDeviceName: Bool = false
+
     @FocusState private var focusedField: Field?
 
     private enum Field: Hashable {
@@ -137,9 +143,69 @@ struct LoginView: View {
             }
 
             signInButton
+
+            secondaryActions
         }
         .padding(.horizontal, 0)
         .padding(.vertical, 40)
+        .sheet(isPresented: $showQuickConnect) {
+            QuickConnectSheet(serverURL: url)
+        }
+    }
+
+    /// "Use Jellyfin Quick Connect" link plus the device-name gear, sitting just
+    /// below the primary sign-in button (#202). The gear opens a popover so the
+    /// user can rename the device Jellyfin shows for this client.
+    @ViewBuilder
+    private var secondaryActions: some View {
+        HStack(spacing: 12) {
+            Button {
+                showQuickConnect = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 11, weight: .bold))
+                    Text("login.quick_connect.link")
+                        .font(Theme.font(13, weight: .semibold))
+                }
+                .foregroundStyle(Theme.teal)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("login.quick_connect.link")
+            .accessibilityHint("login.quick_connect.a11y_hint")
+
+            Spacer(minLength: 0)
+
+            deviceNameGear
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Gear button that reveals the device-name editor. Shows the current name
+    /// in its accessibility label so VoiceOver users know what's editable.
+    @ViewBuilder
+    private var deviceNameGear: some View {
+        Button {
+            showDeviceName = true
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(model.deviceName)
+                    .font(Theme.font(12, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .foregroundStyle(Theme.ink3)
+            .frame(maxWidth: 180, alignment: .trailing)
+        }
+        .buttonStyle(.plain)
+        .help("login.device_name.help")
+        .accessibilityLabel(deviceNameA11yLabel)
+        .popover(isPresented: $showDeviceName, arrowEdge: .bottom) {
+            DeviceNamePopover()
+                .environment(model)
+        }
     }
 
     @ViewBuilder
@@ -410,6 +476,13 @@ struct LoginView: View {
         case .ok: return 2
         case .failed: return 3
         }
+    }
+
+    /// VoiceOver label for the device-name gear, naming the current device so
+    /// the user knows what tapping it edits. Built via `String(localized:)` with
+    /// an argument so the device name isn't baked into the catalog key.
+    private var deviceNameA11yLabel: Text {
+        Text("login.device_name.a11y_label \(model.deviceName)")
     }
 
     private func probeOkLabel(version: String, name: String) -> String {

--- a/macos/Sources/Lyrebird/Screens/QuickConnectSheet.swift
+++ b/macos/Sources/Lyrebird/Screens/QuickConnectSheet.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import AppKit
+@preconcurrency import LyrebirdCore
+
+/// Modal presented from `LoginView` for Jellyfin Quick Connect (#202).
+///
+/// Flow: on appear we ask the core to `quickConnectInitiate` against the
+/// entered server URL, which returns a short numeric `code` (shown big + as a
+/// QR) and an opaque `secret`. We then poll `quickConnectPoll` on a timer; once
+/// the user approves the code in another already-signed-in Jellyfin client the
+/// poll flips to approved and we `quickConnectComplete` to finish sign-in —
+/// `RootView` then routes to `MainShell` because `model.session` is set.
+///
+/// The server URL must be filled in on the login form first (Quick Connect is a
+/// *device-pairing* flow, not a *server-discovery* one), so the sheet shows a
+/// gentle prompt when `serverURL` is empty rather than failing to initiate.
+struct QuickConnectSheet: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    /// The server URL the user entered on the login form. Quick Connect needs a
+    /// concrete server to pair against.
+    let serverURL: String
+
+    private enum Phase: Equatable {
+        case needsServer
+        case loading
+        case waiting(code: String, secret: String)
+        case failed(String)
+    }
+
+    @State private var phase: Phase = .loading
+    /// Drives the polling loop. Reset on disappear so we don't keep hitting the
+    /// server after the sheet closes.
+    @State private var pollTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(spacing: 20) {
+            header
+
+            Group {
+                switch phase {
+                case .needsServer:
+                    needsServerBody
+                case .loading:
+                    loadingBody
+                case .waiting(let code, _):
+                    waitingBody(code: code)
+                case .failed(let message):
+                    failedBody(message: message)
+                }
+            }
+            .frame(maxWidth: .infinity)
+
+            Button("login.quick_connect.cancel") { close() }
+                .buttonStyle(.plain)
+                .font(Theme.font(13, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+                .padding(.top, 4)
+                .accessibilityLabel("login.quick_connect.cancel")
+        }
+        .padding(28)
+        .frame(width: 360)
+        .background(Theme.bg)
+        .task { await start() }
+        .onDisappear { stopPolling() }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "qrcode")
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(Theme.primary)
+            Text("login.quick_connect.title")
+                .font(Theme.font(20, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("login.quick_connect.subtitle")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var needsServerBody: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Theme.warning)
+            Text("login.quick_connect.needs_server")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 12)
+    }
+
+    private var loadingBody: some View {
+        VStack(spacing: 12) {
+            ProgressView().controlSize(.large)
+            Text("login.quick_connect.starting")
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+        .frame(height: 200)
+    }
+
+    private func waitingBody(code: String) -> some View {
+        VStack(spacing: 16) {
+            if let qr = Self.qrImage(for: code) {
+                Image(nsImage: qr)
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: 132, height: 132)
+                    .padding(8)
+                    .background(Color.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .accessibilityHidden(true)
+            }
+
+            VStack(spacing: 4) {
+                Text("login.quick_connect.code_label")
+                    .font(Theme.font(10, weight: .bold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(1.5)
+                Text(spacedCode(code))
+                    .font(Theme.font(30, weight: .black))
+                    .foregroundStyle(Theme.ink)
+                    .monospacedDigit()
+                    .textSelection(.enabled)
+                    .accessibilityLabel(Text(verbatim: code))
+            }
+
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("login.quick_connect.waiting")
+                    .font(Theme.font(12, weight: .medium))
+                    .foregroundStyle(Theme.teal)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func failedBody(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "xmark.octagon")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Theme.danger)
+            Text(message)
+                .font(Theme.font(12, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            Button("login.quick_connect.retry") { Task { await start() } }
+                .buttonStyle(.plain)
+                .font(Theme.font(13, weight: .bold))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Theme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+        }
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Flow
+
+    private func start() async {
+        stopPolling()
+        let trimmed = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            phase = .needsServer
+            return
+        }
+        phase = .loading
+        guard let info = await model.quickConnectInitiate(url: trimmed) else {
+            // `quickConnectInitiate` already set `model.errorMessage`; reflect a
+            // concise message in the sheet too.
+            phase = .failed(String(localized: "login.quick_connect.error", bundle: .main))
+            return
+        }
+        phase = .waiting(code: info.code, secret: info.secret)
+        beginPolling(url: trimmed, secret: info.secret)
+    }
+
+    /// Poll the pairing state ~every 2s until approved or the sheet closes.
+    /// Jellyfin's Quick Connect codes are short-lived; the loop simply stops
+    /// when the task is cancelled (sheet dismissed) — an expired code surfaces
+    /// as a failed `quickConnectComplete` which we map to the failed phase.
+    private func beginPolling(url: String, secret: String) {
+        pollTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                if Task.isCancelled { return }
+                let approved = await model.quickConnectPoll(url: url, secret: secret)
+                if approved {
+                    let ok = await model.quickConnectComplete(url: url, secret: secret)
+                    if ok {
+                        // Session is live; RootView swaps to MainShell. Close the
+                        // sheet so it doesn't linger over the app.
+                        close()
+                    } else {
+                        phase = .failed(String(localized: "login.quick_connect.error", bundle: .main))
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    private func close() {
+        stopPolling()
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    /// Insert a thin gap in the middle of the code so a 6-digit value reads as
+    /// "639 443" rather than a run-on "639443".
+    private func spacedCode(_ code: String) -> String {
+        guard code.count == 6 else { return code }
+        let mid = code.index(code.startIndex, offsetBy: 3)
+        return "\(code[code.startIndex..<mid]) \(code[mid...])"
+    }
+
+    /// Shared CoreImage context for QR rendering. Cheap to keep around and
+    /// `Sendable`, so we don't spin up a Metal pipeline per render.
+    private static let ciContext = CIContext()
+
+    /// Render `string` as a crisp black-on-transparent QR `NSImage`. Returns
+    /// `nil` if CoreImage can't produce an output (the code still shows as text,
+    /// so the QR is a progressive enhancement).
+    static func qrImage(for string: String) -> NSImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+        // Upscale the tiny native QR so it stays sharp at display size.
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cg = ciContext.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return NSImage(cgImage: cg, size: NSSize(width: scaled.extent.width, height: scaled.extent.height))
+    }
+}
+
+/// Popover (anchored on the login gear) for editing the device name Jellyfin
+/// shows for this client (#202). Seeds its field from `model.deviceName`,
+/// commits a trimmed value through `updateDeviceName(_:)`, and disables Save
+/// when the field is blank or unchanged so it can't write an empty `Device`
+/// header.
+struct DeviceNamePopover: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: String = ""
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("login.device_name.title")
+                .font(Theme.font(14, weight: .bold))
+                .foregroundStyle(Theme.ink)
+            Text("login.device_name.subtitle")
+                .font(Theme.font(11, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextField("login.device_name.placeholder", text: $draft)
+                .textFieldStyle(.plain)
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Theme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Theme.border, lineWidth: 1)
+                )
+                .focused($fieldFocused)
+                .submitLabel(.done)
+                .onSubmit(commit)
+                .accessibilityLabel("login.device_name.a11y_field")
+
+            HStack(spacing: 8) {
+                Spacer(minLength: 0)
+                Button("login.device_name.cancel") { dismiss() }
+                    .buttonStyle(.plain)
+                    .font(Theme.font(12, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                Button("login.device_name.save", action: commit)
+                    .buttonStyle(.plain)
+                    .font(Theme.font(12, weight: .bold))
+                    .foregroundStyle(canSave ? Theme.ink : Theme.ink3)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(canSave ? Theme.accent : Theme.surface2)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .disabled(!canSave)
+            }
+        }
+        .padding(16)
+        .frame(width: 280)
+        .background(Theme.bg)
+        .onAppear {
+            draft = model.deviceName
+            fieldFocused = true
+        }
+    }
+
+    private var canSave: Bool {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed != model.deviceName
+    }
+
+    private func commit() {
+        guard canSave else { return }
+        model.updateDeviceName(draft)
+        dismiss()
+    }
+}
+

--- a/macos/Tests/LyrebirdTests/QuickConnectTests.swift
+++ b/macos/Tests/LyrebirdTests/QuickConnectTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for the Quick Connect + device-name feature (#202).
+///
+/// Three layers:
+///
+/// 1. **QR rendering.** `QuickConnectSheet.qrImage(for:)` must turn a code into
+///    a non-empty `NSImage` (the QR is the primary affordance in the sheet).
+/// 2. **Device-name default.** `AppModel.defaultDeviceName()` must never return
+///    an empty string, since it seeds the `Device` auth header.
+/// 3. **Catalog sync.** Every `login.quick_connect.*` / `login.device_name.*`
+///    key the UI references must exist in `Localizable.xcstrings` with a
+///    translated English value — the catalog isn't bundled into the test
+///    binary, so it's read off disk (same idiom as `CountStringsTests`).
+final class QuickConnectTests: XCTestCase {
+
+    // MARK: - QR rendering
+
+    func testQRImageRendersNonEmptyForCode() {
+        let image = QuickConnectSheet.qrImage(for: "639443")
+        let unwrapped = try? XCTUnwrap(image)
+        XCTAssertNotNil(unwrapped, "a 6-digit code should produce a QR image")
+        if let image {
+            XCTAssertGreaterThan(image.size.width, 0, "QR image must have a positive width")
+            XCTAssertGreaterThan(image.size.height, 0, "QR image must have a positive height")
+        }
+    }
+
+    func testQRImageHandlesEmptyStringWithoutCrashing() {
+        // CoreImage's QR generator accepts empty input; we only require that the
+        // helper returns cleanly (nil or an image) rather than trapping.
+        _ = QuickConnectSheet.qrImage(for: "")
+    }
+
+    // MARK: - Device-name default
+
+    @MainActor
+    func testDefaultDeviceNameIsNonEmpty() {
+        let name = AppModel.defaultDeviceName().trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(
+            name.isEmpty,
+            "the host-derived default device name must never be empty — it seeds the Device auth header"
+        )
+    }
+
+    // MARK: - Catalog sync
+
+    func testQuickConnectAndDeviceNameKeysExistInCatalog() throws {
+        let catalog = try loadCatalog()
+        let requiredKeys = [
+            "login.quick_connect.link",
+            "login.quick_connect.a11y_hint",
+            "login.quick_connect.title",
+            "login.quick_connect.subtitle",
+            "login.quick_connect.code_label",
+            "login.quick_connect.starting",
+            "login.quick_connect.waiting",
+            "login.quick_connect.needs_server",
+            "login.quick_connect.error",
+            "login.quick_connect.retry",
+            "login.quick_connect.cancel",
+            "login.device_name.help",
+            "login.device_name.a11y_label %@",
+            "login.device_name.title",
+            "login.device_name.subtitle",
+            "login.device_name.placeholder",
+            "login.device_name.a11y_field",
+            "login.device_name.save",
+            "login.device_name.cancel",
+        ]
+        for key in requiredKeys {
+            guard let entry = catalog[key] as? [String: Any] else {
+                XCTFail("missing catalog key: \(key)")
+                continue
+            }
+            let value = englishValue(entry)
+            XCTAssertNotNil(value, "catalog key \(key) has no English value")
+            XCTAssertFalse(
+                (value ?? "").isEmpty,
+                "catalog key \(key) has an empty English value"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The `strings` dictionary of `Localizable.xcstrings`, read off disk
+    /// relative to this test file (the catalog isn't bundled into the test
+    /// binary — SwiftPM copies resources only into the `.app`).
+    private func loadCatalog(file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let here = URL(fileURLWithPath: "\(#filePath)")
+        let target = here
+            .deletingLastPathComponent()          // Tests/LyrebirdTests
+            .deletingLastPathComponent()          // Tests
+            .deletingLastPathComponent()          // macos
+            .appendingPathComponent("Sources/Lyrebird/Resources/Localizable.xcstrings")
+        let data = try Data(contentsOf: target)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let strings = json?["strings"] as? [String: Any] else {
+            XCTFail("Could not parse strings table from \(target.path)", file: file, line: line)
+            return [:]
+        }
+        return strings
+    }
+
+    /// Pulls `localizations.en.stringUnit.value` out of a decoded catalog entry.
+    private func englishValue(_ entry: [String: Any]) -> String? {
+        guard
+            let localizations = entry["localizations"] as? [String: Any],
+            let en = localizations["en"] as? [String: Any],
+            let unit = en["stringUnit"] as? [String: Any],
+            let value = unit["value"] as? String
+        else { return nil }
+        return value
+    }
+}


### PR DESCRIPTION
Lets users sign in via Jellyfin Quick Connect (no password typing) and control how this client is named on the server, both from the login screen.

## What

- **Core FFI** (`core/src/client.rs`, `core/src/lib.rs`, `core/src/models.rs`): `quick_connect_initiate` / `quick_connect_poll` / `quick_connect_complete` backed by Jellyfin's `/QuickConnect/Initiate`, `/QuickConnect/Connect`, and `/Users/AuthenticateWithQuickConnect`; plus `device_name` / `set_device_name`. Device name is now persisted in the core DB and a user-edited value wins over the platform default on launch. Quick-connect sign-in persists the session identically to a password login, so `resume_session` works afterwards.
- **LoginView** (`macos/Sources/Lyrebird/Screens/LoginView.swift`): a "Use Jellyfin Quick Connect" secondary link under the sign-in button that opens a sheet showing the 6-digit code + a QR and polls until approved, and a gear popover (`DeviceNamePopover`) for renaming the device.
- **New sheet** (`macos/Sources/Lyrebird/Screens/QuickConnectSheet.swift`): handshake UI + 2s polling loop + the device-name editor. All blocking FFI runs off the main actor via `Task.detached` (CLAUDE.md gap pattern #2); the host-derived default seeds an empty-rejecting `Device` header.

## Verification

- Rust: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, full `cargo test` green (293 lib + contract + e2e + doc) including 2 new tests (`quick_connect_initiate_poll_and_complete_persists_session`, `set_device_name_persists_overrides_default_and_rejects_empty`).
- Swift: clean `swift build` against regenerated bindings; 4 new tests in `QuickConnectTests` green (QR render, non-empty default name, catalog-key sync).
- Quick Connect endpoints validated against the real server (10.12.0) before implementing.

Note: the `Lyrebird.xcframework` + `lyrebird_core.swift` bindings are gitignored and regenerated by CI from `core/` — they were regenerated locally only to run the Swift gate.

Closes #202

pipeline:
- builder-session: feat/202-quickconnect-device-name
- slice: client (macos + core)
- hotspot: core (client.rs / lib.rs / models.rs — built sequentially, no parallel core agent)
- build-gate: PASS (fmt + clippy + cargo test + swift build + swift test)
- diff-stat: 10 files, +1226 / -21 (228 of the additions are localization-catalog entries; 2 new Swift source/test files)