### PR TITLE
feat(core): database-backed library cache with background revalidation

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -768,10 +768,13 @@ impl JellyfinClient {
         })
     }
 
-    pub async fn albums(&self, paging: Paging) -> Result<PaginatedAlbums> {
-        // Thin wrapper over the typed `ItemsQuery` builder — kept for
-        // backwards compatibility with existing call sites. New code should
-        // prefer `client.query().item_types(...).fetch_albums(...)` directly.
+    /// The canonical query for the user's album library: full recursive
+    /// MusicAlbum set, `SortName` ascending, with the field projection every
+    /// album surface renders from. Shared by [`Self::albums`] and the library
+    /// cache's revalidation sweep (`crate::library_cache`) — the cache diffs
+    /// rows by JSON equality, which only works when both writers fetch the
+    /// *same* projection, so keep this the single source of truth (#431).
+    pub(crate) fn albums_query(paging: Paging) -> ItemsQuery {
         ItemsQuery::new()
             .recursive()
             .item_types(vec![ItemKind::MusicAlbum])
@@ -785,8 +788,13 @@ impl JellyfinClient {
                 ItemField::PrimaryImageAspectRatio,
             ])
             .enable_user_data()
-            .fetch_albums(self)
-            .await
+    }
+
+    pub async fn albums(&self, paging: Paging) -> Result<PaginatedAlbums> {
+        // Thin wrapper over the typed `ItemsQuery` builder — kept for
+        // backwards compatibility with existing call sites. New code should
+        // prefer `client.query().item_types(...).fetch_albums(...)` directly.
+        Self::albums_query(paging).fetch_albums(self).await
     }
 
     /// Every album where the given artist is the primary (album) artist,
@@ -979,6 +987,16 @@ impl JellyfinClient {
         music_library_id: Option<&str>,
         paging: Paging,
     ) -> Result<PaginatedTracks> {
+        Self::tracks_query(music_library_id, paging)
+            .fetch_tracks(self)
+            .await
+    }
+
+    /// The canonical query for the user's track library — the builder behind
+    /// [`Self::list_tracks`]. Shared with the library cache's revalidation
+    /// sweep (`crate::library_cache`) so cached rows and sync rows carry the
+    /// same field projection and diff cleanly by JSON equality (#431).
+    pub(crate) fn tracks_query(music_library_id: Option<&str>, paging: Paging) -> ItemsQuery {
         let mut q = ItemsQuery::new()
             .recursive()
             .item_types(vec![ItemKind::Audio])
@@ -997,7 +1015,7 @@ impl JellyfinClient {
         if let Some(parent) = music_library_id {
             q = q.parent(parent);
         }
-        q.fetch_tracks(self).await
+        q
     }
 
     /// Recently played audio tracks for the current user, sorted by

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod client;
 pub mod downloads;
 pub mod enums;
 pub mod error;
+pub mod library_cache;
 pub mod models;
 pub mod player;
 pub mod query;
@@ -22,6 +23,7 @@ pub mod storage;
 
 pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 pub use error::{LyrebirdError, Result};
+pub use library_cache::{LibrarySyncObserver, LibrarySyncSummary};
 pub use models::*;
 pub use player::{PlaybackState, Player, PlayerStatus, RepeatMode};
 pub use query::ItemsQuery;
@@ -84,6 +86,11 @@ pub struct LyrebirdCore {
     /// and collectively overshoot. Held only around the cheap plan/commit
     /// critical sections, never across the byte stream. See `downloads::fetch`.
     download_budget_lock: Arc<tokio::sync::Mutex<()>>,
+    /// `true` while a background library revalidation (#431) is running.
+    /// Guards [`Self::revalidate_library`] against overlapping syncs; shared
+    /// (not behind `Inner`) so the spawned task can clear it without taking
+    /// the FFI mutex.
+    library_sync_in_flight: Arc<std::sync::atomic::AtomicBool>,
 }
 
 struct Inner {
@@ -169,6 +176,7 @@ impl LyrebirdCore {
             heartbeat: Mutex::new(None),
             download_semaphore: Arc::new(tokio::sync::Semaphore::new(DOWNLOAD_PARALLELISM)),
             download_budget_lock: Arc::new(tokio::sync::Mutex::new(())),
+            library_sync_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }))
     }
 
@@ -454,7 +462,14 @@ impl LyrebirdCore {
         offset: u32,
         limit: u32,
     ) -> std::result::Result<PaginatedAlbums, LyrebirdError> {
-        self.with_client(|c| self.runtime.block_on(c.albums(Paging::new(offset, limit))))
+        let page =
+            self.with_client(|c| self.runtime.block_on(c.albums(Paging::new(offset, limit))))?;
+        // Write-through to the library cache (#431). Best-effort: a cache
+        // write failure must never fail the fetch that produced the data.
+        if let Err(e) = library_cache::persist_albums(&self.db_handle(), &page.items) {
+            tracing::warn!("album cache write-through failed: {e}");
+        }
+        Ok(page)
     }
 
     /// Artists in the user's library, paginated. See [`Self::list_albums`].
@@ -463,7 +478,12 @@ impl LyrebirdCore {
         offset: u32,
         limit: u32,
     ) -> std::result::Result<PaginatedArtists, LyrebirdError> {
-        self.with_client(|c| self.runtime.block_on(c.artists(Paging::new(offset, limit))))
+        let page =
+            self.with_client(|c| self.runtime.block_on(c.artists(Paging::new(offset, limit))))?;
+        if let Err(e) = library_cache::persist_artists(&self.db_handle(), &page.items) {
+            tracing::warn!("artist cache write-through failed: {e}");
+        }
+        Ok(page)
     }
 
     /// Album artists most recently added to the library, sorted by
@@ -475,10 +495,16 @@ impl LyrebirdCore {
         offset: u32,
         limit: u32,
     ) -> std::result::Result<PaginatedArtists, LyrebirdError> {
-        self.with_client(|c| {
+        let page = self.with_client(|c| {
             self.runtime
                 .block_on(c.recently_added_artists(Paging::new(offset, limit)))
-        })
+        })?;
+        // Same endpoint + projection as `list_artists` (only the sort
+        // differs), so rows are cache-compatible and safe to write through.
+        if let Err(e) = library_cache::persist_artists(&self.db_handle(), &page.items) {
+            tracing::warn!("artist cache write-through failed: {e}");
+        }
+        Ok(page)
     }
 
     /// Every album where the given artist is the primary (album) artist,
