### PR TITLE
test(core): real-server smoke gate — search, queue, playback reporting e2e + Scripts/smoke-test.sh

### DIFF
--- a/POLISH_TARGETS.md
+++ b/POLISH_TARGETS.md
@@ -28,7 +28,7 @@ The pipeline runs each `check:` line as a sanity gate. A target is satisfied iff
       slices: slice:scaffold, slice:screens
 
 - [ ] Real-server smoke test passes for: login, library page 1, search, queue add, playback start/stop
-      check: # add a smoke-test script here, e.g. Scripts/smoke-test.sh
+      check: Scripts/smoke-test.sh
       slices: slice:client, slice:state
 
 - [ ] All `priority:p0` issues are either resolved or downgraded with rationale

--- a/Scripts/smoke-test.sh
+++ b/Scripts/smoke-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Real-server smoke test — backs the POLISH_TARGETS gate for: login, library
+# page 1, search, queue add, playback start/stop.
+#
+# Thin wrapper over the live e2e suite (core/tests/e2e_live.rs) so the gate
+# exercises the actual core library — auth header handling, response
+# deserialization, queue state — rather than re-implementing REST calls in
+# shell. Defaults to the shared read-only test account authorized in
+# CLAUDE.md; point LYREBIRD_E2E_URL / _USER / _PASS elsewhere to smoke another
+# server.
+set -euo pipefail
+
+: "${LYREBIRD_E2E_URL:=https://music.skalthoff.com}"
+: "${LYREBIRD_E2E_USER:=test}"
+: "${LYREBIRD_E2E_PASS:=test}"
+export LYREBIRD_E2E_URL LYREBIRD_E2E_USER LYREBIRD_E2E_PASS
+
+cd "$(dirname "$0")/.."
+
+# Fail fast with a readable message when the server is down, instead of
+# letting every test time out individually.
+curl -fsS --max-time 20 "$LYREBIRD_E2E_URL/System/Info/Public" > /dev/null \
+  || { echo "smoke-test: server $LYREBIRD_E2E_URL unreachable" >&2; exit 1; }
+
+# Serial (--test-threads=1) to keep load on the shared test server polite,
+# matching the e2e workflow.
+cargo test --package lyrebird_core --test e2e_live -- --nocapture --test-threads=1
+
+echo "smoke-test: PASS — login, library page 1, search, queue add, playback start/stop (+ downloads)"

--- a/core/tests/e2e_live.rs
+++ b/core/tests/e2e_live.rs
@@ -12,6 +12,18 @@
 //! - `login_issues_access_token` — `POST /Users/AuthenticateByName`
 //! - `list_albums_returns_envelope` — authenticated `/Items` query; verifies
 //!   the pagination envelope shape, agnostic to library contents.
+//! - `search_returns_results_for_known_album` — typed search against the
+//!   name of a real album from page 1.
+//! - `queue_set_add_and_play_next_update_status` — queue primitives (#282)
+//!   over real library tracks, verified through the `status()` projection.
+//! - `playback_start_stop_reporting_round_trips` — `POST /Items/{id}/
+//!   PlaybackInfo` + `/Sessions/Playing` + `/Sessions/Playing/Stopped`,
+//!   echoing the server-issued `PlaySessionId` like `AudioEngine` does.
+//!
+//! Together these back the POLISH_TARGETS "real-server smoke test" gate
+//! (login, library page 1, search, queue add, playback start/stop) —
+//! `Scripts/smoke-test.sh` is the wrapper that runs this suite against the
+//! shared test server.
 //!
 //! These cover the paths that wiremock-based unit tests can only simulate: the
 //! actual Jellyfin response shapes, auth header handling, and HTTP edge cases.
@@ -163,4 +175,160 @@ fn download_track_to_disk_round_trips() {
         !std::path::Path::new(&local_path).exists(),
         "deleting a download removes its file"
     );
