### PR TITLE
feat(macos): smart playlist rules editor — duration field + genre is-not fix

### DIFF
--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -2125,6 +2125,18 @@
         }
       }
     },
+    "smart_playlist.field.duration" : {
+      "comment" : "Smart playlist rule field: Duration (track length in seconds). The rule value is a plain integer number of seconds; e.g. 300 = 5 minutes.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration (sec)"
+          }
+        }
+      }
+    },
     "smart_playlist.field.last_played" : {
       "comment" : "Smart playlist rule field: Last Played. Sourced from Jellyfin's per-track lastPlayedAt (the server projection exposes last-played, not date-added), so the label reflects last-played semantics.",
       "extractionState" : "manual",

--- a/macos/Sources/Lyrebird/System/SmartPlaylist.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylist.swift
@@ -40,6 +40,10 @@ import Foundation
 /// |               | reflects what the data actually means. The seam is |
 /// |               | the single `dateAdded` assignment in               |
 /// |               | `TrackFacts.init`.                                 |
+/// | `.duration`   | `runtimeTicks / 10_000_000` (seconds). Value unit   |
+/// |               | is **whole seconds** so rules like "Duration > 300" |
+/// |               | mean "longer than 5 minutes". Operators: `is`,     |
+/// |               | `isNot`, `greaterThan`, `lessThan`.                |
 
 // MARK: - Field
 
@@ -54,13 +58,17 @@ enum SmartPlaylistField: String, Codable, CaseIterable, Hashable, Sendable {
     case playCount
     case isFavorite
     case dateAdded
+    /// Track length in **whole seconds** (sourced from `Track.runtimeTicks /
+    /// 10_000_000`). The user enters a plain integer ("300" = 5 minutes). Raw
+    /// value is stable; operators: `is`, `isNot`, `greaterThan`, `lessThan`.
+    case duration
 
     /// The natural value kind this field compares against. Drives which
     /// operators are offered and how the value editor renders.
     var valueKind: SmartPlaylistValueKind {
         switch self {
         case .genre, .artist, .album: return .text
-        case .year, .playCount: return .number
+        case .year, .playCount, .duration: return .number
         case .isFavorite: return .boolean
         case .dateAdded: return .date
         }
@@ -85,6 +93,7 @@ enum SmartPlaylistField: String, Codable, CaseIterable, Hashable, Sendable {
         case .playCount: return String(localized: "smart_playlist.field.play_count", bundle: .main)
         case .isFavorite: return String(localized: "smart_playlist.field.favorite", bundle: .main)
         case .dateAdded: return String(localized: "smart_playlist.field.last_played", bundle: .main)
+        case .duration: return String(localized: "smart_playlist.field.duration", bundle: .main)
         }
     }
 }

--- a/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
+++ b/macos/Sources/Lyrebird/System/SmartPlaylistEvaluator.swift
@@ -35,6 +35,12 @@ struct TrackFacts: Hashable, Sendable {
     /// `dateAdded` — a stable persisted storage key that predates the
     /// honest label and must not be renamed (see `SmartPlaylistField`).
     var dateAdded: Date?
+    /// Track length in **whole seconds** derived from `runtimeTicks`. Zero
+    /// when the server omits the duration (practically never, but tolerated).
+    /// The `.duration` rule compares against this value using numeric
+    /// operators (`is`, `isNot`, `greaterThan`, `lessThan`); the rule value
+    /// is also in seconds ("300" = 5 minutes).
+    var durationSeconds: Double
 
     init(
         id: String,
@@ -45,7 +51,8 @@ struct TrackFacts: Hashable, Sendable {
         year: Int? = nil,
         playCount: Int = 0,
         isFavorite: Bool = false,
-        dateAdded: Date? = nil
+        dateAdded: Date? = nil,
+        durationSeconds: Double = 0
     ) {
         self.id = id
         self.title = title
@@ -56,6 +63,7 @@ struct TrackFacts: Hashable, Sendable {
         self.playCount = playCount
         self.isFavorite = isFavorite
         self.dateAdded = dateAdded
+        self.durationSeconds = durationSeconds
     }
 }
 
@@ -84,6 +92,9 @@ extension TrackFacts {
         // `SmartPlaylistField.dateAdded`-style case rather than overloading
         // this one (the label would otherwise lie again).
         self.dateAdded = track.userData?.lastPlayedAt.flatMap(SmartPlaylistEvaluator.parseDate)
+        // Duration in whole seconds, rounded down. Zero when runtimeTicks is 0
+        // (a server-side gap, not a zero-length track in practice).
+        self.durationSeconds = Double(track.runtimeTicks) / 10_000_000.0
     }
 }
 
@@ -210,15 +221,41 @@ enum SmartPlaylistEvaluator {
     static func matches(_ facts: TrackFacts, rule: SmartPlaylistRule, now: Date = Date()) -> Bool {
         switch rule.field {
         case .genre:
-            // Genre is multi-valued: the rule holds if *any* of the track's
-            // genres satisfies it. Some Jellyfin libraries store a track's
-            // genres as a single semicolon-joined element
-            // ("Pop;Folk Pop;Rock") rather than a split array, so split on
-            // `;` first — otherwise a `genre is "Pop"` rule would miss those
-            // items (only `contains` would catch them). See the real-server
+            // Genre is multi-valued: some Jellyfin libraries store a track's
+            // genres as a single semicolon-joined element ("Pop;Folk Pop;Rock")
+            // rather than a split array, so split on `;` first — otherwise a
+            // `genre is "Pop"` rule would miss those items. See the real-server
             // probe in the #77 work.
             let atomicGenres = facts.genres.flatMap { $0.split(separator: ";").map(String.init) }
-            return atomicGenres.contains { textMatch($0, rule: rule) }
+
+            // Operator semantics for multi-valued genre (#1013):
+            //
+            // `.is` / `.contains`:  passes if ANY genre satisfies the test.
+            //
+            // `.isNot`:  passes if NO genre is (exactly) the specified value.
+            //   This is a global-exclusion test — a track that has Classical
+            //   among its genres must not pass "genre is not Classical", even if
+            //   it also has Rock. Using `contains { textMatch(.isNot) }` was
+            //   wrong: it returned `true` when any OTHER genre was not-X, so a
+            //   "Classical;Rock" track passed "genre is not Classical" because
+            //   Rock != Classical. The correct form is `!anyGenreMatchesIs`.
+            //
+            //   Ungenred-track special case: `atomicGenres.isEmpty` → a track
+            //   with no genre is by definition not any specific genre, so it
+            //   passes `.isNot` (and fails every other operator, since there is
+            //   nothing to match).
+            switch rule.op {
+            case .isNot:
+                // Empty genres → no genre to exclude against → passes.
+                // Non-empty → passes only if the exclusion genre is absent.
+                guard !atomicGenres.isEmpty else { return true }
+                let target = fold(rule.value)
+                return !atomicGenres.contains { fold($0) == target }
+            default:
+                // `.is`, `.contains`: need at least one genre to match against.
+                guard !atomicGenres.isEmpty else { return false }
+                return atomicGenres.contains { textMatch($0, rule: rule) }
+            }
         case .artist:
             return textMatch(facts.artist, rule: rule)
         case .album:
@@ -232,6 +269,8 @@ enum SmartPlaylistEvaluator {
             return booleanMatch(facts.isFavorite, rule: rule)
         case .dateAdded:
             return dateMatch(facts.dateAdded, rule: rule, now: now)
+        case .duration:
+            return numberMatch(facts.durationSeconds, rule: rule)
         }
     }
 

--- a/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistEvaluatorTests.swift
@@ -23,12 +23,14 @@ final class SmartPlaylistEvaluatorTests: XCTestCase {
         year: Int? = nil,
         playCount: Int = 0,
         isFavorite: Bool = false,
-        dateAdded: Date? = nil
+        dateAdded: Date? = nil,
+        durationSeconds: Double = 0
     ) -> TrackFacts {
         TrackFacts(
             id: id, title: title, artist: artist, album: album,
             genres: genres, year: year, playCount: playCount,
-            isFavorite: isFavorite, dateAdded: dateAdded
+            isFavorite: isFavorite, dateAdded: dateAdded,
+            durationSeconds: durationSeconds
         )
     }
 
@@ -497,5 +499,112 @@ final class SmartPlaylistEvaluatorTests: XCTestCase {
         let index = SmartPlaylistEvaluator.albumGenreIndex(albums)
         XCTAssertEqual(index["a"], ["Rock", "Indie"])
         XCTAssertNil(index["b"])
+    }
+
+    // MARK: - Duration field (#238)
+
+    func testDurationGreaterThan() {
+        // 4 minutes = 240s; rule: duration > 180 (3 minutes).
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 240), rule: rule(.duration, .greaterThan, "180")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 120), rule: rule(.duration, .greaterThan, "180")))
+    }
+
+    func testDurationLessThan() {
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 100), rule: rule(.duration, .lessThan, "180")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 200), rule: rule(.duration, .lessThan, "180")))
+    }
+
+    func testDurationIs() {
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 300), rule: rule(.duration, .is, "300")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 299), rule: rule(.duration, .is, "300")))
+    }
+
+    func testDurationIsNot() {
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 200), rule: rule(.duration, .isNot, "300")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(
+            facts(durationSeconds: 300), rule: rule(.duration, .isNot, "300")))
+    }
+
+    /// `TrackFacts(track:)` converts `runtimeTicks` to duration seconds; the
+    /// conversion (÷ 10_000_000) is tested here via the FFI adapter.
+    func testTrackAdapterConvertsDurationSeconds() {
+        // 3 minutes = 180 seconds = 1_800_000_000 ticks
+        let track = makeTrack(id: "dur", runtimeTicks: 1_800_000_000)
+        let f = TrackFacts(track: track)
+        XCTAssertEqual(f.durationSeconds, 180.0, accuracy: 0.001)
+    }
+
+    // MARK: - Genre is-not nil-genre fix (#1013)
+
+    /// A track with NO genres passes a "genre is not X" rule — a track with
+    /// no genre is by definition not any specific genre.
+    /// Regression for #1013: previously `atomicGenres.contains { textMatch }` on
+    /// an empty array short-circuited to `false`, incorrectly excluding the track.
+    func testGenreIsNotPassesForUngenredTrack() {
+        let ungenred = facts(genres: [])
+        let r = rule(.genre, .isNot, "Classical")
+        XCTAssertTrue(
+            SmartPlaylistEvaluator.matches(ungenred, rule: r),
+            "a track with no genres has no genre to exclude — it should pass is-not"
+        )
+    }
+
+    /// An ungenred track still fails "genre is X" (no genre to match).
+    func testGenreIsFailsForUngenredTrack() {
+        let ungenred = facts(genres: [])
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(ungenred, rule: rule(.genre, .is, "Rock")))
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(ungenred, rule: rule(.genre, .contains, "rock")))
+    }
+
+    /// A track whose genre IS X fails "genre is not X".
+    func testGenreIsNotFailsForMatchingGenre() {
+        let classical = facts(genres: ["Classical"])
+        XCTAssertFalse(SmartPlaylistEvaluator.matches(classical, rule: rule(.genre, .isNot, "Classical")))
+    }
+
+    /// A track with genres that do NOT include X passes "genre is not X".
+    func testGenreIsNotPassesWhenNoGenreMatches() {
+        let rock = facts(genres: ["Rock", "Indie"])
+        XCTAssertTrue(SmartPlaylistEvaluator.matches(rock, rule: rule(.genre, .isNot, "Classical")))
+    }
+
+    /// "Genre is not X" + match-all against a mix of ungenred, matching, and
+    /// non-matching tracks. Confirms the fix holds end-to-end over a set
+    /// evaluation (not just the single-rule path).
+    func testGenreIsNotOverMixedSet() {
+        let tracks = [
+            facts(id: "ungenred",   genres: []),                     // should match: no genre ≠ Classical
+            facts(id: "classical",  genres: ["Classical"]),           // should NOT match: is Classical
+            facts(id: "rock",       genres: ["Rock"]),                // should match: Rock ≠ Classical
+            facts(id: "semi",       genres: ["Classical;Rock"]),      // should NOT match: contains Classical
+        ]
+        let p = SmartPlaylist(name: "Not Classical", matchMode: .all,
+                              rules: [rule(.genre, .isNot, "Classical")])
+        let result = SmartPlaylistEvaluator.evaluate(p, over: tracks)
+        XCTAssertEqual(result.map(\.id), ["ungenred", "rock"])
+    }
+}
+
+// MARK: - makeTrack runtimeTicks overload
+
+private extension SmartPlaylistEvaluatorTests {
+    func makeTrack(
+        id: String,
+        runtimeTicks: UInt64
+    ) -> Track {
+        Track(
+            id: id, name: "Track", albumId: nil, albumName: nil,
+            artistName: "Artist", artistId: nil, indexNumber: nil,
+            discNumber: nil, year: nil, runtimeTicks: runtimeTicks,
+            isFavorite: false, playCount: 0, container: nil,
+            bitrate: nil, imageTag: nil, playlistItemId: nil, userData: nil
+        )
     }
 }

