### PR TITLE
feat(macos): crossfade between tracks on the DSP path

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Crossfade.swift
+++ b/macos/Sources/Lyrebird/AppModel+Crossfade.swift
@@ -1,0 +1,32 @@
+import Foundation
+import LyrebirdAudio
+
+/// Crossfade routing (#41).
+///
+/// `CrossfadeSettings` is the value type (defined in `LyrebirdAudio` next to
+/// the dual-deck pipeline it drives); this extension is the app-side glue:
+/// persist edits to `UserDefaults` and push them onto the engine, which
+/// applies them to the live `EngineDSPPipeline` when the DSP path (#39) is
+/// running. Unlike the equalizer there is no engine-held canonical copy —
+/// `UserDefaults` is the single source of truth (the duration key predates
+/// the engine support; see `CrossfadeSettings.DefaultsKey`), and the
+/// pipeline re-reads it on construction, so no `AppModel.init` seeding is
+/// needed.
+extension AppModel {
+    /// Current crossfade settings as persisted. The Playback pane's
+    /// `@AppStorage` bindings read the same keys for instant UI; edits route
+    /// back through `setCrossfade(_:)`.
+    var crossfadeSettings: CrossfadeSettings {
+        CrossfadeSettings.load(from: .standard)
+    }
+
+    /// Persist new crossfade settings and push them onto the engine. When
+    /// the DSP pipeline is live the change applies to the very next
+    /// transition (and turning crossfade off disarms a pending overlap);
+    /// when it isn't, the settings still persist so they're waiting once
+    /// the engine path is enabled.
+    func setCrossfade(_ settings: CrossfadeSettings) {
+        settings.save(to: .standard)
+        audio.dspApplyCrossfade(settings)
+    }
+}

