### PR TITLE
fix(macos): split suggestedSearchArtists daySeed to fix type-check timeout

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Search.swift
+++ b/macos/Sources/Lyrebird/AppModel+Search.swift
@@ -374,7 +374,14 @@ extension AppModel {
         // Derive a stable daily seed from today's UTC date so the set
         // rotates overnight but stays consistent within one session.
         let today = Calendar.current.dateComponents([.year, .month, .day], from: Date())
-        let daySeed = UInt64((today.year ?? 0) * 10000 + (today.month ?? 0) * 100 + (today.day ?? 0))
+        // Split into explicitly-typed Int sub-expressions: the chained
+        // optional-arithmetic + UInt64() conversion on one line trips the
+        // Swift type-checker's "unable to type-check in reasonable time"
+        // blowup on a clean build.
+        let year: Int = today.year ?? 0
+        let month: Int = today.month ?? 0
+        let day: Int = today.day ?? 0
+        let daySeed = UInt64(year * 10000 + month * 100 + day)
         // Prefer artists that have never been played; fall through to all
         // artists so the section still renders in fully-played libraries.
         let unplayed = artists.filter { ($0.userData?.playCount ?? 0) == 0 }


### PR DESCRIPTION
## What

`AppModel+Search.swift:377` packed chained optional-arithmetic and a `UInt64()` conversion onto one line:

```swift
let daySeed = UInt64((today.year ?? 0) * 10000 + (today.month ?? 0) * 100 + (today.day ?? 0))
```

That tripped the Swift type-checker's *"unable to type-check this expression in reasonable time"* blowup on a **clean** build. It passed warm-cache local builds (which is how it merged), but timed out on CI's clean `macOS app` build and on `swift build -c release` — leaving `main` red and the `v2.0.0-rc2` release build failing.

## Fix

Split into explicitly-typed `Int` sub-expressions so the type-checker resolves it trivially. Pure refactor — identical behaviour (same daily-rotating seed). Verified with a clean `build-core.sh --debug` + `swift build` (0 errors).

Unblocks `main` CI and the `v2.0.0-rc2` release build.