--- a/macos/Tests/LyrebirdTests/SmartPlaylistLocalizationTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistLocalizationTests.swift
@@ -170,6 +170,7 @@ final class SmartPlaylistLocalizationTests: XCTestCase {
             "smart_playlist.field.play_count",
             "smart_playlist.field.favorite",
             "smart_playlist.field.last_played",
+            "smart_playlist.field.duration",
             // Operator labels
             "smart_playlist.op.is",
             "smart_playlist.op.is_not",

--- a/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
+++ b/macos/Tests/LyrebirdTests/SmartPlaylistModelTests.swift
@@ -22,6 +22,7 @@ final class SmartPlaylistModelTests: XCTestCase {
         XCTAssertEqual(SmartPlaylistField.playCount.valueKind, .number)
         XCTAssertEqual(SmartPlaylistField.isFavorite.valueKind, .boolean)
         XCTAssertEqual(SmartPlaylistField.dateAdded.valueKind, .date)
+        XCTAssertEqual(SmartPlaylistField.duration.valueKind, .number)
     }
 
     /// The operator sets are scoped to the value kind: text gets equality +
@@ -195,6 +196,7 @@ final class SmartPlaylistModelTests: XCTestCase {
         XCTAssertEqual(SmartPlaylistField.playCount.rawValue, "playCount")
         XCTAssertEqual(SmartPlaylistField.isFavorite.rawValue, "isFavorite")
         XCTAssertEqual(SmartPlaylistField.dateAdded.rawValue, "dateAdded")
+        XCTAssertEqual(SmartPlaylistField.duration.rawValue, "duration")
         XCTAssertEqual(SmartPlaylistOperator.greaterThan.rawValue, "greaterThan")
         XCTAssertEqual(SmartPlaylistOperator.inLast.rawValue, "inLast")
         XCTAssertEqual(SmartPlaylistMatchMode.all.rawValue, "all")


### PR DESCRIPTION
## Why

The smart playlist rules editor shipped in #961/#964 but two gaps remained open:

1. **Duration field missing** — the issue spec (#238) lists duration as a rule field, but the initial implementation omitted it. Users cannot filter by track length.
2. **Genre `is-not` silently excludes ungenred tracks** (#1013) — `atomicGenres.contains { textMatch(.isNot, ...) }` returned `false` for empty genre arrays (correct short-circuit for `.is`/`.contains`, wrong for `.isNot`). A track with no genre is by definition _not_ any specific genre and must pass a "genre is not X" rule. A real-server probe against `https://music.skalthoff.com` found ~4% of the first 200 albums carry no genres — on a ~20 k-album library this silently drops ~800 albums from "not Classical"-style playlists.

## Changes

**`SmartPlaylist.swift`**
- New `SmartPlaylistField.duration` case (raw value `"duration"`, stable storage key).
- `valueKind == .number` — operators offered: `is`, `isNot`, `greaterThan`, `lessThan`. No new operator type needed.
- `displayName` → `smart_playlist.field.duration` catalog key ("Duration (sec)").

**`SmartPlaylistEvaluator.swift`**
- `TrackFacts` gains `durationSeconds: Double` (= `runtimeTicks / 10_000_000`). Zero when the server omits the field.
- `TrackFacts(track:)` populates `durationSeconds` from `track.runtimeTicks`.
- **Genre `is-not` fix** — the genre `.isNot` path now uses a dedicated exclusion check (`!atomicGenres.contains { fold($0) == target }`) instead of routing through `textMatch`, which was broken for multi-genre tracks (e.g. "Classical;Rock" incorrectly passed "genre is not Classical" because "Rock != Classical" was `true`). Ungenred tracks (empty `atomicGenres`) return `true` for `.isNot` and `false` for every other operator.
- New `case .duration` in the `matches` switch dispatches to `numberMatch(durationSeconds, rule:)`.

**Localizable.xcstrings** — adds `smart_playlist.field.duration` with English value "Duration (sec)".

**Tests**
- `SmartPlaylistEvaluatorTests` — 9 new tests: duration (`greaterThan`, `lessThan`, `is`, `isNot`, FFI adapter tick→seconds), genre `is-not` with ungenred track, genre `is` fails for ungenred, genre `is-not` fails when track has the excluded genre, mixed-set end-to-end covering ungenred/matching/non-matching/semicolon-joined cases.
- `SmartPlaylistModelTests` — `duration` added to `testFieldValueKinds` and `testEnumRawValuesAreStable`.
- `SmartPlaylistLocalizationTests` — `smart_playlist.field.duration` added to the catalog-sync coverage list.

## Rule semantics: nil-genre / duration

**Genre `is-not` for ungenred tracks**: a track with no genres passes "genre is not X" because it has no genre to be excluded by. A track with genres all different from X also passes. A track with X among its genres fails — this holds for both plain-array and semicolon-joined genre strings.

**Duration**: rule value is whole seconds (`300` = 5 min). Operators: `is`, `isNot`, `greaterThan`, `lessThan`. A track with `runtimeTicks == 0` (server gap, rarely occurs in practice) has `durationSeconds == 0` and is evaluated against zero.

## Evaluation scope

Evaluation is over `AppModel.tracks` (the in-memory snapshot loaded by the library pager). For libraries larger than one page only the tracks loaded so far are evaluated. A rule result on a partially-loaded library will grow as more pages arrive; this is consistent with the existing smart-playlist behavior and documented in CLAUDE.md gap pattern #3.

## Test evidence

```
swift test --package-path macos
Executed 995 tests, with 0 failures (0 unexpected)
```

Closes #238
Closes #1013