--- a/macos/Sources/Lyrebird/Capabilities.swift
+++ b/macos/Sources/Lyrebird/Capabilities.swift
@@ -68,14 +68,16 @@ extension AppModel {
     /// until that lands, rather than persisting a preference nothing reads.
     var supportsStreamQualitySelection: Bool { false }
 
-    /// Crossfade between tracks (#116). Gates the crossfade slider in the
-    /// Playback pane. Overlapping the tail of one track with the head of
-    /// the next needs a second player / mixer in `AudioEngine`; the
-    /// engine has no crossfade path today, so the slider would persist a
-    /// value nothing honours. Disabled until the engine supports
-    /// overlapping playback. Gapless (no-overlap joins) is a separate,
-    /// already-wired feature — see `armNextTrackPreload`.
-    var supportsCrossfade: Bool { false }
+    /// Crossfade between tracks (#41 / #116). Gates the crossfade slider +
+    /// curve picker in the Playback pane. Overlapping playback lives on the
+    /// AVAudioEngine DSP pipeline's dual decks (#41), so the controls are
+    /// only live while that path is routing playback *this session* — the
+    /// same session gate as the equalizer (#40). With the DSP engine off
+    /// (the default) the row shows disabled with a pointer at the engine
+    /// opt-in; the persisted value is honoured the moment the engine path
+    /// is active. Gapless (no-overlap joins) is a separate, already-wired
+    /// feature — see `armNextTrackPreload`.
+    var supportsCrossfade: Bool { engineDSPActiveThisSession }
     /// Playlist search results. The current `core.search` endpoint does
     /// not return playlists, so `bucketSearchResults` leaves that bucket
     /// empty. Gating the Playlists scope chip + section behind this flag

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -1,3 +1,4 @@
+import LyrebirdAudio
 import SwiftUI
 
 /// Playback preferences pane.
@@ -9,15 +10,17 @@ import SwiftUI
 /// which is their canonical home; the duplicates were removed here so each
 /// setting has exactly one editing surface.
 ///
-/// What's live vs. coming soon:
+/// What's live:
 /// - **Gapless** and **Stop after current track** are wired into the engine /
 ///   queue (`AppModel.armNextTrackPreload` reads `gaplessEnabled`;
 ///   `handleTrackEnded` consumes `stopAfterCurrent`).
 /// - **Normalization** and **Pre-gain** route through `AppModel.setNormalization`
 ///   onto the live ReplayGain path (#42).
-/// - **Crossfade** has no engine support yet (no overlapping-playback path in
-///   `AudioEngine`), so its slider is gated behind `supportsCrossfade` and
-///   shown disabled rather than persisting a value nothing honours.
+/// - **Crossfade** (#41) rides the AVAudioEngine DSP pipeline's dual decks,
+///   so its slider + curve picker gate on `supportsCrossfade` — live only
+///   while the DSP engine (#39, opted into via the Equalizer pane) is
+///   routing playback this session. The value persists either way and is
+///   honoured as soon as the engine path is active.
 ///
 /// Design: matches the native Preferences aesthetic inside the Lyrebird shell.
 /// Sections sit on `Theme.surface` with `Theme.border` outlines; labels use
@@ -27,26 +30,63 @@ import SwiftUI
 ///
 /// Preference keys (user-facing `@AppStorage`):
 /// - `playback.crossfadeSeconds`     — `Double` (0 = off, 1…12)
+/// - `playback.crossfadeCurve`       — `CrossfadeSettings.Curve` raw value
 /// - `playback.gaplessEnabled`       — `Bool` (default true)
 /// - `playback.normalization`        — `NormalizationMode`
 /// - `playback.preGainDb`            — `Double` (±12)
 /// - `playback.stopAfterCurrent`     — `Bool`
 ///
-/// Spec: `research/03-ux-patterns.md` Issue 68 and GitHub issues #260 / #116.
+/// Spec: `research/03-ux-patterns.md` Issue 68 and GitHub issues #260 / #116 / #41.
 struct PreferencesPlayback: View {
     @Environment(AppModel.self) private var model
 
-    // #116 gap-fill knobs. Gapless / stop-after-current / normalization /
-    // pre-gain are wired; crossfade is gated behind `model.supportsCrossfade`
-    // until the engine grows an overlapping-playback path. Raw types are
-    // chosen so the key names survive any later enum/struct refactor — a
-    // Double for the slider is portable and the Bool toggles are the obvious
-    // shape.
+    // #116 gap-fill knobs. Raw types are chosen so the key names survive any
+    // later enum/struct refactor — a Double for the slider is portable and
+    // the Bool toggles are the obvious shape. The crossfade key literals
+    // match `CrossfadeSettings.DefaultsKey` (#41), which is how the engine
+    // reads them back.
     @AppStorage("playback.crossfadeSeconds") private var crossfadeSeconds: Double = 0
+    @AppStorage("playback.crossfadeCurve") private var crossfadeCurveRaw: String = CrossfadeSettings.Curve.equalPower.rawValue
     @AppStorage("playback.gaplessEnabled") private var gaplessEnabled: Bool = true
     @AppStorage("playback.normalization") private var normalizationRaw: String = NormalizationMode.off.rawValue
     @AppStorage("playback.preGainDb") private var preGainDb: Double = 0
     @AppStorage("playback.stopAfterCurrent") private var stopAfterCurrent: Bool = false
+
+    /// Crossfade duration binding. Reads `@AppStorage` for instant UI, and
+    /// routes the change through `AppModel.setCrossfade` so the live DSP
+    /// pipeline picks it up for the very next transition (#41) — the same
+    /// eager-apply shape as the normalization picker below.
+    private var crossfadeDuration: Binding<Double> {
+        Binding(
+            get: { crossfadeSeconds },
+            set: { newValue in
+                crossfadeSeconds = newValue
+                model.setCrossfade(currentCrossfadeSettings(duration: newValue))
+            }
+        )
+    }
+
+    /// Crossfade curve binding — equal-power holds perceived loudness
+    /// through the overlap; linear can dip at the midpoint (#41 offers both).
+    private var crossfadeCurve: Binding<CrossfadeSettings.Curve> {
+        Binding(
+            get: { CrossfadeSettings.Curve(rawValue: crossfadeCurveRaw) ?? .equalPower },
+            set: { newCurve in
+                crossfadeCurveRaw = newCurve.rawValue
+                model.setCrossfade(currentCrossfadeSettings(curve: newCurve))
+            }
+        )
+    }
+
+    private func currentCrossfadeSettings(
+        duration: Double? = nil,
+        curve: CrossfadeSettings.Curve? = nil
+    ) -> CrossfadeSettings {
+        CrossfadeSettings(
+            durationSeconds: duration ?? crossfadeSeconds,
+            curve: curve ?? CrossfadeSettings.Curve(rawValue: crossfadeCurveRaw) ?? .equalPower
+        )
+    }
 
     /// Normalization picker binding. Reads `@AppStorage` for instant UI, and
     /// routes the change through `AppModel` so the live player re-reads the
@@ -103,15 +143,32 @@ struct PreferencesPlayback: View {
 
                 PreferenceRow(
                     label: "Crossfade",
-                    help: model.supportsCrossfade ? crossfadeHelp : "Coming soon."
+                    help: model.supportsCrossfade
+                        ? crossfadeHelp
+                        : "Requires the DSP audio engine — turn it on in the Equalizer pane."
                 ) {
-                    CrossfadeSlider(seconds: $crossfadeSeconds)
+                    CrossfadeSlider(seconds: crossfadeDuration)
                         .disabled(!model.supportsCrossfade)
                 }
-                // Dim the whole row when crossfade isn't available so it reads
-                // as not-yet-functional rather than broken — matching the
-                // disabled Last.fm row in `PreferencesScrobbling`.
+                // Dim the whole row while the DSP engine isn't routing
+                // playback this session so it reads as inactive rather than
+                // broken — the same gated-feature idiom as the EQ pane (#40).
                 .opacity(model.supportsCrossfade ? 1 : 0.55)
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Crossfade curve",
+                    help: crossfadeCurve.wrappedValue == .equalPower
+                        ? "Holds perceived loudness steady through the overlap."
+                        : "Straight-line gains — can dip slightly mid-overlap."
+                ) {
+                    CrossfadeCurvePicker(selection: crossfadeCurve)
+                        .disabled(!model.supportsCrossfade || crossfadeSeconds < CrossfadeSettings.minimumActiveDuration)
+                }
+                .opacity(model.supportsCrossfade && crossfadeSeconds >= CrossfadeSettings.minimumActiveDuration ? 1 : 0.55)
             }
 
             PreferenceSection(
@@ -171,14 +228,15 @@ struct PreferencesPlayback: View {
     }
 
     /// Footnote under the Transitions section. Describes gapless always, and
-    /// crossfade only when the engine actually supports it — otherwise the
-    /// section would promise a working crossfade feature that doesn't exist.
+    /// crossfade per its availability — the overlap rides the DSP engine's
+    /// dual decks (#41), so without that engine the footnote points at the
+    /// opt-in instead of promising an inactive feature.
     private var transitionsFootnote: String {
         let gapless = "Gapless joins tracks with no silence when the source supports it."
         if model.supportsCrossfade {
-            return gapless + " Crossfade overlaps the last and next track by the selected number of seconds."
+            return gapless + " Crossfade overlaps the last and next track by the selected number of seconds; tracks from the same album stay gapless, and skipping mid-track uses a short fade instead."
         }
-        return gapless + " Crossfade is planned and isn't available in this build yet."
+        return gapless + " Crossfade runs on Lyrebird's DSP engine — enable it in the Equalizer pane (takes effect after relaunch). Your setting is saved either way."
     }
 
     /// Subtitle under the crossfade row. Reads "Off" when the slider is at
@@ -335,6 +393,24 @@ enum PreferredAudioCodec: String, CaseIterable, Identifiable {
 // Note: the streaming/download `QualityPicker` and the `CodecPicker` that used
 // to live here moved to the Audio pane (#117) — the single home for quality and
 // codec selection now that the duplicate sections were removed from this pane.
+
+/// Segmented picker for the crossfade gain envelope (#41). Two mutually-
+/// exclusive options — the same control shape as `NormalizationPicker`.
+private struct CrossfadeCurvePicker: View {
+    @Binding var selection: CrossfadeSettings.Curve
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(CrossfadeSettings.Curve.allCases) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: 240)
+        .accessibilityLabel("Crossfade curve")
+    }
+}
 
 /// Segmented picker for the three-option normalization mode. Off / Track /
 /// Album — a segmented control reads best for a mutually-exclusive short

--- a/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
+++ b/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
@@ -111,6 +111,7 @@ enum DiagnosticBundle {
         "general.showInMenuBar",
         "hasCompletedOnboarding",
         "libraryViewMode",
+        "playback.crossfadeCurve",
         "playback.crossfadeSeconds",
         "playback.downloadQuality",
         "playback.gaplessEnabled",

--- a/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
@@ -17,14 +17,26 @@ private let dspLog = Logger(subsystem: "org.lyrebird.desktop", category: "dsp")
 /// AVQueuePlayer path — `PlaybackInfo` resolution, `reportPlaybackStarted` /
 /// `reportPlaybackProgress` / `reportPlaybackStopped`, `markTrackStarted`,
 /// `markState` / `markPosition` (1 Hz, playing only), the 5s heartbeat, and
-/// `MediaSession` transport notifications.
+/// `MediaSession` transport notifications. A crossfade handoff (#41) keeps
+/// that parity too: the outgoing track reports Stopped at the position the
+/// fade began, the incoming reports Started against the play session its
+/// stream was resolved with, and the heartbeat re-keys to the new session.
 ///
 /// Known #39 gaps on this path (cleanly degraded, listed in the PR):
-/// gapless preload is a no-op (tracks advance with a rebuild, like
-/// `gaplessEnabled == false`), ReplayGain normalization is not applied,
-/// stall recovery is skip-on-error rather than bounded in-place retries, and
-/// Ogg containers (which AudioToolbox cannot parse) skip to the next track.
+/// ReplayGain normalization is not applied, stall recovery is skip-on-error
+/// rather than bounded in-place retries, and Ogg containers (which
+/// AudioToolbox cannot parse) skip to the next track. Gapless preload is a
+/// no-op only while crossfade is off — with crossfade on (#41) the armed
+/// next track buffers ahead and transitions overlap (or zero-fade join for
+/// same-album pairs).
 extension AudioEngine {
+    /// `UserDefaults` key for the "Stop after current track" one-shot. The
+    /// literal matches `AppModel+PlaybackControls` / `PreferencesPlayback`
+    /// (the app layer owns the feature; the engine only peeks — without
+    /// consuming — so an armed stop suppresses crossfade and the track runs
+    /// to its true end before `handleTrackEnded` halts the queue).
+    private static let stopAfterCurrentDefaultsKey = "playback.stopAfterCurrent"
+
     /// Build (or reuse) the pipeline. Only ever called from DSP-routed
     /// methods, which are themselves gated on `dspPipelineEnabled` — so the
     /// AVQueuePlayer path never constructs one.
@@ -53,19 +65,59 @@ extension AudioEngine {
             self.core.markState(state: .ended)
             self.onTrackEnded?()
         }
+        pipeline.onCrossfadeBegan = { [weak self] _ in
+            guard let self else { return }
+            // The crossfade handoff (#41) is this path's gapless auto-
+            // advance: the armed track is already audible. Fire the same
+            // end-of-item contract as a natural finish — AppModel advances
+            // its queue and calls play(track:), which adopts the live deck
+            // via `adoptHandedOffTrack` instead of reloading.
+            self.core.markState(state: .ended)
+            self.onTrackEnded?()
+        }
+        pipeline.onShouldBeginCrossfade = {
+            // "Stop after current track" (#116) must halt at the track's
+            // *true* end — starting a crossfade would cut its final seconds.
+            // Peek (never consume — `handleTrackEnded` owns the one-shot).
+            !UserDefaults.standard.bool(forKey: AudioEngine.stopAfterCurrentDefaultsKey)
+        }
         pipeline.setOutputDevice(uid: outputDeviceUID)
         // Re-apply the persisted EQ curve (#40) — the pipeline constructs
         // flat/bypassed, so a rebuild (or the first DSP-routed play of the
         // session) must restore the user's settings before audio renders.
         pipeline.applyEqualizer(equalizer)
+        // Same deal for the crossfade settings (#41): `UserDefaults` is the
+        // single source of truth (seeded by the Playback pane via
+        // `dspApplyCrossfade`), so a fresh pipeline restores it directly.
+        pipeline.applyCrossfade(CrossfadeSettings.load(from: .standard))
         dspPipeline = pipeline
         return pipeline
     }
 
+    /// Push new crossfade settings onto the live pipeline (#41). No-op while
+    /// the DSP flag is off — the value persists in `UserDefaults` and the
+    /// pipeline restores it on construction, so nothing is lost and the
+    /// AVQueuePlayer path stays byte-for-byte untouched.
+    public func dspApplyCrossfade(_ settings: CrossfadeSettings) {
+        guard dspPipelineEnabled else { return }
+        dspEnsurePipeline().applyCrossfade(settings)
+    }
+
     /// DSP-path `play(track:)`. Mirrors the AVQueuePlayer path's resolution
     /// + reporting sequence exactly; only the audio transport differs.
+    ///
+    /// When the requested track is the one a crossfade handoff just made
+    /// audible (#41), the pipeline is already playing it — adopt it: emit
+    /// the same report swap a reload would (outgoing Stopped at the fade
+    /// position, incoming Started against its resolved session) without
+    /// touching the audio.
     func dspPlay(track: Track) async throws {
         let pipeline = dspEnsurePipeline()
+
+        if let receipt = pipeline.adoptHandedOffTrack(key: track.id) {
+            dspAdoptCrossfadedTrack(track, receipt: receipt)
+            return
+        }
 
         // Resolve local copy vs stream — identical decision tree to the
         // AVQueuePlayer path (#819 offline gate included).
@@ -109,7 +161,9 @@ extension AudioEngine {
             url: url,
             authHeader: authHeader,
             containerHint: track.container,
-            durationHint: durationHint
+            durationHint: durationHint,
+            trackKey: track.id,
+            albumKey: track.albumId
         )
 
         // Close out the previous server session before opening the new one
@@ -130,6 +184,121 @@ extension AudioEngine {
             playMethod: nil
         )
         core.startHeartbeat(intervalSecs: 5, playSessionId: playSessionId)
+
+        dspArmNextTrackForCrossfade(after: track)
+    }
+
+    /// The reporting half of a crossfade handoff (#41). The audio swap
+    /// already happened inside the pipeline; this mirrors `dspPlay`'s
+    /// session bookkeeping for it: the outgoing track's Stopped report
+    /// carries the position the fade began at, the incoming track's Started
+    /// report (and the heartbeat) re-key to the play session its stream was
+    /// resolved with at arm time.
+    private func dspAdoptCrossfadedTrack(_ track: Track, receipt: EngineDSPPipeline.HandoffReceipt) {
+        let outgoingTicks = Int64(max(0, receipt.outgoingPositionSeconds) * 10_000_000)
+        core.setPlaySessionId(playSessionId: receipt.playSessionId)
+        reportStopped(positionTicks: outgoingTicks)
+
+        let core = self.core
+        Task.detached { core.markTrackStarted(track: track) }
+        core.markState(state: .playing)
+        mediaSession?.trackChanged(track)
+
+        reportStarted(
+            trackId: track.id,
+            mediaSourceId: receipt.mediaSourceId,
+            playSessionId: receipt.playSessionId,
+            playMethod: nil
+        )
+        core.startHeartbeat(intervalSecs: 5, playSessionId: receipt.playSessionId)
+
+        dspArmNextTrackForCrossfade(after: track)
+    }
+
+    /// Arm the queue's next track on the pipeline so the upcoming transition
+    /// can crossfade (#41). Resolves the stream exactly like `dspPlay`
+    /// (offline gate, PlaybackInfo session correlation, bitrate ceiling) but
+    /// fire-and-forget: any failure just means this transition falls back to
+    /// the ordinary end-of-track rebuild.
+    ///
+    /// `core.peekNext()` honours the live queue + repeat mode (the same
+    /// lookahead `AppModel.armNextTrackPreload` reads), so the armed track
+    /// is the one `skipNext()` will return at the handoff. A queue edit
+    /// after arming makes the armed track stale — `dspPlay` then sees a key
+    /// mismatch and reloads fresh, the same staleness contract as the
+    /// AVQueuePlayer path's pre-inserted item.
+    private func dspArmNextTrackForCrossfade(after current: Track) {
+        guard let pipeline = dspPipeline, pipeline.crossfadeIsEnabled else { return }
+        guard let next = core.peekNext() else {
+            pipeline.disarmNextTrack()
+            return
+        }
+
+        let currentKey = current.id
+        let offlineEnabled = offlinePlaybackEnabled
+        let bitrateCap = maxStreamingBitrate
+        let core = self.core
+        Task.detached { [weak self] in
+            // Resolution mirrors `preloadNextTrack`'s detached body: local
+            // copy first (#819), else PlaybackInfo → stream URL → auth.
+            let localPath = offlineEnabled ? core.downloadLocalPath(trackId: next.id) : nil
+            let url: URL?
+            var authHeader: String?
+            var mediaSourceId: String?
+            var playSessionId: String?
+            if let localPath, !localPath.isEmpty {
+                url = URL(fileURLWithPath: localPath)
+            } else {
+                let opts = PlaybackInfoOpts(
+                    userId: nil,
+                    startTimeTicks: nil,
+                    mediaSourceId: nil,
+                    maxStreamingBitrate: nil,
+                    enableDirectPlay: nil,
+                    enableDirectStream: nil,
+                    enableTranscoding: nil,
+                    autoOpenLiveStream: nil,
+                    deviceProfile: nil
+                )
+                let info = try? core.playbackInfo(itemId: next.id, opts: opts)
+                mediaSourceId = info?.mediaSources.first?.id
+                playSessionId = info?.playSessionId
+                guard let urlString = try? core.streamUrl(
+                    trackId: next.id,
+                    mediaSourceId: mediaSourceId,
+                    playSessionId: playSessionId,
+                    maxStreamingBitrate: bitrateCap
+                ), let streamURL = URL(string: urlString) else {
+                    dspLog.notice("crossfade arm skipped: could not resolve stream for \(next.id, privacy: .public)")
+                    return
+                }
+                url = streamURL
+                authHeader = try? core.authHeader()
+            }
+            guard let url else { return }
+
+            let durationHint: Double? = next.runtimeTicks > 0
+                ? Double(next.runtimeTicks) / 10_000_000.0
+                : nil
+            let armedTrack = EngineDSPPipeline.ArmedNextTrack(
+                key: next.id,
+                albumKey: next.albumId,
+                url: url,
+                authHeader: authHeader,
+                containerHint: next.container,
+                durationHint: durationHint,
+                mediaSourceId: mediaSourceId,
+                playSessionId: playSessionId
+            )
+            await MainActor.run {
+                guard let self, let pipeline = self.dspPipeline else { return }
+                // Stale guard: only arm if the track we resolved against is
+                // still the one playing (a rapid skip mid-resolve supersedes
+                // this arm — its own dspPlay re-arms).
+                guard pipeline.currentTrackKey == currentKey else { return }
+                pipeline.armNextTrack(armedTrack)
+            }
+        }
     }
 
     func dspPause() {

--- a/macos/Sources/LyrebirdAudio/CrossfadeSettings.swift
+++ b/macos/Sources/LyrebirdAudio/CrossfadeSettings.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// User-facing crossfade state (#41).
+///
+/// The DSP pipeline (#39) keeps two `AVAudioPlayerNode` decks live in its
+/// node graph, each behind its own `AVAudioMixerNode`; this struct is the
+/// single value type that flows from the Preferences pane through `AppModel`
+/// → `AudioEngine.dspApplyCrossfade(_:)` → `EngineDSPPipeline.applyCrossfade(_:)`
+/// onto those gain stages, and round-trips to `UserDefaults` so the choice
+/// survives relaunch — the same shape as `EqualizerSettings` (#40).
+///
+/// Two facts persist:
+/// - `durationSeconds` — the overlap window. Reuses the pre-existing
+///   `playback.crossfadeSeconds` key the Playback pane has written since #116
+///   (0 = off, 1…12 s), so a value a user set before the engine support
+///   landed is honoured the moment the DSP path turns on.
+/// - `curve` — the gain envelope: equal-power (the default; preserves
+///   perceived loudness through the overlap) or linear (can dip slightly at
+///   the midpoint). Issue #41 asks for both.
+///
+/// Off (`durationSeconds == 0`, or anything below one second) is a true
+/// no-op: the pipeline never arms a second deck, never starts a fade, and
+/// track transitions behave exactly as they did before #41 — the gapless
+/// contract the issue's acceptance criteria demand.
+public struct CrossfadeSettings: Equatable, Sendable {
+    // MARK: - Gain curves
+
+    /// The fade envelope shape. Raw values are stable user-defaults strings —
+    /// do not rename without a migration.
+    public enum Curve: String, CaseIterable, Sendable, Identifiable {
+        /// `gainIn(t) = sin(t·π/2)`, `gainOut(t) = cos(t·π/2)` — the power
+        /// sum is 1 at every point, so the overlap holds perceived loudness.
+        case equalPower
+
+        /// `gainIn(t) = t`, `gainOut(t) = 1 − t` — amplitude-constant, which
+        /// dips perceptibly around the midpoint on correlated material.
+        case linear
+
+        public var id: String { rawValue }
+
+        /// Display label for the Preferences picker.
+        public var label: String {
+            switch self {
+            case .equalPower: return "Equal power"
+            case .linear: return "Linear"
+            }
+        }
+    }
+
+    // MARK: - Ranges
+
+    /// Slider range in seconds. 0 reads as "Off"; the issue specifies an
+    /// active range of 1–12 s, matching the existing Playback-pane slider.
+    public static let durationRange: ClosedRange<Double> = 0...12
+
+    /// Anything below this is treated as off — the slider steps in whole
+    /// seconds, so sub-second values only appear via hand-edited defaults.
+    public static let minimumActiveDuration: Double = 1
+
+    /// Default overlap when the user enables crossfade (issue spec: 4 s).
+    public static let defaultActiveDuration: Double = 4
+
+    /// The short fade applied to the *outgoing* track on a manual skip while
+    /// crossfade is on, so a mid-track next never pops (issue spec: 250 ms).
+    public static let quickSwitchDuration: Double = 0.25
+
+    // MARK: - State
+
+    /// Overlap window in seconds. 0 (or anything below
+    /// `minimumActiveDuration`) means crossfade is off.
+    public var durationSeconds: Double
+
+    /// Selected gain envelope.
+    public var curve: Curve
+
+    public init(
+        durationSeconds: Double = 0,
+        curve: Curve = .equalPower
+    ) {
+        self.durationSeconds = CrossfadeSettings.normalizedDuration(durationSeconds)
+        self.curve = curve
+    }
+
+    /// Whether crossfade participates in playback at all. Off must behave
+    /// byte-for-byte like the pre-#41 pipeline.
+    public var isEnabled: Bool {
+        durationSeconds >= CrossfadeSettings.minimumActiveDuration
+    }
+
+    // MARK: - Normalization
+
+    /// Coerce an arbitrary persisted duration into a valid one: zero
+    /// non-finite values (a corrupted plist must never reach the fade
+    /// scheduler) and clamp to `durationRange`.
+    public static func normalizedDuration(_ raw: Double) -> Double {
+        guard raw.isFinite else { return 0 }
+        return min(max(raw, durationRange.lowerBound), durationRange.upperBound)
+    }
+
+    // MARK: - Envelope math
+
+    /// Incoming-track gain for fade progress `t` in [0, 1]. Clamps out-of-
+    /// range progress so a jittery timer can never push an out-of-range gain
+    /// onto a mixer node.
+    public static func fadeInGain(progress: Double, curve: Curve) -> Float {
+        let t = min(max(progress, 0), 1)
+        switch curve {
+        case .equalPower: return Float(sin(t * .pi / 2))
+        case .linear: return Float(t)
+        }
+    }
+
+    /// Outgoing-track gain for fade progress `t` in [0, 1].
+    public static func fadeOutGain(progress: Double, curve: Curve) -> Float {
+        let t = min(max(progress, 0), 1)
+        switch curve {
+        case .equalPower: return Float(cos(t * .pi / 2))
+        case .linear: return Float(1 - t)
+        }
+    }
+
+    // MARK: - Scheduling decisions (pure, testable)
+
+    /// How early before the fade window the standby deck starts buffering the
+    /// armed track. Generous enough to ride out network jitter while keeping
+    /// the double-stream overlap short.
+    public static let prepareLeadSeconds: Double = 10
+
+    /// The overlap to use for a specific transition — or 0 for a zero-fade
+    /// join (the armed track starts the instant the outgoing one finishes,
+    /// with no overlap and no envelope).
+    ///
+    /// Zero-fade applies when:
+    /// - the configured duration is off,
+    /// - current and next track share an album (`sameAlbum`) — issue #41's
+    ///   gapless-album rule: don't smear continuous album audio together,
+    /// - the outgoing track is too short to give the fade room (shorter than
+    ///   twice the window), or its duration is unknown (no metadata to place
+    ///   the fade against).
+    public static func effectiveFadeDuration(
+        configured: Double,
+        trackDurationSeconds: Double?,
+        sameAlbum: Bool
+    ) -> Double {
+        let window = normalizedDuration(configured)
+        guard window >= minimumActiveDuration else { return 0 }
+        guard !sameAlbum else { return 0 }
+        guard let duration = trackDurationSeconds,
+              duration.isFinite,
+              duration >= window * 2
+        else { return 0 }
+        return window
+    }
+
+    /// What the 1 Hz position tick should do about an armed next track.
+    public enum TickAction: Equatable {
+        /// Outside every window — keep playing.
+        case none
+        /// Inside the buffering window — start streaming the armed track on
+        /// the standby deck (no audio yet).
+        case prepare
+        /// Inside the fade window and the standby deck is ready — begin the
+        /// gain ramps now.
+        case beginFade
+    }
+
+    /// Pure decision function for the crossfade scheduler. `remainingSeconds`
+    /// is the outgoing track's time left; `fadeDuration` is the value
+    /// returned by `effectiveFadeDuration` (0 ⇒ zero-fade join, which never
+    /// begins a ramp — the handoff happens at track completion instead).
+    public static func tickAction(
+        remainingSeconds: Double,
+        fadeDuration: Double,
+        prepStarted: Bool,
+        standbyReady: Bool
+    ) -> TickAction {
+        guard remainingSeconds.isFinite else { return .none }
+        if fadeDuration > 0, prepStarted, standbyReady, remainingSeconds <= fadeDuration {
+            return .beginFade
+        }
+        if !prepStarted, remainingSeconds <= fadeDuration + prepareLeadSeconds {
+            return .prepare
+        }
+        return .none
+    }
+
+    // MARK: - Persistence
+
+    /// `UserDefaults` keys. `duration` is the pre-existing #116 Playback-pane
+    /// key (kept verbatim so prior opt-ins survive); `curve` is new with #41.
+    public enum DefaultsKey {
+        public static let duration = "playback.crossfadeSeconds"
+        public static let curve = "playback.crossfadeCurve"
+    }
+
+    /// Load persisted settings; missing/partial keys fall back to the shipped
+    /// default (off, equal-power) so a fresh install behaves exactly like the
+    /// pre-#41 pipeline.
+    public static func load(from defaults: UserDefaults) -> CrossfadeSettings {
+        let duration = defaults.double(forKey: DefaultsKey.duration)
+        let curve = defaults.string(forKey: DefaultsKey.curve)
+            .flatMap(Curve.init(rawValue:)) ?? .equalPower
+        return CrossfadeSettings(durationSeconds: duration, curve: curve)
+    }
+
+    /// Persist both facts as plist-native scalars so `defaults read` stays
+    /// inspectable for support/debugging (same contract as the EQ keys).
+    public func save(to defaults: UserDefaults) {
+        defaults.set(CrossfadeSettings.normalizedDuration(durationSeconds), forKey: DefaultsKey.duration)
+        defaults.set(curve.rawValue, forKey: DefaultsKey.curve)
+    }
+}

--- a/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
+++ b/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
@@ -9,25 +9,39 @@ private let pipelineLog = Logger(subsystem: "org.lyrebird.desktop", category: "d
 /// AVAudioEngine-based playback pipeline (#39) — the DSP foundation for the
 /// EQ (#40) and crossfade (#41) features that `AVQueuePlayer` cannot host.
 ///
-/// Node graph:
+/// Node graph (#41 dual-deck layout):
 ///
-///     AVAudioPlayerNode → AVAudioUnitEQ (10-band, flat) → mainMixerNode
+///     deck A: AVAudioPlayerNode → AVAudioMixerNode ─┐
+///                                                   ├→ blend mixer → AVAudioUnitEQ (10-band) → mainMixerNode
+///     deck B: AVAudioPlayerNode → AVAudioMixerNode ─┘
+///
+/// Exactly one deck is *active* (the current track) at any time. The second
+/// deck exists for crossfade (#41): the upcoming track is armed + buffered on
+/// it, and at the fade window each deck's per-node `AVAudioMixerNode` ramps
+/// its `outputVolume` along the configured gain envelope — outgoing down,
+/// incoming up — through the shared blend → EQ → main-mixer stage, so the EQ
+/// applies to both sides of the overlap. With crossfade off (the default)
+/// the standby deck is never loaded and both fade mixers sit at unity gain,
+/// which is audibly (float-mix at 1.0) identical to the pre-#41 single-node
+/// graph.
 ///
 /// The EQ ships **flat and bypassed** (`globalGain == 0`, every band
 /// `bypass == true`) so the engine path makes no audible DSP alteration —
-/// #40 owns the preset/slider UI that will drive real band gains through
-/// the `eq` node this class already keeps live in the graph.
+/// #40 owns the preset/slider UI that drives real band gains through the
+/// `eq` node this class keeps live in the graph.
 ///
-/// Tracks are fed by a `DSPTrackStreamer` (URLSession → AudioToolbox parse →
-/// `AVAudioConverter` decode → scheduled `AVAudioPCMBuffer`s), one per track.
+/// Tracks are fed by a `DSPTrackStreamer` per deck (URLSession → AudioToolbox
+/// parse → `AVAudioConverter` decode → scheduled `AVAudioPCMBuffer`s).
 /// `AudioEngine` owns an instance of this class only while the
 /// `engine.useAVAudioEngine` feature flag is on; with the flag off (the
 /// default) this type is never constructed.
 ///
 /// Energy contract (CLAUDE.md gap #2): the position tick runs at 1 Hz and
-/// only while playing — `pause()` both pauses the node *and* pauses the
+/// only while playing — `pause()` both pauses the nodes *and* pauses the
 /// engine's render thread, and invalidates the timer, so an idle app does
-/// zero per-second work on this path too.
+/// zero per-second work on this path too. The gain-ramp timer only exists
+/// while a fade is actually in progress (≤ 12 s per transition) and is
+/// invalidated the moment the last ramp completes.
 @MainActor
 public final class EngineDSPPipeline {
     public enum TransportState {
@@ -36,51 +50,155 @@ public final class EngineDSPPipeline {
         case paused
     }
 
+    // MARK: - Crossfade value types (#41)
+
+    /// Owner-resolved parameters for the next track, armed ahead of time so
+    /// the pipeline can buffer + fade into it without a queue lookup of its
+    /// own. `key` / `albumKey` / `mediaSourceId` / `playSessionId` are opaque
+    /// to the pipeline — they exist so the owner can match the handoff back
+    /// to its queue item and mirror its server-reporting contract.
+    public struct ArmedNextTrack {
+        public let key: String
+        public let albumKey: String?
+        public let url: URL
+        public let authHeader: String?
+        public let containerHint: String?
+        public let durationHint: Double?
+        public let mediaSourceId: String?
+        public let playSessionId: String?
+
+        public init(
+            key: String,
+            albumKey: String?,
+            url: URL,
+            authHeader: String?,
+            containerHint: String?,
+            durationHint: Double?,
+            mediaSourceId: String?,
+            playSessionId: String?
+        ) {
+            self.key = key
+            self.albumKey = albumKey
+            self.url = url
+            self.authHeader = authHeader
+            self.containerHint = containerHint
+            self.durationHint = durationHint
+            self.mediaSourceId = mediaSourceId
+            self.playSessionId = playSessionId
+        }
+    }
+
+    /// What the owner needs to keep reporting parity across a crossfade
+    /// handoff: the outgoing track's position at the moment the incoming one
+    /// became audible (its `reportPlaybackStopped` mark), plus the reporting
+    /// context the armed track's stream was resolved with.
+    public struct HandoffReceipt {
+        public let outgoingPositionSeconds: Double
+        public let mediaSourceId: String?
+        public let playSessionId: String?
+    }
+
     // MARK: - Owner callbacks
 
     /// Fired when a fully-streamed track finishes playing back — the DSP
     /// path's end-of-item signal (`AVPlayerItemDidPlayToEndTime` parity).
+    /// Not fired for a transition the crossfade handoff already announced
+    /// via `onCrossfadeBegan`.
     public var onTrackFinished: (() -> Void)?
 
     /// 1 Hz position tick, fired only while playing (never when paused or
     /// stopped). Drives `core.markPosition` parity with the AVPlayer path's
-    /// periodic time observer.
+    /// periodic time observer. Always reports the *active* deck — during a
+    /// crossfade that is the incoming track.
     public var onPositionTick: ((Double) -> Void)?
 
     /// Fired when the current track's stream dies (network failure,
     /// unsupported container, decode error). Carries a diagnostic message;
-    /// the owner decides the user-facing copy.
+    /// the owner decides the user-facing copy. A *standby* (armed next
+    /// track) stream failure never fires this — the crossfade is quietly
+    /// abandoned and the transition falls back to the rebuild path.
     public var onStreamError: ((String) -> Void)?
+
+    /// Fired the moment an armed next track becomes audible — either at the
+    /// start of a gain-ramp crossfade or at a zero-fade join on track
+    /// completion. Carries the armed track's `key`. This is the DSP path's
+    /// gapless-auto-advance signal: the owner should advance its queue and
+    /// re-route `play(track:)` into `adoptHandedOffTrack(key:)` instead of
+    /// reloading. `onTrackFinished` does NOT also fire for this transition.
+    public var onCrossfadeBegan: ((String) -> Void)?
+
+    /// Veto hook consulted immediately before an armed track takes over
+    /// (both the ramped and the zero-fade paths). Returning `false` lets the
+    /// outgoing track run to its natural end instead — the owner uses this
+    /// for "stop after current track", which must halt at the *true* end of
+    /// the track rather than `crossfadeDuration` seconds early. Re-checked
+    /// every tick, so disarming the stop mid-window re-enables the fade.
+    public var onShouldBeginCrossfade: (() -> Bool)?
+
+    // MARK: - Deck
+
+    /// One playback lane: a player node feeding a dedicated gain mixer, plus
+    /// the per-track streaming/position state that used to live directly on
+    /// the pipeline before #41 doubled it.
+    private final class Deck {
+        let player = AVAudioPlayerNode()
+        let fadeMixer = AVAudioMixerNode()
+        var streamer: DSPTrackStreamer?
+        /// Engine processing format of the loaded track; nil until the
+        /// stream header parses (and again after unload).
+        var format: AVAudioFormat?
+        /// The format the player → fadeMixer → blend chain is physically
+        /// wired with. Sticky across unloads so an identical-format reload
+        /// skips graph surgery entirely.
+        var wiredFormat: AVAudioFormat?
+        var sampleRate: Double = 44_100
+        /// Stream frame corresponding to node sample time 0 — reset by
+        /// load (0) and seek (the landing frame).
+        var baseFrame: AVAudioFramePosition = 0
+        /// Last node sample time successfully read while rendering, so the
+        /// position survives pauses.
+        var lastKnownSampleTime: AVAudioFramePosition = 0
+        /// Duration hint (seconds) from track metadata; drives the crossfade
+        /// window math. nil ⇒ no auto-crossfade for this track.
+        var durationSeconds: Double?
+        /// Opaque owner identity of the loaded track (track id).
+        var trackKey: String?
+        /// Opaque album identity — same-album transitions zero-fade (#41).
+        var albumKey: String?
+        /// Bumped per load/unload so a stale streamer's late callbacks
+        /// (format-ready, finished, error, seek) can't cross tracks.
+        var generation: Int = 0
+    }
 
     // MARK: - Node graph
 
     private let engine = AVAudioEngine()
-    private let playerNode = AVAudioPlayerNode()
+    private let decks = [Deck(), Deck()]
+    private var activeDeckIndex = 0
+    private var activeDeck: Deck { decks[activeDeckIndex] }
+    private var standbyDeckIndex: Int { 1 - activeDeckIndex }
+
+    /// Merge point for the two decks; its output feeds the EQ so the EQ
+    /// stage applies to both sides of a crossfade overlap.
+    private let blendMixer = AVAudioMixerNode()
 
     /// The EQ stage. Flat/bypassed by default; exposed so #40's preset UI
     /// can drive band gains on the live graph.
     public let eq = AVAudioUnitEQ(numberOfBands: 10)
 
-    private var streamer: DSPTrackStreamer?
-    private var processingFormat: AVAudioFormat?
+    /// Format the shared blend → EQ → main-mixer chain is wired with.
+    /// Rewired to the incoming track's format only while no other deck is
+    /// live (rewiring under a rendering deck would glitch it); the blend
+    /// mixer sample-rate-converts any mismatched deck in the meantime.
+    private var sharedChainFormat: AVAudioFormat?
+
     private var configurationChangeObserver: NSObjectProtocol?
 
     // MARK: - Transport / position state
 
     public private(set) var state: TransportState = .idle
 
-    /// Stream frame corresponding to node sample time 0 — reset by
-    /// `load` (0) and `seek` (the landing frame). Position is
-    /// `baseFrame + playerTime.sampleTime`.
-    private var baseFrame: AVAudioFramePosition = 0
-
-    /// Last node sample time successfully read while rendering, so the
-    /// position survives pauses (when `playerTime(forNodeTime:)` goes nil).
-    private var lastKnownSampleTime: AVAudioFramePosition = 0
-
-    private var sampleRate: Double = 44_100
-
-    /// Pending volume applied to the mixer once the graph exists.
+    /// Pending volume applied to the main mixer once the graph exists.
     private var volume: Float = 1.0
 
     /// Core Audio output device UID the engine output should pin to
@@ -89,19 +207,70 @@ public final class EngineDSPPipeline {
 
     private var positionTimer: Timer?
 
-    /// Bumped per `load` so a stale streamer's late callbacks (format-ready,
-    /// finished, error) can't cross tracks.
-    private var loadGeneration: Int = 0
+    // MARK: - Crossfade state (#41)
+
+    private var crossfade = CrossfadeSettings()
+
+    /// The owner-armed upcoming track, if any. Consumed at handoff.
+    private var armed: ArmedNextTrack?
+
+    /// Key of the armed track whose stream has been started on the standby
+    /// deck; nil until the prepare window opens.
+    private var prepStartedForKey: String?
+
+    /// Whether the standby deck's stream has resolved its format and begun
+    /// scheduling — the gate for actually starting the fade.
+    private var standbyReady = false
+
+    /// Deck currently fading out (auto-crossfade or quick-switch). nil when
+    /// no fade is in flight.
+    private var retiringDeckIndex: Int?
+
+    /// Fade-in applied to the active deck's next node start (quick-switch
+    /// path: the incoming track ramps up over 250 ms).
+    private var pendingFadeInDuration: Double?
+
+    /// Set at handoff, consumed by `adoptHandedOffTrack(key:)`.
+    private var pendingAdoptKey: String?
+    private var handoffReceipt: HandoffReceipt?
+
+    // MARK: - Gain ramps
+
+    private enum RampDirection {
+        case fadeIn
+        case fadeOut
+    }
+
+    private struct GainRamp {
+        let deckIndex: Int
+        let direction: RampDirection
+        let duration: Double
+        let curve: CrossfadeSettings.Curve
+        var elapsed: Double = 0
+        var onComplete: (() -> Void)?
+    }
+
+    private var ramps: [GainRamp] = []
+    private var rampTimer: Timer?
+    private let rampInterval: TimeInterval = 1.0 / 50.0
 
     public init() {
-        engine.attach(playerNode)
+        for deck in decks {
+            engine.attach(deck.player)
+            engine.attach(deck.fadeMixer)
+            deck.fadeMixer.outputVolume = 1
+        }
+        engine.attach(blendMixer)
         engine.attach(eq)
         configureFlatEQ()
         // Initial wiring with a placeholder format so the graph is valid
-        // before the first track's real format is known; `connectGraph`
-        // rewires with the source format per track.
+        // before the first track's real format is known; the per-deck and
+        // shared chains rewire with real source formats per track.
         if let placeholder = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2) {
-            connectGraph(format: placeholder)
+            for index in decks.indices {
+                wireDeckChain(index, format: placeholder)
+            }
+            wireSharedChain(format: placeholder)
         }
         // An output-device disappearance (unplugged interface) stops the
         // engine. Restart best-effort so playback continues on the new
@@ -122,6 +291,7 @@ public final class EngineDSPPipeline {
             NotificationCenter.default.removeObserver(observer)
         }
         positionTimer?.invalidate()
+        rampTimer?.invalidate()
     }
 
     // MARK: - Loading
@@ -132,47 +302,58 @@ public final class EngineDSPPipeline {
     ///
     /// `containerHint` is the Jellyfin container string ("flac", "mp3", …)
     /// used to bias AudioToolbox's container sniffing; `durationHint` (in
-    /// seconds) backs seek estimation on streams without packet tables.
+    /// seconds) backs seek estimation on streams without packet tables and
+    /// the crossfade window math; `trackKey` / `albumKey` are the opaque
+    /// track/album identities the crossfade scheduler matches against.
+    ///
+    /// With crossfade on and audio currently rendering, the outgoing track
+    /// quick-fades out over 250 ms on its own deck while the new one loads on
+    /// the other — the issue #41 manual-skip contract (no pop). With
+    /// crossfade off this is byte-for-byte the pre-#41 hard swap.
     public func load(
         url: URL,
         authHeader: String?,
         containerHint: String? = nil,
-        durationHint: Double? = nil
+        durationHint: Double? = nil,
+        trackKey: String? = nil,
+        albumKey: String? = nil
     ) {
-        unloadCurrentTrack()
+        // Any pending handoff is dead the moment the owner loads something
+        // explicitly — the receipt must not leak into the new track.
+        pendingAdoptKey = nil
+        handoffReceipt = nil
+        settleFadeImmediately()
+        disarmNextTrack()
 
-        loadGeneration &+= 1
-        let generation = loadGeneration
+        let quickSwitch = crossfade.isEnabled
+            && state == .playing
+            && engine.isRunning
+            && activeDeck.player.isPlaying
 
-        let streamer = DSPTrackStreamer(
+        if quickSwitch {
+            beginQuickRetire(of: activeDeckIndex)
+            activeDeckIndex = 1 - activeDeckIndex
+            pendingFadeInDuration = CrossfadeSettings.quickSwitchDuration
+        } else {
+            unload(deck: activeDeck)
+            stopPositionTimer()
+            // `stop()` on the engine mirrors the pre-#41 teardown — required
+            // so a paused track's tail can't leak into the next one. Never
+            // taken on the quick-switch path, where the outgoing tail must
+            // keep rendering through its fade.
+            engine.stop()
+        }
+
+        loadTrack(
+            onDeckAt: activeDeckIndex,
             url: url,
             authHeader: authHeader,
-            playerNode: playerNode,
-            fileTypeHint: EngineDSPPipeline.fileTypeHint(forContainer: containerHint),
-            durationHintSeconds: durationHint
+            containerHint: containerHint,
+            durationHint: durationHint,
+            trackKey: trackKey,
+            albumKey: albumKey,
+            initialGain: pendingFadeInDuration == nil ? 1 : 0
         )
-        streamer.onFormatReady = { [weak self] format in
-            guard let self, generation == self.loadGeneration else { return }
-            self.handleFormatReady(format)
-        }
-        streamer.onPlaybackFinished = { [weak self] in
-            guard let self, generation == self.loadGeneration else { return }
-            self.stopPositionTimer()
-            self.state = .idle
-            self.onTrackFinished?()
-        }
-        streamer.onStreamError = { [weak self] message in
-            guard let self, generation == self.loadGeneration else { return }
-            self.stopPositionTimer()
-            self.state = .idle
-            self.onStreamError?(message)
-        }
-        streamer.onSeekCommitted = { [weak self] landedFrame in
-            guard let self, generation == self.loadGeneration else { return }
-            self.baseFrame = landedFrame
-        }
-        self.streamer = streamer
-        streamer.start()
     }
 
     // MARK: - Transport
@@ -183,17 +364,26 @@ public final class EngineDSPPipeline {
     public func play() {
         state = .playing
         startNodeIfReady()
+        resumeRetiringNodeIfNeeded()
+        resumeRampTimerIfNeeded()
         startPositionTimer()
     }
 
     public func pause() {
         guard state == .playing else { return }
-        // Snapshot the position while the render clock is still readable —
-        // `playerTime(forNodeTime:)` returns nil once the node pauses.
-        refreshLastKnownSampleTime()
+        // Snapshot positions while the render clock is still readable —
+        // `playerTime(forNodeTime:)` returns nil once a node pauses.
+        refreshLastKnownSampleTime(of: activeDeck)
+        if let retiring = retiringDeckIndex {
+            refreshLastKnownSampleTime(of: decks[retiring])
+        }
         state = .paused
         stopPositionTimer()
-        playerNode.pause()
+        suspendRampTimer()
+        activeDeck.player.pause()
+        if let retiring = retiringDeckIndex {
+            decks[retiring].player.pause()
+        }
         engine.pause()
     }
 
@@ -201,13 +391,21 @@ public final class EngineDSPPipeline {
         guard state != .playing else { return }
         state = .playing
         startNodeIfReady()
+        resumeRetiringNodeIfNeeded()
+        resumeRampTimerIfNeeded()
         startPositionTimer()
     }
 
-    /// Full teardown: cancel the stream, drop scheduled audio, stop the
-    /// engine, reset position.
+    /// Full teardown: cancel both decks' streams, drop scheduled audio, stop
+    /// the engine, reset positions, clear any armed crossfade.
     public func stop() {
-        unloadCurrentTrack()
+        settleFadeImmediately()
+        disarmNextTrack()
+        pendingAdoptKey = nil
+        handoffReceipt = nil
+        unload(deck: activeDeck)
+        stopPositionTimer()
+        engine.stop()
         state = .idle
     }
 
@@ -216,22 +414,27 @@ public final class EngineDSPPipeline {
     /// resumes from there. Position reflects the target immediately; the
     /// streamer corrects it via `onSeekCommitted` if the landing differs
     /// (estimated VBR offsets, or a server that ignored the Range header).
+    ///
+    /// A fade in flight is settled first (outgoing deck silenced, incoming
+    /// snapped to full gain) — scrubbing during an overlap targets the track
+    /// the UI already shows, and two clocks can't fight over the position.
     public func seek(toSeconds seconds: Double) {
-        guard let streamer else { return }
+        settleFadeImmediately()
+        let deck = activeDeck
+        guard let streamer = deck.streamer else { return }
         // Before the stream header has parsed there is no packet table to
         // seek within (and `sampleRate` is still the placeholder) — drop the
-        // request instead of lying about the position. The streamer would
-        // ignore it anyway; this keeps `baseFrame` honest too.
-        guard processingFormat != nil else { return }
-        let targetFrame = AVAudioFramePosition(max(0, seconds) * sampleRate)
+        // request instead of lying about the position.
+        guard deck.format != nil else { return }
+        let targetFrame = AVAudioFramePosition(max(0, seconds) * deck.sampleRate)
 
         // Generation-bump the streamer *before* stopping the node so the
         // completions fired by `stop()` can't advance stale bookkeeping.
         streamer.seek(toFrame: targetFrame)
 
-        playerNode.stop()
-        baseFrame = targetFrame
-        lastKnownSampleTime = 0
+        deck.player.stop()
+        deck.baseFrame = targetFrame
+        deck.lastKnownSampleTime = 0
 
         // Playing: restart the node so re-streamed buffers render as they
         // arrive. Paused: leave everything parked — the streamer keeps
@@ -258,60 +461,221 @@ public final class EngineDSPPipeline {
 
     // MARK: - Position
 
-    /// Current playback position in stream seconds. Reads the node's render
-    /// clock while playing; falls back to the last known position while
-    /// paused/stopped.
+    /// Current playback position in stream seconds for the *active* track.
+    /// Reads the node's render clock while playing; falls back to the last
+    /// known position while paused/stopped.
     public var positionSeconds: Double {
-        refreshLastKnownSampleTime()
-        return Double(baseFrame + lastKnownSampleTime) / sampleRate
+        position(of: activeDeck)
     }
 
-    // MARK: - Internals
-
-    private func unloadCurrentTrack() {
-        // Invalidate callbacks from the outgoing streamer before touching
-        // the node so nothing it fires mid-teardown lands on fresh state.
-        loadGeneration &+= 1
-        streamer?.cancel()
-        streamer = nil
-        stopPositionTimer()
-        // `stop()` drops every scheduled buffer — required so a paused
-        // track's tail can't leak into the next one. Safe on an attached
-        // node regardless of whether the engine is currently rendering.
-        playerNode.stop()
-        engine.stop()
-        baseFrame = 0
-        lastKnownSampleTime = 0
+    /// Opaque key of the track currently loaded on the active deck — the
+    /// owner's stale-arm guard.
+    public var currentTrackKey: String? {
+        activeDeck.trackKey
     }
 
-    private func handleFormatReady(_ format: AVAudioFormat) {
-        processingFormat = format
-        sampleRate = format.sampleRate
-        connectGraph(format: format)
-        engine.prepare()
-        // Only now may the streamer schedule decoded buffers — scheduling
-        // against a graph wired for a different format raises inside
-        // AVFoundation.
-        streamer?.beginScheduling()
-        if state == .playing {
-            startNodeIfReady()
+    // MARK: - Crossfade (#41)
+
+    /// Drive the crossfade scheduler from user settings. Safe to call at any
+    /// time; turning crossfade off mid-track disarms any pending next track
+    /// (a fade already in progress completes — it is audibly underway).
+    public func applyCrossfade(_ settings: CrossfadeSettings) {
+        crossfade = settings
+        if !settings.isEnabled {
+            disarmNextTrack()
         }
     }
 
-    private func connectGraph(format: AVAudioFormat) {
-        engine.connect(playerNode, to: eq, format: format)
-        engine.connect(eq, to: engine.mainMixerNode, format: format)
-        engine.mainMixerNode.outputVolume = volume
+    /// Whether the applied settings enable crossfade — the owner's cheap
+    /// guard before resolving an arm.
+    public var crossfadeIsEnabled: Bool {
+        crossfade.isEnabled
     }
 
-    /// Start the engine + node when both the transport intent is "playing"
-    /// and the graph has a real format. Safe to call repeatedly.
+    /// Arm the upcoming track for a crossfaded transition. Replaces any
+    /// previously armed track; the streamer doesn't start until the prepare
+    /// window opens (`CrossfadeSettings.prepareLeadSeconds` before the fade),
+    /// so arming is cheap and re-arming after queue edits costs nothing.
+    public func armNextTrack(_ next: ArmedNextTrack) {
+        guard crossfade.isEnabled else { return }
+        if let inFlight = prepStartedForKey, inFlight != next.key {
+            // The armed target changed after its stream already started —
+            // drop the stale prep so the window math re-prepares the right
+            // track.
+            cancelPrep()
+        }
+        armed = next
+    }
+
+    /// Drop the armed next track and any standby prep for it. Never touches
+    /// a deck that is mid-retirement.
+    public func disarmNextTrack() {
+        armed = nil
+        cancelPrep()
+    }
+
+    /// Hand the owner the receipt for a transition `onCrossfadeBegan`
+    /// announced, if `key` matches the track that took over. The owner calls
+    /// this from its `play(track:)` path: a non-nil receipt means the track
+    /// is *already playing* on the active deck — adopt it (mirror the
+    /// reporting swap) instead of reloading. One-shot.
+    public func adoptHandedOffTrack(key: String) -> HandoffReceipt? {
+        guard pendingAdoptKey == key, let receipt = handoffReceipt else { return nil }
+        pendingAdoptKey = nil
+        handoffReceipt = nil
+        return receipt
+    }
+
+    // MARK: - Internals: loading
+
+    private func loadTrack(
+        onDeckAt deckIndex: Int,
+        url: URL,
+        authHeader: String?,
+        containerHint: String?,
+        durationHint: Double?,
+        trackKey: String?,
+        albumKey: String?,
+        initialGain: Float
+    ) {
+        let deck = decks[deckIndex]
+        deck.generation &+= 1
+        let generation = deck.generation
+        deck.format = nil
+        deck.baseFrame = 0
+        deck.lastKnownSampleTime = 0
+        deck.durationSeconds = durationHint
+        deck.trackKey = trackKey
+        deck.albumKey = albumKey
+        deck.fadeMixer.outputVolume = initialGain
+
+        let streamer = DSPTrackStreamer(
+            url: url,
+            authHeader: authHeader,
+            playerNode: deck.player,
+            fileTypeHint: EngineDSPPipeline.fileTypeHint(forContainer: containerHint),
+            durationHintSeconds: durationHint
+        )
+        streamer.onFormatReady = { [weak self] format in
+            guard let self, generation == self.decks[deckIndex].generation else { return }
+            self.handleFormatReady(format, deckIndex: deckIndex)
+        }
+        streamer.onPlaybackFinished = { [weak self] in
+            guard let self, generation == self.decks[deckIndex].generation else { return }
+            self.handleStreamerFinished(deckIndex: deckIndex)
+        }
+        streamer.onStreamError = { [weak self] message in
+            guard let self, generation == self.decks[deckIndex].generation else { return }
+            self.handleStreamerError(message, deckIndex: deckIndex)
+        }
+        streamer.onSeekCommitted = { [weak self] landedFrame in
+            guard let self, generation == self.decks[deckIndex].generation else { return }
+            self.decks[deckIndex].baseFrame = landedFrame
+        }
+        deck.streamer = streamer
+        streamer.start()
+    }
+
+    private func unload(deck: Deck) {
+        // Invalidate callbacks from the outgoing streamer before touching
+        // the node so nothing it fires mid-teardown lands on fresh state.
+        deck.generation &+= 1
+        deck.streamer?.cancel()
+        deck.streamer = nil
+        // `stop()` drops every scheduled buffer — required so a paused
+        // track's tail can't leak into the next one. Safe on an attached
+        // node regardless of whether the engine is currently rendering.
+        deck.player.stop()
+        deck.format = nil
+        deck.baseFrame = 0
+        deck.lastKnownSampleTime = 0
+        deck.durationSeconds = nil
+        deck.trackKey = nil
+        deck.albumKey = nil
+    }
+
+    private func handleFormatReady(_ format: AVAudioFormat, deckIndex: Int) {
+        let deck = decks[deckIndex]
+        deck.format = format
+        deck.sampleRate = format.sampleRate
+        wireDeckChain(deckIndex, format: format)
+        rewireSharedChainIfQuiet(format: format, loadingDeckIndex: deckIndex)
+        if !engine.isRunning {
+            engine.prepare()
+        }
+        // Only now may the streamer schedule decoded buffers — scheduling
+        // against a graph wired for a different format raises inside
+        // AVFoundation.
+        deck.streamer?.beginScheduling()
+
+        if deckIndex == activeDeckIndex {
+            if state == .playing {
+                startNodeIfReady()
+            }
+        } else if prepStartedForKey != nil, deckIndex == standbyDeckIndex {
+            // The armed track's stream is decoding — the fade may begin.
+            standbyReady = true
+        }
+    }
+
+    // MARK: - Internals: graph wiring
+
+    /// Wire (or rewire) one deck's player → fadeMixer → blendMixer chain for
+    /// `format`. Skips entirely when the deck is already wired for an equal
+    /// format, so a same-format reload never disturbs the running graph —
+    /// and a prep load on the standby deck only touches its own subgraph,
+    /// never the rendering deck's.
+    private func wireDeckChain(_ deckIndex: Int, format: AVAudioFormat) {
+        let deck = decks[deckIndex]
+        if let wired = deck.wiredFormat, wired == format { return }
+        engine.connect(deck.player, to: deck.fadeMixer, format: format)
+        engine.connect(deck.fadeMixer, to: blendMixer, fromBus: 0, toBus: deckIndex, format: format)
+        deck.wiredFormat = format
+    }
+
+    private func wireSharedChain(format: AVAudioFormat) {
+        engine.connect(blendMixer, to: eq, format: format)
+        engine.connect(eq, to: engine.mainMixerNode, format: format)
+        engine.mainMixerNode.outputVolume = volume
+        sharedChainFormat = format
+    }
+
+    /// Rewire the shared blend → EQ → main chain to `format`, but only while
+    /// no *other* deck is live (rendering or buffering) — changing the chain
+    /// under a playing deck glitches it. When the chain can't move, the
+    /// blend mixer converts the mismatched deck's rate/channels instead, so
+    /// playback is always correct; the chain re-aligns to the source format
+    /// on the next quiet load.
+    private func rewireSharedChainIfQuiet(format: AVAudioFormat, loadingDeckIndex: Int) {
+        if let current = sharedChainFormat, current == format { return }
+        let otherIndex = 1 - loadingDeckIndex
+        guard decks[otherIndex].streamer == nil, retiringDeckIndex == nil else { return }
+        wireSharedChain(format: format)
+    }
+
+    /// Start the engine + active node when both the transport intent is
+    /// "playing" and the active deck has a real format. Safe to call
+    /// repeatedly. Consumes a pending quick-switch fade-in on first start.
     private func startNodeIfReady() {
-        guard state == .playing, processingFormat != nil else { return }
+        guard state == .playing, activeDeck.format != nil else { return }
         ensureEngineRunning()
         guard engine.isRunning else { return }
-        if !playerNode.isPlaying {
-            playerNode.play()
+        if !activeDeck.player.isPlaying {
+            if let fadeIn = pendingFadeInDuration {
+                pendingFadeInDuration = nil
+                activeDeck.fadeMixer.outputVolume = 0
+                addRamp(deckIndex: activeDeckIndex, direction: .fadeIn, duration: fadeIn)
+            }
+            activeDeck.player.play()
+        }
+    }
+
+    /// Resume the outgoing deck's tail after a pause that interrupted a fade.
+    private func resumeRetiringNodeIfNeeded() {
+        guard let retiring = retiringDeckIndex, engine.isRunning else { return }
+        let deck = decks[retiring]
+        if !deck.player.isPlaying {
+            deck.player.play()
         }
     }
 
@@ -325,12 +689,17 @@ public final class EngineDSPPipeline {
         }
     }
 
-    private func refreshLastKnownSampleTime() {
-        guard let nodeTime = playerNode.lastRenderTime,
-              let playerTime = playerNode.playerTime(forNodeTime: nodeTime),
+    private func refreshLastKnownSampleTime(of deck: Deck) {
+        guard let nodeTime = deck.player.lastRenderTime,
+              let playerTime = deck.player.playerTime(forNodeTime: nodeTime),
               playerTime.isSampleTimeValid
         else { return }
-        lastKnownSampleTime = max(0, playerTime.sampleTime)
+        deck.lastKnownSampleTime = max(0, playerTime.sampleTime)
+    }
+
+    private func position(of deck: Deck) -> Double {
+        refreshLastKnownSampleTime(of: deck)
+        return Double(deck.baseFrame + deck.lastKnownSampleTime) / deck.sampleRate
     }
 
     private func handleConfigurationChange() {
@@ -339,9 +708,11 @@ public final class EngineDSPPipeline {
         // default). If we were playing, restart on the new configuration.
         guard state == .playing else { return }
         ensureEngineRunning()
-        if engine.isRunning, !playerNode.isPlaying {
-            playerNode.play()
+        guard engine.isRunning else { return }
+        if !activeDeck.player.isPlaying {
+            activeDeck.player.play()
         }
+        resumeRetiringNodeIfNeeded()
     }
 
     private func applyOutputDevice() {
@@ -363,6 +734,334 @@ public final class EngineDSPPipeline {
         }
     }
 
+    // MARK: - Internals: streamer events
+
+    private func handleStreamerFinished(deckIndex: Int) {
+        if deckIndex == retiringDeckIndex {
+            // The outgoing track drained mid-fade — its deck is silent now;
+            // finish the retirement early. The incoming ramp keeps running.
+            finishRetiringDeck()
+            return
+        }
+        guard deckIndex == activeDeckIndex else { return }
+
+        // Natural end of the active track. If an armed next track is fully
+        // buffered, take the zero-fade join (same-album rule, short tracks,
+        // or a fade window the position never crossed) instead of bouncing
+        // through the owner's rebuild path.
+        if let armed,
+           crossfade.isEnabled,
+           standbyReady,
+           prepStartedForKey == armed.key,
+           onShouldBeginCrossfade?() ?? true {
+            performZeroFadeHandoff(of: armed)
+            return
+        }
+
+        stopPositionTimer()
+        state = .idle
+        onTrackFinished?()
+    }
+
+    private func handleStreamerError(_ message: String, deckIndex: Int) {
+        if deckIndex == retiringDeckIndex {
+            // The outgoing tail died during its fade — it was ending anyway.
+            finishRetiringDeck()
+            return
+        }
+        if deckIndex != activeDeckIndex {
+            // The *armed* track's prep stream failed. Quietly abandon the
+            // crossfade — the transition falls back to the owner's rebuild
+            // path at track end, which surfaces its own error if the track
+            // is genuinely unreachable. Never skip the currently-playing
+            // track over a preload failure.
+            pipelineLog.error("DSP crossfade prep failed, falling back to rebuild: \(message, privacy: .public)")
+            disarmNextTrack()
+            return
+        }
+        stopPositionTimer()
+        state = .idle
+        onStreamError?(message)
+    }
+
+    // MARK: - Internals: crossfade scheduling
+
+    /// Driven by the 1 Hz position tick (playing only — the energy
+    /// contract's existing cadence; no new timers while idle).
+    private func evaluateCrossfadeWindow() {
+        guard state == .playing,
+              retiringDeckIndex == nil,
+              let armed,
+              crossfade.isEnabled,
+              let duration = activeDeck.durationSeconds, duration > 0
+        else { return }
+
+        let sameAlbum = armed.albumKey != nil && armed.albumKey == activeDeck.albumKey
+        let fadeDuration = CrossfadeSettings.effectiveFadeDuration(
+            configured: crossfade.durationSeconds,
+            trackDurationSeconds: duration,
+            sameAlbum: sameAlbum
+        )
+        let remaining = duration - position(of: activeDeck)
+
+        switch CrossfadeSettings.tickAction(
+            remainingSeconds: remaining,
+            fadeDuration: fadeDuration,
+            prepStarted: prepStartedForKey == armed.key,
+            standbyReady: standbyReady
+        ) {
+        case .none:
+            break
+        case .prepare:
+            beginPrep(of: armed)
+        case .beginFade:
+            guard onShouldBeginCrossfade?() ?? true else { return }
+            // Late starts (slow prep, seek into the window) shorten the
+            // fade to what's actually left so the ramp never outlives the
+            // outgoing audio by more than the scheduling slack.
+            let usable = min(fadeDuration, max(remaining, CrossfadeSettings.quickSwitchDuration))
+            beginAutoCrossfade(of: armed, fadeDuration: usable)
+        }
+    }
+
+    /// Start buffering the armed track on the standby deck. No audio yet —
+    /// the node stays stopped and the deck's fade mixer is parked at 0.
+    private func beginPrep(of armed: ArmedNextTrack) {
+        let deckIndex = standbyDeckIndex
+        unload(deck: decks[deckIndex])
+        prepStartedForKey = armed.key
+        standbyReady = false
+        loadTrack(
+            onDeckAt: deckIndex,
+            url: armed.url,
+            authHeader: armed.authHeader,
+            containerHint: armed.containerHint,
+            durationHint: armed.durationHint,
+            trackKey: armed.key,
+            albumKey: armed.albumKey,
+            initialGain: 0
+        )
+    }
+
+    private func cancelPrep() {
+        guard prepStartedForKey != nil else { return }
+        prepStartedForKey = nil
+        standbyReady = false
+        let deckIndex = standbyDeckIndex
+        guard deckIndex != retiringDeckIndex else { return }
+        unload(deck: decks[deckIndex])
+    }
+
+    /// The ramped overlap: swap the active deck to the armed track, start
+    /// its node at gain 0, and run both envelopes. `onCrossfadeBegan` fires
+    /// after audio starts so the owner's queue advance observes a track
+    /// that is genuinely audible.
+    private func beginAutoCrossfade(of armed: ArmedNextTrack, fadeDuration: Double) {
+        let outgoingIndex = activeDeckIndex
+        let incomingIndex = standbyDeckIndex
+        let incoming = decks[incomingIndex]
+        guard incoming.format != nil else { return }
+        ensureEngineRunning()
+        guard engine.isRunning else { return }
+
+        handoffReceipt = HandoffReceipt(
+            outgoingPositionSeconds: position(of: decks[outgoingIndex]),
+            mediaSourceId: armed.mediaSourceId,
+            playSessionId: armed.playSessionId
+        )
+        pendingAdoptKey = armed.key
+        let key = armed.key
+        self.armed = nil
+        prepStartedForKey = nil
+        standbyReady = false
+
+        retiringDeckIndex = outgoingIndex
+        activeDeckIndex = incomingIndex
+        incoming.fadeMixer.outputVolume = 0
+        incoming.player.play()
+        addRamp(deckIndex: incomingIndex, direction: .fadeIn, duration: fadeDuration)
+        addRamp(deckIndex: outgoingIndex, direction: .fadeOut, duration: fadeDuration) { [weak self] in
+            self?.finishRetiringDeck()
+        }
+        pipelineLog.info("crossfade began: \(fadeDuration, privacy: .public)s overlap")
+        onCrossfadeBegan?(key)
+    }
+
+    /// The zero-fade join: the outgoing track has fully played out, and the
+    /// armed one starts immediately at full gain — the issue's same-album /
+    /// short-track gapless contract.
+    private func performZeroFadeHandoff(of armed: ArmedNextTrack) {
+        let outgoingIndex = activeDeckIndex
+        let incomingIndex = standbyDeckIndex
+        let incoming = decks[incomingIndex]
+        ensureEngineRunning()
+        guard engine.isRunning, incoming.format != nil else {
+            // Can't take over — degrade to the plain finish so the owner
+            // rebuilds the next track the ordinary way.
+            disarmNextTrack()
+            stopPositionTimer()
+            state = .idle
+            onTrackFinished?()
+            return
+        }
+
+        handoffReceipt = HandoffReceipt(
+            outgoingPositionSeconds: position(of: decks[outgoingIndex]),
+            mediaSourceId: armed.mediaSourceId,
+            playSessionId: armed.playSessionId
+        )
+        pendingAdoptKey = armed.key
+        let key = armed.key
+        self.armed = nil
+        prepStartedForKey = nil
+        standbyReady = false
+
+        activeDeckIndex = incomingIndex
+        incoming.fadeMixer.outputVolume = 1
+        incoming.player.play()
+
+        let outgoing = decks[outgoingIndex]
+        unload(deck: outgoing)
+        outgoing.fadeMixer.outputVolume = 1
+        pipelineLog.info("zero-fade handoff")
+        onCrossfadeBegan?(key)
+    }
+
+    /// Quick-switch retirement (manual skip while crossfade is on): the
+    /// outgoing deck keeps rendering its already-scheduled audio through a
+    /// 250 ms fade-out, then stops. Its streamer is cancelled immediately —
+    /// the node holds several seconds of scheduled buffers, far more than
+    /// the fade needs.
+    private func beginQuickRetire(of deckIndex: Int) {
+        let deck = decks[deckIndex]
+        deck.generation &+= 1
+        deck.streamer?.cancel()
+        deck.streamer = nil
+        retiringDeckIndex = deckIndex
+        addRamp(
+            deckIndex: deckIndex,
+            direction: .fadeOut,
+            duration: CrossfadeSettings.quickSwitchDuration
+        ) { [weak self] in
+            self?.finishRetiringDeck()
+        }
+    }
+
+    /// Stop + reset the retiring deck once its fade-out (or its own stream
+    /// completion) finishes. Idempotent.
+    private func finishRetiringDeck() {
+        guard let retiring = retiringDeckIndex else { return }
+        retiringDeckIndex = nil
+        ramps.removeAll { $0.deckIndex == retiring }
+        let deck = decks[retiring]
+        unload(deck: deck)
+        deck.fadeMixer.outputVolume = 1
+        if ramps.isEmpty {
+            stopRampTimer()
+        }
+    }
+
+    /// Hard-finish any fade in flight: outgoing deck silenced + unloaded,
+    /// active deck snapped to full gain. Used by seek/stop/load, where a
+    /// half-faded state has no meaning.
+    private func settleFadeImmediately() {
+        if let retiring = retiringDeckIndex {
+            retiringDeckIndex = nil
+            let deck = decks[retiring]
+            unload(deck: deck)
+            deck.fadeMixer.outputVolume = 1
+        }
+        ramps.removeAll()
+        stopRampTimer()
+        pendingFadeInDuration = nil
+        activeDeck.fadeMixer.outputVolume = 1
+    }
+
+    // MARK: - Internals: gain ramps
+
+    /// Install a gain envelope on a deck's fade mixer. Replaces any ramp
+    /// already running on that deck. The 50 Hz ramp timer exists only while
+    /// at least one ramp is active.
+    private func addRamp(
+        deckIndex: Int,
+        direction: RampDirection,
+        duration: Double,
+        onComplete: (() -> Void)? = nil
+    ) {
+        ramps.removeAll { $0.deckIndex == deckIndex }
+        guard duration > 0 else {
+            decks[deckIndex].fadeMixer.outputVolume = direction == .fadeIn ? 1 : 0
+            onComplete?()
+            return
+        }
+        ramps.append(GainRamp(
+            deckIndex: deckIndex,
+            direction: direction,
+            duration: duration,
+            curve: crossfade.curve,
+            onComplete: onComplete
+        ))
+        startRampTimerIfNeeded()
+    }
+
+    private func startRampTimerIfNeeded() {
+        guard rampTimer == nil, !ramps.isEmpty else { return }
+        let timer = Timer(timeInterval: rampInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.rampTick()
+            }
+        }
+        timer.tolerance = rampInterval / 4
+        RunLoop.main.add(timer, forMode: .common)
+        rampTimer = timer
+    }
+
+    private func suspendRampTimer() {
+        rampTimer?.invalidate()
+        rampTimer = nil
+    }
+
+    private func resumeRampTimerIfNeeded() {
+        startRampTimerIfNeeded()
+    }
+
+    private func stopRampTimer() {
+        rampTimer?.invalidate()
+        rampTimer = nil
+    }
+
+    private func rampTick() {
+        guard state == .playing else { return }
+        guard !ramps.isEmpty else {
+            stopRampTimer()
+            return
+        }
+        var remaining: [GainRamp] = []
+        var completions: [() -> Void] = []
+        for var ramp in ramps {
+            ramp.elapsed += rampInterval
+            let progress = min(1, ramp.elapsed / ramp.duration)
+            let gain: Float = ramp.direction == .fadeIn
+                ? CrossfadeSettings.fadeInGain(progress: progress, curve: ramp.curve)
+                : CrossfadeSettings.fadeOutGain(progress: progress, curve: ramp.curve)
+            decks[ramp.deckIndex].fadeMixer.outputVolume = gain
+            if progress >= 1 {
+                if let onComplete = ramp.onComplete {
+                    completions.append(onComplete)
+                }
+            } else {
+                remaining.append(ramp)
+            }
+        }
+        ramps = remaining
+        if ramps.isEmpty {
+            stopRampTimer()
+        }
+        for completion in completions {
+            completion()
+        }
+    }
+
     // MARK: - Position timer (1 Hz, playing only)
 
     private func startPositionTimer() {
@@ -373,8 +1072,9 @@ public final class EngineDSPPipeline {
                 // Skip the tick when nothing is actually rendering yet
                 // (stream still buffering) — matches the AVPlayer observer's
                 // rate != 0 guard.
-                guard self.engine.isRunning, self.playerNode.isPlaying else { return }
+                guard self.engine.isRunning, self.activeDeck.player.isPlaying else { return }
                 self.onPositionTick?(self.positionSeconds)
+                self.evaluateCrossfadeWindow()
             }
         }
         timer.tolerance = 0.2
@@ -441,20 +1141,51 @@ public final class EngineDSPPipeline {
     }
 
     #if DEBUG
-    /// Test seam: whether the EQ node is attached to this pipeline's engine
-    /// and wired between the player node and the main mixer.
+    /// Test seam: whether the active deck's chain reaches the main mixer
+    /// through its fade mixer, the blend mixer, and the EQ — the #41 dual-
+    /// deck topology with the EQ stage shared by both decks.
     var isEQWiredForTesting: Bool {
-        guard eq.engine === engine, playerNode.engine === engine else { return false }
-        let playerFeedsEQ = engine.outputConnectionPoints(for: playerNode, outputBus: 0)
+        guard eq.engine === engine, activeDeck.player.engine === engine else { return false }
+        let playerFeedsFade = engine.outputConnectionPoints(for: activeDeck.player, outputBus: 0)
+            .contains { $0.node === activeDeck.fadeMixer }
+        let fadeFeedsBlend = engine.outputConnectionPoints(for: activeDeck.fadeMixer, outputBus: 0)
+            .contains { $0.node === blendMixer }
+        let blendFeedsEQ = engine.outputConnectionPoints(for: blendMixer, outputBus: 0)
             .contains { $0.node === eq }
         let eqFeedsMixer = engine.outputConnectionPoints(for: eq, outputBus: 0)
             .contains { $0.node === engine.mainMixerNode }
-        return playerFeedsEQ && eqFeedsMixer
+        return playerFeedsFade && fadeFeedsBlend && blendFeedsEQ && eqFeedsMixer
     }
 
     /// Test seam: the EQ must be audibly inert until #40 ships controls.
     var isEQFlatForTesting: Bool {
         eq.globalGain == 0 && eq.bands.allSatisfy { $0.bypass && $0.gain == 0 }
     }
+
+    /// Test seam: both decks must feed the blend mixer through their own
+    /// fade mixers (the #41 per-node gain stages), each parked at unity.
+    var areBothDecksWiredForTesting: Bool {
+        decks.allSatisfy { deck in
+            let playerFeedsFade = engine.outputConnectionPoints(for: deck.player, outputBus: 0)
+                .contains { $0.node === deck.fadeMixer }
+            let fadeFeedsBlend = engine.outputConnectionPoints(for: deck.fadeMixer, outputBus: 0)
+                .contains { $0.node === blendMixer }
+            return playerFeedsFade && fadeFeedsBlend
+        }
+    }
+
+    /// Test seam: per-deck fade-mixer gains, deck order (A, B).
+    var fadeMixerGainsForTesting: [Float] {
+        decks.map { $0.fadeMixer.outputVolume }
+    }
+
+    /// Test seam: index of the deck the transport currently drives.
+    var activeDeckIndexForTesting: Int { activeDeckIndex }
+
+    /// Test seam: the armed next track's key, if any.
+    var armedTrackKeyForTesting: String? { armed?.key }
+
+    /// Test seam: whether a fade (auto or quick-switch) is in flight.
+    var isFadeInFlightForTesting: Bool { retiringDeckIndex != nil }
     #endif
 }

--- a/macos/Tests/LyrebirdTests/CrossfadeSettingsTests.swift
+++ b/macos/Tests/LyrebirdTests/CrossfadeSettingsTests.swift
@@ -1,0 +1,288 @@
+import AVFoundation
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Coverage for crossfade between tracks (#41):
+///
+///   1. `CrossfadeSettings` value semantics — duration normalization (clamp
+///      to 0…12, zero non-finite), the off contract (anything below 1 s is
+///      disabled), and curve fallback for unknown persisted raw values.
+///   2. Gain envelope math — linear and equal-power shapes, the equal-power
+///      constant-power identity, and progress clamping so a jittery timer
+///      can never push an out-of-range gain onto a mixer node.
+///   3. Scheduling decisions — `effectiveFadeDuration` (off / same-album /
+///      short-track / unknown-duration ⇒ zero-fade) and the pure
+///      `tickAction` window function the 1 Hz tick drives.
+///   4. `UserDefaults` persistence round-trips on the pre-existing
+///      `playback.crossfadeSeconds` key (#116) plus the new curve key, and
+///      missing/garbage keys degrade to the shipped default (off,
+///      equal-power).
+///   5. `AudioEngine` integration — `dspApplyCrossfade` never constructs the
+///      pipeline while the DSP flag is off (zero-behaviour-change contract),
+///      and a freshly built pipeline restores the persisted settings.
+@MainActor
+final class CrossfadeSettingsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "crossfade-tests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        // The engine restores crossfade settings from the *standard* domain
+        // when it builds a pipeline — keep that domain pristine for the
+        // integration tests below.
+        UserDefaults.standard.removeObject(forKey: CrossfadeSettings.DefaultsKey.duration)
+        UserDefaults.standard.removeObject(forKey: CrossfadeSettings.DefaultsKey.curve)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        UserDefaults.standard.removeObject(forKey: CrossfadeSettings.DefaultsKey.duration)
+        UserDefaults.standard.removeObject(forKey: CrossfadeSettings.DefaultsKey.curve)
+        super.tearDown()
+    }
+
+    private func makeEngine() throws -> AudioEngine {
+        let dir = NSTemporaryDirectory() + "lyrebird-crossfade-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "crossfade-test"))
+        return AudioEngine(core: core)
+    }
+
+    // MARK: - 1. Value semantics
+
+    func testShippedDefaultIsOffEqualPower() {
+        let settings = CrossfadeSettings()
+        XCTAssertEqual(settings.durationSeconds, 0)
+        XCTAssertEqual(settings.curve, .equalPower)
+        XCTAssertFalse(settings.isEnabled, "crossfade must ship off")
+    }
+
+    func testDurationNormalizationClampsAndSanitizes() {
+        XCTAssertEqual(CrossfadeSettings.normalizedDuration(99), 12, "clamp to the slider ceiling")
+        XCTAssertEqual(CrossfadeSettings.normalizedDuration(-3), 0, "clamp negatives to off")
+        XCTAssertEqual(CrossfadeSettings.normalizedDuration(.nan), 0, "NaN must never reach the scheduler")
+        XCTAssertEqual(CrossfadeSettings.normalizedDuration(.infinity), 0)
+        XCTAssertEqual(CrossfadeSettings.normalizedDuration(7), 7, "in-range values pass through")
+        XCTAssertEqual(CrossfadeSettings(durationSeconds: 500).durationSeconds, 12, "init normalizes")
+    }
+
+    func testSubSecondDurationsReadAsOff() {
+        XCTAssertFalse(CrossfadeSettings(durationSeconds: 0.5).isEnabled)
+        XCTAssertTrue(CrossfadeSettings(durationSeconds: 1).isEnabled)
+        XCTAssertTrue(CrossfadeSettings(durationSeconds: 12).isEnabled)
+    }
+
+    // MARK: - 2. Envelope math
+
+    func testLinearEnvelope() {
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 0, curve: .linear), 0)
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 0.5, curve: .linear), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 1, curve: .linear), 1)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 0, curve: .linear), 1)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 0.5, curve: .linear), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 1, curve: .linear), 0)
+    }
+
+    func testEqualPowerEnvelopeEndpointsAndMidpoint() {
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 0, curve: .equalPower), 0, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 1, curve: .equalPower), 1, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 0, curve: .equalPower), 1, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 1, curve: .equalPower), 0, accuracy: 0.0001)
+        // Midpoint: sin(π/4) == cos(π/4) == √2/2 ≈ 0.7071 — both sides
+        // louder than linear's 0.5, which is the whole point of the curve.
+        XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 0.5, curve: .equalPower), 0.70710678, accuracy: 0.0001)
+        XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 0.5, curve: .equalPower), 0.70710678, accuracy: 0.0001)
+    }
+
+    /// The defining property: gainIn² + gainOut² == 1 at every point, so the
+    /// summed acoustic power through the overlap is constant.
+    func testEqualPowerHoldsConstantPower() {
+        for step in 0...20 {
+            let t = Double(step) / 20
+            let gainIn = Double(CrossfadeSettings.fadeInGain(progress: t, curve: .equalPower))
+            let gainOut = Double(CrossfadeSettings.fadeOutGain(progress: t, curve: .equalPower))
+            XCTAssertEqual(gainIn * gainIn + gainOut * gainOut, 1, accuracy: 0.0001, "power sum must be 1 at t=\(t)")
+        }
+    }
+
+    func testEnvelopeClampsOutOfRangeProgress() {
+        for curve in CrossfadeSettings.Curve.allCases {
+            XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: -1, curve: curve), 0, accuracy: 0.0001)
+            XCTAssertEqual(CrossfadeSettings.fadeInGain(progress: 2, curve: curve), 1, accuracy: 0.0001)
+            XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: -1, curve: curve), 1, accuracy: 0.0001)
+            XCTAssertEqual(CrossfadeSettings.fadeOutGain(progress: 2, curve: curve), 0, accuracy: 0.0001)
+        }
+    }
+
+    // MARK: - 3. Scheduling decisions
+
+    func testEffectiveFadeDuration() {
+        // Normal case: configured window passes through.
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 4, trackDurationSeconds: 240, sameAlbum: false),
+            4
+        )
+        // Off stays off.
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 0, trackDurationSeconds: 240, sameAlbum: false),
+            0
+        )
+        // Same-album pairs zero-fade (#41's gapless-album rule).
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 4, trackDurationSeconds: 240, sameAlbum: true),
+            0
+        )
+        // A track shorter than twice the window has no room for the fade.
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 12, trackDurationSeconds: 20, sameAlbum: false),
+            0
+        )
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 12, trackDurationSeconds: 24, sameAlbum: false),
+            12,
+            "exactly 2× the window is enough room"
+        )
+        // Unknown duration ⇒ nowhere to place the window.
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: 4, trackDurationSeconds: nil, sameAlbum: false),
+            0
+        )
+        // Corrupted configured values sanitize through the same path.
+        XCTAssertEqual(
+            CrossfadeSettings.effectiveFadeDuration(configured: .nan, trackDurationSeconds: 240, sameAlbum: false),
+            0
+        )
+    }
+
+    func testTickActionWindows() {
+        // Far from the end: nothing to do.
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 120, fadeDuration: 4, prepStarted: false, standbyReady: false),
+            .none
+        )
+        // Inside the buffering window (fade + lead): start the prep once.
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 13, fadeDuration: 4, prepStarted: false, standbyReady: false),
+            .prepare
+        )
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 13, fadeDuration: 4, prepStarted: true, standbyReady: false),
+            .none,
+            "prep must not restart every tick"
+        )
+        // Inside the fade window but the standby stream isn't decodable yet:
+        // keep waiting (the fade shortens as remaining shrinks).
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 3, fadeDuration: 4, prepStarted: true, standbyReady: false),
+            .none
+        )
+        // Inside the fade window and ready: begin.
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 3, fadeDuration: 4, prepStarted: true, standbyReady: true),
+            .beginFade
+        )
+        // Zero-fade transitions (same album / short track) never ramp — they
+        // hand off at completion — but they still buffer ahead.
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 8, fadeDuration: 0, prepStarted: false, standbyReady: false),
+            .prepare
+        )
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: 1, fadeDuration: 0, prepStarted: true, standbyReady: true),
+            .none
+        )
+        // Defensive: a non-finite remaining can't fire anything.
+        XCTAssertEqual(
+            CrossfadeSettings.tickAction(remainingSeconds: .nan, fadeDuration: 4, prepStarted: false, standbyReady: false),
+            .none
+        )
+    }
+
+    // MARK: - 4. Persistence
+
+    func testLoadFromEmptyDefaultsIsShippedDefault() {
+        let settings = CrossfadeSettings.load(from: defaults)
+        XCTAssertEqual(settings, CrossfadeSettings())
+        XCTAssertFalse(settings.isEnabled)
+    }
+
+    func testSaveLoadRoundTrip() {
+        let original = CrossfadeSettings(durationSeconds: 6, curve: .linear)
+        original.save(to: defaults)
+        XCTAssertEqual(CrossfadeSettings.load(from: defaults), original)
+
+        // The duration rides the pre-existing #116 Playback-pane key, so a
+        // value written before #41 landed is honoured as-is.
+        XCTAssertEqual(defaults.double(forKey: "playback.crossfadeSeconds"), 6)
+        XCTAssertEqual(defaults.string(forKey: "playback.crossfadeCurve"), "linear")
+    }
+
+    func testGarbagePersistedValuesDegrade() {
+        defaults.set("totally-not-a-curve", forKey: CrossfadeSettings.DefaultsKey.curve)
+        defaults.set(Double.infinity, forKey: CrossfadeSettings.DefaultsKey.duration)
+        let settings = CrossfadeSettings.load(from: defaults)
+        XCTAssertEqual(settings.curve, .equalPower, "unknown curve raw must fall back, not crash")
+        XCTAssertEqual(settings.durationSeconds, 0, "non-finite duration must sanitize to off")
+    }
+
+    func testSaveNormalizesOutOfRangeDuration() {
+        var settings = CrossfadeSettings(durationSeconds: 4)
+        settings.durationSeconds = 99 // bypass init normalization
+        settings.save(to: defaults)
+        XCTAssertEqual(defaults.double(forKey: CrossfadeSettings.DefaultsKey.duration), 12)
+    }
+
+    // MARK: - 5. AudioEngine integration
+
+    /// Flag off ⇒ zero behaviour change: pushing crossfade settings must not
+    /// construct the DSP pipeline (the AVQueuePlayer path stays untouched).
+    func testApplyCrossfadeIsNoOpWhileFlagOff() throws {
+        let engine = try makeEngine()
+        XCTAssertFalse(engine.dspPipelineEnabled)
+        engine.dspApplyCrossfade(CrossfadeSettings(durationSeconds: 8, curve: .linear))
+        XCTAssertNil(engine.dspPipeline, "flag off ⇒ no DSP pipeline may ever be built")
+    }
+
+    /// A freshly built pipeline restores the persisted settings — the same
+    /// construct-then-restore contract as the EQ (#40), so the crossfade
+    /// survives pipeline rebuilds and app relaunches.
+    func testPipelineConstructionRestoresPersistedSettings() throws {
+        CrossfadeSettings(durationSeconds: 5, curve: .linear).save(to: .standard)
+
+        let engine = try makeEngine()
+        engine.dspPipelineEnabled = true
+        engine.setVolume(0.5) // cheapest pipeline-constructing call; never starts audio
+
+        let pipeline = try XCTUnwrap(engine.dspPipeline)
+        XCTAssertTrue(pipeline.crossfadeIsEnabled, "persisted 5s crossfade must be live on construction")
+    }
+
+    /// Live edits route through `dspApplyCrossfade` onto the existing
+    /// pipeline: enable → the scheduler sees it; disable → pending arms drop.
+    func testApplyCrossfadeDrivesLivePipeline() throws {
+        let engine = try makeEngine()
+        engine.dspPipelineEnabled = true
+        engine.setVolume(0.5)
+        let pipeline = try XCTUnwrap(engine.dspPipeline)
+        XCTAssertFalse(pipeline.crossfadeIsEnabled)
+
+        engine.dspApplyCrossfade(CrossfadeSettings(durationSeconds: 4))
+        XCTAssertTrue(pipeline.crossfadeIsEnabled)
+
+        engine.dspApplyCrossfade(CrossfadeSettings(durationSeconds: 0))
+        XCTAssertFalse(pipeline.crossfadeIsEnabled)
+    }
+}