+}
+
+/// Typed search end-to-end: take a real album from page 1 and assert the
+/// search endpoint surfaces results for its name. Library-agnostic — the
+/// query is derived from whatever the server actually holds rather than a
+/// hard-coded title.
+#[test]
+fn search_returns_results_for_known_album() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with the test account");
+
+    let albums = core.list_albums(0, 1).expect("list_albums");
+    let album = albums
+        .items
+        .into_iter()
+        .next()
+        .expect("the live library should have at least one album");
+
+    let results = core.search(album.name.clone(), 0, 20).expect("search");
+    assert!(
+        results.total_record_count > 0,
+        "searching for an existing album's name ({:?}) should match at least one item",
+        album.name
+    );
+}
+
+/// Queue primitives end-to-end (#282): build a queue from real library
+/// tracks, then exercise `add_to_queue` (append) and `play_next` (insert
+/// after the playhead) and verify the `status()` projection tracks the
+/// changes without clobbering the current track — the regression the old
+/// fall-through-to-`play()` semantics used to cause.
+#[test]
+fn queue_set_add_and_play_next_update_status() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with the test account");
+
+    // Gather at least three real tracks across the first albums.
+    let albums = core.list_albums(0, 25).expect("list_albums");
+    let mut tracks = Vec::new();
+    for album in albums.items {
+        if let Ok(album_tracks) = core.album_tracks(album.id.clone()) {
+            tracks.extend(album_tracks);
+        }
+        if tracks.len() >= 3 {
+            break;
+        }
+    }
+    assert!(
+        tracks.len() >= 3,
+        "the live library should provide at least three tracks"
+    );
+    let (a, b, c) = (tracks[0].clone(), tracks[1].clone(), tracks[2].clone());
+
+    let current = core.set_queue(vec![a.clone()], 0).expect("set_queue");
+    assert_eq!(
+        current.map(|t| t.id),
+        Some(a.id.clone()),
+        "set_queue primes the playhead onto the start track"
+    );
+
+    let len = core.add_to_queue(vec![b]);
+    assert_eq!(len, 2, "add_to_queue appends to the end of the queue");
+
+    let len = core.play_next(vec![c]);
+    assert_eq!(len, 3, "play_next inserts after the playhead");
+
+    let status = core.status();
+    assert_eq!(status.queue_length, 3);
+    assert_eq!(
+        status.queue_position, 0,
+        "queue mutations must not move the playhead"
+    );
+    assert_eq!(
+        status.current_track.map(|t| t.id),
+        Some(a.id),
+        "queue mutations must not clobber the current track"
+    );
+}
+
+/// Playback start/stop reporting end-to-end: resolve `PlaybackInfo` for a
+/// real track, then `POST /Sessions/Playing` and `/Sessions/Playing/Stopped`,
+/// echoing the server-issued `PlaySessionId` exactly like `AudioEngine` does
+/// (#569). Drives the same server flow that backs PlayCount increments and
+/// "Now Playing on macOS" in Jellyfin Web. The test account's reports are
+/// scoped to that user, so production data stays clean.
+#[test]
+fn playback_start_stop_reporting_round_trips() {
+    use lyrebird_core::{PlaybackInfoOpts, PlaybackStartInfo, PlaybackStopInfo};
+
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with the test account");
+
+    // Find a real track to report against: first album with tracks.
+    let albums = core.list_albums(0, 25).expect("list_albums");
+    let mut track = None;
+    for album in albums.items {
+        if let Ok(album_tracks) = core.album_tracks(album.id.clone()) {
+            if let Some(first) = album_tracks.into_iter().next() {
+                track = Some(first);
+                break;
+            }
+        }
+    }
+    let track = track.expect("the live library should have at least one album track");
+
+    let info = core
+        .playback_info(track.id.clone(), PlaybackInfoOpts::default())
+        .expect("playback_info against the live server");
+    assert!(
+        info.error_code.is_none(),
+        "PlaybackInfo should not carry an error code: {:?}",
+        info.error_code
+    );
+    assert!(
+        !info.media_sources.is_empty(),
+        "PlaybackInfo should resolve at least one media source"
+    );
+    let play_session_id = info.play_session_id.clone();
+
+    core.report_playback_started(PlaybackStartInfo {
+        item_id: track.id.clone(),
+        play_session_id: play_session_id.clone(),
+        play_method: Some("DirectPlay".to_string()),
+        position_ticks: Some(0),
+        can_seek: true,
+        ..Default::default()
+    })
+    .expect("report_playback_started");
+
+    core.report_playback_stopped(PlaybackStopInfo {
+        item_id: track.id,
+        failed: false,
+        position_ticks: 0,
+        media_source_id: None,
+        play_session_id,
+        session_id: None,
+    })
+    .expect("report_playback_stopped");
 }


### PR DESCRIPTION
POLISH_TARGETS' real-server smoke target had a placeholder check line.
Make it real:

- Extend core/tests/e2e_live.rs with the three flows the gate names that
  weren't yet covered: typed search (query derived from a real page-1
  album, library-agnostic), queue primitives (set_queue + add_to_queue +
  play_next verified through status() without clobbering the playhead,
  #282 semantics), and playback start/stop reporting (PlaybackInfo →
  /Sessions/Playing → /Sessions/Playing/Stopped, echoing PlaySessionId
  like AudioEngine, #569). All gated on LYREBIRD_E2E_URL like the
  existing tests, so the default cargo run stays hermetic.
- Add Scripts/smoke-test.sh: healthcheck + cargo test --test e2e_live
  against the shared test server (env-overridable), serial to keep load
  on the shared account polite. Wire it into the POLISH_TARGETS check
  line.

Verified against music.skalthoff.com: 7/7 pass in ~10s. fmt + clippy
clean.
