### PR TITLE
feat(macos): 10-band graphic equalizer with presets

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Equalizer.swift
+++ b/macos/Sources/Lyrebird/AppModel+Equalizer.swift
@@ -1,0 +1,38 @@
+import Foundation
+import LyrebirdAudio
+
+/// Equalizer routing (#40).
+///
+/// `EqualizerSettings` is the value type (defined in `LyrebirdAudio` next to
+/// the node it drives); this extension is the app-side glue: persist edits to
+/// `UserDefaults` and push them onto the engine, which applies them to the
+/// live `AVAudioUnitEQ` when the DSP pipeline (#39) is running. The canonical
+/// in-memory copy lives on `AudioEngine.equalizer` — seeded once in
+/// `AppModel.init` from the persisted defaults — so there is exactly one
+/// source of truth between the Preferences pane and the audio graph.
+extension AppModel {
+    /// Current equalizer settings as held by the engine. The Preferences
+    /// pane snapshots this into local `@State` on appear and writes back
+    /// through `setEqualizer(_:)`.
+    var equalizerSettings: EqualizerSettings {
+        audio.equalizer
+    }
+
+    /// Whether the AVAudioEngine DSP path is actually routing playback this
+    /// session. Distinct from `supportsEngineDSP`, which reads the defaults
+    /// key *live*: right after the user flips the engine opt-in toggle the
+    /// two disagree until relaunch (the engine path is chosen once at
+    /// launch). UI that controls the real EQ node must gate on this one.
+    var engineDSPActiveThisSession: Bool {
+        audio.dspPipelineEnabled
+    }
+
+    /// Persist new equalizer settings and push them onto the engine. When
+    /// the DSP pipeline is live the band gains/bypass flags change in real
+    /// time (no graph rebuild); when it isn't, the settings still persist so
+    /// the curve is waiting once the engine path is enabled.
+    func setEqualizer(_ settings: EqualizerSettings) {
+        audio.equalizer = settings
+        settings.save(to: .standard)
+    }
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -867,6 +867,11 @@ final class AppModel {
         // never constructs the DSP pipeline and every transport call takes
         // the AVQueuePlayer path unchanged. See `supportsEngineDSP`.
         self.audio.dspPipelineEnabled = supportsEngineDSP
+        // Equalizer (#40): seed the persisted EQ curve so the pipeline's EQ
+        // node is configured from the first DSP-routed track (the engine
+        // re-applies it whenever the pipeline is (re)built). With the DSP
+        // flag off this is inert state. See `AppModel+Equalizer.swift`.
+        self.audio.equalizer = EqualizerSettings.load(from: .standard)
         // Streaming quality (#260): seed the engine's transcode ceiling from the
         // persisted Streaming Quality preference so the first track honours it
         // without waiting for a `play(tracks:)`. Defaults to 320 kbps when the

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -110,14 +110,14 @@ extension AppModel {
     /// `AudioEngine` routes play/pause/seek/advance through the streaming
     /// AVAudioEngine pipeline (`EngineDSPPipeline`: player node →
     /// `AVAudioUnitEQ` → main mixer) instead of `AVQueuePlayer`. The pipeline
-    /// is the foundation for EQ (#40) and crossfade (#41) — neither UI ships
-    /// yet, so the EQ node runs flat/bypassed and this flag defaults to
-    /// **off**: a missing key reads `false`, and nothing in the app writes it,
-    /// so playback stays byte-for-byte on the AVQueuePlayer path until the
-    /// user (or a future Settings toggle from #40/#41) opts in via the
-    /// defaults key above. Read once at launch (`AppModel.init` seeds
+    /// hosts the equalizer (#40) and is the foundation for crossfade (#41).
+    /// Defaults to **off**: a missing key reads `false`, so playback stays
+    /// byte-for-byte on the AVQueuePlayer path until the user opts in — via
+    /// the Preferences ▸ Equalizer engine toggle (which writes this key) or
+    /// `defaults write`. Read once at launch (`AppModel.init` seeds
     /// `audio.dspPipelineEnabled`); relaunch to apply — flipping mid-session
-    /// would strand a live player on the other path.
+    /// would strand a live player on the other path. UI that drives the live
+    /// EQ node therefore gates on `engineDSPActiveThisSession`, not this.
     var supportsEngineDSP: Bool {
         UserDefaults.standard.bool(forKey: AppModel.engineDSPDefaultsKey)
     }

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesEqualizer.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesEqualizer.swift
@@ -1,0 +1,301 @@
+import LyrebirdAudio
+import SwiftUI
+
+/// Equalizer preferences pane (#40): the 10-band graphic EQ with the classic
+/// iTunes-style preset list, riding the AVAudioEngine DSP pipeline (#39).
+///
+/// Layout: an engine opt-in section (the DSP path is chosen once at launch,
+/// so the toggle advertises the relaunch), the enable/preset/reset controls,
+/// and the band slider stack. The EQ controls follow the app's gated-feature
+/// idiom (see the crossfade slider in `PreferencesPlayback`): visible but
+/// disabled + dimmed while the DSP engine isn't routing playback this
+/// session, with the footnote explaining why instead of hiding the pane.
+///
+/// State flow: the pane snapshots `model.equalizerSettings` into local
+/// `@State` on appear and pushes every edit through `model.setEqualizer(_:)`,
+/// which persists to `UserDefaults` and applies to the live `AVAudioUnitEQ`
+/// in real time — no Apply button, matching every other pane.
+///
+/// Preference keys:
+/// - `engine.useAVAudioEngine` — DSP engine opt-in (#39, read at launch)
+/// - `audio.eq.enabled` / `audio.eq.preset` / `audio.eq.customGains` (#40)
+struct PreferencesEqualizer: View {
+    @Environment(AppModel.self) private var model
+
+    /// DSP engine opt-in (#39). Written live; `AudioEngine` reads it once at
+    /// launch, hence the relaunch hint when it diverges from the running path.
+    @AppStorage(AppModel.engineDSPDefaultsKey) private var dspOptIn: Bool = false
+
+    /// Local working copy; the engine's `equalizer` is the canonical one.
+    @State private var settings = EqualizerSettings()
+
+    /// Whether the DSP pipeline is routing playback *this session* — the EQ
+    /// node only exists on that path, so the controls gate on this rather
+    /// than on the live defaults key.
+    private var eqActive: Bool { model.engineDSPActiveThisSession }
+
+    private var needsRelaunch: Bool { dspOptIn != model.engineDSPActiveThisSession }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+
+            PreferenceSection(
+                title: "Playback Engine",
+                footnote: "The equalizer runs on Lyrebird's DSP engine, which routes playback through an effect graph instead of the system player. Off — the default — keeps streaming on the original bit-perfect path. Changing this takes effect after relaunching Lyrebird."
+            ) {
+                PreferenceRow(
+                    label: "DSP Audio Engine",
+                    help: needsRelaunch
+                        ? "Relaunch Lyrebird to \(dspOptIn ? "activate the DSP engine" : "return to the system player")."
+                        : (dspOptIn ? "Active — the equalizer is live." : "Off — the equalizer is unavailable.")
+                ) {
+                    Toggle("", isOn: $dspOptIn)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("DSP audio engine")
+                }
+            }
+
+            PreferenceSection(
+                title: "Equalizer",
+                footnote: eqActive
+                    ? "Preset and band changes apply in real time. With the equalizer off — or any band at 0 dB — that stage is bypassed entirely, so Flat is bit-identical to no EQ."
+                    : "Requires the DSP engine above. Your settings are saved and will apply once it's active."
+            ) {
+                PreferenceRow(label: "Enable Equalizer") {
+                    Toggle("", isOn: enabledBinding)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Enable equalizer")
+                }
+
+                PreferenceRow(label: "Preset", help: presetHelp) {
+                    HStack(spacing: 10) {
+                        Picker("", selection: presetBinding) {
+                            ForEach(EqualizerPreset.all) { preset in
+                                Text(preset.name).tag(preset.id)
+                            }
+                            Text("Custom").tag(EqualizerPreset.customID)
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 160)
+                        .accessibilityLabel("Equalizer preset")
+
+                        Button("Reset") { reset() }
+                            .disabled(settings.presetID == EqualizerPreset.flat.id && settings.isActiveCurveFlat)
+                            .help("Return to the Flat preset and zero the custom curve.")
+                            .accessibilityLabel("Reset equalizer")
+                    }
+                }
+            }
+            .disabled(!eqActive)
+            .opacity(eqActive ? 1 : 0.55)
+
+            PreferenceSection(
+                title: "Bands",
+                footnote: "Per-band gain from −12 dB to +12 dB across the standard octave centers. Dragging a slider switches the preset to Custom."
+            ) {
+                bandStack
+            }
+            .disabled(!eqActive || !settings.isEnabled)
+            .opacity(eqActive && settings.isEnabled ? 1 : 0.55)
+
+            Spacer(minLength: 0)
+        }
+        .onAppear { settings = model.equalizerSettings }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Equalizer")
+                .font(Theme.font(28, weight: .black, italic: true))
+                .foregroundStyle(Theme.ink)
+            Text("10-band graphic equalizer with presets.")
+                .font(Theme.font(13, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { settings.isEnabled },
+            set: { enabled in
+                settings.isEnabled = enabled
+                apply()
+            }
+        )
+    }
+
+    private var presetBinding: Binding<String> {
+        Binding(
+            get: { settings.presetID },
+            set: { id in
+                settings.presetID = id
+                apply()
+            }
+        )
+    }
+
+    /// Per-band slider binding. Writing while a named preset is selected
+    /// forks it into Custom seeded from that preset's curve — the universal
+    /// EQ behaviour (Music.app, foobar2000, …), and the reason `customGains`
+    /// is captured from `activeGains` rather than overwritten blind.
+    private func bandBinding(_ index: Int) -> Binding<Float> {
+        Binding(
+            get: { settings.activeGains[index] },
+            set: { newValue in
+                var gains = settings.activeGains
+                gains[index] = newValue
+                settings.customGains = gains
+                settings.presetID = EqualizerPreset.customID
+                apply()
+            }
+        )
+    }
+
+    private func apply() {
+        model.setEqualizer(settings)
+    }
+
+    private func reset() {
+        settings.presetID = EqualizerPreset.flat.id
+        settings.customGains = [Float](repeating: 0, count: EqualizerSettings.bandCount)
+        apply()
+    }
+
+    private var presetHelp: String? {
+        settings.presetID == EqualizerPreset.customID ? "Your own curve — adjust the bands below." : nil
+    }
+
+    // MARK: - Band sliders
+
+    private var bandStack: some View {
+        HStack(alignment: .top, spacing: 6) {
+            dbAxis
+            ForEach(0..<EqualizerSettings.bandCount, id: \.self) { index in
+                BandColumn(
+                    frequency: EqualizerSettings.bandFrequencies[index],
+                    gain: bandBinding(index)
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, 4)
+    }
+
+    /// Leading dB scale: top/center/bottom of the slider track height, with
+    /// an empty readout slot above and a label slot below so the marks align
+    /// with the sliders' tracks rather than the columns' full height.
+    private var dbAxis: some View {
+        VStack(spacing: 6) {
+            Text(" ")
+                .font(Theme.font(10, weight: .semibold))
+            VStack {
+                Text("+12")
+                Spacer()
+                Text("0")
+                Spacer()
+                Text("−12")
+            }
+            .font(Theme.font(9, weight: .semibold))
+            .foregroundStyle(Theme.ink3)
+            .monospacedDigit()
+            .frame(height: BandColumn.trackLength)
+            Text(" ")
+                .font(Theme.font(10, weight: .semibold))
+        }
+        .accessibilityHidden(true)
+    }
+
+    /// "31" … "500", then "1K" … "16K" — compact axis labels.
+    static func frequencyLabel(_ hz: Float) -> String {
+        hz >= 1_000 ? "\(Int(hz / 1_000))K" : "\(Int(hz))"
+    }
+}
+
+/// One EQ band: gain readout on top, vertical slider, frequency label below.
+///
+/// SwiftUI has no native vertical `Slider`; the standard macOS technique is a
+/// horizontal slider rotated −90° (right → up) inside a fixed frame that
+/// reserves the rotated footprint. `rotationEffect` transforms hit-testing
+/// along with rendering, so dragging tracks the visual orientation.
+private struct BandColumn: View {
+    static let trackLength: CGFloat = 150
+
+    let frequency: Float
+    @Binding var gain: Float
+
+    private var frequencyLabel: String {
+        PreferencesEqualizer.frequencyLabel(frequency)
+    }
+
+    private var accessibilityFrequency: String {
+        frequency >= 1_000 ? "\(Int(frequency / 1_000)) kilohertz" : "\(Int(frequency)) hertz"
+    }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(readout)
+                .font(Theme.font(10, weight: .semibold))
+                .foregroundStyle(gain == 0 ? Theme.ink3 : Theme.ink)
+                .monospacedDigit()
+                .lineLimit(1)
+                .fixedSize()
+
+            Slider(
+                value: $gain,
+                in: EqualizerSettings.gainRange,
+                step: 0.5
+            )
+            .frame(width: BandColumn.trackLength)
+            .rotationEffect(.degrees(-90))
+            .frame(width: 32, height: BandColumn.trackLength)
+
+            Text(frequencyLabel)
+                .font(Theme.font(10, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
+                .lineLimit(1)
+                .fixedSize()
+        }
+        .frame(width: 38)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(accessibilityFrequency) band")
+        .accessibilityValue(accessibilityReadout)
+        .accessibilityAdjustableAction { direction in
+            let step: Float = direction == .increment ? 1 : -1
+            gain = min(
+                max(gain + step, EqualizerSettings.gainRange.lowerBound),
+                EqualizerSettings.gainRange.upperBound
+            )
+        }
+    }
+
+    /// "+4", "−2.5", "0" — unicode minus per the app's audio-copy convention
+    /// (see `PreGainSlider`), halves only when the value actually has one.
+    private var readout: String {
+        if gain == 0 { return "0" }
+        let sign = gain > 0 ? "+" : "−"
+        let magnitude = abs(gain)
+        let isWhole = magnitude.rounded() == magnitude
+        return sign + (isWhole ? "\(Int(magnitude))" : String(format: "%.1f", magnitude))
+    }
+
+    private var accessibilityReadout: String {
+        if gain == 0 { return "0 decibels" }
+        let direction = gain > 0 ? "plus" : "minus"
+        let magnitude = abs(gain)
+        let isWhole = magnitude.rounded() == magnitude
+        let value = isWhole ? "\(Int(magnitude))" : String(format: "%.1f", magnitude)
+        return "\(direction) \(value) decibels"
+    }
+}
+
+// Note: real rendering requires an `AppModel` in the environment — the pane
+// routes EQ changes onto the live engine through it. The Settings scene
+// injects it at runtime; a bare `#Preview` would crash on the missing
+// environment value, so it's intentionally omitted here — matching
+// `PreferencesAudio` / `PreferencesPlayback`.

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesEqualizer.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesEqualizer.swift
@@ -84,7 +84,10 @@ struct PreferencesEqualizer: View {
                         .accessibilityLabel("Equalizer preset")
 
                         Button("Reset") { reset() }
-                            .disabled(settings.presetID == EqualizerPreset.flat.id && settings.isActiveCurveFlat)
+                            .disabled(
+                                settings.presetID == EqualizerPreset.flat.id
+                                    && settings.customGains.allSatisfy { $0 == 0 }
+                            )
                             .help("Return to the Flat preset and zero the custom curve.")
                             .accessibilityLabel("Reset equalizer")
                     }

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// other caller that wants the minimal account view).
 struct PreferencesView: View {
     enum Pane: String, CaseIterable, Hashable, Identifiable {
-        case general, server, playback, audio, library, appearance, keyboard, notifications, scrobbling, lyrics, downloads, advanced, experiments, about
+        case general, server, playback, audio, equalizer, library, appearance, keyboard, notifications, scrobbling, lyrics, downloads, advanced, experiments, about
 
         var id: String { rawValue }
 
@@ -28,6 +28,7 @@ struct PreferencesView: View {
             case .server: return "Server"
             case .playback: return "Playback"
             case .audio: return "Audio"
+            case .equalizer: return "Equalizer"
             case .library: return "Library"
             case .appearance: return "Appearance"
             case .keyboard: return "Keyboard"
@@ -47,6 +48,7 @@ struct PreferencesView: View {
             case .server: return "server.rack"
             case .playback: return "play.circle"
             case .audio: return "speaker.wave.2"
+            case .equalizer: return "slider.vertical.3"
             case .library: return "music.note.list"
             case .appearance: return "paintpalette"
             case .keyboard: return "keyboard"
@@ -91,6 +93,7 @@ struct PreferencesView: View {
         case .server: PreferencesServer()
         case .playback: PreferencesPlayback()
         case .audio: PreferencesAudio()
+        case .equalizer: PreferencesEqualizer()
         case .library: PreferencesLibrary()
         case .appearance: AppearancePane()
         case .keyboard: PreferencesKeyboard()

--- a/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
@@ -54,6 +54,10 @@ extension AudioEngine {
             self.onTrackEnded?()
         }
         pipeline.setOutputDevice(uid: outputDeviceUID)
+        // Re-apply the persisted EQ curve (#40) — the pipeline constructs
+        // flat/bypassed, so a rebuild (or the first DSP-routed play of the
+        // session) must restore the user's settings before audio renders.
+        pipeline.applyEqualizer(equalizer)
         dspPipeline = pipeline
         return pipeline
     }

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -106,6 +106,17 @@ public final class AudioEngine: NSObject {
     /// non-nil after the first DSP-routed `play(track:)`; see
     /// `AudioEngine+DSP.swift`.
     var dspPipeline: EngineDSPPipeline?
+
+    /// 10-band graphic-equalizer state (#40). Seeded at startup by the owner
+    /// (`AppModel`) from the persisted defaults and pushed again on every
+    /// Preferences edit; assignment applies to the live pipeline's EQ node
+    /// immediately, and `dspEnsurePipeline` re-applies it on construction so
+    /// the curve survives pipeline rebuilds. With the DSP flag off this only
+    /// holds state — the pipeline (and its EQ node) is never constructed, so
+    /// the AVQueuePlayer path stays byte-for-byte untouched.
+    public var equalizer: EqualizerSettings = EqualizerSettings() {
+        didSet { dspPipeline?.applyEqualizer(equalizer) }
+    }
     private var timeObserver: Any?
     private var endObserver: NSObjectProtocol?
     private var rateObservation: NSKeyValueObservation?

--- a/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
+++ b/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
@@ -391,15 +391,36 @@ public final class EngineDSPPipeline {
 
     /// Standard 10-band layout (31 Hz … 16 kHz), flat. `bypass = true` on
     /// every band plus `globalGain = 0` guarantees the engine path is
-    /// audibly identical to no-EQ until #40 ships controls.
+    /// audibly identical to no-EQ until `applyEqualizer` installs the
+    /// user's settings (#40).
     private func configureFlatEQ() {
-        let frequencies: [Float] = [31, 62, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000]
+        let frequencies = EqualizerSettings.bandFrequencies
         for (index, band) in eq.bands.enumerated() {
             band.filterType = .parametric
             band.frequency = index < frequencies.count ? frequencies[index] : 1_000
             band.bandwidth = 0.5
             band.gain = 0
             band.bypass = true
+        }
+        eq.globalGain = 0
+    }
+
+    /// Drive the live EQ node from user settings (#40). Safe to call at any
+    /// time — `AVAudioUnitEQ` band parameters apply in real time, so preset
+    /// switches and slider drags take effect mid-render without a graph
+    /// rebuild (and without clicks; the unit ramps parameter changes).
+    ///
+    /// Bit-perfect contract: a band whose gain is 0 — and *every* band while
+    /// `isEnabled == false` — is bypassed outright rather than run as a
+    /// zero-gain filter, so EQ-off and the Flat preset are bit-identical to
+    /// the engine-disabled output. `globalGain` stays 0; the issue reserves
+    /// make-up gain for a future loudness pass.
+    public func applyEqualizer(_ settings: EqualizerSettings) {
+        let gains = settings.activeGains
+        for (index, band) in eq.bands.enumerated() {
+            let gain = index < gains.count ? gains[index] : 0
+            band.gain = gain
+            band.bypass = !settings.isEnabled || gain == 0
         }
         eq.globalGain = 0
     }

--- a/macos/Sources/LyrebirdAudio/EqualizerSettings.swift
+++ b/macos/Sources/LyrebirdAudio/EqualizerSettings.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+/// User-facing 10-band graphic-equalizer state (#40).
+///
+/// The DSP pipeline (#39) keeps an `AVAudioUnitEQ(numberOfBands: 10)` live in
+/// its node graph; this struct is the single value type that flows from the
+/// Preferences pane through `AppModel` → `AudioEngine.equalizer` →
+/// `EngineDSPPipeline.applyEqualizer(_:)` onto that node, and round-trips to
+/// `UserDefaults` so the curve survives relaunch.
+///
+/// Three facts persist (`audio.eq.*` keys):
+/// - `isEnabled` — global enable. Off means every band is bypassed, which is
+///   the bit-perfect contract the issue demands ("Off" must equal the
+///   engine-disabled output, not "all gains zero through live filters").
+/// - `presetID` — the selected entry of `EqualizerPreset.all`, or
+///   `EqualizerPreset.customID` for the user's own curve.
+/// - `customGains` — the custom slider positions, kept even while a named
+///   preset is selected so switching back to Custom restores them.
+///
+/// The *active* curve is always derived (`activeGains`), never stored twice —
+/// a named preset resolves through the preset table, Custom resolves through
+/// `customGains`, and an unknown id (a renamed/removed preset from a future
+/// build) degrades to Flat instead of crashing or persisting garbage.
+public struct EqualizerSettings: Equatable, Sendable {
+    // MARK: - Band layout
+
+    /// Matches `EngineDSPPipeline.configureFlatEQ` — the standard 10-band
+    /// ISO octave centers. Index i of any gains array maps to this frequency.
+    public static let bandFrequencies: [Float] = [
+        31, 62, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000,
+    ]
+
+    public static var bandCount: Int { bandFrequencies.count }
+
+    /// Per-band gain range in dB. ±12 matches the macOS Music.app EQ window
+    /// and keeps any single band well inside `AVAudioUnitEQ`'s ±96 dB limits.
+    public static let gainRange: ClosedRange<Float> = -12...12
+
+    // MARK: - State
+
+    /// Global enable. `false` bypasses every band (bit-perfect off).
+    public var isEnabled: Bool
+
+    /// Selected preset id — an `EqualizerPreset.all` id or
+    /// `EqualizerPreset.customID`.
+    public var presetID: String
+
+    /// The user's custom curve. Normalized on init; consumers re-normalize
+    /// at point of use so a hand-mutated value can never push an out-of-range
+    /// gain into the audio node or the defaults plist.
+    public var customGains: [Float]
+
+    public init(
+        isEnabled: Bool = false,
+        presetID: String = EqualizerPreset.flat.id,
+        customGains: [Float] = [Float](repeating: 0, count: EqualizerSettings.bandCount)
+    ) {
+        self.isEnabled = isEnabled
+        self.presetID = presetID
+        self.customGains = EqualizerSettings.normalizedGains(customGains)
+    }
+
+    /// The curve the EQ node should run right now: the named preset's table
+    /// entry, the custom gains, or Flat when `presetID` doesn't resolve.
+    /// Always exactly `bandCount` values, each clamped to `gainRange`.
+    public var activeGains: [Float] {
+        if presetID == EqualizerPreset.customID {
+            return EqualizerSettings.normalizedGains(customGains)
+        }
+        guard let preset = EqualizerPreset.preset(id: presetID) else {
+            return EqualizerPreset.flat.gains
+        }
+        return EqualizerSettings.normalizedGains(preset.gains)
+    }
+
+    /// True when the active curve is all-zero — together with band-level
+    /// bypass this is what makes the Flat preset bit-identical to no EQ.
+    public var isActiveCurveFlat: Bool {
+        activeGains.allSatisfy { $0 == 0 }
+    }
+
+    // MARK: - Normalization
+
+    /// Coerce an arbitrary gains array into a valid curve: clamp each value
+    /// to `gainRange`, zero non-finite values (a corrupted plist must never
+    /// reach the audio node), truncate extras, and pad short arrays with 0.
+    public static func normalizedGains(_ gains: [Float]) -> [Float] {
+        var result = gains.prefix(bandCount).map { gain -> Float in
+            guard gain.isFinite else { return 0 }
+            return min(max(gain, gainRange.lowerBound), gainRange.upperBound)
+        }
+        while result.count < bandCount {
+            result.append(0)
+        }
+        return Array(result)
+    }
+
+    // MARK: - Persistence
+
+    /// `UserDefaults` keys. Dotted `audio.*` namespace matches the app's other
+    /// audio preferences (`audio.transcodingPreference`, `audio.outputDevice`).
+    public enum DefaultsKey {
+        public static let enabled = "audio.eq.enabled"
+        public static let preset = "audio.eq.preset"
+        public static let customGains = "audio.eq.customGains"
+    }
+
+    /// Load persisted settings; missing/partial keys fall back to the shipped
+    /// default (disabled, Flat, zeroed custom curve) so a fresh install and a
+    /// pre-#40 profile both come up bit-perfect.
+    public static func load(from defaults: UserDefaults) -> EqualizerSettings {
+        let enabled = defaults.bool(forKey: DefaultsKey.enabled)
+        let storedPreset = defaults.string(forKey: DefaultsKey.preset)
+        let presetID: String = {
+            guard let storedPreset else { return EqualizerPreset.flat.id }
+            let known = storedPreset == EqualizerPreset.customID
+                || EqualizerPreset.preset(id: storedPreset) != nil
+            return known ? storedPreset : EqualizerPreset.flat.id
+        }()
+        let storedGains = (defaults.array(forKey: DefaultsKey.customGains) as? [Double]) ?? []
+        return EqualizerSettings(
+            isEnabled: enabled,
+            presetID: presetID,
+            customGains: normalizedGains(storedGains.map(Float.init))
+        )
+    }
+
+    /// Persist all three facts. Gains are written as `[Double]` (a plist-
+    /// native array) rather than encoded blobs so `defaults read` stays
+    /// inspectable for support/debugging.
+    public func save(to defaults: UserDefaults) {
+        defaults.set(isEnabled, forKey: DefaultsKey.enabled)
+        defaults.set(presetID, forKey: DefaultsKey.preset)
+        defaults.set(
+            EqualizerSettings.normalizedGains(customGains).map(Double.init),
+            forKey: DefaultsKey.customGains
+        )
+    }
+}
+
+/// A named EQ curve. The table mirrors the classic iTunes / Music.app preset
+/// set — the values come straight from issue #40's spec so users moving over
+/// from Music find the names *and* the curves they expect.
+public struct EqualizerPreset: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let name: String
+    /// Exactly `EqualizerSettings.bandCount` per-band dB gains, low→high.
+    public let gains: [Float]
+
+    /// Sentinel id for the user's own curve. Not a member of `all` — the
+    /// UI appends its own "Custom" row so the preset table stays purely the
+    /// named curves.
+    public static let customID = "custom"
+
+    public static let flat = EqualizerPreset(
+        id: "flat", name: "Flat",
+        gains: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    public static let bassBoost = EqualizerPreset(
+        id: "bassBoost", name: "Bass Boost",
+        gains: [6, 5, 4, 3, 1, 0, 0, 0, 0, 0])
+    public static let trebleBoost = EqualizerPreset(
+        id: "trebleBoost", name: "Treble Boost",
+        gains: [0, 0, 0, 0, 0, 1, 3, 5, 6, 6])
+    public static let bassAndTreble = EqualizerPreset(
+        id: "bassAndTreble", name: "Bass & Treble",
+        gains: [5, 4, 3, 1, 0, 0, 2, 3, 5, 5])
+    public static let vocalBoost = EqualizerPreset(
+        id: "vocalBoost", name: "Vocal Boost",
+        gains: [-2, -1, 0, 1, 3, 4, 3, 1, 0, -1])
+    public static let acoustic = EqualizerPreset(
+        id: "acoustic", name: "Acoustic",
+        gains: [4, 4, 3, 1, 2, 2, 3, 4, 3, 2])
+    public static let dance = EqualizerPreset(
+        id: "dance", name: "Dance",
+        gains: [4, 6, 5, 0, 1, 3, 5, 4, 3, 0])
+    public static let electronic = EqualizerPreset(
+        id: "electronic", name: "Electronic",
+        gains: [4, 4, 2, 0, -2, 2, 1, 2, 4, 5])
+    public static let hipHop = EqualizerPreset(
+        id: "hipHop", name: "Hip-Hop",
+        gains: [5, 4, 1, 3, -1, -1, 1, -1, 2, 3])
+    public static let jazz = EqualizerPreset(
+        id: "jazz", name: "Jazz",
+        gains: [4, 3, 2, 2, -1, -1, 0, 1, 2, 3])
+    public static let classical = EqualizerPreset(
+        id: "classical", name: "Classical",
+        gains: [5, 4, 3, 2, -2, -2, 0, 2, 3, 4])
+    public static let rock = EqualizerPreset(
+        id: "rock", name: "Rock",
+        gains: [5, 4, 3, 1, -1, -1, 0, 2, 3, 4])
+    public static let pop = EqualizerPreset(
+        id: "pop", name: "Pop",
+        gains: [-1, -1, 0, 2, 4, 4, 2, 0, -1, -1])
+    public static let piano = EqualizerPreset(
+        id: "piano", name: "Piano",
+        gains: [3, 2, 0, 2, 3, 1, 3, 4, 3, 3])
+
+    /// Every named preset, Flat first, the rest alphabetical-ish in the order
+    /// the issue lists them (the order users see in the picker).
+    public static let all: [EqualizerPreset] = [
+        .flat, .bassBoost, .trebleBoost, .bassAndTreble, .vocalBoost,
+        .acoustic, .dance, .electronic, .hipHop, .jazz, .classical,
+        .rock, .pop, .piano,
+    ]
+
+    public static func preset(id: String) -> EqualizerPreset? {
+        all.first { $0.id == id }
+    }
+}

--- a/macos/Tests/LyrebirdTests/EqualizerSettingsTests.swift
+++ b/macos/Tests/LyrebirdTests/EqualizerSettingsTests.swift
@@ -1,0 +1,310 @@
+import AVFoundation
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Coverage for the 10-band graphic equalizer (#40):
+///
+///   1. The band layout (count, ISO octave centers) matches what
+///      `EngineDSPPipeline` actually configures on its `AVAudioUnitEQ`.
+///   2. Gain normalization — clamp to ±12 dB, zero non-finite values,
+///      pad/truncate to exactly 10 bands — so no corrupt persisted value can
+///      reach the audio node.
+///   3. The preset table is well-formed and `activeGains` resolves named
+///      presets / Custom / unknown ids correctly.
+///   4. `UserDefaults` persistence round-trips, and missing/garbage keys
+///      degrade to the shipped default (disabled, Flat).
+///   5. `applyEqualizer` drives band gains + bypass flags with the
+///      bit-perfect contract: disabled ⇒ all bypassed, and a 0 dB band is
+///      bypassed rather than run as a zero-gain filter.
+///   6. `AudioEngine` re-applies the stored settings when the pipeline is
+///      (re)constructed and pushes live edits onto an existing pipeline.
+@MainActor
+final class EqualizerSettingsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "eq-tests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeEngine() throws -> AudioEngine {
+        let dir = NSTemporaryDirectory() + "lyrebird-eq-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "eq-test"))
+        return AudioEngine(core: core)
+    }
+
+    // MARK: - 1. Band layout
+
+    func testBandLayoutMatchesPipelineConfiguration() {
+        XCTAssertEqual(EqualizerSettings.bandCount, 10)
+        XCTAssertEqual(
+            EqualizerSettings.bandFrequencies,
+            [31, 62, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000]
+        )
+
+        // The model's layout must be the same one the pipeline configures on
+        // the real node — index i of a gains array maps to band i.
+        let pipeline = EngineDSPPipeline()
+        XCTAssertEqual(pipeline.eq.bands.count, EqualizerSettings.bandCount)
+        XCTAssertEqual(
+            pipeline.eq.bands.map(\.frequency),
+            EqualizerSettings.bandFrequencies
+        )
+    }
+
+    // MARK: - 2. Normalization
+
+    func testNormalizedGainsClampToRange() {
+        let normalized = EqualizerSettings.normalizedGains(
+            [-30, 30, 12, -12, 5.5, 0, 1, -1, 11.9, -11.9]
+        )
+        XCTAssertEqual(normalized, [-12, 12, 12, -12, 5.5, 0, 1, -1, 11.9, -11.9])
+    }
+
+    func testNormalizedGainsPadAndTruncateToBandCount() {
+        XCTAssertEqual(
+            EqualizerSettings.normalizedGains([3, -2]),
+            [3, -2, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
+        XCTAssertEqual(
+            EqualizerSettings.normalizedGains([Float](repeating: 1, count: 14)),
+            [Float](repeating: 1, count: 10)
+        )
+        XCTAssertEqual(
+            EqualizerSettings.normalizedGains([]),
+            [Float](repeating: 0, count: 10)
+        )
+    }
+
+    func testNormalizedGainsZeroNonFiniteValues() {
+        let normalized = EqualizerSettings.normalizedGains(
+            [.nan, .infinity, -.infinity, 4, 0, 0, 0, 0, 0, 0]
+        )
+        XCTAssertEqual(normalized, [0, 0, 0, 4, 0, 0, 0, 0, 0, 0])
+    }
+
+    func testInitNormalizesCustomGains() {
+        let settings = EqualizerSettings(customGains: [99, -99, .nan])
+        XCTAssertEqual(settings.customGains, [12, -12, 0, 0, 0, 0, 0, 0, 0, 0])
+    }
+
+    // MARK: - 3. Presets
+
+    func testPresetTableIsWellFormed() {
+        XCTAssertFalse(EqualizerPreset.all.isEmpty)
+        for preset in EqualizerPreset.all {
+            XCTAssertEqual(
+                preset.gains.count, EqualizerSettings.bandCount,
+                "\(preset.id) must define a gain per band"
+            )
+            for gain in preset.gains {
+                XCTAssertTrue(
+                    EqualizerSettings.gainRange.contains(gain),
+                    "\(preset.id) gain \(gain) escapes ±12 dB"
+                )
+            }
+        }
+        // Unique ids, none colliding with the Custom sentinel.
+        let ids = EqualizerPreset.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+        XCTAssertFalse(ids.contains(EqualizerPreset.customID))
+        // Flat heads the list and is all-zero.
+        XCTAssertEqual(EqualizerPreset.all.first, EqualizerPreset.flat)
+        XCTAssertTrue(EqualizerPreset.flat.gains.allSatisfy { $0 == 0 })
+    }
+
+    func testPresetLookup() {
+        XCTAssertEqual(EqualizerPreset.preset(id: "rock"), EqualizerPreset.rock)
+        XCTAssertNil(EqualizerPreset.preset(id: "polka"))
+        XCTAssertNil(EqualizerPreset.preset(id: EqualizerPreset.customID))
+    }
+
+    func testActiveGainsResolution() {
+        // Named preset resolves through the table…
+        var settings = EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.rock.id)
+        XCTAssertEqual(settings.activeGains, EqualizerPreset.rock.gains)
+        XCTAssertFalse(settings.isActiveCurveFlat)
+
+        // …Custom resolves through customGains…
+        settings.presetID = EqualizerPreset.customID
+        settings.customGains = [1, 2, 3, 4, 5, -5, -4, -3, -2, -1]
+        XCTAssertEqual(settings.activeGains, [1, 2, 3, 4, 5, -5, -4, -3, -2, -1])
+
+        // …and an unknown id degrades to Flat instead of trapping.
+        settings.presetID = "removed-in-a-future-build"
+        XCTAssertEqual(settings.activeGains, EqualizerPreset.flat.gains)
+        XCTAssertTrue(settings.isActiveCurveFlat)
+    }
+
+    func testActiveGainsNormalizeHandMutatedCustomCurve() {
+        var settings = EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.customID)
+        // Direct property mutation skips init's normalization on purpose —
+        // the point-of-use normalization must still protect the node.
+        settings.customGains = [50, -50, .nan, 3]
+        XCTAssertEqual(settings.activeGains, [12, -12, 0, 3, 0, 0, 0, 0, 0, 0])
+    }
+
+    // MARK: - 4. Persistence
+
+    func testPersistenceRoundTrip() {
+        let original = EqualizerSettings(
+            isEnabled: true,
+            presetID: EqualizerPreset.customID,
+            customGains: [6, 5, 4, 3, 1, 0, -1, -2, -3, -4]
+        )
+        original.save(to: defaults)
+
+        let loaded = EqualizerSettings.load(from: defaults)
+        XCTAssertEqual(loaded, original)
+    }
+
+    func testNamedPresetSelectionPersists() {
+        let original = EqualizerSettings(
+            isEnabled: true,
+            presetID: EqualizerPreset.jazz.id,
+            customGains: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        )
+        original.save(to: defaults)
+
+        let loaded = EqualizerSettings.load(from: defaults)
+        XCTAssertEqual(loaded.presetID, EqualizerPreset.jazz.id)
+        XCTAssertEqual(loaded.activeGains, EqualizerPreset.jazz.gains)
+        // The custom curve survives alongside the named selection, so
+        // switching back to Custom restores it.
+        XCTAssertEqual(loaded.customGains, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    }
+
+    func testLoadDefaultsWhenKeysMissing() {
+        let loaded = EqualizerSettings.load(from: defaults)
+        XCTAssertFalse(loaded.isEnabled)
+        XCTAssertEqual(loaded.presetID, EqualizerPreset.flat.id)
+        XCTAssertTrue(loaded.isActiveCurveFlat)
+        XCTAssertEqual(loaded.customGains, [Float](repeating: 0, count: 10))
+    }
+
+    func testLoadDegradesGarbageToSafeValues() {
+        // A preset id this build doesn't know (renamed/removed preset, or a
+        // hand-edited plist) must fall back to Flat, and an out-of-range /
+        // wrong-length gains array must come back normalized.
+        defaults.set(true, forKey: EqualizerSettings.DefaultsKey.enabled)
+        defaults.set("turbo-bass-9000", forKey: EqualizerSettings.DefaultsKey.preset)
+        defaults.set([99.0, -99.0, 3.0], forKey: EqualizerSettings.DefaultsKey.customGains)
+
+        let loaded = EqualizerSettings.load(from: defaults)
+        XCTAssertTrue(loaded.isEnabled)
+        XCTAssertEqual(loaded.presetID, EqualizerPreset.flat.id)
+        XCTAssertEqual(loaded.customGains, [12, -12, 3, 0, 0, 0, 0, 0, 0, 0])
+    }
+
+    // MARK: - 5. Pipeline application
+
+    func testApplyEqualizerDrivesBandGainsAndBypass() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyEqualizer(
+            EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.rock.id)
+        )
+
+        for (index, band) in pipeline.eq.bands.enumerated() {
+            let expected = EqualizerPreset.rock.gains[index]
+            XCTAssertEqual(band.gain, expected, accuracy: 0.0001)
+            // Bit-perfect contract: only bands doing real work run.
+            XCTAssertEqual(band.bypass, expected == 0)
+        }
+        XCTAssertEqual(pipeline.eq.globalGain, 0)
+    }
+
+    func testApplyEqualizerDisabledBypassesEveryBand() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyEqualizer(
+            EqualizerSettings(isEnabled: false, presetID: EqualizerPreset.dance.id)
+        )
+        XCTAssertTrue(pipeline.eq.bands.allSatisfy(\.bypass))
+        XCTAssertEqual(pipeline.eq.globalGain, 0)
+    }
+
+    func testFlatEnabledIsFullyBypassed() {
+        // Enabled + Flat must be indistinguishable from EQ-off: every band
+        // bypassed at 0 dB — the same inert state the pipeline ships in.
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyEqualizer(
+            EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.flat.id)
+        )
+        XCTAssertTrue(pipeline.isEQFlatForTesting)
+    }
+
+    func testApplyAfterPresetRestoresBypassedBands() {
+        // Rock leaves bands 6 at 0 dB (bypassed); switching to Treble Boost
+        // must re-engage what it needs and release what it doesn't.
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyEqualizer(
+            EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.rock.id)
+        )
+        pipeline.applyEqualizer(
+            EqualizerSettings(isEnabled: true, presetID: EqualizerPreset.trebleBoost.id)
+        )
+        for (index, band) in pipeline.eq.bands.enumerated() {
+            let expected = EqualizerPreset.trebleBoost.gains[index]
+            XCTAssertEqual(band.gain, expected, accuracy: 0.0001)
+            XCTAssertEqual(band.bypass, expected == 0)
+        }
+    }
+
+    // MARK: - 6. Engine wiring
+
+    func testEngineAppliesSettingsOnPipelineConstruction() throws {
+        let engine = try makeEngine()
+        engine.equalizer = EqualizerSettings(
+            isEnabled: true, presetID: EqualizerPreset.electronic.id
+        )
+        // No pipeline yet — the assignment is just stored state.
+        XCTAssertNil(engine.dspPipeline)
+
+        // Construction must re-apply the stored curve (the node ships flat).
+        let pipeline = engine.dspEnsurePipeline()
+        for (index, band) in pipeline.eq.bands.enumerated() {
+            let expected = EqualizerPreset.electronic.gains[index]
+            XCTAssertEqual(band.gain, expected, accuracy: 0.0001)
+            XCTAssertEqual(band.bypass, expected == 0)
+        }
+    }
+
+    func testEnginePushesLiveEditsOntoExistingPipeline() throws {
+        let engine = try makeEngine()
+        let pipeline = engine.dspEnsurePipeline()
+        XCTAssertTrue(pipeline.isEQFlatForTesting, "pipeline ships flat")
+
+        engine.equalizer = EqualizerSettings(
+            isEnabled: true, presetID: EqualizerPreset.bassBoost.id
+        )
+        for (index, band) in pipeline.eq.bands.enumerated() {
+            let expected = EqualizerPreset.bassBoost.gains[index]
+            XCTAssertEqual(band.gain, expected, accuracy: 0.0001)
+            XCTAssertEqual(band.bypass, expected == 0)
+        }
+
+        // Toggling off live must drop the whole stage back to bypass.
+        engine.equalizer.isEnabled = false
+        XCTAssertTrue(pipeline.eq.bands.allSatisfy(\.bypass))
+    }
+}


### PR DESCRIPTION
The DSP pipeline (#39, #1015) put a flat/bypassed 10-band `AVAudioUnitEQ` in the engine graph; this wires real user controls into that node so the engine path actually earns its keep.

Closes #40

## What's wired

- **`EqualizerSettings` + `EqualizerPreset`** (`LyrebirdAudio/EqualizerSettings.swift`): 10 bands on the standard ISO octave centers (31 Hz – 16 kHz, matching `configureFlatEQ`), per-band gain clamped to ±12 dB, global enable, and the full iTunes-style preset table from the issue spec (Flat, Bass Boost, Treble Boost, Bass & Treble, Vocal Boost, Acoustic, Dance, Electronic, Hip-Hop, Jazz, Classical, Rock, Pop, Piano) plus a Custom curve. Gains arrays are normalized at every consumption point — clamp, zero non-finite, pad/truncate to 10 — so a corrupt plist can never reach the audio node.
- **Persistence**: `audio.eq.enabled` / `audio.eq.preset` / `audio.eq.customGains` in `UserDefaults` (plist-native types, `defaults read`-inspectable). The custom curve survives alongside a named selection, so switching back to Custom restores it. Missing/garbage keys degrade to disabled+Flat.
- **Live apply**: `EngineDSPPipeline.applyEqualizer(_:)` drives band gains + bypass in real time (no graph rebuild). Bit-perfect contract per the issue: EQ off — and any band at 0 dB, so Flat in particular — is *bypassed*, not run as a zero-gain filter. `AudioEngine.equalizer` pushes edits onto a live pipeline via `didSet`, and `dspEnsurePipeline` re-applies the stored curve on every (re)construction, so the curve survives pipeline rebuilds and relaunches.
- **Preferences ▸ Equalizer pane** (`PreferencesEqualizer.swift`): vertical slider stack with dB axis and per-band readouts, preset picker, Reset, enable toggle — `PreferenceSection`/`PreferenceRow`/`Theme` idioms throughout, with accessibility labels/values/adjustable actions on each band. Dragging a band forks the selection into Custom seeded from the active curve. Includes the engine opt-in toggle (writes `engine.useAVAudioEngine`, the #39 contract key, with a relaunch hint); while the DSP path isn't routing this session the EQ controls follow the app's gated-feature idiom — visible, disabled, dimmed, footnote explaining why — and edits made then still persist for when it is.
- **`AppModel` wiring** kept to the extension-file pattern: `AppModel+Equalizer.swift` (persist + push through `audio.equalizer`) plus a single seed block in `init` next to the existing engine seeding.

## Deferred

- Crossfade (#41), ReplayGain on the DSP path, and any pipeline-architecture changes — untouched, as is the entire AVQueuePlayer path (flag off remains byte-for-byte identical).
- `eq.globalGain` stays 0 (no make-up gain / loudness compensation).

## Tests

`EqualizerSettingsTests` (19 cases): band layout matches the pipeline's real node config; clamp/pad/truncate/non-finite normalization; preset table shape + lookup + `activeGains` resolution incl. unknown-id fallback; `UserDefaults` round-trip + garbage degradation; `applyEqualizer` gain/bypass behavior incl. the bit-perfect Flat case and preset-switch re-engagement; engine-level re-apply-on-construction and live-edit push.

Gates: `rm -rf macos/.build && swift build --package-path macos` clean, `swift test --package-path macos` — 985 tests, 0 failures (re-run after rebasing onto the #1022 library-cache merge with regenerated local bindings).