### PR TITLE
feat(macos): AVAudioEngine DSP pipeline behind a feature flag

### DIFF
--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -863,6 +863,10 @@ final class AppModel {
         // stays false, so `AudioEngine.play` never queries the core for a local
         // path and the streaming path is byte-for-byte unchanged.
         self.audio.offlinePlaybackEnabled = supportsDownloads
+        // AVAudioEngine DSP path (#39): off by default. While off the engine
+        // never constructs the DSP pipeline and every transport call takes
+        // the AVQueuePlayer path unchanged. See `supportsEngineDSP`.
+        self.audio.dspPipelineEnabled = supportsEngineDSP
         // Streaming quality (#260): seed the engine's transcode ceiling from the
         // persisted Streaming Quality preference so the first track honours it
         // without waiting for a `play(tracks:)`. Defaults to 320 kbps when the

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -100,4 +100,25 @@ extension AppModel {
     /// `.id` on the selection so a switch recolours the UI live. Enabled; kept as
     /// a kill-switch / regression fallback (same pattern as `supportsGenreActions`).
     var supportsThemeSelection: Bool { true }
+
+    /// `UserDefaults` key backing `supportsEngineDSP` (#39). The literal comes
+    /// from the issue's contract so a dev/test opt-in is a one-liner:
+    /// `defaults write org.lyrebird.desktop engine.useAVAudioEngine -bool YES`.
+    static let engineDSPDefaultsKey = "engine.useAVAudioEngine"
+
+    /// AVAudioEngine-based DSP playback path (#39). Gates whether
+    /// `AudioEngine` routes play/pause/seek/advance through the streaming
+    /// AVAudioEngine pipeline (`EngineDSPPipeline`: player node →
+    /// `AVAudioUnitEQ` → main mixer) instead of `AVQueuePlayer`. The pipeline
+    /// is the foundation for EQ (#40) and crossfade (#41) — neither UI ships
+    /// yet, so the EQ node runs flat/bypassed and this flag defaults to
+    /// **off**: a missing key reads `false`, and nothing in the app writes it,
+    /// so playback stays byte-for-byte on the AVQueuePlayer path until the
+    /// user (or a future Settings toggle from #40/#41) opts in via the
+    /// defaults key above. Read once at launch (`AppModel.init` seeds
+    /// `audio.dspPipelineEnabled`); relaunch to apply — flipping mid-session
+    /// would strand a live player on the other path.
+    var supportsEngineDSP: Bool {
+        UserDefaults.standard.bool(forKey: AppModel.engineDSPDefaultsKey)
+    }
 }

--- a/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
@@ -1,0 +1,180 @@
+import AVFoundation
+import Foundation
+import os
+@preconcurrency import LyrebirdCore
+
+private let dspLog = Logger(subsystem: "org.lyrebird.desktop", category: "dsp")
+
+/// AVAudioEngine DSP routing for `AudioEngine` (#39).
+///
+/// When `dspPipelineEnabled` is on, every public transport method branches
+/// here instead of the AVQueuePlayer path. The split is deliberately at the
+/// top of each method so that with the flag **off** (the default) the
+/// existing path is byte-for-byte untouched — `dspPipeline` is never even
+/// constructed.
+///
+/// Reporting parity: this path drives the exact same server contract as the
+/// AVQueuePlayer path — `PlaybackInfo` resolution, `reportPlaybackStarted` /
+/// `reportPlaybackProgress` / `reportPlaybackStopped`, `markTrackStarted`,
+/// `markState` / `markPosition` (1 Hz, playing only), the 5s heartbeat, and
+/// `MediaSession` transport notifications.
+///
+/// Known #39 gaps on this path (cleanly degraded, listed in the PR):
+/// gapless preload is a no-op (tracks advance with a rebuild, like
+/// `gaplessEnabled == false`), ReplayGain normalization is not applied,
+/// stall recovery is skip-on-error rather than bounded in-place retries, and
+/// Ogg containers (which AudioToolbox cannot parse) skip to the next track.
+extension AudioEngine {
+    /// Build (or reuse) the pipeline. Only ever called from DSP-routed
+    /// methods, which are themselves gated on `dspPipelineEnabled` — so the
+    /// AVQueuePlayer path never constructs one.
+    func dspEnsurePipeline() -> EngineDSPPipeline {
+        if let pipeline = dspPipeline { return pipeline }
+        let pipeline = EngineDSPPipeline()
+        pipeline.onTrackFinished = { [weak self] in
+            guard let self else { return }
+            // Same contract as `AVPlayerItemDidPlayToEndTime`: mark ended,
+            // let the owner advance its queue (AppModel.handleTrackEnded).
+            self.core.markState(state: .ended)
+            self.onTrackEnded?()
+        }
+        pipeline.onPositionTick = { [weak self] seconds in
+            guard let self, seconds.isFinite, seconds >= 0 else { return }
+            self.core.markPosition(seconds: seconds)
+        }
+        pipeline.onStreamError = { [weak self] message in
+            guard let self else { return }
+            // Diagnostic detail goes to the log only — stream URLs carry the
+            // api_key token, and transient NSURLError descriptions can embed
+            // them. The user-facing copy matches the AVPlayer path's
+            // transient-skip behaviour.
+            dspLog.error("DSP track failed, skipping: \(message, privacy: .public)")
+            self.delegate?.audioEngineDidEncounterTransientError("Playback failed — skipping")
+            self.core.markState(state: .ended)
+            self.onTrackEnded?()
+        }
+        pipeline.setOutputDevice(uid: outputDeviceUID)
+        dspPipeline = pipeline
+        return pipeline
+    }
+
+    /// DSP-path `play(track:)`. Mirrors the AVQueuePlayer path's resolution
+    /// + reporting sequence exactly; only the audio transport differs.
+    func dspPlay(track: Track) async throws {
+        let pipeline = dspEnsurePipeline()
+
+        // Resolve local copy vs stream — identical decision tree to the
+        // AVQueuePlayer path (#819 offline gate included).
+        let url: URL
+        let authHeader: String?
+        let mediaSourceId: String?
+        let playSessionId: String?
+        if let localURL = await resolveLocalAssetURL(for: track.id) {
+            url = localURL
+            authHeader = nil
+            mediaSourceId = nil
+            playSessionId = nil
+            core.setPlaySessionId(playSessionId: nil)
+        } else {
+            let (resolvedSource, resolvedSession) = await resolvePlaybackSource(for: track.id)
+            mediaSourceId = resolvedSource
+            playSessionId = resolvedSession
+            let urlString = try core.streamUrl(
+                trackId: track.id,
+                mediaSourceId: mediaSourceId,
+                playSessionId: playSessionId,
+                maxStreamingBitrate: maxStreamingBitrate
+            )
+            guard let streamURL = URL(string: urlString) else {
+                throw AudioEngineError.invalidURL(urlString)
+            }
+            url = streamURL
+            core.setPlaySessionId(playSessionId: playSessionId)
+            authHeader = try core.authHeader()
+        }
+
+        // Capture the outgoing track's position before the pipeline reloads,
+        // so the matching Stopped report carries where it actually stopped —
+        // the same capture-before-swap dance as the AVQueuePlayer path.
+        let previousPositionTicks = dspPositionTicks()
+
+        let durationHint: Double? = track.runtimeTicks > 0
+            ? Double(track.runtimeTicks) / 10_000_000.0
+            : nil
+        pipeline.load(
+            url: url,
+            authHeader: authHeader,
+            containerHint: track.container,
+            durationHint: durationHint
+        )
+
+        // Close out the previous server session before opening the new one
+        // (Jellyfin keys sessions by PlaySessionId and leaks a transcode job
+        // otherwise).
+        reportStopped(positionTicks: previousPositionTicks)
+
+        let core = self.core
+        Task.detached { core.markTrackStarted(track: track) }
+        core.markState(state: .playing)
+        pipeline.play()
+        mediaSession?.trackChanged(track)
+
+        reportStarted(
+            trackId: track.id,
+            mediaSourceId: mediaSourceId,
+            playSessionId: playSessionId,
+            playMethod: nil
+        )
+        core.startHeartbeat(intervalSecs: 5, playSessionId: playSessionId)
+    }
+
+    func dspPause() {
+        dspPipeline?.pause()
+        core.markState(state: .paused)
+        mediaSession?.rateChanged(isPlaying: false)
+        reportProgressSnapshot(isPaused: true)
+    }
+
+    func dspResume() {
+        dspPipeline?.resume()
+        core.markState(state: .playing)
+        mediaSession?.rateChanged(isPlaying: true)
+        reportProgressSnapshot(isPaused: false)
+    }
+
+    func dspStop() {
+        // Emit Stopped before tearing the pipeline down so the report still
+        // reflects the last playback position — same order as the
+        // AVQueuePlayer path.
+        reportStopped()
+        core.stopHeartbeat()
+        dspPipeline?.stop()
+        core.stop()
+        mediaSession?.trackChanged(nil)
+    }
+
+    func dspSeek(toSeconds seconds: Double) {
+        guard let pipeline = dspPipeline else { return }
+        pipeline.seek(toSeconds: seconds)
+        // The pipeline's position reflects the target synchronously, so the
+        // widget + server snapshot can publish immediately (the streamer
+        // corrects the base frame asynchronously only for estimated VBR
+        // landings / range-less servers).
+        mediaSession?.seeked(to: seconds)
+        reportProgressSnapshot(isPaused: pipeline.state != .playing)
+    }
+
+    func dspSetVolume(_ v: Float) {
+        dspEnsurePipeline().setVolume(max(0, min(1, v)))
+        core.setVolume(volume: v)
+    }
+
+    /// Position in Jellyfin ticks for the reporting helpers. Mirrors
+    /// `positionTicks()`'s clamping for the AVPlayer path.
+    func dspPositionTicks() -> Int64 {
+        guard let pipeline = dspPipeline else { return 0 }
+        let seconds = pipeline.positionSeconds
+        guard seconds.isFinite, seconds >= 0 else { return 0 }
+        return Int64(seconds * 10_000_000)
+    }
+}

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -90,8 +90,22 @@ public extension AudioEngineDelegate {
 /// will splice the pre-built item in gaplessly.
 @MainActor
 public final class AudioEngine: NSObject {
-    private let core: LyrebirdCore
+    /// Internal (not private) so the DSP extension (`AudioEngine+DSP.swift`)
+    /// can drive the same core contract — never reach for this from outside
+    /// the engine.
+    let core: LyrebirdCore
     private var player: AVQueuePlayer?
+
+    /// AVAudioEngine DSP path feature flag (#39). Seeded once at startup by
+    /// the owner (`AppModel`, from `supportsEngineDSP`); **off by default**.
+    /// While off, every transport method takes the AVQueuePlayer path
+    /// byte-for-byte unchanged and `dspPipeline` is never constructed.
+    public var dspPipelineEnabled: Bool = false
+
+    /// Lazily-built AVAudioEngine pipeline (player node → EQ → mixer). Only
+    /// non-nil after the first DSP-routed `play(track:)`; see
+    /// `AudioEngine+DSP.swift`.
+    var dspPipeline: EngineDSPPipeline?
     private var timeObserver: Any?
     private var endObserver: NSObjectProtocol?
     private var rateObservation: NSKeyValueObservation?
@@ -180,7 +194,12 @@ public final class AudioEngine: NSObject {
     /// engine re-applies it to the live player immediately and to every player
     /// it builds afterwards (`play`, gapless preload, stall recovery).
     public var outputDeviceUID: String? {
-        didSet { applyOutputDevice(to: player) }
+        didSet {
+            applyOutputDevice(to: player)
+            // No-op while the DSP flag is off — the pipeline only exists on
+            // the flag-on path (#39).
+            dspPipeline?.setOutputDevice(uid: outputDeviceUID)
+        }
     }
 
     /// ReplayGain / loudness-normalization mode (#42). Mirrors the
@@ -318,7 +337,7 @@ public final class AudioEngine: NSObject {
     /// Runs off the main actor: the `core.playbackInfo` FFI blocks the calling
     /// thread on the full `POST /Items/{id}/PlaybackInfo` round-trip, which
     /// would beach-ball the UI if taken on the main actor.
-    private func resolvePlaybackSource(for trackId: String) async -> (mediaSourceId: String?, playSessionId: String?) {
+    func resolvePlaybackSource(for trackId: String) async -> (mediaSourceId: String?, playSessionId: String?) {
         let core = self.core
         let opts = PlaybackInfoOpts(
             userId: nil,
@@ -349,7 +368,7 @@ public final class AudioEngine: NSObject {
     /// core's `downloadLocalPath` already verifies the file exists on disk, so a
     /// non-nil result is safe to hand straight to AVFoundation. The FFI blocks
     /// on a SQLite read, so it runs off the main actor.
-    private func resolveLocalAssetURL(for trackId: String) async -> URL? {
+    func resolveLocalAssetURL(for trackId: String) async -> URL? {
         guard offlinePlaybackEnabled else { return nil }
         let core = self.core
         let path: String? = await Task.detached {
@@ -368,6 +387,11 @@ public final class AudioEngine: NSObject {
     private var reportingPlaySessionId: String?
 
     private func positionTicks() -> Int64 {
+        // DSP path (#39): the shared reporting helpers (`reportStopped`,
+        // `reportProgressSnapshot`) read position through here, so they get
+        // the pipeline's clock when the flag is on. Flag off ⇒ branch never
+        // taken.
+        if dspPipelineEnabled { return dspPositionTicks() }
         guard let player, let item = player.currentItem else { return 0 }
         let seconds = CMTimeGetSeconds(item.currentTime())
         guard seconds.isFinite, seconds >= 0 else { return 0 }
@@ -378,7 +402,7 @@ public final class AudioEngine: NSObject {
     /// AVQueuePlayer's `currentItem`. Best-effort — Jellyfin accepts the
     /// stream regardless of whether the session-begin report landed, so we
     /// swallow errors rather than surfacing them to the UI.
-    private func reportStarted(
+    func reportStarted(
         trackId: String,
         mediaSourceId: String?,
         playSessionId: String?,
@@ -426,7 +450,7 @@ public final class AudioEngine: NSObject {
     /// (`runtime.block_on` in Rust), so it's dispatched off the main actor.
     /// Clearing the reporting triple stays on the actor and happens
     /// synchronously so a follow-up `reportStarted` can't race it.
-    private func reportStopped(positionTicks explicitPosition: Int64? = nil) {
+    func reportStopped(positionTicks explicitPosition: Int64? = nil) {
         guard let itemId = reportingItemId else { return }
         let info = PlaybackStopInfo(
             itemId: itemId,
@@ -452,7 +476,7 @@ public final class AudioEngine: NSObject {
     /// (`runtime.block_on` in Rust), so the FFI is dispatched off the main
     /// actor. The position snapshot is read on the actor first so it reflects
     /// the player state at call time, not whenever the detached task runs.
-    private func reportProgressSnapshot(isPaused: Bool) {
+    func reportProgressSnapshot(isPaused: Bool) {
         guard let itemId = reportingItemId else { return }
         let info = PlaybackProgressInfo(
             itemId: itemId,
@@ -552,6 +576,13 @@ public final class AudioEngine: NSObject {
     // MARK: - Public
 
     public func play(track: Track) async throws {
+        // DSP path (#39): route through the AVAudioEngine pipeline when the
+        // feature flag is on. Flag off (default) ⇒ the AVQueuePlayer path
+        // below runs byte-for-byte unchanged.
+        if dspPipelineEnabled {
+            try await dspPlay(track: track)
+            return
+        }
         // A stall watchdog scheduled for the *old* track would otherwise fire
         // mid-load of the new one and kick a perfectly healthy fresh stream.
         // `removePlayerObservers()` below tears down the KVO observers but does
@@ -682,6 +713,10 @@ public final class AudioEngine: NSObject {
     }
 
     public func pause() {
+        if dspPipelineEnabled {
+            dspPause()
+            return
+        }
         player?.pause()
         core.markState(state: .paused)
         // `rateObservation` below also fires `rateChanged`, but that
@@ -693,6 +728,10 @@ public final class AudioEngine: NSObject {
     }
 
     public func resume() {
+        if dspPipelineEnabled {
+            dspResume()
+            return
+        }
         player?.play()
         core.markState(state: .playing)
         mediaSession?.rateChanged(isPlaying: true)
@@ -700,6 +739,10 @@ public final class AudioEngine: NSObject {
     }
 
     public func stop() {
+        if dspPipelineEnabled {
+            dspStop()
+            return
+        }
         cancelStallWatchdog()
         // Emit Stopped BEFORE draining the queue so positionTicks still
         // reflects the last known playback position.
@@ -720,6 +763,10 @@ public final class AudioEngine: NSObject {
     }
 
     public func seek(toSeconds seconds: Double) {
+        if dspPipelineEnabled {
+            dspSeek(toSeconds: seconds)
+            return
+        }
         guard let player = player else { return }
         // #582: Cancel any in-flight seek before issuing the new one so
         // rapid scrubber drags don't race against each other.
@@ -751,6 +798,10 @@ public final class AudioEngine: NSObject {
     }
 
     public func setVolume(_ v: Float) {
+        if dspPipelineEnabled {
+            dspSetVolume(v)
+            return
+        }
         player?.volume = max(0, min(1, v))
         core.setVolume(volume: v)
     }
@@ -769,6 +820,12 @@ public final class AudioEngine: NSObject {
     /// is what we want. Existing queued-but-not-yet-playing items are replaced
     /// so rapid skip-next doesn't accumulate stale entries.
     public func preloadNextTrack(_ track: Track) {
+        // DSP path (#39): gapless preload is a listed gap — the pipeline
+        // plays one track at a time and `onTrackEnded` rebuilds the next,
+        // exactly like the `gaplessEnabled == false` behaviour. A queued-
+        // ahead AVPlayerItem would be meaningless here, so bail before the
+        // player guard.
+        if dspPipelineEnabled { return }
         guard player != nil else { return }
 
         #if DEBUG

--- a/macos/Sources/LyrebirdAudio/AudioOutputDevices.swift
+++ b/macos/Sources/LyrebirdAudio/AudioOutputDevices.swift
@@ -103,8 +103,9 @@ public enum AudioOutputDevices {
     }
 
     /// Resolve a UID to a transient `AudioDeviceID` (for property writes that
-    /// the UID-based API can't reach, e.g. hog mode).
-    private static func deviceID(forUID uid: String) -> AudioDeviceID? {
+    /// the UID-based API can't reach, e.g. hog mode, or pinning the DSP
+    /// pipeline's `AVAudioEngine` output unit — see `EngineDSPPipeline`).
+    static func deviceID(forUID uid: String) -> AudioDeviceID? {
         guard let ids = allDeviceIDs() else { return nil }
         return ids.first { stringProperty($0, kAudioDevicePropertyDeviceUID) == uid }
     }

--- a/macos/Sources/LyrebirdAudio/DSPAudioFileStreamParser.swift
+++ b/macos/Sources/LyrebirdAudio/DSPAudioFileStreamParser.swift
@@ -1,0 +1,226 @@
+import AudioToolbox
+import Foundation
+
+/// Thin Swift wrapper around AudioToolbox's `AudioFileStream` C API (#39).
+///
+/// Feed it raw container bytes as they arrive off the network (or disk) via
+/// `parse(_:discontinuity:)`; it emits two callbacks:
+///
+///   * `onReadyToProducePackets` — fired once, when the header has been
+///     parsed far enough to know the stream's `AudioStreamBasicDescription`
+///     (and magic cookie, for formats that carry one). The DSP pipeline uses
+///     this to build the matching `AVAudioConverter` + engine graph.
+///   * `onPackets` — fired for every parsed batch of audio packets. For
+///     VBR/compressed formats the packet descriptions are forwarded; for
+///     CBR/LPCM they're `nil` and the bytes are frame-aligned PCM.
+///
+/// Threading: not internally synchronized. The owner (`DSPTrackStreamer`)
+/// confines every call — including `seekByteOffset` — to its serial decode
+/// queue, matching how the C API expects to be driven.
+///
+/// Container support is whatever `AudioFileStream` supports: MP3, AAC/ADTS,
+/// FLAC, WAV/AIFF, and fast-start MP4/M4A. Ogg (Vorbis/Opus) is *not*
+/// parseable by AudioToolbox — `parse` surfaces the open/parse error and the
+/// caller treats the track as unplayable on the DSP path (a listed #39 gap).
+final class DSPAudioFileStreamParser {
+    /// One parsed batch of audio packets, exactly as the C callback delivered
+    /// it. `packetDescriptions` is `nil` for CBR/LPCM streams (every packet is
+    /// `bytesPerPacket` long); present for VBR streams (MP3/AAC/FLAC).
+    struct PacketBatch {
+        let data: Data
+        let packetDescriptions: [AudioStreamPacketDescription]?
+        let packetCount: Int
+    }
+
+    enum ParserError: Error, LocalizedError {
+        case openFailed(OSStatus)
+        case parseFailed(OSStatus)
+
+        var errorDescription: String? {
+            switch self {
+            case .openFailed(let status): return "AudioFileStreamOpen failed (\(status))"
+            case .parseFailed(let status): return "AudioFileStreamParseBytes failed (\(status))"
+            }
+        }
+    }
+
+    /// Fired once the stream header is fully parsed. Carries the source
+    /// format and the magic cookie (nil for cookie-less formats like MP3).
+    var onReadyToProducePackets: ((AudioStreamBasicDescription, Data?) -> Void)?
+
+    /// Fired per parsed packet batch, after `onReadyToProducePackets`.
+    var onPackets: ((PacketBatch) -> Void)?
+
+    /// Source format, available once `onReadyToProducePackets` has fired.
+    private(set) var streamDescription: AudioStreamBasicDescription?
+
+    /// Byte offset of the first audio packet within the container — the
+    /// header size. Seek math is `dataOffset + packetByteOffset`.
+    private(set) var dataOffset: Int64 = 0
+
+    /// Total audio-data byte count when the container declares it (0 when
+    /// unknown, e.g. a chunked transcode with no length).
+    private(set) var audioDataByteCount: UInt64 = 0
+
+    /// Total audio packet count when the container declares it (0 = unknown).
+    private(set) var audioDataPacketCount: UInt64 = 0
+
+    /// Largest possible packet size, used to size compressed buffers. Falls
+    /// back to a generous default when the stream doesn't declare one.
+    private(set) var maxPacketSize: UInt32 = 0
+
+    private(set) var isReadyToProducePackets = false
+
+    private var streamID: AudioFileStreamID?
+
+    /// `fileTypeHint` biases container sniffing (`kAudioFileFLACType`, …);
+    /// pass 0 to let AudioToolbox detect from the bytes alone.
+    init(fileTypeHint: AudioFileTypeID = 0) throws {
+        var stream: AudioFileStreamID?
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        let status = AudioFileStreamOpen(
+            context,
+            { context, streamID, propertyID, _ in
+                let parser = Unmanaged<DSPAudioFileStreamParser>.fromOpaque(context).takeUnretainedValue()
+                parser.handleProperty(streamID: streamID, propertyID: propertyID)
+            },
+            { context, byteCount, packetCount, bytes, packetDescriptions in
+                let parser = Unmanaged<DSPAudioFileStreamParser>.fromOpaque(context).takeUnretainedValue()
+                parser.handlePackets(
+                    byteCount: byteCount,
+                    packetCount: packetCount,
+                    bytes: bytes,
+                    packetDescriptions: packetDescriptions
+                )
+            },
+            fileTypeHint,
+            &stream
+        )
+        guard status == noErr, let stream else {
+            throw ParserError.openFailed(status)
+        }
+        self.streamID = stream
+    }
+
+    deinit {
+        if let streamID {
+            AudioFileStreamClose(streamID)
+        }
+    }
+
+    /// Push the next chunk of container bytes through the parser. Set
+    /// `discontinuity` after a seek (the bytes don't follow the previous
+    /// call's bytes) so the parser resynchronizes on packet boundaries.
+    func parse(_ data: Data, discontinuity: Bool = false) throws {
+        guard let streamID else { return }
+        guard !data.isEmpty else { return }
+        let flags: AudioFileStreamParseFlags = discontinuity ? [.discontinuity] : []
+        let status = data.withUnsafeBytes { raw -> OSStatus in
+            guard let base = raw.baseAddress else { return noErr }
+            return AudioFileStreamParseBytes(streamID, UInt32(raw.count), base, flags)
+        }
+        guard status == noErr else {
+            throw ParserError.parseFailed(status)
+        }
+    }
+
+    /// Map a packet index to the container byte offset its data starts at
+    /// (relative to the whole file — `dataOffset` already added). Returns
+    /// `nil` when the stream can't seek (header not parsed yet, or the
+    /// format carries no packet table and no bitrate estimate).
+    /// `isEstimated` is true for VBR streams where the offset is the
+    /// parser's average-bitrate guess rather than an exact table lookup.
+    func seekByteOffset(forPacket packet: Int64) -> (byteOffset: Int64, isEstimated: Bool)? {
+        guard let streamID, isReadyToProducePackets else { return nil }
+        var packetByteOffset: Int64 = 0
+        var flags = AudioFileStreamSeekFlags()
+        let status = AudioFileStreamSeek(streamID, packet, &packetByteOffset, &flags)
+        guard status == noErr else { return nil }
+        return (dataOffset + packetByteOffset, flags.contains(.offsetIsEstimated))
+    }
+
+    // MARK: - C callback handlers
+
+    private func handleProperty(streamID: AudioFileStreamID, propertyID: AudioFileStreamPropertyID) {
+        switch propertyID {
+        case kAudioFileStreamProperty_ReadyToProducePackets:
+            var asbd = AudioStreamBasicDescription()
+            var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            guard AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_DataFormat, &size, &asbd) == noErr else {
+                return
+            }
+            streamDescription = asbd
+
+            var offset: Int64 = 0
+            var offsetSize = UInt32(MemoryLayout<Int64>.size)
+            if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_DataOffset, &offsetSize, &offset) == noErr {
+                dataOffset = offset
+            }
+
+            var byteCount: UInt64 = 0
+            var byteCountSize = UInt32(MemoryLayout<UInt64>.size)
+            if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_AudioDataByteCount, &byteCountSize, &byteCount) == noErr {
+                audioDataByteCount = byteCount
+            }
+
+            var packetCount: UInt64 = 0
+            var packetCountSize = UInt32(MemoryLayout<UInt64>.size)
+            if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_AudioDataPacketCount, &packetCountSize, &packetCount) == noErr {
+                audioDataPacketCount = packetCount
+            }
+
+            var upperBound: UInt32 = 0
+            var upperBoundSize = UInt32(MemoryLayout<UInt32>.size)
+            if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_PacketSizeUpperBound, &upperBoundSize, &upperBound) == noErr, upperBound > 0 {
+                maxPacketSize = upperBound
+            } else {
+                var maxSize: UInt32 = 0
+                var maxSizeSize = UInt32(MemoryLayout<UInt32>.size)
+                if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_MaximumPacketSize, &maxSizeSize, &maxSize) == noErr, maxSize > 0 {
+                    maxPacketSize = maxSize
+                }
+            }
+            if maxPacketSize == 0 {
+                // No declared bound (some chunked streams) — a generous
+                // ceiling that comfortably covers MP3 (≤1.5 KB), AAC and
+                // FLAC (≤16 KB typical) frames.
+                maxPacketSize = 32_768
+            }
+
+            // Magic cookie (codec private data — AAC/ALAC carry one, MP3/
+            // FLAC-in-flac don't). Optional by design.
+            var cookieSize: UInt32 = 0
+            var writable: DarwinBoolean = false
+            var cookie: Data?
+            if AudioFileStreamGetPropertyInfo(streamID, kAudioFileStreamProperty_MagicCookieData, &cookieSize, &writable) == noErr, cookieSize > 0 {
+                var cookieBytes = [UInt8](repeating: 0, count: Int(cookieSize))
+                if AudioFileStreamGetProperty(streamID, kAudioFileStreamProperty_MagicCookieData, &cookieSize, &cookieBytes) == noErr {
+                    cookie = Data(cookieBytes)
+                }
+            }
+
+            isReadyToProducePackets = true
+            onReadyToProducePackets?(asbd, cookie)
+        default:
+            break
+        }
+    }
+
+    private func handlePackets(
+        byteCount: UInt32,
+        packetCount: UInt32,
+        bytes: UnsafeRawPointer,
+        packetDescriptions: UnsafeMutablePointer<AudioStreamPacketDescription>?
+    ) {
+        guard byteCount > 0 else { return }
+        let data = Data(bytes: bytes, count: Int(byteCount))
+        var descriptions: [AudioStreamPacketDescription]?
+        if let packetDescriptions, packetCount > 0 {
+            descriptions = Array(UnsafeBufferPointer(start: packetDescriptions, count: Int(packetCount)))
+        }
+        // LPCM streams report packetCount in packets (== frames); compressed
+        // streams match the description count. Either way `packetCount` is
+        // authoritative.
+        onPackets?(PacketBatch(data: data, packetDescriptions: descriptions, packetCount: Int(packetCount)))
+    }
+}

--- a/macos/Sources/LyrebirdAudio/DSPTrackStreamer.swift
+++ b/macos/Sources/LyrebirdAudio/DSPTrackStreamer.swift
@@ -1,0 +1,614 @@
+import AVFoundation
+import AudioToolbox
+import Foundation
+import os
+
+private let streamerLog = Logger(subsystem: "org.lyrebird.desktop", category: "dsp")
+
+/// Per-track streaming bridge for the AVAudioEngine DSP path (#39):
+///
+///   URLSession bytes → `DSPAudioFileStreamParser` (AudioToolbox) →
+///   `AVAudioConverter` decode → `AVAudioPCMBuffer` → scheduled on the
+///   pipeline's `AVAudioPlayerNode`.
+///
+/// `AVPlayer` can't host real-time effect nodes and `MTAudioProcessingTap`
+/// doesn't work over HTTP streaming, so this is the classic AudioStreamer /
+/// SwiftAudioPlayer pattern that feeds a node graph from a network stream.
+///
+/// One streamer per track; `EngineDSPPipeline` builds a fresh one in `load`
+/// and cancels the old one. All parse/decode/schedule work is confined to the
+/// serial `decodeQueue`; the owner talks to it from the main actor through
+/// thread-safe entry points (`start`, `seek`, `cancel`).
+///
+/// Memory stays flat (#39 acceptance): decoded PCM is paced against playback
+/// (at most `maxScheduledAheadFrames` ahead), parsed-but-undecoded packets are
+/// capped, and the URLSession task is suspended when the backlog passes the
+/// high-water mark and resumed below the low-water mark — so neither the raw
+/// bytes nor the decoded audio of a long track ever accumulate unboundedly.
+final class DSPTrackStreamer: NSObject {
+    // MARK: - Tunables
+
+    /// Cap on decoded-and-scheduled audio waiting in the player node:
+    /// ~8 seconds at the source sample rate. Generous enough to ride out
+    /// network jitter, small enough (~2.7 MB of float32 stereo at 44.1 kHz)
+    /// to keep memory flat.
+    private var maxScheduledAheadFrames: AVAudioFramePosition {
+        AVAudioFramePosition(8 * (processingFormat?.sampleRate ?? 44_100))
+    }
+
+    /// Frames per scheduled output buffer (~0.37s at 44.1 kHz).
+    private let outputBufferFrameCapacity: AVAudioFrameCount = 16_384
+
+    /// Suspend the network task when this many parsed-but-undecoded packets
+    /// are queued; resume at half. Roughly 30–60s of compressed audio.
+    private let packetQueueHighWater = 2_048
+
+    // MARK: - Owner-facing callbacks (all invoked on the main queue)
+
+    /// Fired once the source format is known and the converter is built.
+    /// Carries the engine processing format the owner should wire the node
+    /// graph with, plus `framesPerPacket` for seek math.
+    var onFormatReady: ((AVAudioFormat) -> Void)?
+
+    /// Fired when the last scheduled buffer of a fully-delivered stream has
+    /// been *played back* — the DSP path's `AVPlayerItemDidPlayToEndTime`.
+    var onPlaybackFinished: (() -> Void)?
+
+    /// Fired when the stream dies before delivering a complete track
+    /// (network failure, unparseable container, decode error).
+    var onStreamError: ((String) -> Void)?
+
+    /// Fired after a seek lands, with the *actual* stream frame the stream
+    /// resumed from (packet-aligned; may differ slightly from the request,
+    /// and is 0 when a ranged request fell back to the start of the track).
+    var onSeekCommitted: ((AVAudioFramePosition) -> Void)?
+
+    // MARK: - Immutable per-track inputs
+
+    private let url: URL
+    private let authHeader: String?
+    private let fileTypeHint: AudioFileTypeID
+    /// Duration hint from track metadata (ticks → seconds), used only for
+    /// seek-frame estimation on streams without a packet table.
+    private let durationHintSeconds: Double?
+
+    private weak var playerNode: AVAudioPlayerNode?
+
+    // MARK: - Decode-queue confined state
+
+    private let decodeQueue = DispatchQueue(label: "org.lyrebird.desktop.dsp-decode")
+    private lazy var sessionDelegateQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.underlyingQueue = decodeQueue
+        return queue
+    }()
+
+    private var session: URLSession?
+    private var dataTask: URLSessionDataTask?
+    private var parser: DSPAudioFileStreamParser?
+    private var converter: AVAudioConverter?
+    private var sourceFormat: AVAudioFormat?
+    private var processingFormat: AVAudioFormat?
+    private var sourceASBD = AudioStreamBasicDescription()
+    private var isSourceLPCM = false
+    private var framesPerPacket: AVAudioFramePosition = 0
+
+    /// Parsed-but-undecoded packets, in arrival order.
+    private var packetQueue: [(data: Data, description: AudioStreamPacketDescription?)] = []
+    /// Raw bytes that arrived before the parser was ready get replayed
+    /// through it (never happens in practice — ParseBytes consumes
+    /// everything — kept nil-cost for clarity).
+
+    /// Frames scheduled onto the node so far, in stream coordinates
+    /// (starts at the seek target after a seek).
+    private var scheduledFrames: AVAudioFramePosition = 0
+    /// Frames the node has *played* of what we scheduled (advanced by
+    /// buffer completions). Pacing = scheduledFrames - playedFrames.
+    private var playedFrames: AVAudioFramePosition = 0
+
+    /// The stream byte offset the *current* HTTP response body started at.
+    private var responseStartByteOffset: Int64 = 0
+    /// Bytes of the current response consumed so far (for diagnostics).
+    private var receivedByteCount: Int64 = 0
+
+    private var networkDone = false
+    private var converterSawEndOfStream = false
+    private var taskSuspended = false
+    private var cancelled = false
+
+    /// Scheduling stays gated until the owner has rewired the node graph
+    /// for this stream's format (`beginScheduling`). Scheduling a buffer
+    /// whose format mismatches the node's output connection raises an
+    /// NSException inside AVFoundation, so decoded audio must wait for the
+    /// graph — packets simply queue up in the meantime.
+    private var schedulingAllowed = false
+
+    /// Bumped on every seek/cancel; stale buffer-completion callbacks and
+    /// stale response handling compare against it and bail.
+    private var generation: Int = 0
+
+    /// Set while a seek's ranged request is in flight so a `200 OK`
+    /// (range-unsupported) response can be detected and handled as a
+    /// restart-from-zero.
+    private var pendingSeekFrame: AVAudioFramePosition?
+
+    init(
+        url: URL,
+        authHeader: String?,
+        playerNode: AVAudioPlayerNode,
+        fileTypeHint: AudioFileTypeID = 0,
+        durationHintSeconds: Double? = nil
+    ) {
+        self.url = url
+        self.authHeader = authHeader
+        self.playerNode = playerNode
+        self.fileTypeHint = fileTypeHint
+        self.durationHintSeconds = durationHintSeconds
+        super.init()
+    }
+
+    // MARK: - Owner entry points (thread-safe)
+
+    /// Begin fetching + decoding from the start of the stream.
+    func start() {
+        decodeQueue.async { [weak self] in
+            guard let self, !self.cancelled else { return }
+            do {
+                let parser = try DSPAudioFileStreamParser(fileTypeHint: self.fileTypeHint)
+                self.wireParser(parser)
+                self.parser = parser
+            } catch {
+                self.failOnDecodeQueue("Unsupported audio container: \(error.localizedDescription)")
+                return
+            }
+            self.startRequest(fromByte: 0)
+        }
+    }
+
+    /// Seek to (approximately) `targetFrame` in stream coordinates. The
+    /// owner must stop the player node first (dropping its scheduled
+    /// buffers); the streamer flushes its own backlog, issues a ranged
+    /// request, and reports the packet-aligned landing frame via
+    /// `onSeekCommitted` before new buffers start arriving.
+    func seek(toFrame targetFrame: AVAudioFramePosition) {
+        decodeQueue.async { [weak self] in
+            guard let self, !self.cancelled else { return }
+            guard let parser = self.parser, parser.isReadyToProducePackets, self.converter != nil else {
+                // Header not parsed yet — nothing meaningful to seek within.
+                return
+            }
+
+            // Tear down the in-flight transfer + backlog.
+            self.generation &+= 1
+            self.dataTask?.cancel()
+            self.dataTask = nil
+            self.taskSuspended = false
+            self.packetQueue.removeAll(keepingCapacity: true)
+            self.converter?.reset()
+            self.converterSawEndOfStream = false
+            self.networkDone = false
+
+            // Map the requested frame onto a packet boundary, then onto a
+            // byte offset. Prefer the parser's packet table / bitrate
+            // estimate; fall back to a byte-fraction guess for streams
+            // without one (chunked transcodes).
+            var landingFrame: AVAudioFramePosition = 0
+            var byteOffset: Int64 = 0
+            if self.framesPerPacket > 0,
+               let mapped = parser.seekByteOffset(forPacket: targetFrame / self.framesPerPacket) {
+                landingFrame = (targetFrame / self.framesPerPacket) * self.framesPerPacket
+                byteOffset = mapped.byteOffset
+            } else if parser.audioDataByteCount > 0,
+                      let duration = self.durationHintSeconds, duration > 0,
+                      let format = self.processingFormat {
+                let totalFrames = AVAudioFramePosition(duration * format.sampleRate)
+                let fraction = min(1, max(0, Double(targetFrame) / Double(max(1, totalFrames))))
+                byteOffset = parser.dataOffset + Int64(fraction * Double(parser.audioDataByteCount))
+                landingFrame = targetFrame
+            } else {
+                // No packet table, no length — restart from the top.
+                byteOffset = 0
+                landingFrame = 0
+            }
+
+            self.scheduledFrames = landingFrame
+            self.playedFrames = landingFrame
+            self.pendingSeekFrame = landingFrame
+            self.startRequest(fromByte: byteOffset)
+        }
+    }
+
+    /// Unblock buffer scheduling. The owner calls this once the engine
+    /// graph is connected with the format delivered by `onFormatReady` —
+    /// never before, or a format mismatch can raise inside AVFoundation.
+    func beginScheduling() {
+        decodeQueue.async { [weak self] in
+            guard let self, !self.cancelled else { return }
+            self.schedulingAllowed = true
+            self.pump()
+        }
+    }
+
+    /// Stop the transfer and drop all backlog. Safe to call repeatedly.
+    func cancel() {
+        decodeQueue.async { [weak self] in
+            guard let self else { return }
+            self.cancelled = true
+            self.generation &+= 1
+            self.dataTask?.cancel()
+            self.dataTask = nil
+            self.session?.invalidateAndCancel()
+            self.session = nil
+            self.packetQueue.removeAll()
+            self.parser = nil
+            self.converter = nil
+        }
+    }
+
+    // MARK: - Network
+
+    private func startRequest(fromByte byteOffset: Int64) {
+        if session == nil {
+            let config = URLSessionConfiguration.default
+            config.networkServiceType = .avStreaming
+            session = URLSession(configuration: config, delegate: self, delegateQueue: sessionDelegateQueue)
+        }
+        guard let session else { return }
+
+        var request = URLRequest(url: url)
+        if let authHeader {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+        if byteOffset > 0 {
+            request.setValue("bytes=\(byteOffset)-", forHTTPHeaderField: "Range")
+        }
+        responseStartByteOffset = byteOffset
+        receivedByteCount = 0
+        let task = session.dataTask(with: request)
+        dataTask = task
+        taskSuspended = false
+        task.resume()
+    }
+
+    // MARK: - Parse → decode → schedule (decode queue)
+
+    private func wireParser(_ parser: DSPAudioFileStreamParser) {
+        parser.onReadyToProducePackets = { [weak self] asbd, magicCookie in
+            self?.handleFormatReady(asbd, magicCookie: magicCookie)
+        }
+        parser.onPackets = { [weak self] batch in
+            self?.enqueue(batch)
+        }
+    }
+
+    private func handleFormatReady(_ asbd: AudioStreamBasicDescription, magicCookie: Data?) {
+        var asbd = asbd
+        sourceASBD = asbd
+        isSourceLPCM = asbd.mFormatID == kAudioFormatLinearPCM
+        framesPerPacket = AVAudioFramePosition(asbd.mFramesPerPacket)
+
+        guard let inputFormat = AVAudioFormat(streamDescription: &asbd) else {
+            failOnDecodeQueue("Unsupported stream format")
+            return
+        }
+        sourceFormat = inputFormat
+
+        // Canonical engine format: float32, deinterleaved, source sample
+        // rate, source channel count (folded to stereo beyond 2 channels —
+        // AVAudioConverter downmixes). The main mixer resamples to the
+        // output device rate, so no fidelity is lost here.
+        let channels = min(max(asbd.mChannelsPerFrame, 1), 2)
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: asbd.mSampleRate,
+            channels: AVAudioChannelCount(channels),
+            interleaved: false
+        ) else {
+            failOnDecodeQueue("Could not build engine processing format")
+            return
+        }
+        processingFormat = outputFormat
+
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            failOnDecodeQueue("No decoder available for this stream")
+            return
+        }
+        if let magicCookie {
+            converter.magicCookie = magicCookie
+        }
+        self.converter = converter
+
+        DispatchQueue.main.async { [weak self] in
+            self?.onFormatReady?(outputFormat)
+        }
+    }
+
+    private func enqueue(_ batch: DSPAudioFileStreamParser.PacketBatch) {
+        guard !cancelled else { return }
+        if let descriptions = batch.packetDescriptions {
+            for description in descriptions {
+                let start = Int(description.mStartOffset)
+                let length = Int(description.mDataByteSize)
+                guard start >= 0, length > 0, start + length <= batch.data.count else { continue }
+                var rebased = description
+                rebased.mStartOffset = 0
+                packetQueue.append((batch.data.subdata(in: start..<(start + length)), rebased))
+            }
+        } else {
+            // CBR / LPCM: contiguous frame-aligned bytes, no descriptions.
+            packetQueue.append((batch.data, nil))
+        }
+        applyNetworkBackpressure()
+        pump()
+    }
+
+    /// Suspend the transfer while the parsed backlog is deep; resume once
+    /// the decoder works it back down. Keeps long FLAC tracks from buffering
+    /// the whole file into `packetQueue`.
+    private func applyNetworkBackpressure() {
+        guard let task = dataTask else { return }
+        if packetQueue.count > packetQueueHighWater, !taskSuspended {
+            task.suspend()
+            taskSuspended = true
+        } else if packetQueue.count < packetQueueHighWater / 2, taskSuspended {
+            task.resume()
+            taskSuspended = false
+        }
+    }
+
+    /// Decode + schedule while there's input available and the node isn't
+    /// already holding `maxScheduledAheadFrames` of unplayed audio. Called
+    /// whenever packets arrive or a scheduled buffer finishes playing.
+    private func pump() {
+        guard !cancelled, schedulingAllowed, let converter, let outputFormat = processingFormat, let node = playerNode else { return }
+
+        while scheduledFrames - playedFrames < maxScheduledAheadFrames {
+            if packetQueue.isEmpty && !networkDone {
+                return // wait for more bytes
+            }
+            if packetQueue.isEmpty && converterSawEndOfStream {
+                return // fully drained; completion fires off the last buffer
+            }
+
+            guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputBufferFrameCapacity) else {
+                failOnDecodeQueue("Buffer allocation failed")
+                return
+            }
+
+            var conversionError: NSError?
+            let status = converter.convert(to: pcmBuffer, error: &conversionError) { [weak self] requestedPackets, outStatus in
+                guard let self else {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+                guard !self.packetQueue.isEmpty else {
+                    if self.networkDone {
+                        self.converterSawEndOfStream = true
+                        outStatus.pointee = .endOfStream
+                    } else {
+                        outStatus.pointee = .noDataNow
+                    }
+                    return nil
+                }
+                guard let inputBuffer = self.dequeueInputBuffer(maxPackets: Int(requestedPackets)) else {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                outStatus.pointee = .haveData
+                return inputBuffer
+            }
+
+            switch status {
+            case .haveData, .inputRanDry, .endOfStream:
+                if pcmBuffer.frameLength > 0 {
+                    schedule(pcmBuffer, on: node)
+                }
+                if status == .endOfStream || (packetQueue.isEmpty && !networkDone) {
+                    // Either truly finished, or out of input until the
+                    // network delivers more.
+                    if status == .endOfStream {
+                        converterSawEndOfStream = true
+                        checkForCompletion()
+                    }
+                    applyNetworkBackpressure()
+                    return
+                }
+            case .error:
+                failOnDecodeQueue(conversionError?.localizedDescription ?? "Audio decode failed")
+                return
+            @unknown default:
+                return
+            }
+        }
+        applyNetworkBackpressure()
+    }
+
+    /// Build the converter's next input buffer from the packet queue:
+    /// an `AVAudioCompressedBuffer` for encoded sources, an interleaved
+    /// `AVAudioPCMBuffer` for LPCM containers (WAV/AIFF).
+    private func dequeueInputBuffer(maxPackets: Int) -> AVAudioBuffer? {
+        guard let inputFormat = sourceFormat else { return nil }
+        let take = min(max(1, maxPackets), packetQueue.count, 256)
+        let slice = Array(packetQueue.prefix(take))
+        packetQueue.removeFirst(take)
+
+        if isSourceLPCM {
+            // LPCM "packets" are frames; concatenate and wrap as PCM.
+            var combined = Data()
+            for entry in slice { combined.append(entry.data) }
+            let bytesPerFrame = Int(sourceASBD.mBytesPerFrame)
+            guard bytesPerFrame > 0 else { return nil }
+            let frames = combined.count / bytesPerFrame
+            guard frames > 0,
+                  let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: AVAudioFrameCount(frames)) else {
+                return nil
+            }
+            buffer.frameLength = AVAudioFrameCount(frames)
+            combined.withUnsafeBytes { raw in
+                if let base = raw.baseAddress, let dest = buffer.audioBufferList.pointee.mBuffers.mData {
+                    memcpy(dest, base, min(raw.count, Int(buffer.audioBufferList.pointee.mBuffers.mDataByteSize)))
+                }
+            }
+            return buffer
+        }
+
+        let maxPacketSize = Int(parser?.maxPacketSize ?? 32_768)
+        let buffer = AVAudioCompressedBuffer(
+            format: inputFormat,
+            packetCapacity: AVAudioPacketCount(slice.count),
+            maximumPacketSize: maxPacketSize
+        )
+        var byteOffset = 0
+        var packetIndex = 0
+        for entry in slice {
+            let length = entry.data.count
+            guard byteOffset + length <= Int(buffer.byteCapacity) else { break }
+            entry.data.withUnsafeBytes { raw in
+                if let base = raw.baseAddress {
+                    memcpy(buffer.data.advanced(by: byteOffset), base, length)
+                }
+            }
+            if let descriptions = buffer.packetDescriptions {
+                descriptions[packetIndex] = AudioStreamPacketDescription(
+                    mStartOffset: Int64(byteOffset),
+                    mVariableFramesInPacket: entry.description?.mVariableFramesInPacket ?? 0,
+                    mDataByteSize: UInt32(length)
+                )
+            }
+            byteOffset += length
+            packetIndex += 1
+        }
+        buffer.packetCount = AVAudioPacketCount(packetIndex)
+        buffer.byteLength = UInt32(byteOffset)
+        return buffer
+    }
+
+    private func schedule(_ buffer: AVAudioPCMBuffer, on node: AVAudioPlayerNode) {
+        let frames = AVAudioFramePosition(buffer.frameLength)
+        scheduledFrames += frames
+        let scheduleGeneration = generation
+        node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            guard let self else { return }
+            self.decodeQueue.async {
+                guard !self.cancelled, scheduleGeneration == self.generation else { return }
+                self.playedFrames += frames
+                self.pump()
+                self.checkForCompletion()
+            }
+        }
+    }
+
+    /// End-of-track: the network delivered everything, the converter drained,
+    /// and the node has played back every frame we scheduled.
+    private func checkForCompletion() {
+        guard networkDone, converterSawEndOfStream, packetQueue.isEmpty else { return }
+        guard playedFrames >= scheduledFrames else { return }
+        guard !cancelled else { return }
+        // One-shot: bump the generation so a straggling completion can't
+        // re-fire it.
+        generation &+= 1
+        DispatchQueue.main.async { [weak self] in
+            self?.onPlaybackFinished?()
+        }
+    }
+
+    #if DEBUG
+    /// Test seam: synchronous snapshot of decode/schedule progress, read
+    /// off the decode queue so tests don't race the pump.
+    func progressSnapshotForTesting() -> (scheduledFrames: AVAudioFramePosition, playedFrames: AVAudioFramePosition, queuedPackets: Int, networkDone: Bool) {
+        decodeQueue.sync {
+            (scheduledFrames, playedFrames, packetQueue.count, networkDone)
+        }
+    }
+    #endif
+
+    private func failOnDecodeQueue(_ message: String) {
+        guard !cancelled else { return }
+        cancelled = true
+        generation &+= 1
+        dataTask?.cancel()
+        dataTask = nil
+        packetQueue.removeAll()
+        streamerLog.error("DSP stream failed: \(message, privacy: .public)")
+        DispatchQueue.main.async { [weak self] in
+            self?.onStreamError?(message)
+        }
+    }
+}
+
+// MARK: - URLSessionDataDelegate (delegate queue == decodeQueue)
+
+extension DSPTrackStreamer: URLSessionDataDelegate {
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard !cancelled, dataTask === self.dataTask else {
+            completionHandler(.cancel)
+            return
+        }
+        if let http = response as? HTTPURLResponse {
+            guard (200...299).contains(http.statusCode) else {
+                completionHandler(.cancel)
+                failOnDecodeQueue("Stream request failed (HTTP \(http.statusCode))")
+                return
+            }
+            // A ranged (seek) request that came back `200 OK` means the
+            // server ignored the Range header — the body restarts at byte
+            // zero. Land the seek at frame 0 so position stays honest.
+            if let seekFrame = pendingSeekFrame {
+                let landed: AVAudioFramePosition
+                if responseStartByteOffset > 0 && http.statusCode != 206 {
+                    landed = 0
+                    responseStartByteOffset = 0
+                    scheduledFrames = 0
+                    playedFrames = 0
+                } else {
+                    landed = seekFrame
+                }
+                pendingSeekFrame = nil
+                DispatchQueue.main.async { [weak self] in
+                    self?.onSeekCommitted?(landed)
+                }
+            }
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard !cancelled, dataTask === self.dataTask, let parser else { return }
+        let isFirstBytesAfterSeek = receivedByteCount == 0 && responseStartByteOffset > 0
+        receivedByteCount += Int64(data.count)
+        do {
+            try parser.parse(data, discontinuity: isFirstBytesAfterSeek)
+        } catch {
+            failOnDecodeQueue(error.localizedDescription)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard !cancelled, task === self.dataTask else { return }
+        self.dataTask = nil
+        if let error {
+            let nsError = error as NSError
+            // Explicit cancels (seek teardown) are not failures.
+            guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else { return }
+            failOnDecodeQueue(nsError.localizedDescription)
+            return
+        }
+        networkDone = true
+        // The transfer is finished for good — release the session's strong
+        // reference to this delegate so a fully-played streamer doesn't
+        // linger until the next `cancel()`. (A subsequent seek re-creates
+        // the session lazily in `startRequest`.)
+        session.finishTasksAndInvalidate()
+        self.session = nil
+        // Wake the pump so it can drain the converter to end-of-stream even
+        // if no further completions are pending.
+        pump()
+        checkForCompletion()
+    }
+}

--- a/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
+++ b/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
@@ -1,0 +1,439 @@
+import AVFoundation
+import AudioToolbox
+import CoreAudio
+import Foundation
+import os
+
+private let pipelineLog = Logger(subsystem: "org.lyrebird.desktop", category: "dsp")
+
+/// AVAudioEngine-based playback pipeline (#39) — the DSP foundation for the
+/// EQ (#40) and crossfade (#41) features that `AVQueuePlayer` cannot host.
+///
+/// Node graph:
+///
+///     AVAudioPlayerNode → AVAudioUnitEQ (10-band, flat) → mainMixerNode
+///
+/// The EQ ships **flat and bypassed** (`globalGain == 0`, every band
+/// `bypass == true`) so the engine path makes no audible DSP alteration —
+/// #40 owns the preset/slider UI that will drive real band gains through
+/// the `eq` node this class already keeps live in the graph.
+///
+/// Tracks are fed by a `DSPTrackStreamer` (URLSession → AudioToolbox parse →
+/// `AVAudioConverter` decode → scheduled `AVAudioPCMBuffer`s), one per track.
+/// `AudioEngine` owns an instance of this class only while the
+/// `engine.useAVAudioEngine` feature flag is on; with the flag off (the
+/// default) this type is never constructed.
+///
+/// Energy contract (CLAUDE.md gap #2): the position tick runs at 1 Hz and
+/// only while playing — `pause()` both pauses the node *and* pauses the
+/// engine's render thread, and invalidates the timer, so an idle app does
+/// zero per-second work on this path too.
+@MainActor
+public final class EngineDSPPipeline {
+    public enum TransportState {
+        case idle
+        case playing
+        case paused
+    }
+
+    // MARK: - Owner callbacks
+
+    /// Fired when a fully-streamed track finishes playing back — the DSP
+    /// path's end-of-item signal (`AVPlayerItemDidPlayToEndTime` parity).
+    public var onTrackFinished: (() -> Void)?
+
+    /// 1 Hz position tick, fired only while playing (never when paused or
+    /// stopped). Drives `core.markPosition` parity with the AVPlayer path's
+    /// periodic time observer.
+    public var onPositionTick: ((Double) -> Void)?
+
+    /// Fired when the current track's stream dies (network failure,
+    /// unsupported container, decode error). Carries a diagnostic message;
+    /// the owner decides the user-facing copy.
+    public var onStreamError: ((String) -> Void)?
+
+    // MARK: - Node graph
+
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+
+    /// The EQ stage. Flat/bypassed by default; exposed so #40's preset UI
+    /// can drive band gains on the live graph.
+    public let eq = AVAudioUnitEQ(numberOfBands: 10)
+
+    private var streamer: DSPTrackStreamer?
+    private var processingFormat: AVAudioFormat?
+    private var configurationChangeObserver: NSObjectProtocol?
+
+    // MARK: - Transport / position state
+
+    public private(set) var state: TransportState = .idle
+
+    /// Stream frame corresponding to node sample time 0 — reset by
+    /// `load` (0) and `seek` (the landing frame). Position is
+    /// `baseFrame + playerTime.sampleTime`.
+    private var baseFrame: AVAudioFramePosition = 0
+
+    /// Last node sample time successfully read while rendering, so the
+    /// position survives pauses (when `playerTime(forNodeTime:)` goes nil).
+    private var lastKnownSampleTime: AVAudioFramePosition = 0
+
+    private var sampleRate: Double = 44_100
+
+    /// Pending volume applied to the mixer once the graph exists.
+    private var volume: Float = 1.0
+
+    /// Core Audio output device UID the engine output should pin to
+    /// (nil/empty = system default).
+    private var outputDeviceUID: String?
+
+    private var positionTimer: Timer?
+
+    /// Bumped per `load` so a stale streamer's late callbacks (format-ready,
+    /// finished, error) can't cross tracks.
+    private var loadGeneration: Int = 0
+
+    public init() {
+        engine.attach(playerNode)
+        engine.attach(eq)
+        configureFlatEQ()
+        // Initial wiring with a placeholder format so the graph is valid
+        // before the first track's real format is known; `connectGraph`
+        // rewires with the source format per track.
+        if let placeholder = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2) {
+            connectGraph(format: placeholder)
+        }
+        // An output-device disappearance (unplugged interface) stops the
+        // engine. Restart best-effort so playback continues on the new
+        // default device — parity with AVPlayer's automatic rerouting.
+        configurationChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleConfigurationChange()
+            }
+        }
+    }
+
+    deinit {
+        if let observer = configurationChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        positionTimer?.invalidate()
+    }
+
+    // MARK: - Loading
+
+    /// Tear down the current track (if any) and begin streaming `url`.
+    /// Playback starts as soon as the stream's header parses, *if* `play()`
+    /// has been called (or had been in effect for the previous track).
+    ///
+    /// `containerHint` is the Jellyfin container string ("flac", "mp3", …)
+    /// used to bias AudioToolbox's container sniffing; `durationHint` (in
+    /// seconds) backs seek estimation on streams without packet tables.
+    public func load(
+        url: URL,
+        authHeader: String?,
+        containerHint: String? = nil,
+        durationHint: Double? = nil
+    ) {
+        unloadCurrentTrack()
+
+        loadGeneration &+= 1
+        let generation = loadGeneration
+
+        let streamer = DSPTrackStreamer(
+            url: url,
+            authHeader: authHeader,
+            playerNode: playerNode,
+            fileTypeHint: EngineDSPPipeline.fileTypeHint(forContainer: containerHint),
+            durationHintSeconds: durationHint
+        )
+        streamer.onFormatReady = { [weak self] format in
+            guard let self, generation == self.loadGeneration else { return }
+            self.handleFormatReady(format)
+        }
+        streamer.onPlaybackFinished = { [weak self] in
+            guard let self, generation == self.loadGeneration else { return }
+            self.stopPositionTimer()
+            self.state = .idle
+            self.onTrackFinished?()
+        }
+        streamer.onStreamError = { [weak self] message in
+            guard let self, generation == self.loadGeneration else { return }
+            self.stopPositionTimer()
+            self.state = .idle
+            self.onStreamError?(message)
+        }
+        streamer.onSeekCommitted = { [weak self] landedFrame in
+            guard let self, generation == self.loadGeneration else { return }
+            self.baseFrame = landedFrame
+        }
+        self.streamer = streamer
+        streamer.start()
+    }
+
+    // MARK: - Transport
+
+    /// Declare the transport intent as playing. If the graph is already
+    /// configured the node starts immediately; otherwise it starts the
+    /// moment the stream's format resolves in `handleFormatReady`.
+    public func play() {
+        state = .playing
+        startNodeIfReady()
+        startPositionTimer()
+    }
+
+    public func pause() {
+        guard state == .playing else { return }
+        // Snapshot the position while the render clock is still readable —
+        // `playerTime(forNodeTime:)` returns nil once the node pauses.
+        refreshLastKnownSampleTime()
+        state = .paused
+        stopPositionTimer()
+        playerNode.pause()
+        engine.pause()
+    }
+
+    public func resume() {
+        guard state != .playing else { return }
+        state = .playing
+        startNodeIfReady()
+        startPositionTimer()
+    }
+
+    /// Full teardown: cancel the stream, drop scheduled audio, stop the
+    /// engine, reset position.
+    public func stop() {
+        unloadCurrentTrack()
+        state = .idle
+    }
+
+    /// Seek the current track. Drops everything scheduled, points the
+    /// streamer at the packet-aligned byte offset (ranged request), and
+    /// resumes from there. Position reflects the target immediately; the
+    /// streamer corrects it via `onSeekCommitted` if the landing differs
+    /// (estimated VBR offsets, or a server that ignored the Range header).
+    public func seek(toSeconds seconds: Double) {
+        guard let streamer else { return }
+        // Before the stream header has parsed there is no packet table to
+        // seek within (and `sampleRate` is still the placeholder) — drop the
+        // request instead of lying about the position. The streamer would
+        // ignore it anyway; this keeps `baseFrame` honest too.
+        guard processingFormat != nil else { return }
+        let targetFrame = AVAudioFramePosition(max(0, seconds) * sampleRate)
+
+        // Generation-bump the streamer *before* stopping the node so the
+        // completions fired by `stop()` can't advance stale bookkeeping.
+        streamer.seek(toFrame: targetFrame)
+
+        playerNode.stop()
+        baseFrame = targetFrame
+        lastKnownSampleTime = 0
+
+        // Playing: restart the node so re-streamed buffers render as they
+        // arrive. Paused: leave everything parked — the streamer keeps
+        // scheduling against the stopped node and `resume()` picks it up.
+        if state == .playing {
+            startNodeIfReady()
+        }
+    }
+
+    public func setVolume(_ v: Float) {
+        volume = max(0, min(1, v))
+        engine.mainMixerNode.outputVolume = volume
+    }
+
+    /// Pin engine output to a Core Audio device by UID (empty/nil = system
+    /// default). Matches `AVPlayer.audioOutputDeviceUniqueID` semantics as
+    /// closely as the HAL output unit allows: an explicit device pins; the
+    /// default falls back to whatever device is the system default at the
+    /// time playback (re)starts.
+    public func setOutputDevice(uid: String?) {
+        outputDeviceUID = uid
+        applyOutputDevice()
+    }
+
+    // MARK: - Position
+
+    /// Current playback position in stream seconds. Reads the node's render
+    /// clock while playing; falls back to the last known position while
+    /// paused/stopped.
+    public var positionSeconds: Double {
+        refreshLastKnownSampleTime()
+        return Double(baseFrame + lastKnownSampleTime) / sampleRate
+    }
+
+    // MARK: - Internals
+
+    private func unloadCurrentTrack() {
+        // Invalidate callbacks from the outgoing streamer before touching
+        // the node so nothing it fires mid-teardown lands on fresh state.
+        loadGeneration &+= 1
+        streamer?.cancel()
+        streamer = nil
+        stopPositionTimer()
+        // `stop()` drops every scheduled buffer — required so a paused
+        // track's tail can't leak into the next one. Safe on an attached
+        // node regardless of whether the engine is currently rendering.
+        playerNode.stop()
+        engine.stop()
+        baseFrame = 0
+        lastKnownSampleTime = 0
+    }
+
+    private func handleFormatReady(_ format: AVAudioFormat) {
+        processingFormat = format
+        sampleRate = format.sampleRate
+        connectGraph(format: format)
+        engine.prepare()
+        // Only now may the streamer schedule decoded buffers — scheduling
+        // against a graph wired for a different format raises inside
+        // AVFoundation.
+        streamer?.beginScheduling()
+        if state == .playing {
+            startNodeIfReady()
+        }
+    }
+
+    private func connectGraph(format: AVAudioFormat) {
+        engine.connect(playerNode, to: eq, format: format)
+        engine.connect(eq, to: engine.mainMixerNode, format: format)
+        engine.mainMixerNode.outputVolume = volume
+    }
+
+    /// Start the engine + node when both the transport intent is "playing"
+    /// and the graph has a real format. Safe to call repeatedly.
+    private func startNodeIfReady() {
+        guard state == .playing, processingFormat != nil else { return }
+        ensureEngineRunning()
+        guard engine.isRunning else { return }
+        if !playerNode.isPlaying {
+            playerNode.play()
+        }
+    }
+
+    private func ensureEngineRunning() {
+        guard !engine.isRunning else { return }
+        applyOutputDevice()
+        do {
+            try engine.start()
+        } catch {
+            pipelineLog.error("AVAudioEngine start failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func refreshLastKnownSampleTime() {
+        guard let nodeTime = playerNode.lastRenderTime,
+              let playerTime = playerNode.playerTime(forNodeTime: nodeTime),
+              playerTime.isSampleTimeValid
+        else { return }
+        lastKnownSampleTime = max(0, playerTime.sampleTime)
+    }
+
+    private func handleConfigurationChange() {
+        // The engine stops itself when the output device configuration
+        // changes (device unplugged, default switched while pinned-to-
+        // default). If we were playing, restart on the new configuration.
+        guard state == .playing else { return }
+        ensureEngineRunning()
+        if engine.isRunning, !playerNode.isPlaying {
+            playerNode.play()
+        }
+    }
+
+    private func applyOutputDevice() {
+        guard let audioUnit = engine.outputNode.audioUnit else { return }
+        guard let uid = outputDeviceUID, !uid.isEmpty,
+              let deviceID = AudioOutputDevices.deviceID(forUID: uid)
+        else { return }
+        var device = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &device,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        if status != noErr {
+            pipelineLog.error("Output device pin failed (\(status)) for \(uid, privacy: .public)")
+        }
+    }
+
+    // MARK: - Position timer (1 Hz, playing only)
+
+    private func startPositionTimer() {
+        guard positionTimer == nil else { return }
+        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, self.state == .playing else { return }
+                // Skip the tick when nothing is actually rendering yet
+                // (stream still buffering) — matches the AVPlayer observer's
+                // rate != 0 guard.
+                guard self.engine.isRunning, self.playerNode.isPlaying else { return }
+                self.onPositionTick?(self.positionSeconds)
+            }
+        }
+        timer.tolerance = 0.2
+        RunLoop.main.add(timer, forMode: .common)
+        positionTimer = timer
+    }
+
+    private func stopPositionTimer() {
+        positionTimer?.invalidate()
+        positionTimer = nil
+    }
+
+    // MARK: - EQ
+
+    /// Standard 10-band layout (31 Hz … 16 kHz), flat. `bypass = true` on
+    /// every band plus `globalGain = 0` guarantees the engine path is
+    /// audibly identical to no-EQ until #40 ships controls.
+    private func configureFlatEQ() {
+        let frequencies: [Float] = [31, 62, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000]
+        for (index, band) in eq.bands.enumerated() {
+            band.filterType = .parametric
+            band.frequency = index < frequencies.count ? frequencies[index] : 1_000
+            band.bandwidth = 0.5
+            band.gain = 0
+            band.bypass = true
+        }
+        eq.globalGain = 0
+    }
+
+    /// Map Jellyfin's container string to an AudioToolbox file-type hint.
+    /// Unknown containers return 0 (sniff from bytes).
+    static func fileTypeHint(forContainer container: String?) -> AudioFileTypeID {
+        switch container?.lowercased() {
+        case "mp3": return kAudioFileMP3Type
+        case "flac": return kAudioFileFLACType
+        case "aac", "adts": return kAudioFileAAC_ADTSType
+        case "m4a", "m4b", "alac", "mp4": return kAudioFileM4AType
+        case "wav": return kAudioFileWAVEType
+        case "aiff", "aif": return kAudioFileAIFFType
+        case "caf": return kAudioFileCAFType
+        default: return 0
+        }
+    }
+
+    #if DEBUG
+    /// Test seam: whether the EQ node is attached to this pipeline's engine
+    /// and wired between the player node and the main mixer.
+    var isEQWiredForTesting: Bool {
+        guard eq.engine === engine, playerNode.engine === engine else { return false }
+        let playerFeedsEQ = engine.outputConnectionPoints(for: playerNode, outputBus: 0)
+            .contains { $0.node === eq }
+        let eqFeedsMixer = engine.outputConnectionPoints(for: eq, outputBus: 0)
+            .contains { $0.node === engine.mainMixerNode }
+        return playerFeedsEQ && eqFeedsMixer
+    }
+
+    /// Test seam: the EQ must be audibly inert until #40 ships controls.
+    var isEQFlatForTesting: Bool {
+        eq.globalGain == 0 && eq.bands.allSatisfy { $0.bypass && $0.gain == 0 }
+    }
+    #endif
+}

--- a/macos/Tests/LyrebirdTests/EngineDSPPipelineTests.swift
+++ b/macos/Tests/LyrebirdTests/EngineDSPPipelineTests.swift
@@ -1,0 +1,335 @@
+import AVFoundation
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Coverage for the AVAudioEngine DSP pipeline behind the
+/// `engine.useAVAudioEngine` feature flag (#39):
+///
+///   1. The flag defaults **off**, and while off the AVQueuePlayer path runs
+///      untouched — the DSP pipeline type is never even constructed.
+///   2. With the flag on, transport routes to the pipeline and the gapless
+///      preload (an AVQueuePlayer concept) becomes a no-op.
+///   3. The byte-stream bridge — `DSPAudioFileStreamParser` parse +
+///      `AVAudioConverter` decode + node scheduling — is exercised against a
+///      synthesized WAV fixture, with no audio hardware required (the engine
+///      is never started).
+///   4. The node graph keeps a live-but-flat `AVAudioUnitEQ` between the
+///      player node and the mixer (the #40 EQ UI's mounting point).
+@MainActor
+final class EngineDSPPipelineTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        // Each test starts from the shipping default: flag absent ⇒ off.
+        UserDefaults.standard.removeObject(forKey: AppModel.engineDSPDefaultsKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: AppModel.engineDSPDefaultsKey)
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeEngine() throws -> AudioEngine {
+        let dir = NSTemporaryDirectory() + "lyrebird-dsp-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "dsp-test"))
+        return AudioEngine(core: core)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 0,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    /// Synthesize a PCM16 WAV in memory: 44-byte canonical header + a sine
+    /// tone. Deterministic, no bundled binary fixture needed.
+    private static func makeWavData(
+        sampleRate: Int = 44_100,
+        channels: Int = 2,
+        frames: Int = 22_050
+    ) -> Data {
+        let bytesPerFrame = channels * 2
+        let dataSize = frames * bytesPerFrame
+        var data = Data(capacity: 44 + dataSize)
+
+        func append(_ string: String) { data.append(contentsOf: Array(string.utf8)) }
+        func append32(_ value: UInt32) {
+            withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+        }
+        func append16(_ value: UInt16) {
+            withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+        }
+
+        append("RIFF")
+        append32(UInt32(36 + dataSize))
+        append("WAVE")
+        append("fmt ")
+        append32(16)
+        append16(1) // PCM
+        append16(UInt16(channels))
+        append32(UInt32(sampleRate))
+        append32(UInt32(sampleRate * bytesPerFrame))
+        append16(UInt16(bytesPerFrame))
+        append16(16)
+        append("data")
+        append32(UInt32(dataSize))
+
+        var samples = [Int16]()
+        samples.reserveCapacity(frames * channels)
+        for frame in 0..<frames {
+            let value = Int16(sin(2.0 * .pi * 440.0 * Double(frame) / Double(sampleRate)) * 16_000)
+            for _ in 0..<channels { samples.append(value) }
+        }
+        samples.withUnsafeBytes { data.append(contentsOf: $0) }
+        return data
+    }
+
+    // MARK: - Flag gating
+
+    /// The capability ships dark: a fresh install (no defaults key) must read
+    /// `false`, and the engine must come up with the DSP path disabled and the
+    /// pipeline unconstructed. Opting in via the documented defaults key
+    /// flips the capability, and `AppModel.init` seeds the engine from it.
+    func testEngineDSPFlagDefaultsOffAndSeedsEngine() throws {
+        let model = try AppModel()
+        XCTAssertFalse(model.supportsEngineDSP, "engine.useAVAudioEngine must default off")
+        XCTAssertFalse(model.audio.dspPipelineEnabled, "AppModel.init must seed the engine flag off by default")
+        XCTAssertNil(model.audio.dspPipeline, "flag off ⇒ the pipeline is never constructed")
+
+        UserDefaults.standard.set(true, forKey: AppModel.engineDSPDefaultsKey)
+        let optedIn = try AppModel()
+        XCTAssertTrue(optedIn.supportsEngineDSP)
+        XCTAssertTrue(optedIn.audio.dspPipelineEnabled, "AppModel.init must seed the engine flag from the capability")
+        XCTAssertNil(optedIn.audio.dspPipeline, "pipeline construction is lazy — nothing built until first DSP play")
+    }
+
+    /// Flag off ⇒ zero behaviour change: every transport entry point runs the
+    /// AVQueuePlayer path and never constructs the DSP pipeline.
+    func testFlagOffTransportNeverTouchesPipeline() throws {
+        let engine = try makeEngine()
+        XCTAssertFalse(engine.dspPipelineEnabled)
+
+        engine.installEmptyPlayerForTesting()
+        engine.pause()
+        engine.resume()
+        engine.seek(toSeconds: 12)
+        engine.setVolume(0.4)
+        engine.preloadNextTrack(makeTrack("a"))
+        engine.stop()
+
+        XCTAssertNil(engine.dspPipeline, "flag off ⇒ no DSP pipeline may ever be built")
+    }
+
+    /// Flag on ⇒ the gapless preload is a documented no-op on the DSP path
+    /// (the pipeline plays one track at a time; `onTrackEnded` rebuilds).
+    /// The guard must short-circuit before the preload records intent or
+    /// touches the AVQueuePlayer.
+    func testFlagOnPreloadIsNoOp() throws {
+        let engine = try makeEngine()
+        engine.dspPipelineEnabled = true
+        engine.installEmptyPlayerForTesting()
+
+        engine.preloadNextTrack(makeTrack("next"))
+
+        XCTAssertNil(engine.lastPreloadedTrackIdForTesting, "DSP path must not arm the AVQueuePlayer preload")
+        XCTAssertEqual(engine.queuedItemCountForTesting, 0)
+    }
+
+    /// Flag on ⇒ transport routes to the pipeline (volume is the cheapest
+    /// member to observe: it lazily constructs the pipeline and never starts
+    /// audio hardware).
+    func testFlagOnVolumeRoutesToPipeline() throws {
+        let engine = try makeEngine()
+        engine.dspPipelineEnabled = true
+        XCTAssertNil(engine.dspPipeline)
+
+        engine.setVolume(0.5)
+
+        XCTAssertNotNil(engine.dspPipeline, "DSP-routed transport should lazily build the pipeline")
+    }
+
+    // MARK: - Node graph
+
+    /// The EQ node must be live in the graph (player → EQ → main mixer) and
+    /// flat/bypassed — #39 ships the mounting point, #40 ships the controls.
+    func testPipelineGraphKeepsFlatEQBetweenPlayerAndMixer() {
+        let pipeline = EngineDSPPipeline()
+        XCTAssertTrue(pipeline.isEQWiredForTesting, "AVAudioUnitEQ must sit between the player node and the mixer")
+        XCTAssertTrue(pipeline.isEQFlatForTesting, "EQ must ship flat/bypassed until #40 lands controls")
+        XCTAssertEqual(pipeline.eq.bands.count, 10)
+        XCTAssertEqual(pipeline.state, .idle)
+        XCTAssertEqual(pipeline.positionSeconds, 0, accuracy: 0.0001)
+    }
+
+    /// Jellyfin container strings map onto AudioToolbox sniffing hints;
+    /// unknown containers fall back to byte-sniffing (0).
+    func testContainerHintMapping() {
+        XCTAssertEqual(EngineDSPPipeline.fileTypeHint(forContainer: "flac"), kAudioFileFLACType)
+        XCTAssertEqual(EngineDSPPipeline.fileTypeHint(forContainer: "MP3"), kAudioFileMP3Type)
+        XCTAssertEqual(EngineDSPPipeline.fileTypeHint(forContainer: "m4a"), kAudioFileM4AType)
+        XCTAssertEqual(EngineDSPPipeline.fileTypeHint(forContainer: "ogg"), 0)
+        XCTAssertEqual(EngineDSPPipeline.fileTypeHint(forContainer: nil), 0)
+    }
+
+    // MARK: - Byte-stream bridge
+
+    /// Chunked parse of a synthesized WAV: the parser must surface the
+    /// stream's format, the canonical 44-byte data offset, every audio byte
+    /// as packets, and an exact (non-estimated) seek byte mapping.
+    func testParserParsesWavFixture() throws {
+        let sampleRate = 44_100
+        let channels = 2
+        let frames = 11_025
+        let wav = Self.makeWavData(sampleRate: sampleRate, channels: channels, frames: frames)
+
+        let parser = try DSPAudioFileStreamParser(fileTypeHint: kAudioFileWAVEType)
+        var readyFormat: AudioStreamBasicDescription?
+        var packetBytes = 0
+        parser.onReadyToProducePackets = { asbd, _ in readyFormat = asbd }
+        parser.onPackets = { batch in packetBytes += batch.data.count }
+
+        // Feed in deliberately awkward chunk sizes to exercise resumable
+        // parsing across boundaries.
+        var offset = 0
+        while offset < wav.count {
+            let end = min(offset + 999, wav.count)
+            try parser.parse(wav.subdata(in: offset..<end))
+            offset = end
+        }
+
+        let format = try XCTUnwrap(readyFormat, "header must parse to a stream description")
+        XCTAssertEqual(format.mFormatID, kAudioFormatLinearPCM)
+        XCTAssertEqual(format.mSampleRate, Double(sampleRate))
+        XCTAssertEqual(Int(format.mChannelsPerFrame), channels)
+        XCTAssertEqual(parser.dataOffset, 44, "canonical PCM16 WAV header is 44 bytes")
+        XCTAssertEqual(packetBytes, frames * channels * 2, "every audio byte must come back out as packets")
+
+        // LPCM packets are frames: packet 1000 starts exactly at
+        // dataOffset + 1000 * bytesPerFrame.
+        let mapping = try XCTUnwrap(parser.seekByteOffset(forPacket: 1_000))
+        XCTAssertEqual(mapping.byteOffset, 44 + 1_000 * Int64(channels * 2))
+        XCTAssertFalse(mapping.isEstimated, "LPCM seek offsets are exact")
+    }
+
+    /// End-to-end bridge over a local file URL (URLSession → parse → decode
+    /// → schedule): every frame of the fixture must end up scheduled on the
+    /// player node, without ever starting audio hardware.
+    func testStreamerDecodesAndSchedulesWavEndToEnd() throws {
+        let frames = 22_050
+        let wav = Self.makeWavData(sampleRate: 44_100, channels: 2, frames: frames)
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("dsp-fixture-\(UUID().uuidString).wav")
+        try wav.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let engine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        engine.attach(node)
+
+        let streamer = DSPTrackStreamer(
+            url: fileURL,
+            authHeader: nil,
+            playerNode: node,
+            fileTypeHint: kAudioFileWAVEType
+        )
+
+        let formatReady = expectation(description: "format resolved")
+        var resolvedFormat: AVAudioFormat?
+        streamer.onFormatReady = { format in
+            resolvedFormat = format
+            // Mirror EngineDSPPipeline.handleFormatReady: wire the graph for
+            // the resolved format, then unblock scheduling.
+            engine.connect(node, to: engine.mainMixerNode, format: format)
+            streamer.beginScheduling()
+            formatReady.fulfill()
+        }
+        var streamFailure: String?
+        streamer.onStreamError = { message in streamFailure = message }
+
+        streamer.start()
+        wait(for: [formatReady], timeout: 10)
+
+        let format = try XCTUnwrap(resolvedFormat)
+        XCTAssertEqual(format.commonFormat, .pcmFormatFloat32, "engine processing format is canonical float32")
+        XCTAssertEqual(format.sampleRate, 44_100)
+        XCTAssertEqual(format.channelCount, 2)
+
+        // The whole fixture is far below the ~8s pacing cap, so every frame
+        // should schedule without any playback-completion callbacks (the
+        // engine is never started). Poll the decode queue's snapshot.
+        let deadline = Date().addingTimeInterval(10)
+        var snapshot = streamer.progressSnapshotForTesting()
+        while Date() < deadline {
+            snapshot = streamer.progressSnapshotForTesting()
+            if snapshot.networkDone && snapshot.scheduledFrames >= AVAudioFramePosition(frames) && snapshot.queuedPackets == 0 {
+                break
+            }
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        XCTAssertNil(streamFailure, "local-file stream must decode cleanly")
+        XCTAssertTrue(snapshot.networkDone, "URLSession should finish delivering the fixture")
+        XCTAssertEqual(snapshot.scheduledFrames, AVAudioFramePosition(frames), "every fixture frame must be decoded and scheduled")
+        XCTAssertEqual(snapshot.queuedPackets, 0, "decoder should drain the parsed packet backlog")
+
+        streamer.cancel()
+    }
+
+    /// An unparseable byte stream (no valid container) must surface
+    /// `onStreamError` — the hook the engine uses to skip to the next track —
+    /// rather than hanging or crashing.
+    func testStreamerSurfacesErrorForGarbageBytes() throws {
+        let garbage = Data((0..<4_096).map { _ in UInt8.random(in: 0...255) })
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("dsp-garbage-\(UUID().uuidString).bin")
+        try garbage.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let engine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        engine.attach(node)
+
+        let streamer = DSPTrackStreamer(
+            url: fileURL,
+            authHeader: nil,
+            playerNode: node,
+            fileTypeHint: kAudioFileWAVEType
+        )
+
+        let failed = expectation(description: "stream error surfaced")
+        streamer.onStreamError = { _ in failed.fulfill() }
+        streamer.onFormatReady = { _ in
+            XCTFail("garbage bytes must not resolve a format")
+        }
+
+        streamer.start()
+        wait(for: [failed], timeout: 10)
+    }
+}


### PR DESCRIPTION
Routes playback through an AVAudioEngine node graph (player → 10-band `AVAudioUnitEQ` → mixer) behind a default-off flag, since AVQueuePlayer cannot host real-time effect nodes — this unblocks EQ (#40) and crossfade (#41).

Closes #39

## Architecture
- `EngineDSPPipeline.swift` (new) — `@MainActor` facade owning the engine graph; transport, frame-based position, 1Hz playing-only tick, config-change recovery, output-device pinning.
- `DSPTrackStreamer.swift` (new) — per-track bridge: URLSession bytes → `AudioFileStream` parse → `AVAudioConverter` → paced `scheduleBuffer` (~8s ahead cap, packet-queue backpressure); seek via `AudioFileStreamSeek` + HTTP Range (200-fallback restarts at 0); end-of-stream completion.
- `DSPAudioFileStreamParser.swift` (new) — AudioToolbox `AudioFileStream` wrapper (format/cookie/packets/seek byte mapping).
- `AudioEngine+DSP.swift` (new) — flag-on routing with full reporting parity (PlaybackInfo, play-session id, started/progress/stopped, 5s heartbeat, MediaSession); stream errors skip-with-toast.
- `AudioEngine.swift` — early-return guards on the flag; `Capabilities.swift` gains `supportsEngineDSP`; one seed line in `AppModel.init`.

## Flag
`engine.useAVAudioEngine` (UserDefaults, read once at launch), surfaced as `AppModel.supportsEngineDSP`. Default OFF — missing key reads false, nothing writes it. Flag off ⇒ the pipeline is never constructed and the AVQueuePlayer path is byte-identical (test-verified).

## Known gaps (flag-ON path only)
- Gapless preload is a no-op (rebuild-per-track advance, same as gapless-off); ReplayGain not applied
- No bounded stall-retry — stream errors skip to next track with a toast
- Ogg Vorbis/Opus and non-fast-start M4A/ALAC are unparseable by AudioToolbox → skip
- Seek on transcoded (range-less) streams falls back to track start
- Position can drift slightly ahead during a network underrun (no auto-pause rebuffer yet)
- Pinned output doesn't follow later default-device changes

## Validation
- Clean rebuild (`rm -rf macos/.build`) + `swift test`: 966/966, including 9 new DSP tests
- Bundle smoke-launch with flag off and flag on
- Real-server streaming: 24/44.1 FLAC direct stream (206 + byte ranges) and ID3-prefixed MP3 transcode (200, no ranges) both decode to Float32; ranged seek to 60s landed packet-aligned (2644992/2646000) with continued decode; ~8s scheduling cap confirmed