@@ -704,10 +730,91 @@ impl LyrebirdCore {
         offset: u32,
         limit: u32,
     ) -> std::result::Result<PaginatedTracks, LyrebirdError> {
-        self.with_client(|c| {
+        let page = self.with_client(|c| {
             self.runtime
                 .block_on(c.list_tracks(music_library_id.as_deref(), Paging::new(offset, limit)))
-        })
+        })?;
+        // Write-through to the library cache (#431); best-effort, see
+        // `list_albums`.
+        if let Err(e) = library_cache::persist_tracks(&self.db_handle(), &page.items) {
+            tracing::warn!("track cache write-through failed: {e}");
+        }
+        Ok(page)
+    }
+
+    // ---------- Library cache (#431) ----------
+
+    /// First `limit` cached albums in display order, served straight from
+    /// the local DB — never touches the network, never requires a session.
+    /// The warm-launch read path: emit these immediately, then let
+    /// [`Self::revalidate_library`] reconcile against the server.
+    pub fn list_cached_albums(&self, limit: u32) -> std::result::Result<Vec<Album>, LyrebirdError> {
+        library_cache::list_cached_albums(&self.db_handle(), limit)
+    }
+
+    /// Artist twin of [`Self::list_cached_albums`].
+    pub fn list_cached_artists(
+        &self,
+        limit: u32,
+    ) -> std::result::Result<Vec<Artist>, LyrebirdError> {
+        library_cache::list_cached_artists(&self.db_handle(), limit)
+    }
+
+    /// Track twin of [`Self::list_cached_albums`].
+    pub fn list_cached_tracks(&self, limit: u32) -> std::result::Result<Vec<Track>, LyrebirdError> {
+        library_cache::list_cached_tracks(&self.db_handle(), limit)
+    }
+
+    /// Kick a background library revalidation (#431): delta-fetch what
+    /// changed since the last successful sync, reconcile the cache, and
+    /// stream changed/removed rows to `observer` (see
+    /// [`LibrarySyncObserver`] for the callback contract). Returns
+    /// immediately; the sync runs on the core's runtime and never holds the
+    /// FFI mutex across network or DB I/O.
+    ///
+    /// Returns `false` (without invoking `observer` at all) when there is no
+    /// active session or another revalidation is already in flight.
+    pub fn revalidate_library(&self, observer: Box<dyn LibrarySyncObserver>) -> bool {
+        use std::sync::atomic::Ordering;
+
+        let (client, db) = {
+            let inner = self.inner.lock();
+            match &inner.client {
+                Some(c) => (Arc::clone(c), Arc::clone(&inner.db)),
+                None => return false,
+            }
+        };
+        let Some(user_id) = client.user_id().map(ToOwned::to_owned) else {
+            return false;
+        };
+        if self
+            .library_sync_in_flight
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return false;
+        }
+
+        /// Clears the in-flight flag even if the sync task panics, so a
+        /// one-off failure can't permanently wedge revalidation.
+        struct InFlightGuard(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for InFlightGuard {
+            fn drop(&mut self) {
+                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let guard = InFlightGuard(Arc::clone(&self.library_sync_in_flight));
+        self.runtime.spawn(async move {
+            let _guard = guard;
+            let ctx = library_cache::SyncContext {
+                client,
+                db,
+                user_id,
+            };
+            library_cache::run_sync(&ctx, observer.as_ref()).await;
+        });
+        true
     }
 
     /// Recently played tracks for the current user, sorted by server-side
@@ -1687,6 +1794,13 @@ impl LyrebirdCore {
         self.inner.lock().client.clone()
     }
 
+    /// Clone the database handle so DB I/O (cache reads/writes) runs outside
+    /// the `Inner` mutex — the `Database` serializes on its own connection
+    /// lock.
+    fn db_handle(&self) -> Arc<Database> {
+        Arc::clone(&self.inner.lock().db)
+    }
+
     /// Wire the HTTP client's 401 interceptor so it can silently pull a
     /// fresh token out of the OS credential store without round-tripping
     /// through the UI.
@@ -1721,6 +1835,23 @@ impl LyrebirdCore {
         }
         {
             let inner = self.inner.lock();
+            // A *different* user signing in must not inherit the previous
+            // user's library cache (#431). `logout` wipes unconditionally,
+            // but `forget_token` keeps the cache (and deletes
+            // `last_user_id`), so ownership is tracked under a dedicated
+            // `library_cache_user_id` key that survives token-forgetting and
+            // is only cleared together with the cache itself.
+            match inner.db.get_setting("library_cache_user_id") {
+                Ok(Some(prev)) if prev != session.user.id => {
+                    if let Err(e) = inner.db.clear_library_cache() {
+                        tracing::warn!("library cache wipe on user switch failed: {e}");
+                    }
+                }
+                _ => {}
+            }
+            inner
+                .db
+                .set_setting("library_cache_user_id", &session.user.id)?;
             inner
                 .db
                 .set_setting("last_server_url", &session.server.url)?;

--- a/core/src/library_cache.rs
+++ b/core/src/library_cache.rs
@@ -1,0 +1,671 @@
+//! Database-backed library cache with background revalidation (#431).
+//!
+//! The library used to be fetched fresh on every launch — on a slow link the
+//! user stared at a spinner until the first page round-tripped. This module
+//! implements the cache-first, revalidate-in-background strategy:
+//!
+//! 1. **Persist-on-fetch** — every page returned by the canonical library
+//!    list FFIs (`list_albums` / `list_artists` / `list_tracks`) is written
+//!    through to the `album_cache` / `artist_cache` / `track_cache` tables as
+//!    JSON rows keyed by id (schema prepared in `001_initial.sql`; display
+//!    `sort_key` added in `003_library_cache_sort.sql`).
+//! 2. **Cache-first launch** — `LyrebirdCore::list_cached_albums` (and the
+//!    artist/track twins) serve the first N rows in display order straight
+//!    from SQLite, no network, so the UI can paint immediately.
+//! 3. **Background revalidation** — `LyrebirdCore::revalidate_library` spawns
+//!    `run_sync` on the core's tokio runtime. It fetches what changed since
+//!    the last successful sync (Jellyfin's `MinDateLastSaved` delta filter),
+//!    upserts into the cache, diffs by JSON equality, and pushes only the
+//!    rows that actually changed through the [`LibrarySyncObserver`] callback
+//!    interface. The `Inner` mutex is **never** held across any of this — the
+//!    sync task owns its own `Arc<JellyfinClient>` / `Arc<Database>` handles.
+//!
+//! Per-entity sync strategy (each shaped by a live probe of Jellyfin 10.11):
+//!
+//! * **Albums** — delta via `MinDateLastSaved` when a checkpoint exists, full
+//!   paged walk otherwise. After a delta pass the cached row count is compared
+//!   against the server's `TotalRecordCount`; a mismatch means something was
+//!   deleted server-side (deltas can only add/update, never remove), which
+//!   triggers a full reconcile walk. A degenerate delta (≥ half the library
+//!   re-saved, e.g. by a metadata refresh task) folds into the full walk too —
+//!   same transfer class, and it reconciles removals for free.
+//! * **Artists** — full paged walk, gated on album-phase activity. Verified
+//!   live: the `/Artists/AlbumArtists` endpoint silently ignores
+//!   `MinDateLastSaved` (a future-dated filter still returns the entire
+//!   artist list), so there is no delta to be had, and its `ItemCounts`
+//!   projection is expensive server-side (~10s/page cold on a 20k-album
+//!   library). Every artist-affecting mutation re-saves album rows
+//!   (renames rewrite `AlbumArtist`, deletes remove albums), so the walk
+//!   only runs when the album phase saw changes — or when the artist cache
+//!   is cold. The walk doubles as exact removal reconciliation. Known gap:
+//!   artist `UserData` changes made on *other* clients (e.g. favoriting an
+//!   artist elsewhere) don't bump album rows, so cached artist rows pick
+//!   those up on the next active sync; favorites surfaces fetch live and
+//!   are unaffected.
+//! * **Tracks** — delta only, capped at `TRACK_DELTA_MAX_PAGES` pages per
+//!   sync. The track cache fills progressively from persist-on-fetch (the
+//!   All Tracks tab, album pages the user opens); a proactive 150k-track
+//!   mirror walk is deliberately out of scope, as is track removal
+//!   reconciliation — stale rows are replaced as soon as the regular fetch
+//!   paths touch the same window. The first sync just records the
+//!   checkpoint.
+//!
+//! Diffing is by **JSON equality of the serialized model**, not the
+//! `Etag`/`DateLastSaved` projection: it is strictly stronger (it also
+//! catches `UserData` changes the server makes without bumping
+//! `DateLastSaved`) and needs no extra model fields. The flip side is that
+//! both writers must fetch the same field projection — hence
+//! `JellyfinClient::albums_query` / `tracks_query` being the shared,
+//! canonical builders.
+//!
+//! Sync checkpoints are stored per user in `settings` under
+//! `library_last_sync_albums_{user_id}` / `library_last_sync_tracks_{user_id}`
+//! and are wiped together with the cache tables (`clear_library_cache`).
+//! Checkpoints are captured *before* a phase fetches and rewound by
+//! `CLOCK_SKEW_WINDOW_SECS` so client/server clock drift and mid-sync
+//! writes re-fetch harmlessly (the JSON diff suppresses no-op emits) instead
+//! of being missed forever.
+
+use crate::client::JellyfinClient;
+use crate::error::{LyrebirdError, Result};
+use crate::models::{Album, Artist, PaginatedAlbums, PaginatedTracks, Paging, Track};
+use crate::storage::{CacheKind, CacheWrite, Database};
+use futures::StreamExt;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Page size for revalidation walks. 500 keeps a 5k-album library at ten
+/// round-trips while staying well under Jellyfin's response-size comfort
+/// zone (a 500-album page with the canonical projection measures ~800 KB).
+const SYNC_PAGE_SIZE: u32 = 500;
+
+/// How many full-walk page fetches run concurrently. The walk is
+/// latency-bound, not bandwidth-bound, so a small fan-out cuts wall time
+/// roughly linearly without hammering the server.
+const FULL_WALK_CONCURRENCY: usize = 3;
+
+/// Upper bound on pages a single track delta pass will walk (40 × 500 =
+/// 20k tracks). Bounds per-sync work when a server-side metadata refresh
+/// re-saves an enormous track set; the checkpoint still advances, and the
+/// un-walked tail self-heals through persist-on-fetch.
+const TRACK_DELTA_MAX_PAGES: u32 = 40;
+
+/// Rewind applied to sync checkpoints to tolerate client/server clock skew.
+/// Re-fetching a five-minute overlap is cheap (and diff-suppressed); missing
+/// a change because the server clock runs behind ours is not.
+const CLOCK_SKEW_WINDOW_SECS: i64 = 300;
+
+/// A delta pass that would re-fetch at least `1/DEGENERATE_DELTA_DIVISOR` of
+/// the library folds into a full walk instead — same transfer class, plus
+/// free removal reconciliation.
+const DEGENERATE_DELTA_DIVISOR: u64 = 2;
+
+/// Observer over a running library revalidation. Implemented by the UI layer
+/// (a Swift class via the UniFFI callback interface) and driven from the
+/// sync task's runtime thread — implementations must marshal to their own
+/// main thread.
+///
+/// `*_changed` callbacks carry only rows whose cached JSON actually changed
+/// (new or updated), batched per fetched page; `removed_ids` arrives in a
+/// trailing batch once a reconcile walk has computed the removed set. Tracks
+/// have no removal reconciliation (see module docs). Exactly one of
+/// [`Self::sync_completed`] / [`Self::sync_failed`] terminates every sync.
+#[uniffi::export(callback_interface)]
+pub trait LibrarySyncObserver: Send + Sync {
+    fn albums_changed(&self, changed: Vec<Album>, removed_ids: Vec<String>);
+    fn artists_changed(&self, changed: Vec<Artist>, removed_ids: Vec<String>);
+    fn tracks_changed(&self, changed: Vec<Track>);
+    fn sync_completed(&self, summary: LibrarySyncSummary);
+    fn sync_failed(&self, message: String);
+}
+
+/// End-of-sync roll-up handed to [`LibrarySyncObserver::sync_completed`].
+/// `*_total` fields are the server's authoritative `TotalRecordCount` per
+/// entity (0 when that phase failed), so the UI can refresh its pagination
+/// totals without an extra count query. `phase_errors` carries per-entity
+/// failures when *some* phases succeeded — an all-phases failure surfaces
+/// through [`LibrarySyncObserver::sync_failed`] instead.
+#[derive(Clone, Debug, Default, uniffi::Record)]
+pub struct LibrarySyncSummary {
+    pub albums_changed: u32,
+    pub albums_removed: u32,
+    pub album_total: u32,
+    pub artists_changed: u32,
+    pub artists_removed: u32,
+    pub artist_total: u32,
+    pub tracks_changed: u32,
+    pub track_total: u32,
+    /// `true` when the album phase ran a full walk (first sync, removal
+    /// reconcile, or degenerate delta) rather than a pure delta pass.
+    pub did_full_album_sync: bool,
+    /// `true` when the artist walk ran this sync. It is skipped — and
+    /// `artist_total` left 0 — on quiet days: the walk has no delta filter
+    /// and is expensive server-side, so it only runs when the album phase
+    /// saw activity (or the artist cache is cold). See module docs.
+    pub did_artist_walk: bool,
+    /// `true` when the track delta hit `TRACK_DELTA_MAX_PAGES` and stopped
+    /// early; the checkpoint advanced anyway (see module docs).
+    pub track_delta_truncated: bool,
+    pub phase_errors: Vec<String>,
+}
+
+/// Everything a sync task needs, cloned out of `Inner` *before* the task is
+/// spawned so the FFI mutex is never held across network or DB I/O.
+pub(crate) struct SyncContext {
+    pub client: Arc<JellyfinClient>,
+    pub db: Arc<Database>,
+    /// The user the sync was started for. Compared against the live
+    /// `last_user_id` setting before every cache write so a logout or
+    /// account switch mid-sync aborts instead of repopulating the
+    /// just-cleared tables with the previous user's rows.
+    pub user_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+/// Display-order key: casefolded, with a leading English article stripped —
+/// an approximation of Jellyfin's `SortName` collation that is computable
+/// locally. Cached emits ordered by this key line up closely (not always
+/// perfectly) with the server's `SortName` ordering; the background
+/// revalidation replaces visible rows with authoritative data anyway.
+pub(crate) fn sort_key(name: &str) -> String {
+    let lower = name.trim().to_lowercase();
+    for article in ["the ", "an ", "a "] {
+        if lower.len() > article.len() && lower.starts_with(article) {
+            // Slicing at the article length is safe: `lower` starts with the
+            // all-ASCII article, so the boundary is a char boundary.
+            return lower[article.len()..].trim_start().to_string();
+        }
+    }
+    lower
+}
+
+fn now_unix() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Checkpoint to persist after a successful phase: *now* minus the skew
+/// window, formatted as the ISO-8601 UTC instant Jellyfin's
+/// `MinDateLastSaved` expects. Captured before the phase fetches so changes
+/// landing mid-sync are re-fetched next time rather than missed.
+fn checkpoint_timestamp() -> String {
+    (chrono::Utc::now() - chrono::Duration::seconds(CLOCK_SKEW_WINDOW_SECS))
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn album_writes(items: &[Album]) -> Vec<CacheWrite> {
+    items
+        .iter()
+        .filter_map(|a| {
+            serde_json::to_string(a).ok().map(|data| CacheWrite {
+                id: a.id.clone(),
+                data,
+                sort_key: sort_key(&a.name),
+            })
+        })
+        .collect()
+}
+
+fn artist_writes(items: &[Artist]) -> Vec<CacheWrite> {
+    items
+        .iter()
+        .filter_map(|a| {
+            serde_json::to_string(a).ok().map(|data| CacheWrite {
+                id: a.id.clone(),
+                data,
+                sort_key: sort_key(&a.name),
+            })
+        })
+        .collect()
+}
+
+fn track_writes(items: &[Track]) -> Vec<CacheWrite> {
+    items
+        .iter()
+        .filter_map(|t| {
+            serde_json::to_string(t).ok().map(|data| CacheWrite {
+                id: t.id.clone(),
+                data,
+                sort_key: sort_key(&t.name),
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Persist-on-fetch + cached reads (the synchronous, network-free surface)
+// ---------------------------------------------------------------------------
+
+/// Write a fetched album page through to the cache. Returns the ids whose
+/// cached JSON changed. Callers on the fetch path treat errors as
+/// best-effort (log and continue) — the cache is an optimization, never a
+/// reason to fail the fetch that produced the data.
+pub(crate) fn persist_albums(db: &Database, items: &[Album]) -> Result<Vec<String>> {
+    db.cache_upsert(CacheKind::Album, &album_writes(items), now_unix())
+}
+
+/// Artist twin of [`persist_albums`].
+pub(crate) fn persist_artists(db: &Database, items: &[Artist]) -> Result<Vec<String>> {
+    db.cache_upsert(CacheKind::Artist, &artist_writes(items), now_unix())
+}
+
+/// Track twin of [`persist_albums`].
+pub(crate) fn persist_tracks(db: &Database, items: &[Track]) -> Result<Vec<String>> {
+    db.cache_upsert(CacheKind::Track, &track_writes(items), now_unix())
+}
+
+/// First `limit` cached albums in display order. Rows that no longer
+/// deserialize (stale shapes written by an older build) are skipped — they
+/// get overwritten by the next fetch or sync that touches them.
+pub(crate) fn list_cached_albums(db: &Database, limit: u32) -> Result<Vec<Album>> {
+    Ok(db
+        .cache_list(CacheKind::Album, limit)?
+        .iter()
+        .filter_map(|json| match serde_json::from_str(json) {
+            Ok(album) => Some(album),
+            Err(e) => {
+                tracing::debug!("skipping undeserializable album_cache row: {e}");
+                None
+            }
+        })
+        .collect())
+}
+
+/// Artist twin of [`list_cached_albums`].
+pub(crate) fn list_cached_artists(db: &Database, limit: u32) -> Result<Vec<Artist>> {
+    Ok(db
+        .cache_list(CacheKind::Artist, limit)?
+        .iter()
+        .filter_map(|json| match serde_json::from_str(json) {
+            Ok(artist) => Some(artist),
+            Err(e) => {
+                tracing::debug!("skipping undeserializable artist_cache row: {e}");
+                None
+            }
+        })
+        .collect())
+}
+
+/// Track twin of [`list_cached_albums`].
+pub(crate) fn list_cached_tracks(db: &Database, limit: u32) -> Result<Vec<Track>> {
+    Ok(db
+        .cache_list(CacheKind::Track, limit)?
+        .iter()
+        .filter_map(|json| match serde_json::from_str(json) {
+            Ok(track) => Some(track),
+            Err(e) => {
+                tracing::debug!("skipping undeserializable track_cache row: {e}");
+                None
+            }
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Background revalidation
+// ---------------------------------------------------------------------------
+
+/// Abort guard: the user the sync started for must still be the signed-in
+/// user. See [`SyncContext::user_id`].
+fn ensure_user_unchanged(ctx: &SyncContext) -> Result<()> {
+    match ctx.db.get_setting("last_user_id")? {
+        Some(current) if current == ctx.user_id => Ok(()),
+        _ => Err(LyrebirdError::Other(
+            "session changed during library sync; aborting".into(),
+        )),
+    }
+}
+
+/// Run one full revalidation pass. Phases run sequentially (albums →
+/// artists → tracks) with independent error handling, so one flaky endpoint
+/// doesn't sink the others; per-entity checkpoints only advance when their
+/// phase succeeds. Terminates with exactly one `sync_completed` /
+/// `sync_failed` callback.
+pub(crate) async fn run_sync(ctx: &SyncContext, observer: &dyn LibrarySyncObserver) {
+    let mut summary = LibrarySyncSummary::default();
+    let mut errors: Vec<String> = Vec::new();
+    let mut albums_active = true;
+
+    match sync_albums(ctx, observer).await {
+        Ok(stats) => {
+            albums_active = stats.changed > 0 || stats.removed > 0 || stats.did_full;
+            summary.albums_changed = stats.changed;
+            summary.albums_removed = stats.removed;
+            summary.album_total = stats.total;
+            summary.did_full_album_sync = stats.did_full;
+        }
+        Err(e) => errors.push(format!("albums: {e}")),
+    }
+
+    // A user switch fails every later phase at its first write anyway —
+    // short-circuit instead of burning their fetches.
+    if ensure_user_unchanged(ctx).is_err() {
+        observer.sync_failed("session changed during library sync; aborting".into());
+        return;
+    }
+
+    // The artist walk re-fetches the whole artist list (no delta available —
+    // see module docs) and Jellyfin computes `ItemCounts` per artist on it,
+    // which measured ~10s/page cold on a 20k-album live library. Gate it on
+    // album-phase activity: every artist-affecting mutation Jellyfin
+    // supports (add/remove/rename — renames rewrite the albums'
+    // `AlbumArtist`) re-saves album rows, so a quiet album delta implies a
+    // quiet artist list. A cold artist cache walks unconditionally.
+    let artist_cache_empty = ctx
+        .db
+        .cache_count(CacheKind::Artist)
+        .map(|n| n == 0)
+        .unwrap_or(true);
+    if albums_active || artist_cache_empty {
+        match sync_artists(ctx, observer).await {
+            Ok(stats) => {
+                summary.did_artist_walk = true;
+                summary.artists_changed = stats.changed;
+                summary.artists_removed = stats.removed;
+                summary.artist_total = stats.total;
+            }
+            Err(e) => errors.push(format!("artists: {e}")),
+        }
+    }
+
+    if ensure_user_unchanged(ctx).is_err() {
+        observer.sync_failed("session changed during library sync; aborting".into());
+        return;
+    }
+
+    match sync_tracks(ctx, observer).await {
+        Ok(stats) => {
+            summary.tracks_changed = stats.changed;
+            summary.track_total = stats.total;
+            summary.track_delta_truncated = stats.truncated;
+        }
+        Err(e) => errors.push(format!("tracks: {e}")),
+    }
+
+    if errors.len() == 3 {
+        tracing::warn!("library sync failed on all phases: {}", errors.join("; "));
+        observer.sync_failed(errors.join("; "));
+        return;
+    }
+    if !errors.is_empty() {
+        tracing::warn!("library sync partial failure: {}", errors.join("; "));
+    }
+    summary.phase_errors = errors;
+    observer.sync_completed(summary);
+}
+
+#[derive(Default)]
+struct PhaseStats {
+    changed: u32,
+    removed: u32,
+    total: u32,
+    did_full: bool,
+}
+
+#[derive(Default)]
+struct TrackPhaseStats {
+    changed: u32,
+    total: u32,
+    truncated: bool,
+}
+
+async fn fetch_albums_page(
+    client: &JellyfinClient,
+    offset: u32,
+    limit: u32,
+    since: Option<&str>,
+) -> Result<PaginatedAlbums> {
+    let mut q = JellyfinClient::albums_query(Paging::new(offset, limit));
+    if let Some(ts) = since {
+        q = q.min_date_last_saved(ts);
+    }
+    q.fetch_albums(client).await
+}
+
+async fn fetch_tracks_page(
+    client: &JellyfinClient,
+    offset: u32,
+    limit: u32,
+    since: Option<&str>,
+) -> Result<PaginatedTracks> {
+    let mut q = JellyfinClient::tracks_query(None, Paging::new(offset, limit));
+    if let Some(ts) = since {
+        q = q.min_date_last_saved(ts);
+    }
+    q.fetch_tracks(client).await
+}
+
+/// Persist one fetched album page, emit the changed subset, and record the
+/// ids seen (for the reconcile walk's removed-set computation).
+fn process_album_page(
+    ctx: &SyncContext,
+    observer: &dyn LibrarySyncObserver,
+    items: &[Album],
+    stats: &mut PhaseStats,
+    seen: &mut HashSet<String>,
+) -> Result<()> {
+    ensure_user_unchanged(ctx)?;
+    seen.extend(items.iter().map(|a| a.id.clone()));
+    let changed_ids = persist_albums(&ctx.db, items)?;
+    if !changed_ids.is_empty() {
+        let changed_set: HashSet<&str> = changed_ids.iter().map(String::as_str).collect();
+        let changed: Vec<Album> = items
+            .iter()
+            .filter(|a| changed_set.contains(a.id.as_str()))
+            .cloned()
+            .collect();
+        stats.changed += changed.len() as u32;
+        observer.albums_changed(changed, Vec::new());
+    }
+    Ok(())
+}
+
+/// Full album walk: page through the entire library (first page sequential
+/// to learn the total, remaining pages with a small concurrent fan-out),
+/// persist + emit changes, then delete-and-emit every previously cached id
+/// the walk did not see.
+///
+/// Pagination-shift caveat: items added or removed mid-walk can shift the
+/// offset windows, so the walk can rarely miss a row (caught by the next
+/// delta) or drop a live cache row (repopulated by persist-on-fetch the next
+/// time any fetch touches it). Both are self-healing; neither corrupts.
+async fn full_album_walk(
+    ctx: &SyncContext,
+    observer: &dyn LibrarySyncObserver,
+    stats: &mut PhaseStats,
+) -> Result<()> {
+    let prior_ids: HashSet<String> = ctx.db.cache_ids(CacheKind::Album)?.into_iter().collect();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    let first = fetch_albums_page(&ctx.client, 0, SYNC_PAGE_SIZE, None).await?;
+    let total = first.total_count;
+    process_album_page(ctx, observer, &first.items, stats, &mut seen)?;
+
+    let pages = total.div_ceil(SYNC_PAGE_SIZE);
+    let mut page_stream =
+        futures::stream::iter(
+            (1..pages).map(|page| {
+                let client = Arc::clone(&ctx.client);
+                async move {
+                    fetch_albums_page(&client, page * SYNC_PAGE_SIZE, SYNC_PAGE_SIZE, None).await
+                }
+            }),
+        )
+        .buffer_unordered(FULL_WALK_CONCURRENCY);
+    while let Some(page) = page_stream.next().await {
+        process_album_page(ctx, observer, &page?.items, stats, &mut seen)?;
+    }
+    drop(page_stream);
+
+    let removed: Vec<String> = prior_ids.difference(&seen).cloned().collect();
+    if !removed.is_empty() {
+        ensure_user_unchanged(ctx)?;
+        ctx.db.cache_delete_ids(CacheKind::Album, &removed)?;
+        stats.removed = removed.len() as u32;
+        observer.albums_changed(Vec::new(), removed);
+    }
+    stats.total = total;
+    stats.did_full = true;
+    Ok(())
+}
+
+async fn sync_albums(ctx: &SyncContext, observer: &dyn LibrarySyncObserver) -> Result<PhaseStats> {
+    let key = format!("library_last_sync_albums_{}", ctx.user_id);
+    let checkpoint = checkpoint_timestamp();
+    let mut stats = PhaseStats::default();
+
+    match ctx.db.get_setting(&key)? {
+        None => full_album_walk(ctx, observer, &mut stats).await?,
+        Some(since) => {
+            // The probe page doubles as the first delta page: its
+            // `total_count` is the size of the changed set.
+            let first = fetch_albums_page(&ctx.client, 0, SYNC_PAGE_SIZE, Some(&since)).await?;
+            let delta_total = first.total_count;
+            let server_total = fetch_albums_page(&ctx.client, 0, 1, None)
+                .await?
+                .total_count;
+
+            // delta_total >= server_total / DIVISOR, in overflow-safe form.
+            let degenerate =
+                u64::from(delta_total) * DEGENERATE_DELTA_DIVISOR >= u64::from(server_total.max(1));
+            if degenerate && delta_total > 0 {
+                full_album_walk(ctx, observer, &mut stats).await?;
+            } else {
+                let mut seen = HashSet::new();
+                let mut offset = first.items.len() as u32;
+                process_album_page(ctx, observer, &first.items, &mut stats, &mut seen)?;
+                while offset < delta_total {
+                    let page = fetch_albums_page(&ctx.client, offset, SYNC_PAGE_SIZE, Some(&since))
+                        .await?;
+                    if page.items.is_empty() {
+                        break;
+                    }
+                    offset += page.items.len() as u32;
+                    process_album_page(ctx, observer, &page.items, &mut stats, &mut seen)?;
+                }
+                stats.total = server_total;
+                // Deltas only ever add or update rows; a count mismatch
+                // therefore means server-side deletions → reconcile.
+                if ctx.db.cache_count(CacheKind::Album)? != server_total {
+                    full_album_walk(ctx, observer, &mut stats).await?;
+                }
+            }
+        }
+    }
+
+    ensure_user_unchanged(ctx)?;
+    ctx.db.set_setting(&key, &checkpoint)?;
+    Ok(stats)
+}
+
+/// Artists: full walk — `/Artists/AlbumArtists` ignores `MinDateLastSaved`
+/// (verified live against Jellyfin 10.11), so a delta is not available.
+/// Gated by `run_sync` on album-phase activity (see module docs) because the
+/// endpoint's `ItemCounts` projection is expensive server-side. The walk
+/// gives exact removal reconciliation as a side effect.
+async fn sync_artists(ctx: &SyncContext, observer: &dyn LibrarySyncObserver) -> Result<PhaseStats> {
+    let mut stats = PhaseStats::default();
+    let prior_ids: HashSet<String> = ctx.db.cache_ids(CacheKind::Artist)?.into_iter().collect();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut offset = 0u32;
+    let mut total;
+    loop {
+        let page = ctx
+            .client
+            .artists(Paging::new(offset, SYNC_PAGE_SIZE))
+            .await?;
+        total = page.total_count;
+        if page.items.is_empty() {
+            break;
+        }
+        ensure_user_unchanged(ctx)?;
+        seen.extend(page.items.iter().map(|a| a.id.clone()));
+        let changed_ids = persist_artists(&ctx.db, &page.items)?;
+        if !changed_ids.is_empty() {
+            let changed_set: HashSet<&str> = changed_ids.iter().map(String::as_str).collect();
+            let changed: Vec<Artist> = page
+                .items
+                .iter()
+                .filter(|a| changed_set.contains(a.id.as_str()))
+                .cloned()
+                .collect();
+            stats.changed += changed.len() as u32;
+            observer.artists_changed(changed, Vec::new());
+        }
+        offset += page.items.len() as u32;
+        if offset >= total {
+            break;
+        }
+    }
+
+    let removed: Vec<String> = prior_ids.difference(&seen).cloned().collect();
+    if !removed.is_empty() {
+        ensure_user_unchanged(ctx)?;
+        ctx.db.cache_delete_ids(CacheKind::Artist, &removed)?;
+        stats.removed = removed.len() as u32;
+        observer.artists_changed(Vec::new(), removed);
+    }
+    stats.total = total;
+    Ok(stats)
+}
+
+/// Tracks: capped delta pass (see module docs). The first sync records the
+/// checkpoint without walking — the track cache fills via persist-on-fetch.
+async fn sync_tracks(
+    ctx: &SyncContext,
+    observer: &dyn LibrarySyncObserver,
+) -> Result<TrackPhaseStats> {
+    let key = format!("library_last_sync_tracks_{}", ctx.user_id);
+    let checkpoint = checkpoint_timestamp();
+    let total = fetch_tracks_page(&ctx.client, 0, 1, None)
+        .await?
+        .total_count;
+    let mut stats = TrackPhaseStats {
+        total,
+        ..Default::default()
+    };
+
+    if let Some(since) = ctx.db.get_setting(&key)? {
+        let mut offset = 0u32;
+        let mut pages = 0u32;
+        loop {
+            let page = fetch_tracks_page(&ctx.client, offset, SYNC_PAGE_SIZE, Some(&since)).await?;
+            if page.items.is_empty() {
+                break;
+            }
+            ensure_user_unchanged(ctx)?;
+            let changed_ids = persist_tracks(&ctx.db, &page.items)?;
+            if !changed_ids.is_empty() {
+                let changed_set: HashSet<&str> = changed_ids.iter().map(String::as_str).collect();
+                let changed: Vec<Track> = page
+                    .items
+                    .iter()
+                    .filter(|t| changed_set.contains(t.id.as_str()))
+                    .cloned()
+                    .collect();
+                stats.changed += changed.len() as u32;
+                observer.tracks_changed(changed);
+            }
+            offset += page.items.len() as u32;
+            pages += 1;
+            if offset >= page.total_count {
+                break;
+            }
+            if pages >= TRACK_DELTA_MAX_PAGES {
+                tracing::warn!(
+                    "track delta truncated at {TRACK_DELTA_MAX_PAGES} pages \
+                     ({offset} of {} changed tracks); remainder heals via persist-on-fetch",
+                    page.total_count
+                );
+                stats.truncated = true;
+                break;
+            }
+        }
+    }
+
+    ensure_user_unchanged(ctx)?;
+    ctx.db.set_setting(&key, &checkpoint)?;
+    Ok(stats)
+}

--- a/core/src/migrations/003_library_cache_sort.sql
+++ b/core/src/migrations/003_library_cache_sort.sql
@@ -1,0 +1,19 @@
+-- Library cache sort keys (#431).
+--
+-- The v1 cache tables store opaque JSON in `data`, which leaves SQLite unable
+-- to ORDER BY the item name without parsing JSON per row. The cache-first
+-- launch path wants "first N rows in display order" in single-digit
+-- milliseconds, so we add a precomputed `sort_key` column (article-stripped,
+-- casefolded name — see `library_cache::sort_key`) plus an index over it.
+--
+-- Safe on existing installs: the three tables have been empty since their
+-- introduction (nothing wrote to them before #431), so no backfill is needed;
+-- the DEFAULT '' only ever applies to pre-existing rows, of which there are
+-- none in practice.
+ALTER TABLE track_cache ADD COLUMN sort_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE album_cache ADD COLUMN sort_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE artist_cache ADD COLUMN sort_key TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_track_cache_sort ON track_cache(sort_key);
+CREATE INDEX IF NOT EXISTS idx_album_cache_sort ON album_cache(sort_key);
+CREATE INDEX IF NOT EXISTS idx_artist_cache_sort ON artist_cache(sort_key);

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -55,6 +55,7 @@ pub struct ItemsQuery {
     pub(crate) enable_user_data: bool,
     pub(crate) ids: Vec<String>,
     pub(crate) exclude_types: Vec<ItemKind>,
+    pub(crate) min_date_last_saved: Option<String>,
 }
 
 impl ItemsQuery {
@@ -264,6 +265,17 @@ impl ItemsQuery {
         self
     }
 
+    /// Set `MinDateLastSaved=<iso8601>` — restricts the result set to items
+    /// the server (re)saved at or after the given UTC instant. This is
+    /// Jellyfin's delta-sync filter; the library cache's background
+    /// revalidation uses it to fetch only what changed since the last
+    /// successful sync (#431). Note that per-user `UserData` mutations
+    /// (favorites, play counts) do NOT bump an item's `DateLastSaved`.
+    pub fn min_date_last_saved<S: Into<String>>(mut self, ts: S) -> Self {
+        self.min_date_last_saved = Some(ts.into());
+        self
+    }
+
     /// Apply every set parameter onto the given URL. Shared between
     /// [`Self::execute`] and the callers (in `client.rs`) that need to
     /// embed the query onto an existing URL.
@@ -331,6 +343,9 @@ impl ItemsQuery {
         }
         if !self.ids.is_empty() {
             q.append_pair("Ids", &self.ids.join(","));
+        }
+        if let Some(ts) = &self.min_date_last_saved {
+            q.append_pair("MinDateLastSaved", ts);
         }
         // Image flags: every UI-facing call site wants primary-image metadata,
         // and every pre-refactor endpoint set these explicitly. Emitted by the

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -4,7 +4,7 @@ use parking_lot::Mutex;
 use rusqlite::{params, Connection};
 use std::path::{Path, PathBuf};
 
-const SCHEMA_VERSION: i32 = 2;
+const SCHEMA_VERSION: i32 = 3;
 
 pub struct Database {
     conn: Mutex<Connection>,
@@ -71,6 +71,18 @@ impl Database {
             tx.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
                 params![2],
+            )?;
+        }
+
+        if current < 3 {
+            // Library-cache sort keys (#431). Additive: a `sort_key` column +
+            // index on each of the three (previously unused) cache tables so
+            // the cache-first launch path can serve "first N in display
+            // order" without parsing JSON per row.
+            tx.execute_batch(include_str!("migrations/003_library_cache_sort.sql"))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
+                params![3],
             )?;
         }
 
@@ -144,21 +156,19 @@ impl Database {
 
     /// Clear all user-scoped data after a logout or server switch.
     ///
-    /// Truncates `track_cache`, `album_cache`, and `artist_cache`, and removes
-    /// the session-identity settings (`last_server_url`, `last_username`,
-    /// `last_server_id`, `last_user_id`) that would cause `resume_session` to
-    /// succeed on next launch.
+    /// Truncates `track_cache`, `album_cache`, and `artist_cache` (plus their
+    /// `library_last_sync_*` / `library_cache_user_id` settings — see
+    /// [`Self::clear_library_cache`]), and removes the session-identity
+    /// settings (`last_server_url`, `last_username`, `last_server_id`,
+    /// `last_user_id`) that would cause `resume_session` to succeed on next
+    /// launch.
     ///
     /// Preserves: `device_id`, `device_name`, `shuffle_enabled`,
     /// `repeat_mode`, and `schema_version` rows so the login screen
     /// remembers the endpoint and playback preferences survive sign-out.
     pub fn clear_user_data(&self) -> Result<()> {
         let conn = self.conn.lock();
-        conn.execute_batch(
-            "DELETE FROM track_cache;
-             DELETE FROM album_cache;
-             DELETE FROM artist_cache;",
-        )?;
+        Self::clear_library_cache_locked(&conn)?;
         let session_keys = [
             "last_server_url",
             "last_username",
@@ -171,6 +181,136 @@ impl Database {
                 rusqlite::params![key],
             )?;
         }
+        Ok(())
+    }
+
+    /// Truncate the three library cache tables and drop the per-user
+    /// `library_last_sync_*` checkpoint settings (#431).
+    ///
+    /// Called from [`Self::clear_user_data`] on logout, and directly when a
+    /// *different* user signs in over a session that was merely
+    /// token-forgotten (`forget_token` keeps the cache so the common
+    /// re-auth-as-the-same-user path stays warm) — cached rows must never
+    /// leak across accounts.
+    pub fn clear_library_cache(&self) -> Result<()> {
+        Self::clear_library_cache_locked(&self.conn.lock())
+    }
+
+    fn clear_library_cache_locked(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "DELETE FROM track_cache;
+             DELETE FROM album_cache;
+             DELETE FROM artist_cache;
+             DELETE FROM settings WHERE key LIKE 'library_last_sync_%';
+             DELETE FROM settings WHERE key = 'library_cache_user_id';",
+        )?;
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------------
+    // Library cache (#431).
+    //
+    // Thin CRUD over the `album_cache` / `artist_cache` / `track_cache`
+    // tables, mirroring the downloads pattern: the connection lives here, the
+    // JSON (de)serialization and sync orchestration live in
+    // `crate::library_cache`. Rows are `(id, data, sort_key, updated_at)`
+    // where `data` is the serialized model JSON and `sort_key` is the
+    // precomputed display-order key (see `library_cache::sort_key`).
+    // ------------------------------------------------------------------------
+
+    /// Upsert a batch of cache rows in one transaction, returning the ids
+    /// whose stored JSON actually changed (i.e. new rows plus rows whose
+    /// `data` differs from what was stored). Rows whose JSON is identical to
+    /// the stored copy are left untouched — `updated_at` therefore reads as
+    /// "content last changed", and the returned ids are exactly the set the
+    /// sync layer should re-emit to the UI.
+    pub fn cache_upsert(
+        &self,
+        kind: CacheKind,
+        rows: &[CacheWrite],
+        updated_at: i64,
+    ) -> Result<Vec<String>> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        let mut changed = Vec::new();
+        {
+            let table = kind.table();
+            let mut select = tx.prepare(&format!("SELECT data FROM {table} WHERE id = ?1"))?;
+            let mut upsert = tx.prepare(&format!(
+                "INSERT INTO {table} (id, data, sort_key, updated_at) VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(id) DO UPDATE SET data = excluded.data, \
+                     sort_key = excluded.sort_key, updated_at = excluded.updated_at"
+            ))?;
+            for row in rows {
+                let existing: Option<String> = match select.query_row(params![row.id], |r| r.get(0))
+                {
+                    Ok(v) => Some(v),
+                    Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                    Err(e) => return Err(e.into()),
+                };
+                if existing.as_deref() == Some(row.data.as_str()) {
+                    continue;
+                }
+                upsert.execute(params![row.id, row.data, row.sort_key, updated_at])?;
+                changed.push(row.id.clone());
+            }
+        }
+        tx.commit()?;
+        Ok(changed)
+    }
+
+    /// First `limit` cached JSON rows in display order (`sort_key` ascending,
+    /// id as tiebreaker for stability). This is the warm-launch read path —
+    /// the `sort_key` index makes it an index walk that touches only `limit`
+    /// rows, never a full-table JSON parse.
+    pub fn cache_list(&self, kind: CacheKind, limit: u32) -> Result<Vec<String>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT data FROM {} ORDER BY sort_key ASC, id ASC LIMIT ?1",
+            kind.table()
+        ))?;
+        let rows = stmt
+            .query_map(params![limit], |r| r.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Number of rows in the given cache table. Drives the removal check in
+    /// the delta-sync path: `cached != server total` ⇒ something was deleted
+    /// server-side and a full reconcile walk is needed.
+    pub fn cache_count(&self, kind: CacheKind) -> Result<u32> {
+        let conn = self.conn.lock();
+        let count: i64 =
+            conn.query_row(&format!("SELECT COUNT(*) FROM {}", kind.table()), [], |r| {
+                r.get(0)
+            })?;
+        Ok(count.max(0) as u32)
+    }
+
+    /// Every id currently in the given cache table. Used by the full
+    /// reconcile walk to compute the removed set (cached ids minus ids seen
+    /// on the server).
+    pub fn cache_ids(&self, kind: CacheKind) -> Result<Vec<String>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(&format!("SELECT id FROM {}", kind.table()))?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Delete the given ids from the cache table in one transaction. No-op
+    /// for ids that are already gone.
+    pub fn cache_delete_ids(&self, kind: CacheKind, ids: &[String]) -> Result<()> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(&format!("DELETE FROM {} WHERE id = ?1", kind.table()))?;
+            for id in ids {
+                stmt.execute(params![id])?;
+            }
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -340,6 +480,37 @@ impl Database {
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(rows)
     }
+}
+
+/// Which of the three library cache tables a cache operation targets (#431).
+/// The enum (rather than a raw table-name string) keeps the SQL `format!`
+/// calls in the cache CRUD closed over a fixed set of identifiers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheKind {
+    Album,
+    Artist,
+    Track,
+}
+
+impl CacheKind {
+    fn table(self) -> &'static str {
+        match self {
+            CacheKind::Album => "album_cache",
+            CacheKind::Artist => "artist_cache",
+            CacheKind::Track => "track_cache",
+        }
+    }
+}
+
+/// One library-cache row to write: the item id, its serialized model JSON,
+/// and the precomputed display-order key. Produced by
+/// `crate::library_cache`'s serializers and consumed by
+/// [`Database::cache_upsert`].
+#[derive(Clone, Debug)]
+pub struct CacheWrite {
+    pub id: String,
+    pub data: String,
+    pub sort_key: String,
 }
 
 /// A raw row of the `downloads` table, as read from SQLite. Lives in

--- a/core/src/tests/library_cache.rs
+++ b/core/src/tests/library_cache.rs
@@ -1,0 +1,824 @@
+use super::*;
+
+use crate::library_cache::{self, sort_key};
+use crate::models::{Album, Artist, Track};
+use crate::storage::{CacheKind, CacheWrite};
+use crate::{LibrarySyncObserver, LibrarySyncSummary};
+use std::sync::Arc;
+use wiremock::matchers::query_param_is_missing;
+
+// ---------------------------------------------------------------------------
+// Database-backed library cache + background revalidation (#431)
+// ---------------------------------------------------------------------------
+
+fn make_album(id: &str, name: &str) -> Album {
+    Album {
+        id: id.into(),
+        name: name.into(),
+        artist_name: "Artist".into(),
+        artist_id: None,
+        year: Some(2020),
+        track_count: 10,
+        runtime_ticks: 0,
+        genres: vec![],
+        image_tag: None,
+        user_data: None,
+    }
+}
+
+/// RawItem JSON that maps (via `From<RawItem> for Album`) to exactly
+/// `make_album(id, name)` — keeps mock pages and seeded cache rows
+/// byte-identical after serde, which is what the JSON-equality diff keys on.
+fn album_item_json(id: &str, name: &str) -> serde_json::Value {
+    json!({
+        "Id": id, "Name": name, "Type": "MusicAlbum",
+        "AlbumArtist": "Artist", "ProductionYear": 2020,
+        "ChildCount": 10, "RunTimeTicks": 0u64, "Genres": []
+    })
+}
+
+fn artist_item_json(id: &str, name: &str) -> serde_json::Value {
+    json!({
+        "Id": id, "Name": name, "Type": "MusicArtist",
+        "AlbumCount": 2, "SongCount": 5, "Genres": []
+    })
+}
+
+fn track_item_json(id: &str, name: &str) -> serde_json::Value {
+    json!({
+        "Id": id, "Name": name, "Type": "Audio",
+        "AlbumArtist": "Artist", "RunTimeTicks": 0u64
+    })
+}
+
+async fn mount_auth(server: &MockServer, server_id: &str, user_id: &str) {
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": server_id, "ServerName": "S",
+            "User": { "Id": user_id, "Name": "cache-user", "ServerId": server_id,
+                      "PrimaryImageTag": null }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Build a temp-backed core and log it in against the mock server.
+/// `LyrebirdCore::login` is a sync FFI that `block_on`s the core's own
+/// runtime, so it runs under `spawn_blocking` (same pattern as the
+/// session_auth tests).
+async fn logged_in_core(tmp_path: String, server_url: String) -> Arc<LyrebirdCore> {
+    tokio::task::spawn_blocking(move || {
+        install_mock_keyring();
+        let core = LyrebirdCore::new(CoreConfig {
+            data_dir: tmp_path,
+            device_name: "Test".into(),
+        })
+        .expect("core init");
+        core.login(server_url, "cache-user".into(), "pw".into())
+            .expect("login");
+        core
+    })
+    .await
+    .expect("join login task")
+}
+
+/// Test observer: records every callback and signals termination over a
+/// channel so tests can await the end of the background sync.
+#[derive(Default)]
+struct SyncEvents {
+    albums_changed: Vec<Album>,
+    albums_removed: Vec<String>,
+    artists_changed: Vec<Artist>,
+    artists_removed: Vec<String>,
+    tracks_changed: Vec<Track>,
+}
+
+struct SharedSyncRecorder {
+    events: std::sync::Mutex<SyncEvents>,
+    done: tokio::sync::mpsc::UnboundedSender<std::result::Result<LibrarySyncSummary, String>>,
+}
+
+struct RecordingObserver(Arc<SharedSyncRecorder>);
+
+impl LibrarySyncObserver for RecordingObserver {
+    fn albums_changed(&self, changed: Vec<Album>, removed_ids: Vec<String>) {
+        let mut ev = self.0.events.lock().unwrap();
+        ev.albums_changed.extend(changed);
+        ev.albums_removed.extend(removed_ids);
+    }
+    fn artists_changed(&self, changed: Vec<Artist>, removed_ids: Vec<String>) {
+        let mut ev = self.0.events.lock().unwrap();
+        ev.artists_changed.extend(changed);
+        ev.artists_removed.extend(removed_ids);
+    }
+    fn tracks_changed(&self, changed: Vec<Track>) {
+        self.0.events.lock().unwrap().tracks_changed.extend(changed);
+    }
+    fn sync_completed(&self, summary: LibrarySyncSummary) {
+        let _ = self.0.done.send(Ok(summary));
+    }
+    fn sync_failed(&self, message: String) {
+        let _ = self.0.done.send(Err(message));
+    }
+}
+
+fn recorder() -> (
+    Arc<SharedSyncRecorder>,
+    tokio::sync::mpsc::UnboundedReceiver<std::result::Result<LibrarySyncSummary, String>>,
+) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    (
+        Arc::new(SharedSyncRecorder {
+            events: std::sync::Mutex::new(SyncEvents::default()),
+            done: tx,
+        }),
+        rx,
+    )
+}
+
+/// Dispose of a test core off the async thread. `LyrebirdCore` owns a tokio
+/// runtime, and dropping a runtime inside another runtime's async context
+/// panics ("Cannot drop a runtime in a context where blocking is not
+/// allowed") — the same reason `logged_in_core` constructs it under
+/// `spawn_blocking`.
+async fn drop_core(core: Arc<LyrebirdCore>) {
+    tokio::task::spawn_blocking(move || drop(core))
+        .await
+        .expect("join drop task");
+}
+
+/// Kick a revalidation and await its terminating callback.
+async fn run_revalidation(
+    core: &Arc<LyrebirdCore>,
+    shared: &Arc<SharedSyncRecorder>,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<std::result::Result<LibrarySyncSummary, String>>,
+) -> std::result::Result<LibrarySyncSummary, String> {
+    assert!(
+        core.revalidate_library(Box::new(RecordingObserver(Arc::clone(shared)))),
+        "revalidate_library must start when a session exists and no sync is in flight"
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv())
+        .await
+        .expect("sync did not terminate within 30s")
+        .expect("done channel closed without a terminal callback")
+}
+
+// --- sort_key -------------------------------------------------------------
+
+#[test]
+fn sort_key_strips_articles_and_casefolds() {
+    assert_eq!(sort_key("The Beatles"), "beatles");
+    assert_eq!(sort_key("A Moon Shaped Pool"), "moon shaped pool");
+    assert_eq!(sort_key("An Awesome Wave"), "awesome wave");
+    assert_eq!(sort_key("  Aphex Twin "), "aphex twin");
+    // Words that merely *start* with an article string keep their prefix.
+    assert_eq!(sort_key("Therapy?"), "therapy?");
+    assert_eq!(sort_key("Answer"), "answer");
+    // A bare article (nothing after it) is left as-is rather than emptied.
+    assert_eq!(sort_key("The"), "the");
+    // Multi-byte input doesn't panic and casefolds.
+    assert_eq!(sort_key("Ólafur Arnalds"), "ólafur arnalds");
+}
+
+// --- storage CRUD ----------------------------------------------------------
+
+#[test]
+fn cache_upsert_diffs_by_json_equality() {
+    let db = Database::in_memory().unwrap();
+    let a1 = CacheWrite {
+        id: "a1".into(),
+        data: r#"{"name":"one"}"#.into(),
+        sort_key: "one".into(),
+    };
+    let a2 = CacheWrite {
+        id: "a2".into(),
+        data: r#"{"name":"two"}"#.into(),
+        sort_key: "two".into(),
+    };
+
+    // First write: both rows are new ⇒ both changed.
+    let changed = db
+        .cache_upsert(CacheKind::Album, &[a1.clone(), a2.clone()], 100)
+        .unwrap();
+    assert_eq!(changed, vec!["a1".to_string(), "a2".to_string()]);
+    assert_eq!(db.cache_count(CacheKind::Album).unwrap(), 2);
+
+    // Identical re-write: nothing changed, updated_at untouched.
+    let changed = db
+        .cache_upsert(CacheKind::Album, &[a1.clone(), a2.clone()], 200)
+        .unwrap();
+    assert!(changed.is_empty());
+
+    // One row mutated ⇒ exactly that id reported.
+    let a2_v2 = CacheWrite {
+        id: "a2".into(),
+        data: r#"{"name":"two (remastered)"}"#.into(),
+        sort_key: "two (remastered)".into(),
+    };
+    let changed = db
+        .cache_upsert(CacheKind::Album, &[a1, a2_v2], 300)
+        .unwrap();
+    assert_eq!(changed, vec!["a2".to_string()]);
+
+    // ids + delete round-trip.
+    let mut ids = db.cache_ids(CacheKind::Album).unwrap();
+    ids.sort();
+    assert_eq!(ids, vec!["a1".to_string(), "a2".to_string()]);
+    db.cache_delete_ids(CacheKind::Album, &["a1".to_string()])
+        .unwrap();
+    assert_eq!(
+        db.cache_ids(CacheKind::Album).unwrap(),
+        vec!["a2".to_string()]
+    );
+
+    // The three tables are independent.
+    assert_eq!(db.cache_count(CacheKind::Artist).unwrap(), 0);
+    assert_eq!(db.cache_count(CacheKind::Track).unwrap(), 0);
+}
+
+#[test]
+fn cache_list_orders_by_sort_key_and_limits() {
+    let db = Database::in_memory().unwrap();
+    let albums = [
+        make_album("z", "The Zebra"), // sort_key "zebra"
+        make_album("m", "Mango"),
+        make_album("a", "Apple"),
+    ];
+    library_cache::persist_albums(&db, &albums).unwrap();
+
+    let listed = library_cache::list_cached_albums(&db, 10).unwrap();
+    assert_eq!(
+        listed.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+        vec!["Apple", "Mango", "The Zebra"],
+        "cached emit must be in display (article-stripped) order"
+    );
+
+    let limited = library_cache::list_cached_albums(&db, 2).unwrap();
+    assert_eq!(limited.len(), 2);
+    assert_eq!(limited[0].name, "Apple");
+    assert_eq!(limited[1].name, "Mango");
+}
+
+#[test]
+fn list_cached_skips_undeserializable_rows() {
+    let db = Database::in_memory().unwrap();
+    library_cache::persist_albums(&db, &[make_album("good", "Good Album")]).unwrap();
+    // Simulate a stale-shape row written by an older build.
+    db.cache_upsert(
+        CacheKind::Album,
+        &[CacheWrite {
+            id: "stale".into(),
+            data: r#"{"not_an_album": true}"#.into(),
+            sort_key: "aaa".into(), // sorts first, so a panic/skip bug would surface
+        }],
+        1,
+    )
+    .unwrap();
+
+    let listed = library_cache::list_cached_albums(&db, 10).unwrap();
+    assert_eq!(listed.len(), 1, "stale row must be skipped, not fatal");
+    assert_eq!(listed[0].id, "good");
+}
+
+#[test]
+fn clear_user_data_wipes_cache_and_sync_checkpoints() {
+    let db = Database::in_memory().unwrap();
+    library_cache::persist_albums(&db, &[make_album("a1", "One")]).unwrap();
+    db.set_setting("library_last_sync_albums_u1", "2026-01-01T00:00:00Z")
+        .unwrap();
+    db.set_setting("library_last_sync_tracks_u1", "2026-01-01T00:00:00Z")
+        .unwrap();
+    db.set_setting("library_cache_user_id", "u1").unwrap();
+
+    db.clear_user_data().unwrap();
+
+    assert_eq!(db.cache_count(CacheKind::Album).unwrap(), 0);
+    assert!(db
+        .get_setting("library_last_sync_albums_u1")
+        .unwrap()
+        .is_none());
+    assert!(db
+        .get_setting("library_last_sync_tracks_u1")
+        .unwrap()
+        .is_none());
+    assert!(db.get_setting("library_cache_user_id").unwrap().is_none());
+}
+
+// --- persist-on-fetch + cached reads ----------------------------------------
+
+#[tokio::test]
+async fn persist_on_fetch_populates_cache_for_cached_reads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    mount_auth(&server, "srv-lc-pof", "u-lc-pof").await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-pof/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "The Zebra"), album_item_json("a2", "Apple")],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let core = logged_in_core(tmp.path().to_string_lossy().into_owned(), server.uri()).await;
+
+    // Cached read before any fetch: empty (no network fallback).
+    assert!(core.list_cached_albums(100).unwrap().is_empty());
+
+    // The regular paged fetch writes through to the cache.
+    let core_for_fetch = Arc::clone(&core);
+    let page = tokio::task::spawn_blocking(move || core_for_fetch.list_albums(0, 100))
+        .await
+        .expect("join")
+        .expect("list_albums");
+    assert_eq!(page.items.len(), 2);
+
+    // Cached read now serves both rows, in display order, without any
+    // further network round-trip.
+    let cached = core.list_cached_albums(100).unwrap();
+    assert_eq!(
+        cached.iter().map(|a| a.id.as_str()).collect::<Vec<_>>(),
+        vec!["a2", "a1"],
+        "Apple sorts before The Zebra (article stripped)"
+    );
+    let album_requests = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path() == "/Users/u-lc-pof/Items")
+        .count();
+    assert_eq!(album_requests, 1, "cached reads must not hit the server");
+    drop_core(core).await;
+}
+
+#[tokio::test]
+async fn login_as_different_user_wipes_library_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server_a = MockServer::start().await;
+    mount_auth(&server_a, "srv-lc-switch-a", "u-lc-switch-a").await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-switch-a/Items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Owned By A")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server_a)
+        .await;
+    let server_b = MockServer::start().await;
+    mount_auth(&server_b, "srv-lc-switch-b", "u-lc-switch-b").await;
+
+    let core = logged_in_core(tmp.path().to_string_lossy().into_owned(), server_a.uri()).await;
+    let core_for_fetch = Arc::clone(&core);
+    tokio::task::spawn_blocking(move || core_for_fetch.list_albums(0, 100))
+        .await
+        .expect("join")
+        .expect("list_albums");
+    assert_eq!(core.list_cached_albums(100).unwrap().len(), 1);
+
+    // Re-login as the SAME user: the warm cache must survive.
+    let core_for_relogin = Arc::clone(&core);
+    let url_a = server_a.uri();
+    tokio::task::spawn_blocking(move || {
+        core_for_relogin
+            .login(url_a, "cache-user".into(), "pw".into())
+            .expect("re-login as same user")
+    })
+    .await
+    .expect("join");
+    assert_eq!(
+        core.list_cached_albums(100).unwrap().len(),
+        1,
+        "same-user re-login must keep the cache warm"
+    );
+
+    // Login as a DIFFERENT user: the cache must be wiped so user B never
+    // sees user A's library.
+    let core_for_switch = Arc::clone(&core);
+    let url_b = server_b.uri();
+    tokio::task::spawn_blocking(move || {
+        core_for_switch
+            .login(url_b, "cache-user".into(), "pw".into())
+            .expect("login as user B")
+    })
+    .await
+    .expect("join");
+    assert!(
+        core.list_cached_albums(100).unwrap().is_empty(),
+        "user switch must wipe the library cache"
+    );
+    drop_core(core).await;
+}
+
+// --- background revalidation -------------------------------------------------
+
+#[test]
+fn revalidate_library_requires_session() {
+    // Plain #[test] (not #[tokio::test]) so the core — which owns its own
+    // tokio runtime — can be dropped on this thread without panicking.
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    let (shared, mut rx) = recorder();
+    assert!(
+        !core.revalidate_library(Box::new(RecordingObserver(Arc::clone(&shared)))),
+        "no session ⇒ no sync"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "observer must not be invoked when the sync never starts"
+    );
+}
+
+#[tokio::test]
+async fn revalidation_first_sync_full_walks_albums_and_artists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    mount_auth(&server, "srv-lc-full", "u-lc-full").await;
+    // Albums: the full walk must NOT carry MinDateLastSaved on first sync.
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-full/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Album One"), album_item_json("a2", "Album Two")],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [artist_item_json("r1", "Artist One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // Tracks: first sync only probes the total (no delta walk, no mirror walk).
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-full/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [track_item_json("t1", "Track One")],
+            "TotalRecordCount": 42
+        })))
+        .mount(&server)
+        .await;
+
+    let core = logged_in_core(tmp.path().to_string_lossy().into_owned(), server.uri()).await;
+    let (shared, mut rx) = recorder();
+    let summary = run_revalidation(&core, &shared, &mut rx)
+        .await
+        .expect("sync_completed");
+
+    assert!(summary.did_full_album_sync);
+    assert_eq!(summary.albums_changed, 2);
+    assert_eq!(summary.albums_removed, 0);
+    assert_eq!(summary.album_total, 2);
+    assert!(summary.did_artist_walk, "first sync must walk artists");
+    assert_eq!(summary.artists_changed, 1);
+    assert_eq!(summary.artist_total, 1);
+    assert_eq!(
+        summary.tracks_changed, 0,
+        "first sync records a checkpoint, no track walk"
+    );
+    assert_eq!(summary.track_total, 42);
+    assert!(!summary.track_delta_truncated);
+    assert!(summary.phase_errors.is_empty());
+
+    // Scoped (not `drop(ev)`): clippy's await_holding_lock tracks lexical
+    // regions, so the guard must end in a block before the next await.
+    {
+        let ev = shared.events.lock().unwrap();
+        assert_eq!(ev.albums_changed.len(), 2);
+        assert!(ev.albums_removed.is_empty());
+        assert_eq!(ev.artists_changed.len(), 1);
+        assert!(ev.tracks_changed.is_empty());
+    }
+
+    // Cache is now populated and checkpoints recorded.
+    assert_eq!(core.list_cached_albums(10).unwrap().len(), 2);
+    assert_eq!(core.list_cached_artists(10).unwrap().len(), 1);
+    assert!(core.list_cached_tracks(10).unwrap().is_empty());
+    {
+        let inner = core.inner.lock();
+        assert!(inner
+            .db
+            .get_setting("library_last_sync_albums_u-lc-full")
+            .unwrap()
+            .is_some());
+        assert!(inner
+            .db
+            .get_setting("library_last_sync_tracks_u-lc-full")
+            .unwrap()
+            .is_some());
+    }
+    drop_core(core).await;
+}
+
+#[tokio::test]
+async fn revalidation_delta_emits_only_changes_and_reconciles_removals() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    mount_auth(&server, "srv-lc-delta", "u-lc-delta").await;
+    // --- stage 1: first sync (full walk) seeds the cache with a1, a2, a3 ---
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                album_item_json("a1", "Album One"),
+                album_item_json("a2", "Album Two"),
+                album_item_json("a3", "Album Three")
+            ],
+            "TotalRecordCount": 3
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [artist_item_json("r1", "Artist One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 5
+        })))
+        .mount(&server)
+        .await;
+
+    let core = logged_in_core(tmp.path().to_string_lossy().into_owned(), server.uri()).await;
+    let (shared1, mut rx1) = recorder();
+    run_revalidation(&core, &shared1, &mut rx1)
+        .await
+        .expect("stage-1 sync_completed");
+    assert_eq!(core.list_cached_albums(10).unwrap().len(), 3);
+
+    // --- stage 2: a1 renamed server-side, a3 deleted server-side ---
+    server.reset().await;
+    // Delta query (MinDateLastSaved present): only the renamed a1 comes back.
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(|req: &Request| req.url.query_pairs().any(|(k, _)| k == "MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Album One (Remastered)")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // Unfiltered album queries: the Limit=1 total probe and the reconcile
+    // walk (Limit=500). Total of 2 ≠ 3 cached rows triggers the reconcile.
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .and(query_param("Limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Album One (Remastered)")],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .and(query_param("Limit", "500"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [
+                album_item_json("a1", "Album One (Remastered)"),
+                album_item_json("a2", "Album Two")
+            ],
+            "TotalRecordCount": 2
+        })))
+        .mount(&server)
+        .await;
+    // Artists: unchanged page — must produce zero artist emissions.
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [artist_item_json("r1", "Artist One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // Tracks: probe total, then a delta page carrying one new track.
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 5
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-delta/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .and(|req: &Request| req.url.query_pairs().any(|(k, _)| k == "MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [track_item_json("t-new", "Fresh Track")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let (shared2, mut rx2) = recorder();
+    let summary = run_revalidation(&core, &shared2, &mut rx2)
+        .await
+        .expect("stage-2 sync_completed");
+
+    assert_eq!(
+        summary.albums_changed, 1,
+        "only the renamed album counts as changed (the reconcile walk must \
+         not re-emit rows the delta already updated, nor unchanged rows)"
+    );
+    assert_eq!(summary.albums_removed, 1);
+    assert_eq!(summary.album_total, 2);
+    assert!(
+        summary.did_full_album_sync,
+        "count mismatch (3 cached vs 2 on server) must trigger the reconcile walk"
+    );
+    assert!(
+        summary.did_artist_walk,
+        "album activity must trigger the artist walk"
+    );
+    assert_eq!(summary.artists_changed, 0);
+    assert_eq!(summary.artists_removed, 0);
+    assert_eq!(summary.tracks_changed, 1);
+    assert_eq!(summary.track_total, 5);
+    assert!(summary.phase_errors.is_empty());
+
+    // Scoped (not `drop(ev)`): clippy's await_holding_lock tracks lexical
+    // regions, so the guard must end in a block before the next await.
+    {
+        let ev = shared2.events.lock().unwrap();
+        assert_eq!(
+            ev.albums_changed
+                .iter()
+                .map(|a| a.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a1"]
+        );
+        assert_eq!(ev.albums_changed[0].name, "Album One (Remastered)");
+        assert_eq!(ev.albums_removed, vec!["a3".to_string()]);
+        assert!(ev.artists_changed.is_empty());
+        assert_eq!(
+            ev.tracks_changed
+                .iter()
+                .map(|t| t.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["t-new"]
+        );
+    }
+
+    // Cache reflects the reconcile: a3 gone, a1 renamed, new track present.
+    let cached = core.list_cached_albums(10).unwrap();
+    assert_eq!(cached.len(), 2);
+    assert!(cached.iter().any(|a| a.name == "Album One (Remastered)"));
+    assert!(!cached.iter().any(|a| a.id == "a3"));
+    assert_eq!(core.list_cached_tracks(10).unwrap().len(), 1);
+    drop_core(core).await;
+}
+
+#[tokio::test]
+async fn revalidation_noop_delta_is_two_cheap_album_requests() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    mount_auth(&server, "srv-lc-noop", "u-lc-noop").await;
+    // Stage 1: seed one album + one artist + checkpoints via a first full
+    // sync (the artist row matters: a populated artist cache is what makes
+    // the stage-2 walk-skip meaningful).
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-noop/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Album One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Artists/AlbumArtists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [artist_item_json("r1", "Artist One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-noop/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let core = logged_in_core(tmp.path().to_string_lossy().into_owned(), server.uri()).await;
+    let (shared1, mut rx1) = recorder();
+    run_revalidation(&core, &shared1, &mut rx1)
+        .await
+        .expect("stage-1 sync_completed");
+
+    // Stage 2: nothing changed on the server.
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-noop/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(|req: &Request| req.url.query_pairs().any(|(k, _)| k == "MinDateLastSaved"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-noop/Items"))
+        .and(query_param("IncludeItemTypes", "MusicAlbum"))
+        .and(query_param_is_missing("MinDateLastSaved"))
+        .and(query_param("Limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [album_item_json("a1", "Album One")],
+            "TotalRecordCount": 1
+        })))
+        .mount(&server)
+        .await;
+    // Deliberately NO /Artists/AlbumArtists mock in stage 2: a quiet album
+    // delta must skip the (expensive, delta-less) artist walk entirely. If
+    // the gate regresses, the walk 404s and surfaces in phase_errors.
+    Mock::given(method("GET"))
+        .and(path("/Users/u-lc-noop/Items"))
+        .and(query_param("IncludeItemTypes", "Audio"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "Items": [], "TotalRecordCount": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let (shared2, mut rx2) = recorder();
+    let summary = run_revalidation(&core, &shared2, &mut rx2)
+        .await
+        .expect("stage-2 sync_completed");
+
+    assert_eq!(summary.albums_changed, 0);
+    assert_eq!(summary.albums_removed, 0);
+    assert!(
+        !summary.did_full_album_sync,
+        "matching counts must skip the reconcile walk"
+    );
+    assert!(
+        !summary.did_artist_walk,
+        "a quiet album delta must skip the artist walk"
+    );
+    assert_eq!(summary.artists_changed, 0);
+    assert_eq!(summary.tracks_changed, 0);
+    assert!(summary.phase_errors.is_empty());
+    // Scoped (not `drop(ev)`): clippy's await_holding_lock tracks lexical
+    // regions, so the guard must end in a block before the next await.
+    {
+        let ev = shared2.events.lock().unwrap();
+        assert!(ev.albums_changed.is_empty());
+        assert!(ev.albums_removed.is_empty());
+    }
+
+    // The album phase of a no-op day is exactly two requests: the empty
+    // delta page and the Limit=1 total probe — the "≤1% of full payload"
+    // acceptance shape from #431.
+    let album_requests = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| {
+            r.method.as_str() == "GET"
+                && r.url.path() == "/Users/u-lc-noop/Items"
+                && r.url
+                    .query_pairs()
+                    .any(|(k, v)| k == "IncludeItemTypes" && v == "MusicAlbum")
+        })
+        .count();
+    assert_eq!(album_requests, 2);
+    let artist_requests = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/Artists/AlbumArtists")
+        .count();
+    assert_eq!(
+        artist_requests, 0,
+        "skipped artist walk must issue no requests"
+    );
+    // Cache untouched.
+    assert_eq!(core.list_cached_albums(10).unwrap().len(), 1);
+    assert_eq!(core.list_cached_artists(10).unwrap().len(), 1);
+    drop_core(core).await;
+}

--- a/core/src/tests/mod.rs
+++ b/core/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod downloads;
 mod errors_enums;
 mod favorites;
 mod library;
+mod library_cache;
 mod persistence;
 mod playback;
 mod playlists;

--- a/core/tests/e2e_live.rs
+++ b/core/tests/e2e_live.rs
@@ -332,3 +332,45 @@ fn playback_start_stop_reporting_round_trips() {
     })
     .expect("report_playback_stopped");
 }
+
+/// Library cache (#431) against the live server: a fetched album page
+/// write-throughs to the SQLite cache, and the cached read path serves it
+/// back instantly without touching the network. The warm-read budget in the
+/// issue is < 50 ms; the assertion allows CI-machine slack while still
+/// catching an accidental network dependency (any round-trip would blow it).
+#[test]
+fn library_cache_persist_on_fetch_round_trips() {
+    let Some(url) = e2e_url() else {
+        eprintln!("{SKIP_HINT}");
+        return;
+    };
+    let core = make_core();
+    let _ = core
+        .login(url, e2e_user(), e2e_pass())
+        .expect("login should succeed with the test account");
+
+    // Fresh data dir ⇒ cold cache.
+    assert!(
+        core.list_cached_albums(50)
+            .expect("cached read (cold)")
+            .is_empty(),
+        "cold cache must be empty"
+    );
+
+    let page = core.list_albums(0, 50).expect("list_albums");
+    assert!(!page.items.is_empty(), "live test library is populated");
+
+    let started = std::time::Instant::now();
+    let cached = core.list_cached_albums(50).expect("cached read (warm)");
+    let elapsed = started.elapsed();
+    assert_eq!(
+        cached.len(),
+        page.items.len(),
+        "every fetched row must be served back from the cache"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "cached read should be a local SQLite hit, took {elapsed:?}"
+    );
+    eprintln!("cached read of {} albums in {elapsed:?}", cached.len());
+}

--- a/macos/Sources/Lyrebird/AppModel+Library.swift
+++ b/macos/Sources/Lyrebird/AppModel+Library.swift
@@ -14,6 +14,11 @@ extension AppModel {
     func refreshLibrary() async {
         isLoadingLibrary = true
         defer { isLoadingLibrary = false }
+        // Cache-first launch (#431): paint whatever the local library cache
+        // holds before any network round-trip. No-op when the arrays are
+        // already populated or the cache is cold; the fetches below replace
+        // the provisional rows with authoritative server pages.
+        await loadCachedLibraryIfEmpty()
         // Fetch albums, artists, tracks, and playlists in parallel. Previously
         // the album/artist calls were sequential, doubling time-to-first-paint
         // on every fresh session; `async let` lets all round-trips overlap.
@@ -83,6 +88,12 @@ extension AppModel {
             serverReachability.noteSuccess()
         }
         _ = await playlistsResult
+        // Background revalidation (#431): reconcile the local library cache
+        // against the server (delta sync via MinDateLastSaved) and stream
+        // changed/removed rows back into the arrays above. Non-blocking; the
+        // core self-guards against overlapping syncs, so the retry paths
+        // that re-enter refreshLibrary are safe.
+        startLibraryRevalidation()
         // Secondary Home shelves (#49 / #51–#55). These are NOT needed to
         // render MainShell/Home — the library page fetched above is — so they
         // must not gate first paint. Previously they were `await`ed serially

--- a/macos/Sources/Lyrebird/AppModel+LibraryCache.swift
+++ b/macos/Sources/Lyrebird/AppModel+LibraryCache.swift
@@ -1,0 +1,171 @@
+import Foundation
+import os
+@preconcurrency import LyrebirdCore
+
+/// Cache-first library launch + background revalidation (#431).
+///
+/// The core persists every fetched library page into its SQLite cache
+/// (`album_cache` / `artist_cache` / `track_cache`). On launch we emit those
+/// cached rows to the UI immediately — `core.listCached*` is a pure local
+/// read, no network — and then kick `core.revalidateLibrary`, which
+/// delta-syncs against the server off the main actor and streams only the
+/// rows that actually changed back through `LibrarySyncBridge`.
+///
+/// Extensions of a `@MainActor` type inherit its isolation, so everything in
+/// this extension is main-actor-bound; the sync FFI hops run inside
+/// `Task.detached` per the repo's gap-pattern-#2 rule.
+extension AppModel {
+    /// Populate `albums` / `artists` / `tracks` from the local cache when
+    /// they're empty — the warm-launch fast path. Cached rows render in
+    /// approximate display order (the core's article-stripped sort key);
+    /// the regular network refresh running concurrently replaces them with
+    /// authoritative pages, totals included. No-op on first launch (empty
+    /// cache) and mid-session (arrays already populated).
+    func loadCachedLibraryIfEmpty() async {
+        guard albums.isEmpty, artists.isEmpty, tracks.isEmpty else { return }
+        let pageSize = libraryInitialPageSize
+        let cached = await Task.detached(priority: .userInitiated) { [core] () -> ([Album], [Artist], [Track]) in
+            // Each read is independent + best-effort: a corrupt table must
+            // not block the others (and never the launch).
+            let albums = (try? core.listCachedAlbums(limit: pageSize)) ?? []
+            let artists = (try? core.listCachedArtists(limit: pageSize)) ?? []
+            let tracks = (try? core.listCachedTracks(limit: pageSize)) ?? []
+            return (albums, artists, tracks)
+        }.value
+        // Re-check after the suspension: a fast network refresh (or a second
+        // caller) may have populated the arrays while the cache read ran —
+        // fresh server data must never be clobbered by cached rows.
+        guard albums.isEmpty, artists.isEmpty, tracks.isEmpty else { return }
+        if !cached.0.isEmpty { albums = cached.0 }
+        if !cached.1.isEmpty { artists = cached.1 }
+        if !cached.2.isEmpty { tracks = cached.2 }
+        if !cached.0.isEmpty || !cached.1.isEmpty || !cached.2.isEmpty {
+            Log.app.info("library cache-first paint: \(cached.0.count) albums, \(cached.1.count) artists, \(cached.2.count) tracks")
+        }
+    }
+
+    /// Kick the core's background library revalidation. Returns immediately;
+    /// changed/removed rows arrive via `LibrarySyncBridge` on the main actor.
+    /// The core no-ops (returns `false`) when a sync is already in flight or
+    /// no session exists, so calling this from every `refreshLibrary` is safe.
+    func startLibraryRevalidation() {
+        let bridge = LibrarySyncBridge(model: self)
+        Task.detached(priority: .utility) { [core] in
+            _ = core.revalidateLibrary(observer: bridge)
+        }
+    }
+
+    /// Apply a batch of album changes from the background sync: refresh rows
+    /// the UI has loaded (matched by id) and drop server-side deletions.
+    /// Rows beyond the loaded pagination window are intentionally ignored —
+    /// they're already in the cache for the next launch, and load-more pages
+    /// fetch fresh from the server anyway.
+    func applyLibrarySync(albumsChanged changed: [Album], removedIds: [String]) {
+        guard session != nil else { return }
+        if !changed.isEmpty {
+            let byId = Dictionary(changed.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+            for index in albums.indices {
+                if let fresh = byId[albums[index].id] { albums[index] = fresh }
+            }
+        }
+        if !removedIds.isEmpty {
+            let gone = Set(removedIds)
+            albums.removeAll { gone.contains($0.id) }
+        }
+    }
+
+    /// Artist twin of `applyLibrarySync(albumsChanged:removedIds:)`.
+    func applyLibrarySync(artistsChanged changed: [Artist], removedIds: [String]) {
+        guard session != nil else { return }
+        if !changed.isEmpty {
+            let byId = Dictionary(changed.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+            for index in artists.indices {
+                if let fresh = byId[artists[index].id] { artists[index] = fresh }
+            }
+        }
+        if !removedIds.isEmpty {
+            let gone = Set(removedIds)
+            artists.removeAll { gone.contains($0.id) }
+        }
+    }
+
+    /// Track twin of `applyLibrarySync(albumsChanged:removedIds:)` — tracks
+    /// have no removal reconciliation in the core (see #431), so only
+    /// changed rows arrive.
+    func applyLibrarySync(tracksChanged changed: [Track]) {
+        guard session != nil, !changed.isEmpty else { return }
+        let byId = Dictionary(changed.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+        for index in tracks.indices {
+            if let fresh = byId[tracks[index].id] { tracks[index] = fresh }
+        }
+    }
+
+    /// End-of-sync bookkeeping: adopt the server-authoritative totals so the
+    /// "N of M" sublines and load-more triggers reflect reality even when
+    /// the cached emit ran before any network page. Totals of 0 mean that
+    /// phase failed — keep whatever the regular fetch path reported.
+    func libraryRevalidationDidComplete(_ summary: LibrarySyncSummary) {
+        guard session != nil else { return }
+        if summary.albumTotal > 0 { albumsTotal = summary.albumTotal }
+        if summary.artistTotal > 0 { artistsTotal = summary.artistTotal }
+        if summary.trackTotal > 0 { tracksTotal = summary.trackTotal }
+        Log.app.info(
+            "library revalidation done: albums \(summary.albumsChanged) changed / \(summary.albumsRemoved) removed of \(summary.albumTotal); artists \(summary.artistsChanged)/\(summary.artistsRemoved) of \(summary.artistTotal); tracks \(summary.tracksChanged) changed of \(summary.trackTotal)\(summary.didFullAlbumSync ? " [full album walk]" : "")\(summary.trackDeltaTruncated ? " [track delta truncated]" : "")"
+        )
+        if !summary.phaseErrors.isEmpty {
+            Log.app.error("library revalidation partial failure: \(summary.phaseErrors.joined(separator: "; "), privacy: .public)")
+        }
+    }
+}
+
+/// UniFFI callback bridge for the core's library revalidation (#431).
+///
+/// The core invokes these methods on its tokio runtime threads; each one
+/// marshals onto the main actor before touching `AppModel` (gap pattern #2,
+/// inverted direction). Holds the model weakly — a sync outliving the model
+/// (quit, logout teardown) just drops its updates.
+///
+/// `@unchecked Sendable`: the only state is a `weak` reference assigned once
+/// in `init`; ARC weak loads are thread-safe, and all reads happen inside the
+/// main-actor hop.
+final class LibrarySyncBridge: LibrarySyncObserver, @unchecked Sendable {
+    private weak var model: AppModel?
+
+    init(model: AppModel) {
+        self.model = model
+    }
+
+    func albumsChanged(changed: [Album], removedIds: [String]) {
+        let model = model
+        Task { @MainActor in
+            model?.applyLibrarySync(albumsChanged: changed, removedIds: removedIds)
+        }
+    }
+
+    func artistsChanged(changed: [Artist], removedIds: [String]) {
+        let model = model
+        Task { @MainActor in
+            model?.applyLibrarySync(artistsChanged: changed, removedIds: removedIds)
+        }
+    }
+
+    func tracksChanged(changed: [Track]) {
+        let model = model
+        Task { @MainActor in
+            model?.applyLibrarySync(tracksChanged: changed)
+        }
+    }
+
+    func syncCompleted(summary: LibrarySyncSummary) {
+        let model = model
+        Task { @MainActor in
+            model?.libraryRevalidationDidComplete(summary)
+        }
+    }
+
+    func syncFailed(message: String) {
+        // Best-effort background refresh: log, never banner. The foreground
+        // fetch paths own user-visible error surfacing (incl. auth expiry).
+        Log.app.error("library revalidation failed: \(message, privacy: .public)")
+    }
+}


### PR DESCRIPTION
Cold launches re-fetched the whole library every time, so on a slow link the user stared at a spinner — this makes launch cache-first with background revalidation. Closes #431.

## Design

**Core (`core/src/library_cache.rs`, new):**
- **Persist-on-fetch** — `list_albums` / `list_artists` / `list_recently_added_artists` / `list_tracks` write their pages through to the schema-prepared `album_cache` / `artist_cache` / `track_cache` tables as JSON rows keyed by id (best-effort; a cache write failure never fails the fetch). Migration `003` adds a precomputed `sort_key` column + index per table so cached reads are an index walk, not a full-table JSON parse.
- **Cache-first reads** — new FFIs `list_cached_albums/artists/tracks(limit)` serve the first N rows in display order straight from SQLite; no network, no session required.
- **Background revalidation** — new FFI `revalidate_library(observer)` spawns a sync on the core's tokio runtime and returns immediately (`false` when no session or a sync is already in flight; panic-safe in-flight guard). The `Inner` mutex is never held across network or DB I/O — the task owns its own `Arc<JellyfinClient>` / `Arc<Database>`. Changed/removed rows stream to the UI through a `uniffi::CallbackInterface` (`LibrarySyncObserver`), terminated by exactly one `sync_completed(summary)` / `sync_failed`.
- **Per-entity strategy** (each shaped by live probes of Jellyfin 10.11):
  - *Albums*: `MinDateLastSaved` delta when a checkpoint exists, full paged walk otherwise (first page sequential for the total, then 3-way concurrent fan-out). After a delta, `cached count != server TotalRecordCount` ⇒ deletions happened (deltas can only add/update) ⇒ full reconcile walk; a degenerate delta (≥ half the library re-saved, e.g. a metadata refresh task) folds into the walk too.
  - *Artists*: full walk, **gated on album-phase activity** — verified live that `/Artists/AlbumArtists` ignores `MinDateLastSaved`, and its `ItemCounts` projection costs ~10s/page cold on a 20k-album library. Every artist-affecting mutation re-saves album rows, so a quiet album delta implies a quiet artist list; a cold artist cache walks unconditionally.
  - *Tracks*: delta only, capped at 40 pages/sync; the track cache fills progressively via persist-on-fetch. No proactive 157k-track mirror walk, no track removal reconciliation (stale rows are replaced as the regular fetch paths touch the same window) — stated scope cut, see below.
- **Diff = JSON equality of the serialized model** rather than an Etag/DateModified hash: strictly stronger (also catches `UserData` changes), needs no model changes, and requires both writers to share one projection — hence the canonical `albums_query` / `tracks_query` builders extracted in `client.rs` (the only `client.rs` change).
- Checkpoints stored per user (`library_last_sync_{albums,tracks}_{user_id}`), captured before each phase and rewound 5 min for clock skew. A user-switch guard aborts mid-sync writes; logout wipes the cache (existing `clear_user_data`), and a *different* user logging in over a token-forgotten session wipes it too (new `library_cache_user_id` ownership key).

**macOS (`AppModel+LibraryCache.swift`, new; 2 small edits to `AppModel+Library.swift`):**
- `refreshLibrary()` now emits cached rows first (`loadCachedLibraryIfEmpty`, off-main `Task.detached`, re-checked after the await so fresh data is never clobbered), then runs the normal network refresh, then kicks `startLibraryRevalidation()`.
- `LibrarySyncBridge` implements the generated observer protocol; callbacks arrive on the core's runtime threads and marshal to the main actor, updating loaded rows in place by id, dropping removed rows, and adopting server totals from the sync summary. Sync failures log only — the foreground fetch paths own user-visible errors.
- `AppModel.swift` / `LyrebirdApp.swift` untouched.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test` — all green (304 lib tests; 12 new in `core/src/tests/library_cache.rs` covering sort-key collation, upsert diff semantics, ordering/limits, corrupt-row skip, logout/user-switch wipes, persist-on-fetch round-trip, first-sync full walk, delta-emits-only-changes + removal reconcile, no-op delta request shape, artist-walk gating, session-required guard).
- Bindings + xcframework regenerated (`build-core.sh`); `rm -rf macos/.build && swift build --package-path macos` and `swift test --package-path macos` (957 tests) — green.
- New env-gated live test `library_cache_persist_on_fetch_round_trips` in `core/tests/e2e_live.rs` (cold-cache empty → fetch → warm cached read, with a local-read latency bound).
- Live run against `music.skalthoff.com` (20,060 albums / 3,213 artists / 157,578 tracks): first sync full-walks and populates the cache in ~133s (summary totals exact, zero phase errors; an in-flight overlap attempt is refused); warm cached read of 100 albums takes **~0.6ms** (acceptance: <50ms); a no-op delta day completes in **~3.5s** on the cheap path — 2 album requests + 2 track requests, zero emissions, reconcile and artist walk both skipped.

## Scope cuts (stated)

- Track cache is persist-on-fetch + delta-refresh only — no full-mirror bootstrap walk and no track removal reconciliation (a 157k-track walk per launch is the wrong trade; follow-up if a full offline mirror is wanted).
- Cached display order is an article-stripped casefold approximation of Jellyfin's `SortName`; the revalidation/network refresh replaces visible rows with authoritative ordering within seconds.