--- a/macos/Tests/LyrebirdTests/EngineDSPPipelineTests.swift
+++ b/macos/Tests/LyrebirdTests/EngineDSPPipelineTests.swift
@@ -177,15 +177,75 @@ final class EngineDSPPipelineTests: XCTestCase {
 
     // MARK: - Node graph
 
-    /// The EQ node must be live in the graph (player → EQ → main mixer) and
+    /// The EQ node must be live in the graph (deck players → fade mixers →
+    /// blend mixer → EQ → main mixer, the #41 dual-deck layout) and
     /// flat/bypassed — #39 ships the mounting point, #40 ships the controls.
     func testPipelineGraphKeepsFlatEQBetweenPlayerAndMixer() {
         let pipeline = EngineDSPPipeline()
-        XCTAssertTrue(pipeline.isEQWiredForTesting, "AVAudioUnitEQ must sit between the player node and the mixer")
+        XCTAssertTrue(pipeline.isEQWiredForTesting, "AVAudioUnitEQ must sit between the active deck and the mixer")
         XCTAssertTrue(pipeline.isEQFlatForTesting, "EQ must ship flat/bypassed until #40 lands controls")
         XCTAssertEqual(pipeline.eq.bands.count, 10)
         XCTAssertEqual(pipeline.state, .idle)
         XCTAssertEqual(pipeline.positionSeconds, 0, accuracy: 0.0001)
+    }
+
+    /// #41 graph contract: both decks reach the blend mixer through their
+    /// own per-node gain mixers, and with crossfade off both gain stages sit
+    /// at unity (a 1.0 float mix is audibly identical to the pre-#41 single-
+    /// node graph).
+    func testDualDeckGraphShipsAtUnityGain() {
+        let pipeline = EngineDSPPipeline()
+        XCTAssertTrue(pipeline.areBothDecksWiredForTesting, "both decks must feed the blend mixer via their fade mixers")
+        XCTAssertEqual(pipeline.fadeMixerGainsForTesting, [1, 1], "fade mixers must ship at unity gain")
+        XCTAssertEqual(pipeline.activeDeckIndexForTesting, 0)
+        XCTAssertFalse(pipeline.isFadeInFlightForTesting)
+        XCTAssertNil(pipeline.armedTrackKeyForTesting)
+    }
+
+    /// Crossfade off (the default) must ignore arming entirely — the standby
+    /// deck stays cold and the scheduler never sees a next track, preserving
+    /// the pre-#41 transition behaviour byte-for-byte.
+    func testArmIsIgnoredWhileCrossfadeDisabled() {
+        let pipeline = EngineDSPPipeline()
+        XCTAssertFalse(pipeline.crossfadeIsEnabled, "crossfade ships off")
+        pipeline.armNextTrack(EngineDSPPipeline.ArmedNextTrack(
+            key: "next",
+            albumKey: nil,
+            url: URL(fileURLWithPath: "/dev/null"),
+            authHeader: nil,
+            containerHint: nil,
+            durationHint: 180,
+            mediaSourceId: nil,
+            playSessionId: nil
+        ))
+        XCTAssertNil(pipeline.armedTrackKeyForTesting, "arming must be a no-op while crossfade is off")
+        XCTAssertNil(pipeline.adoptHandedOffTrack(key: "next"), "no handoff may ever be pending while off")
+    }
+
+    /// With crossfade on, arming records the next track; turning the setting
+    /// off again disarms it (a pending overlap must not fire after the user
+    /// disabled the feature); and the adopt receipt stays nil until a real
+    /// handoff happens.
+    func testArmAndDisarmFollowSettings() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyCrossfade(CrossfadeSettings(durationSeconds: 4, curve: .equalPower))
+        XCTAssertTrue(pipeline.crossfadeIsEnabled)
+
+        pipeline.armNextTrack(EngineDSPPipeline.ArmedNextTrack(
+            key: "next",
+            albumKey: "album",
+            url: URL(fileURLWithPath: "/dev/null"),
+            authHeader: nil,
+            containerHint: nil,
+            durationHint: 180,
+            mediaSourceId: "ms",
+            playSessionId: "ps"
+        ))
+        XCTAssertEqual(pipeline.armedTrackKeyForTesting, "next")
+        XCTAssertNil(pipeline.adoptHandedOffTrack(key: "next"), "no receipt before a handoff")
+
+        pipeline.applyCrossfade(CrossfadeSettings(durationSeconds: 0))
+        XCTAssertNil(pipeline.armedTrackKeyForTesting, "disabling crossfade must disarm the pending track")
     }
 
     /// Jellyfin container strings map onto AudioToolbox sniffing hints;


### PR DESCRIPTION
Crossfade is the last of the DSP trio (#39 pipeline → #40 EQ → this): overlapping track transitions need two players with independent gain, which `AVQueuePlayer` cannot host.

Closes #41

## Design

- **Dual decks.** `EngineDSPPipeline` now runs two `AVAudioPlayerNode`s, each behind its own dedicated `AVAudioMixerNode` gain stage, merged through a blend mixer into the shared `AVAudioUnitEQ` → main-mixer chain — so the EQ applies to both sides of an overlap. With crossfade off, both gain stages sit at unity (a 1.0 float mix is audibly identical to the previous single-node graph) and the standby deck is never loaded.
- **Arming.** After each DSP-routed play, the engine resolves the queue's next track (`core.peekNext()`, honouring repeat mode; same offline gate / PlaybackInfo correlation / bitrate ceiling as `play`) and arms it on the pipeline. ~10 s before the fade window the standby deck starts buffering (HTTP → parse → decode → schedule, node silent); at the window, both fade mixers ramp along the configured envelope and the incoming node starts.
- **Gain envelopes.** Equal-power (`sin`/`cos`, constant acoustic power — default) and linear, per the issue. Ramps run on a 50 Hz timer that exists only while a fade is in flight; the 1 Hz playing-only position tick drives the window scheduling, so the idle-energy contract is untouched.
- **Zero-fade joins.** Same-album pairs (the issue's gapless-album rule), tracks too short for the window (< 2× duration), and unknown-duration streams skip the ramp: the armed track starts the instant the outgoing one finishes — a buffered butt-join instead of a rebuild.
- **Manual skip.** With crossfade on, a mid-track skip quick-fades the outgoing deck over 250 ms and ramps the incoming one in — no pop. With crossfade off, `load` is byte-for-byte the old hard swap.
- **"Stop after current track"** suppresses the handoff (peeked, never consumed), so the track runs to its true end and the queue halts exactly as today.

## Settings + defaults

- `playback.crossfadeSeconds` (`Double`, 0 = off, 1–12 s) — the pre-existing #116 Playback-pane key, now honoured; a value set before this landed goes live with the engine.
- `playback.crossfadeCurve` (`equalPower` default | `linear`) — new key, added to the diagnostic-bundle allowlist.
- `CrossfadeSettings` follows the `EqualizerSettings` pattern (normalize on load, plist-native scalars, garbage degrades to off/equal-power). `UserDefaults` is the single source of truth; the pipeline restores it on construction, so no `AppModel.init` seeding.
- Preferences ▸ Playback: the existing slider goes live and routes through `model.setCrossfade` (eager-apply, like normalization); a new curve picker sits under it. Both gate on `supportsCrossfade`, which is now the DSP-session gate (`engineDSPActiveThisSession`) — disabled + dimmed with a pointer at the Equalizer pane's engine opt-in when the flag is off, matching the EQ pane idiom.

## Reporting parity

A handoff is announced via `onCrossfadeBegan` → the same `markState(.ended)` + `onTrackEnded` contract as a natural finish. `AppModel.handleTrackEnded` advances the queue and calls `play(track:)`, which **adopts** the already-audible deck via a one-shot receipt instead of reloading: the outgoing track reports `Stopped` at the position the fade began, the incoming reports `Started` against the play session its stream was resolved with at arm time, `markTrackStarted` / `MediaSession.trackChanged` / the 5 s heartbeat all re-key — the exact sequence a reload emits, minus the audio teardown. A stale adopt key (queue edited after arming) falls back to a fresh load, the same staleness contract as the AVQueuePlayer path's pre-inserted item.

## Flag-off / crossfade-off guarantees

- DSP flag off: `dspApplyCrossfade` is a guarded no-op — the pipeline is never constructed, the AVQueuePlayer path is untouched (covered by tests).
- Flag on, crossfade off (the shipped default): arming is ignored, no second stream, transitions behave exactly as before this change.

## Tests

`swift test` — 1026 tests, 0 failures (clean `rm -rf .build` build). New coverage:

- `CrossfadeSettingsTests` (16): duration normalization + off contract, both envelopes (incl. the equal-power constant-power identity and progress clamping), `effectiveFadeDuration` (off / same-album / short-track / unknown-duration), the pure `tickAction` window function, `UserDefaults` round-trips + garbage degradation, and the engine integration (flag-off no-op, construction restore, live edits).
- `EngineDSPPipelineTests` (+3, 1 updated): dual-deck topology at unity gain, arm ignored while disabled, arm/disarm following settings; the EQ-wiring assertion now walks player → fade mixer → blend → EQ → main mixer. The existing flag-off transport and preload-no-op guarantees still pass unchanged.

Audio-hardware behaviour (audible overlap, no pop) needs interactive QA on the engine opt-in, same as #39/#40.
