### PR TITLE
feat(core): push playback status events over a callback stream

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,9 @@ pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 pub use error::{LyrebirdError, Result};
 pub use library_cache::{LibrarySyncObserver, LibrarySyncSummary};
 pub use models::*;
-pub use player::{PlaybackState, Player, PlayerStatus, RepeatMode};
+pub use player::{
+    PlaybackState, Player, PlayerEventKind, PlayerObserver, PlayerStatus, RepeatMode,
+};
 pub use query::ItemsQuery;
 
 use crate::client::{JellyfinClient, PublicSystemInfo};
@@ -1584,6 +1586,31 @@ impl LyrebirdCore {
 
     pub fn status(&self) -> PlayerStatus {
         self.player.status()
+    }
+
+    /// Register `observer` to receive push notifications for player-state
+    /// changes (#433) — state transitions, current-track changes, and queue
+    /// changes — replacing the UI's 1 Hz `status()` poll loop. Replaces any
+    /// previously-registered observer.
+    ///
+    /// Contract highlights (full details on [`PlayerObserver`]):
+    /// * Callbacks fire synchronously on the mutating thread; marshal to
+    ///   your main thread and return quickly.
+    /// * No core lock is held during the callback, so re-entering any FFI
+    ///   from inside it is safe.
+    /// * `seq` is monotonic in mutation order — drop pushes whose `seq` is
+    ///   not greater than the last applied one.
+    /// * Position ticks never emit; the platform's own 1 Hz time observer is
+    ///   the position source. Volume / shuffle / repeat setters don't emit
+    ///   either — their UI call sites already refresh `status()` inline.
+    pub fn set_player_observer(&self, observer: Box<dyn PlayerObserver>) {
+        self.player.set_observer(Some(Arc::from(observer)));
+    }
+
+    /// Remove the observer registered via [`Self::set_player_observer`], if
+    /// any. Subsequent player-state changes emit nothing.
+    pub fn clear_player_observer(&self) {
+        self.player.set_observer(None);
     }
 
     // ======================================================================

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -7,6 +7,7 @@
 use crate::error::{LyrebirdError, Result};
 use crate::models::Track;
 use parking_lot::Mutex;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
 pub enum PlaybackState {
@@ -16,6 +17,50 @@ pub enum PlaybackState {
     Paused,
     Stopped,
     Ended,
+}
+
+/// Which facet of player state a [`PlayerObserver::player_changed`] push
+/// reflects. One mutation can change several facets at once (e.g. a skip
+/// moves both the current track and the queue cursor), so the callback
+/// carries a `Vec` of kinds rather than a single value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum PlayerEventKind {
+    /// `status.state` transitioned (play / pause / stop / load / end).
+    StateChanged,
+    /// `status.current_track` changed identity (skip, queue jump,
+    /// `set_queue`, stop-clear). Identity is the track id — re-marking the
+    /// same track does not emit.
+    TrackChanged,
+    /// Queue membership or the playhead index changed (`set_queue`,
+    /// `insert_next`, `append_to_queue`, `clear_queue`, skips).
+    QueueChanged,
+}
+
+/// Push-notification sink for player-state changes (#433). Implemented by
+/// the UI layer (a Swift class via the UniFFI callback interface) and
+/// registered through `LyrebirdCore::set_player_observer`; replaces the UI's
+/// 1 Hz `status()` poll loop.
+///
+/// Contract:
+/// * Invoked **synchronously on the thread that performed the mutation** —
+///   implementations must marshal to their own main thread and return
+///   quickly.
+/// * **No lock is held during the callback**: the player snapshots state and
+///   releases its mutex before invoking, so an implementation may safely
+///   re-enter any core FFI (including `status()` and the registration
+///   methods) from inside the callback without deadlocking.
+/// * `seq` increases monotonically and is assigned in mutation order, so a
+///   late-delivered older snapshot can be detected and dropped: ignore any
+///   push whose `seq` is not greater than the last one applied.
+/// * Position ticks (`mark_position`) deliberately do **not** emit — the
+///   platform side already owns a 1 Hz position source (AVPlayer's periodic
+///   time observer) and mirroring it back out would reintroduce the idle
+///   wake-storm this interface exists to remove.
+#[uniffi::export(callback_interface)]
+pub trait PlayerObserver: Send + Sync {
+    /// One or more facets of [`PlayerStatus`] changed; `status` is the
+    /// complete post-mutation snapshot.
+    fn player_changed(&self, seq: u64, kinds: Vec<PlayerEventKind>, status: PlayerStatus);
 }
 
 /// Queue-wide repeat mode carried on [`PlayerStatus`] and exposed to the
@@ -64,7 +109,16 @@ pub struct PlayerStatus {
 
 pub struct Player {
     shared: Mutex<Shared>,
+    /// Registered push sink, if any. Guarded by its **own** mutex (not
+    /// `shared`) so registration can never contend with a snapshot, and so
+    /// emission can clone the `Arc` out and drop this lock *before* the
+    /// callback runs — see [`Player::emit`].
+    observer: Mutex<Option<Arc<dyn PlayerObserver>>>,
 }
+
+/// A pending observer push, computed under the `shared` lock and delivered
+/// after it is released: `(seq, changed facets, post-mutation snapshot)`.
+type Notification = (u64, Vec<PlayerEventKind>, PlayerStatus);
 
 struct Shared {
     state: PlaybackState,
@@ -76,6 +130,11 @@ struct Shared {
     shuffle: bool,
     repeat_mode: RepeatMode,
     play_session_id: Option<String>,
+    /// Monotonic counter stamped onto every observer push. Incremented under
+    /// the `shared` lock so sequence order always matches mutation order even
+    /// when mutations race on different threads; the subscriber uses it to
+    /// drop out-of-order deliveries.
+    event_seq: u64,
 }
 
 impl Shared {
@@ -90,7 +149,48 @@ impl Shared {
             shuffle: false,
             repeat_mode: RepeatMode::Off,
             play_session_id: None,
+            event_seq: 0,
         }
+    }
+
+    /// Stamp and package an observer push for the given changed facets.
+    /// Must be called while the mutation's lock is still held so the
+    /// sequence number is assigned in mutation order; the caller delivers
+    /// the result via [`Player::emit`] *after* releasing the lock.
+    fn notification(&mut self, kinds: Vec<PlayerEventKind>) -> Option<Notification> {
+        if kinds.is_empty() {
+            return None;
+        }
+        self.event_seq += 1;
+        Some((self.event_seq, kinds, self.snapshot()))
+    }
+
+    /// Track-identity probe used for [`PlayerEventKind::TrackChanged`]
+    /// diffing: the current track's id, if any.
+    fn current_id(&self) -> Option<String> {
+        self.current.as_ref().map(|t| t.id.clone())
+    }
+
+    /// Move the playhead to `idx` (which must be in bounds), realign
+    /// `current`, and return the landed-on track together with a push whose
+    /// kinds are diffed against the pre-move state — so e.g. a
+    /// `RepeatMode::All` wrap on a single-track queue (same index, same
+    /// track) emits nothing. Shared by `skip_next` / `skip_previous`.
+    fn advance_cursor(&mut self, idx: usize) -> (Option<Track>, Option<Notification>) {
+        let before_id = self.current_id();
+        let before_index = self.queue_index;
+        self.queue_index = idx;
+        let track = self.queue.get(idx).cloned();
+        self.current = track.clone();
+        let mut kinds = Vec::new();
+        if self.current_id() != before_id {
+            kinds.push(PlayerEventKind::TrackChanged);
+        }
+        if self.queue_index != before_index {
+            kinds.push(PlayerEventKind::QueueChanged);
+        }
+        let notification = self.notification(kinds);
+        (track, notification)
     }
 
     fn snapshot(&self) -> PlayerStatus {
@@ -124,6 +224,33 @@ impl Player {
     pub fn new() -> Self {
         Self {
             shared: Mutex::new(Shared::new()),
+            observer: Mutex::new(None),
+        }
+    }
+
+    /// Register (or, with `None`, remove) the push sink for player-state
+    /// changes. Replaces any previously-registered observer; the displaced
+    /// one receives no further pushes.
+    pub fn set_observer(&self, observer: Option<Arc<dyn PlayerObserver>>) {
+        *self.observer.lock() = observer;
+    }
+
+    /// Deliver a pending push to the registered observer, if any.
+    ///
+    /// Deadlock safety (#433): callers must have already released the
+    /// `shared` lock — every mutation computes its [`Notification`] inside
+    /// the lock scope and calls this outside it. The `observer` lock is held
+    /// only long enough to clone the `Arc`, never across the callback, so an
+    /// observer may re-enter any `Player` method (including
+    /// [`Player::set_observer`] and [`Player::status`]) from inside
+    /// `player_changed` without deadlocking.
+    fn emit(&self, notification: Option<Notification>) {
+        let Some((seq, kinds, status)) = notification else {
+            return;
+        };
+        let observer = self.observer.lock().clone();
+        if let Some(observer) = observer {
+            observer.player_changed(seq, kinds, status);
         }
     }
 
@@ -141,10 +268,22 @@ impl Player {
                 len: tracks.len(),
             });
         }
-        let mut s = self.shared.lock();
-        s.current = tracks.get(idx).cloned();
-        s.queue = tracks;
-        s.queue_index = idx;
+        let notification = {
+            let mut s = self.shared.lock();
+            let before_id = s.current_id();
+            s.current = tracks.get(idx).cloned();
+            s.queue = tracks;
+            s.queue_index = idx;
+            // Queue membership always changed (a fresh queue replaced the old
+            // one, even at identical length/index); the current track only
+            // changed when its identity moved.
+            let mut kinds = vec![PlayerEventKind::QueueChanged];
+            if s.current_id() != before_id {
+                kinds.insert(0, PlayerEventKind::TrackChanged);
+            }
+            s.notification(kinds)
+        };
+        self.emit(notification);
         Ok(())
     }
 
@@ -167,23 +306,23 @@ impl Player {
     /// "track ended" callback that invokes `skip_next` keeps replaying the
     /// same entry.
     pub fn skip_next(&self) -> Option<Track> {
-        let mut s = self.shared.lock();
-        if matches!(s.repeat_mode, RepeatMode::One) {
-            return s.queue.get(s.queue_index).cloned();
-        }
-        if s.queue_index + 1 < s.queue.len() {
-            s.queue_index += 1;
-            let track = s.queue.get(s.queue_index).cloned();
-            s.current = track.clone();
-            track
-        } else if matches!(s.repeat_mode, RepeatMode::All) && !s.queue.is_empty() {
-            s.queue_index = 0;
-            let track = s.queue.first().cloned();
-            s.current = track.clone();
-            track
-        } else {
-            None
-        }
+        let (track, notification) = {
+            let mut s = self.shared.lock();
+            if matches!(s.repeat_mode, RepeatMode::One) {
+                // Replay-in-place: nothing about the snapshot changes, so
+                // there is nothing to push.
+                (s.queue.get(s.queue_index).cloned(), None)
+            } else if s.queue_index + 1 < s.queue.len() {
+                let next = s.queue_index + 1;
+                s.advance_cursor(next)
+            } else if matches!(s.repeat_mode, RepeatMode::All) && !s.queue.is_empty() {
+                s.advance_cursor(0)
+            } else {
+                (None, None)
+            }
+        };
+        self.emit(notification);
+        track
     }
 
     /// The track [`Player::skip_next`] *would* return, without mutating the
@@ -224,24 +363,23 @@ impl Player {
     /// * [`RepeatMode::One`] — returns the current track without advancing
     ///   the queue index; `current` and `queue_position` are unchanged.
     pub fn skip_previous(&self) -> Option<Track> {
-        let mut s = self.shared.lock();
-        if matches!(s.repeat_mode, RepeatMode::One) {
-            return s.queue.get(s.queue_index).cloned();
-        }
-        if s.queue_index > 0 {
-            s.queue_index -= 1;
-            let track = s.queue.get(s.queue_index).cloned();
-            s.current = track.clone();
-            track
-        } else if matches!(s.repeat_mode, RepeatMode::All) && !s.queue.is_empty() {
-            let last = s.queue.len() - 1;
-            s.queue_index = last;
-            let track = s.queue.get(last).cloned();
-            s.current = track.clone();
-            track
-        } else {
-            None
-        }
+        let (track, notification) = {
+            let mut s = self.shared.lock();
+            if matches!(s.repeat_mode, RepeatMode::One) {
+                // Replay-in-place — see `skip_next`.
+                (s.queue.get(s.queue_index).cloned(), None)
+            } else if s.queue_index > 0 {
+                let prev = s.queue_index - 1;
+                s.advance_cursor(prev)
+            } else if matches!(s.repeat_mode, RepeatMode::All) && !s.queue.is_empty() {
+                let last = s.queue.len() - 1;
+                s.advance_cursor(last)
+            } else {
+                (None, None)
+            }
+        };
+        self.emit(notification);
+        track
     }
 
     /// Insert `tracks` into the queue immediately after the currently-playing
@@ -259,21 +397,31 @@ impl Player {
     /// Returns the new queue length. Closes #282 for the Play Next flows
     /// (album / playlist / track context menu, Up Next panel drag-drop).
     pub fn insert_next(&self, tracks: Vec<Track>) -> u32 {
-        let mut s = self.shared.lock();
-        if tracks.is_empty() {
-            return s.queue.len() as u32;
-        }
-        if s.queue.is_empty() {
-            // No playhead to insert after — start a fresh queue so the
-            // tracks are actually playable (mirrors `set_queue`).
-            s.current = tracks.first().cloned();
-            s.queue = tracks;
-            s.queue_index = 0;
-            return s.queue.len() as u32;
-        }
-        let insert_at = (s.queue_index + 1).min(s.queue.len());
-        s.queue.splice(insert_at..insert_at, tracks);
-        s.queue.len() as u32
+        let (len, notification) = {
+            let mut s = self.shared.lock();
+            if tracks.is_empty() {
+                (s.queue.len() as u32, None)
+            } else if s.queue.is_empty() {
+                // No playhead to insert after — start a fresh queue so the
+                // tracks are actually playable (mirrors `set_queue`). The
+                // playhead priming makes this a track change too.
+                s.current = tracks.first().cloned();
+                s.queue = tracks;
+                s.queue_index = 0;
+                let n = s.notification(vec![
+                    PlayerEventKind::TrackChanged,
+                    PlayerEventKind::QueueChanged,
+                ]);
+                (s.queue.len() as u32, n)
+            } else {
+                let insert_at = (s.queue_index + 1).min(s.queue.len());
+                s.queue.splice(insert_at..insert_at, tracks);
+                let n = s.notification(vec![PlayerEventKind::QueueChanged]);
+                (s.queue.len() as u32, n)
+            }
+        };
+        self.emit(notification);
+        len
     }
 
     /// Append `tracks` to the end of the queue. "Add to Queue" semantics.
@@ -288,17 +436,27 @@ impl Player {
     ///
     /// Returns the new queue length. Closes #282 for Add-to-Queue flows.
     pub fn append_to_queue(&self, tracks: Vec<Track>) -> u32 {
-        let mut s = self.shared.lock();
-        if tracks.is_empty() {
-            return s.queue.len() as u32;
-        }
-        let was_empty = s.queue.is_empty();
-        s.queue.extend(tracks);
-        if was_empty {
-            s.queue_index = 0;
-            s.current = s.queue.first().cloned();
-        }
-        s.queue.len() as u32
+        let (len, notification) = {
+            let mut s = self.shared.lock();
+            if tracks.is_empty() {
+                (s.queue.len() as u32, None)
+            } else {
+                let was_empty = s.queue.is_empty();
+                s.queue.extend(tracks);
+                let mut kinds = vec![PlayerEventKind::QueueChanged];
+                if was_empty {
+                    s.queue_index = 0;
+                    s.current = s.queue.first().cloned();
+                    // Priming the playhead onto the first appended track is a
+                    // track change as well.
+                    kinds.insert(0, PlayerEventKind::TrackChanged);
+                }
+                let n = s.notification(kinds);
+                (s.queue.len() as u32, n)
+            }
+        };
+        self.emit(notification);
+        len
     }
 
     /// Replace the queue with an empty vec. Distinct from [`Player::clear`]
@@ -308,14 +466,24 @@ impl Player {
     /// queue so subsequent `skip_next` correctly reports `None` rather than
     /// falling off a zero-length vec.
     pub fn clear_queue(&self) {
-        let mut s = self.shared.lock();
-        if let Some(current) = s.current.clone() {
-            s.queue = vec![current];
-            s.queue_index = 0;
-        } else {
-            s.queue.clear();
-            s.queue_index = 0;
-        }
+        let notification = {
+            let mut s = self.shared.lock();
+            let before_len = s.queue.len();
+            let before_index = s.queue_index;
+            if let Some(current) = s.current.clone() {
+                s.queue = vec![current];
+                s.queue_index = 0;
+            } else {
+                s.queue.clear();
+                s.queue_index = 0;
+            }
+            if s.queue.len() != before_len || s.queue_index != before_index {
+                s.notification(vec![PlayerEventKind::QueueChanged])
+            } else {
+                None
+            }
+        };
+        self.emit(notification);
     }
 
     /// Mark `track` as the currently-playing entry and force state to
@@ -325,12 +493,26 @@ impl Player {
     /// skip/peek cursor). When it is not in the queue (e.g. a one-off play of
     /// an item that was never enqueued) the index is left untouched.
     pub fn set_current(&self, track: Track) {
-        let mut s = self.shared.lock();
-        if let Some(i) = s.queue.iter().position(|t| t.id == track.id) {
-            s.queue_index = i;
-        }
-        s.current = Some(track);
-        s.state = PlaybackState::Playing;
+        let notification = {
+            let mut s = self.shared.lock();
+            let mut kinds = Vec::new();
+            if s.state != PlaybackState::Playing {
+                kinds.push(PlayerEventKind::StateChanged);
+            }
+            if s.current_id().as_deref() != Some(track.id.as_str()) {
+                kinds.push(PlayerEventKind::TrackChanged);
+            }
+            if let Some(i) = s.queue.iter().position(|t| t.id == track.id) {
+                if s.queue_index != i {
+                    kinds.push(PlayerEventKind::QueueChanged);
+                }
+                s.queue_index = i;
+            }
+            s.current = Some(track);
+            s.state = PlaybackState::Playing;
+            s.notification(kinds)
+        };
+        self.emit(notification);
     }
 
     /// Store the `PlaySessionId` from `POST /Items/{id}/PlaybackInfo`.
@@ -347,9 +529,23 @@ impl Player {
     }
 
     pub fn mark_state(&self, state: PlaybackState) {
-        self.shared.lock().state = state;
+        let notification = {
+            let mut s = self.shared.lock();
+            if s.state == state {
+                None
+            } else {
+                s.state = state;
+                s.notification(vec![PlayerEventKind::StateChanged])
+            }
+        };
+        self.emit(notification);
     }
 
+    /// Record the playback position. Deliberately does **not** push a
+    /// [`PlayerObserver`] event: the platform side already owns the 1 Hz
+    /// position source that calls this (AVPlayer's periodic time observer),
+    /// and echoing every tick back across the FFI would reintroduce the
+    /// per-second wakes #433 removed.
     pub fn mark_position(&self, seconds: f64) {
         self.shared.lock().position_seconds = seconds.max(0.0);
     }
@@ -375,13 +571,27 @@ impl Player {
     }
 
     pub fn clear(&self) {
-        let mut s = self.shared.lock();
-        s.state = PlaybackState::Stopped;
-        s.current = None;
-        s.position_seconds = 0.0;
-        s.play_session_id = None;
-        s.queue.clear();
-        s.queue_index = 0;
+        let notification = {
+            let mut s = self.shared.lock();
+            let mut kinds = Vec::new();
+            if s.state != PlaybackState::Stopped {
+                kinds.push(PlayerEventKind::StateChanged);
+            }
+            if s.current.is_some() {
+                kinds.push(PlayerEventKind::TrackChanged);
+            }
+            if !s.queue.is_empty() || s.queue_index != 0 {
+                kinds.push(PlayerEventKind::QueueChanged);
+            }
+            s.state = PlaybackState::Stopped;
+            s.current = None;
+            s.position_seconds = 0.0;
+            s.play_session_id = None;
+            s.queue.clear();
+            s.queue_index = 0;
+            s.notification(kinds)
+        };
+        self.emit(notification);
     }
 
     pub fn status(&self) -> PlayerStatus {

--- a/core/src/tests/mod.rs
+++ b/core/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod playlists;
 mod scrobble;
 mod search;
 mod session_auth;
+mod status_events;
 
 pub(crate) use crate::client::JellyfinClient;
 pub(crate) use crate::enums::ImageType;

--- a/core/src/tests/status_events.rs
+++ b/core/src/tests/status_events.rs
@@ -1,0 +1,443 @@
+//! Player push-notification stream (#433): `set_player_observer` /
+//! `clear_player_observer` and the per-mutation [`PlayerEventKind`] emission
+//! contract that replaced the UI's 1 Hz `status()` poll.
+
+use super::*;
+use crate::models::Track;
+use crate::player::{PlaybackState, PlayerEventKind, PlayerObserver, PlayerStatus};
+use std::sync::{Arc, Mutex};
+
+fn track(id: &str) -> Track {
+    Track {
+        id: id.into(),
+        name: id.into(),
+        album_id: None,
+        album_name: None,
+        artist_name: "Artist".into(),
+        artist_id: None,
+        index_number: None,
+        disc_number: None,
+        year: None,
+        runtime_ticks: 1_800_000_000,
+        is_favorite: false,
+        play_count: 0,
+        container: None,
+        bitrate: None,
+        image_tag: None,
+        playlist_item_id: None,
+        user_data: None,
+    }
+}
+
+/// Shared event log a test can keep a handle to while the boxed observer is
+/// owned by the core. Each entry is one `player_changed` push.
+#[derive(Default)]
+struct Recorder {
+    events: Mutex<Vec<(u64, Vec<PlayerEventKind>, PlayerStatus)>>,
+}
+
+impl Recorder {
+    fn events(&self) -> Vec<(u64, Vec<PlayerEventKind>, PlayerStatus)> {
+        self.events.lock().unwrap().clone()
+    }
+
+    fn kinds(&self) -> Vec<Vec<PlayerEventKind>> {
+        self.events().into_iter().map(|(_, k, _)| k).collect()
+    }
+}
+
+struct RecorderHandle(Arc<Recorder>);
+
+impl PlayerObserver for RecorderHandle {
+    fn player_changed(&self, seq: u64, kinds: Vec<PlayerEventKind>, status: PlayerStatus) {
+        self.0.events.lock().unwrap().push((seq, kinds, status));
+    }
+}
+
+/// Build a temp-backed core with a recording observer already registered.
+fn observed_core(tmp: &tempfile::TempDir) -> (std::sync::Arc<LyrebirdCore>, Arc<Recorder>) {
+    let core = resume_test_core(tmp);
+    let recorder = Arc::new(Recorder::default());
+    core.set_player_observer(Box::new(RecorderHandle(Arc::clone(&recorder))));
+    (core, recorder)
+}
+
+#[test]
+fn set_queue_pushes_track_and_queue_change_with_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b")], 0).unwrap();
+
+    let events = recorder.events();
+    assert_eq!(events.len(), 1, "one mutation, one push");
+    let (_, kinds, status) = &events[0];
+    assert_eq!(
+        kinds,
+        &vec![PlayerEventKind::TrackChanged, PlayerEventKind::QueueChanged]
+    );
+    // The push carries the complete post-mutation snapshot.
+    assert_eq!(status.current_track.as_ref().unwrap().id, "a");
+    assert_eq!(status.queue_length, 2);
+    assert_eq!(status.queue_position, 0);
+}
+
+#[test]
+fn mark_state_pushes_only_on_actual_transition() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.mark_state(PlaybackState::Playing);
+    core.mark_state(PlaybackState::Playing); // idempotent — no push
+    core.mark_state(PlaybackState::Paused);
+
+    let kinds = recorder.kinds();
+    assert_eq!(
+        kinds,
+        vec![
+            vec![PlayerEventKind::StateChanged],
+            vec![PlayerEventKind::StateChanged],
+        ],
+        "re-marking the same state must not push"
+    );
+    let events = recorder.events();
+    assert_eq!(events[0].2.state, PlaybackState::Playing);
+    assert_eq!(events[1].2.state, PlaybackState::Paused);
+}
+
+#[test]
+fn mark_position_never_pushes() {
+    // The energy contract behind #433: the 1 Hz position tick must not echo
+    // back out as an event, or the idle wake-storm the stream removed would
+    // be reintroduced one layer down.
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a")], 0).unwrap();
+    let baseline = recorder.events().len();
+
+    for tick in 0..60 {
+        core.mark_position(f64::from(tick));
+    }
+
+    assert_eq!(
+        recorder.events().len(),
+        baseline,
+        "mark_position must be event-silent"
+    );
+    // But the next real push carries the freshest position.
+    core.mark_state(PlaybackState::Playing);
+    let events = recorder.events();
+    let (_, _, status) = events.last().unwrap();
+    assert_eq!(status.position_seconds, 59.0);
+}
+
+#[test]
+fn volume_shuffle_repeat_and_session_id_do_not_push() {
+    // These setters' UI call sites refresh `status()` inline, so they are
+    // deliberately outside the event set (state / track / queue).
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_volume(0.5);
+    core.set_shuffle(true);
+    core.set_repeat_mode(RepeatMode::All);
+    core.set_play_session_id(Some("sess-1".into()));
+
+    assert!(
+        recorder.events().is_empty(),
+        "volume/shuffle/repeat/session-id must not push, got {:?}",
+        recorder.kinds()
+    );
+}
+
+#[test]
+fn mark_track_started_pushes_state_and_track_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.mark_track_started(track("a"));
+    // Re-marking the same track while already Playing changes nothing
+    // observable — no push.
+    core.mark_track_started(track("a"));
+
+    let kinds = recorder.kinds();
+    assert_eq!(
+        kinds,
+        vec![vec![
+            PlayerEventKind::StateChanged,
+            PlayerEventKind::TrackChanged,
+        ]],
+        "second same-track mark must be silent"
+    );
+    let events = recorder.events();
+    assert_eq!(events[0].2.state, PlaybackState::Playing);
+    assert_eq!(events[0].2.current_track.as_ref().unwrap().id, "a");
+}
+
+#[test]
+fn mark_track_started_realigns_queue_cursor_and_pushes_queue_change() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b"), track("c")], 0)
+        .unwrap();
+    core.mark_track_started(track("c"));
+
+    let kinds = recorder.kinds();
+    assert_eq!(
+        kinds.last().unwrap(),
+        &vec![
+            PlayerEventKind::StateChanged,
+            PlayerEventKind::TrackChanged,
+            PlayerEventKind::QueueChanged,
+        ],
+        "in-queue track start moves the cursor too"
+    );
+    let events = recorder.events();
+    assert_eq!(events.last().unwrap().2.queue_position, 2);
+}
+
+#[test]
+fn skip_next_pushes_cursor_move_and_is_silent_at_end_of_queue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b")], 0).unwrap();
+    let baseline = recorder.events().len();
+
+    assert_eq!(core.skip_next().unwrap().id, "b");
+    let events = recorder.events();
+    assert_eq!(events.len(), baseline + 1);
+    let (_, kinds, status) = events.last().unwrap();
+    assert_eq!(
+        kinds,
+        &vec![PlayerEventKind::TrackChanged, PlayerEventKind::QueueChanged]
+    );
+    assert_eq!(status.current_track.as_ref().unwrap().id, "b");
+    assert_eq!(status.queue_position, 1);
+
+    // End of queue with RepeatMode::Off: nothing changes, nothing pushes.
+    assert!(core.skip_next().is_none());
+    assert_eq!(recorder.events().len(), baseline + 1);
+}
+
+#[test]
+fn skip_previous_pushes_cursor_move() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b")], 1).unwrap();
+    let baseline = recorder.events().len();
+
+    assert_eq!(core.skip_previous().unwrap().id, "a");
+    let events = recorder.events();
+    assert_eq!(events.len(), baseline + 1);
+    assert_eq!(
+        events.last().unwrap().1,
+        vec![PlayerEventKind::TrackChanged, PlayerEventKind::QueueChanged]
+    );
+
+    // At the start with RepeatMode::Off: silent no-op.
+    assert!(core.skip_previous().is_none());
+    assert_eq!(recorder.events().len(), baseline + 1);
+}
+
+#[test]
+fn repeat_all_wrap_on_single_track_queue_is_silent() {
+    // The wrap lands on the same index and the same track — nothing about
+    // the snapshot changed, so the push must be suppressed even though
+    // skip_next returned Some.
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a")], 0).unwrap();
+    core.set_repeat_mode(RepeatMode::All);
+    let baseline = recorder.events().len();
+
+    assert_eq!(core.skip_next().unwrap().id, "a");
+    assert_eq!(recorder.events().len(), baseline);
+}
+
+#[test]
+fn play_next_and_add_to_queue_push_queue_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b")], 0).unwrap();
+    let baseline = recorder.events().len();
+
+    core.play_next(vec![track("x")]);
+    core.add_to_queue(vec![track("y")]);
+    // Empty inputs are genuine no-ops — silent.
+    core.play_next(vec![]);
+    core.add_to_queue(vec![]);
+
+    let events = recorder.events();
+    assert_eq!(events.len(), baseline + 2);
+    assert_eq!(events[baseline].1, vec![PlayerEventKind::QueueChanged]);
+    assert_eq!(events[baseline + 1].1, vec![PlayerEventKind::QueueChanged]);
+    assert_eq!(events[baseline + 1].2.queue_length, 4);
+}
+
+#[test]
+fn play_next_on_cold_queue_pushes_track_change_too() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.play_next(vec![track("x"), track("y")]);
+
+    let events = recorder.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].1,
+        vec![PlayerEventKind::TrackChanged, PlayerEventKind::QueueChanged],
+        "priming the playhead on an empty queue is a track change"
+    );
+    assert_eq!(events[0].2.current_track.as_ref().unwrap().id, "x");
+}
+
+#[test]
+fn clear_queue_pushes_queue_change_only_when_something_changed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b"), track("c")], 1)
+        .unwrap();
+    let baseline = recorder.events().len();
+
+    core.clear_queue();
+    let events = recorder.events();
+    assert_eq!(events.len(), baseline + 1);
+    assert_eq!(
+        events.last().unwrap().1,
+        vec![PlayerEventKind::QueueChanged]
+    );
+    assert_eq!(events.last().unwrap().2.queue_length, 1);
+
+    // Already a single-item queue holding the current track — second clear
+    // changes nothing and must be silent.
+    core.clear_queue();
+    assert_eq!(recorder.events().len(), baseline + 1);
+}
+
+#[test]
+fn stop_pushes_state_track_and_queue_teardown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b")], 0).unwrap();
+    core.mark_track_started(track("a"));
+    let baseline = recorder.events().len();
+
+    core.stop();
+
+    let events = recorder.events();
+    assert_eq!(events.len(), baseline + 1);
+    let (_, kinds, status) = events.last().unwrap();
+    assert_eq!(
+        kinds,
+        &vec![
+            PlayerEventKind::StateChanged,
+            PlayerEventKind::TrackChanged,
+            PlayerEventKind::QueueChanged,
+        ]
+    );
+    assert_eq!(status.state, PlaybackState::Stopped);
+    assert!(status.current_track.is_none());
+    assert_eq!(status.queue_length, 0);
+
+    // Stopping an already-stopped player changes nothing — silent.
+    core.stop();
+    assert_eq!(recorder.events().len(), baseline + 1);
+}
+
+#[test]
+fn seq_is_monotonic_in_mutation_order() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, recorder) = observed_core(&tmp);
+
+    core.set_queue(vec![track("a"), track("b"), track("c")], 0)
+        .unwrap();
+    core.mark_track_started(track("a"));
+    core.skip_next();
+    core.mark_state(PlaybackState::Paused);
+    core.stop();
+
+    let seqs: Vec<u64> = recorder.events().iter().map(|(s, _, _)| *s).collect();
+    assert!(!seqs.is_empty());
+    assert!(
+        seqs.windows(2).all(|w| w[1] > w[0]),
+        "seq must strictly increase in mutation order, got {seqs:?}"
+    );
+}
+
+#[test]
+fn clear_player_observer_stops_pushes_and_replacement_reroutes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (core, first) = observed_core(&tmp);
+
+    core.mark_state(PlaybackState::Playing);
+    assert_eq!(first.events().len(), 1);
+
+    core.clear_player_observer();
+    core.mark_state(PlaybackState::Paused);
+    assert_eq!(first.events().len(), 1, "cleared observer must go silent");
+
+    // A replacement observer picks up subsequent pushes; the displaced one
+    // stays silent. seq continues from where the player left off, so a
+    // subscriber can still apply its drop-stale-seq rule across swaps.
+    let second = Arc::new(Recorder::default());
+    core.set_player_observer(Box::new(RecorderHandle(Arc::clone(&second))));
+    core.mark_state(PlaybackState::Playing);
+    assert_eq!(first.events().len(), 1);
+    assert_eq!(second.events().len(), 1);
+    assert!(second.events()[0].0 >= 3, "seq keeps counting across swaps");
+}
+
+/// Observer that re-enters the FFI from inside the callback. Exercises the
+/// #433 deadlock contract: no core lock may be held while `player_changed`
+/// runs, so `status()` (player lock), `set_volume` (player lock, mutating),
+/// and `clear_player_observer` (observer-slot lock) must all be callable
+/// here. If emission ever moves back under a lock, this test hangs rather
+/// than passes — treat a timeout as a failure of the contract.
+struct ReentrantObserver {
+    core: std::sync::Arc<LyrebirdCore>,
+    seen_states: Arc<Mutex<Vec<PlaybackState>>>,
+}
+
+impl PlayerObserver for ReentrantObserver {
+    fn player_changed(&self, _seq: u64, _kinds: Vec<PlayerEventKind>, _status: PlayerStatus) {
+        // Player-lock read.
+        let live = self.core.status();
+        // Player-lock write (event-silent, so no recursion).
+        self.core.set_volume(0.42);
+        // Observer-slot-lock write: unregister ourselves mid-callback.
+        self.core.clear_player_observer();
+        self.seen_states.lock().unwrap().push(live.state);
+    }
+}
+
+#[test]
+fn observer_may_reenter_ffi_without_deadlock() {
+    let tmp = tempfile::tempdir().unwrap();
+    let core = resume_test_core(&tmp);
+    let seen_states = Arc::new(Mutex::new(Vec::new()));
+    core.set_player_observer(Box::new(ReentrantObserver {
+        core: std::sync::Arc::clone(&core),
+        seen_states: Arc::clone(&seen_states),
+    }));
+
+    core.mark_state(PlaybackState::Playing);
+
+    let seen = seen_states.lock().unwrap().clone();
+    assert_eq!(
+        seen,
+        vec![PlaybackState::Playing],
+        "re-entrant status() must observe the post-mutation state"
+    );
+    assert_eq!(core.status().volume, 0.42, "re-entrant set_volume applied");
+    // The mid-callback unregistration stuck: further mutations are silent.
+    core.mark_state(PlaybackState::Paused);
+    assert_eq!(seen_states.lock().unwrap().len(), 1);
+}

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -258,15 +258,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Rebuild the Dock tile from the current player status. Idempotent and
     /// cheap: the `DockTileController` throttles its own `display()` to ≤1 Hz
-    /// and skips redundant redraws, so this is safe to call from both the
-    /// state-change observer and the 1 s status poll.
+    /// and skips redundant redraws, so this is safe to call from every
+    /// caller below at once.
     ///
     /// The progress ring's *per-second advance during playback* is driven by
-    /// `AppModel.startPolling()`, whose 1 Hz tick re-reads `core.status()` and
-    /// calls this method — see the `AppDelegate.shared?.refreshDockTile()` call
-    /// in that loop. The local `startDockBadgeObserver` only adds the discrete
-    /// play/pause/stop transitions; it is *not* the source of the ring's fill,
-    /// so the ring is not frozen between transitions.
+    /// `AppModel.handlePositionTick(seconds:)` — the engine's 1 Hz
+    /// playing-only time observer — and the discrete state/track transitions
+    /// arrive via `AppModel.applyPlayerEvent` (the #433 push stream that
+    /// replaced the old status poll); both call this method. The local
+    /// `startDockBadgeObserver` only adds the play/pause/stop badge flips; it
+    /// is *not* the source of the ring's fill, so the ring is not frozen
+    /// between transitions.
     ///
     /// While a track is loaded the controller installs the custom album-art +
     /// progress-ring tile; when nothing is loaded it tears the tile down and

--- a/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
+++ b/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
@@ -5,12 +5,12 @@ import LyrebirdAudio
 
 /// Playback-session reporting on `AppModel`: last.fm-style scrobbling, the
 /// Now-Playing inspector details (track people + lyrics fetched on track
-/// change), end-of-track handling (autoplay / stop-after-current / gapless
-/// advance), and the 1 Hz status poll that mirrors `core.status()` into the
-/// reactive surface.
+/// change), and end-of-track handling (autoplay / stop-after-current /
+/// gapless advance). The reactive `status` surface itself is fed by the
+/// core's push event stream — see `AppModel+PlayerEvents.swift` (#433).
 ///
 /// The backing state (`scrobbleGate`, `currentTrackPeopleForId`,
-/// `currentLyricsForId`, `trackAnnounceTask`, `pollTimer`,
+/// `currentLyricsForId`, `trackAnnounceTask`, `playerEventBridge`,
 /// `currentTrackPeople`, `currentLyrics`, …) stays declared on the
 /// main `AppModel` class — stored properties can't live in an extension.
 /// Extensions of a `@MainActor` type inherit its isolation, so every method
@@ -38,8 +38,10 @@ extension AppModel {
         connectScrobbler(token: nil)
     }
 
-    /// Drive the scrobble gate from one status-poll observation and perform
-    /// whichever action it returns. Called once per poll tick.
+    /// Drive the scrobble gate from one status observation and perform
+    /// whichever action it returns. Called on every player push event
+    /// (track changes fire `playing_now` promptly) and on each 1 Hz
+    /// playing-only position tick (which crosses the listen threshold).
     ///
     /// Both submit paths hop off the main actor via `Task.detached` — they take
     /// the core's `parking_lot` mutex and make a network call, neither of which
@@ -51,7 +53,10 @@ extension AppModel {
     /// interrupt playback or surface a toast. A genuinely bad token shows up
     /// in the pane (the connect call validates it); transient network blips
     /// are simply skipped.
-    private func driveScrobble() {
+    ///
+    /// Internal (not private): the call sites live in
+    /// `AppModel+PlayerEvents.swift`.
+    func driveScrobble() {
         let track = status.currentTrack
         let enabled = ScrobblePreference.enabled && scrobbleConnected
         let action = scrobbleGate.noteTrack(
@@ -214,7 +219,7 @@ extension AppModel {
     ///
     /// Safe to call repeatedly — short-circuits when the current track
     /// id already matches the last successful fetch. Cleared on track
-    /// change by the polling loop (see `startPolling`).
+    /// change by the event-stream hook (see `applyPlayerEvent`).
     func fetchCurrentTrackLyrics() async {
         guard let track = status.currentTrack else {
             currentLyrics = nil
@@ -342,113 +347,11 @@ extension AppModel {
         }
     }
 
-    // MARK: - Status polling
-
-    /// Drive the status poll loop. The timer fires at a 1s cadence (was
-    /// 500ms in rc<=10 — every tick takes the Rust core's `parking_lot`
-    /// mutex on the MainActor and republishes `@Observable` state, which
-    /// SwiftUI treats as a redraw signal even when the actual values
-    /// didn't change).
-    ///
-    /// rc11 also tried to skip the tick body entirely when
-    /// `status.state != .playing`, but `pause()` / `resume()` /
-    /// `skipNext()` / `skipPrevious()` delegate straight to
-    /// `AudioEngine` and never call `refreshStatus()` — so after the
-    /// first user-driven pause the local `status.state` stayed `.paused`
-    /// forever and the PlayerBar froze: clicking play resumed audio
-    /// audibly but no UI signaled the transition (rc12 regression
-    /// caught by the user). The energy win from this skip was small
-    /// compared to the dominant `timeObserver` rate-zero skip in
-    /// `LyrebirdAudio/AudioEngine`, so rc13 keeps the 1s cadence and
-    /// drops the gate. Idle wakes/hour:
-    ///   rc<=10: ~14,400 (500ms pollTimer + 500ms timeObserver)
-    ///   rc11/12: ~0 paused, but UI broke
-    ///   rc13:    ~3,600 paused (1s pollTimer ticks; timeObserver
-    ///            still skips when `player.rate == 0`)
-    /// — which still clears the macOS "high energy use" badge while
-    /// keeping the player UI live.
-    func startPolling() {
-        stopPolling()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            Task { @MainActor in
-                let beforeTrack = self.status.currentTrack
-                let before = beforeTrack?.id
-                let beforeQueuePos = self.status.queuePosition
-                let beforeQueueLen = self.status.queueLength
-                self.status = self.core.status()
-                let after = self.status.currentTrack?.id
-                // Keep the custom Dock tile's progress ring filling in real
-                // time. The controller throttles its own redraws to ≤1 Hz, so
-                // calling it on every 1 s poll tick is the right cadence.
-                AppDelegate.shared?.refreshDockTile()
-                // Feed the scrobble gate the fresh status. Fires a ListenBrainz
-                // `playing_now` on track change and a durable listen once the
-                // current track passes the threshold — both off the main actor.
-                self.driveScrobble()
-                // Trigger a details refetch when the track changes. Scoped
-                // to the polling loop so skipping via the PlayerBar,
-                // media keys, or end-of-track auto-advance all get it
-                // for free.
-                if before != after {
-                    // Record the track we just left onto the in-session
-                    // history (#81). Only push real outgoing tracks — a
-                    // start-from-stopped transition (before == nil) has
-                    // nothing to record.
-                    if let outgoing = beforeTrack {
-                        self.recordSessionPlay(outgoing)
-                    }
-                    if after == nil {
-                        self.currentTrackPeople = []
-                        self.currentTrackPeopleForId = nil
-                        self.currentLyrics = nil
-                        self.currentLyricsForId = nil
-                    } else {
-                        Task { await self.fetchCurrentTrackDetails() }
-                        Task { await self.fetchCurrentTrackLyrics() }
-                        // Notify on the new track. The manager no-ops when the
-                        // banner toggle is off, so this is cheap on every change.
-                        // The first track after a startup-from-resume is left
-                        // unsuppressed — a fresh play is exactly when the user
-                        // wants the banner.
-                        if let track = self.status.currentTrack {
-                            NotificationManager.shared.notifyTrackChange(
-                                title: track.name,
-                                artist: track.artistName,
-                                album: track.albumName
-                            )
-                        }
-                    }
-                }
-                // Menu-bar "while playing" needs no poll-driven mirroring:
-                // `LyrebirdApp`'s `MenuBarExtra(isInserted:)` binding observes
-                // `status.state` directly, so the transient icon tracks
-                // play/pause reactively (#984 retired the old
-                // `MenuBarController.setVisibleWhilePlaying` call here).
-                // Keep MediaSession's queue index in sync when a skip
-                // happens. `AudioEngine.play(track:)` already fires
-                // `trackChanged` for the new item; `queueChanged` handles
-                // the case where the queue length shifts without a new
-                // track starting (e.g. future `setQueue` on the current).
-                // Elapsed time is intentionally NOT pushed on every tick
-                // (see issue #48 — the widget interpolates from
-                // `elapsed + wallclock * rate`).
-                if beforeQueuePos != self.status.queuePosition
-                    || beforeQueueLen != self.status.queueLength {
-                    self.mediaSession.queueChanged()
-                }
-            }
-        }
-        // Pin the timer to .common so it keeps firing while the user is
-        // dragging a slider or interacting with menus (the default
-        // .default mode is suspended during those tracking loops).
-        if let pollTimer {
-            RunLoop.main.add(pollTimer, forMode: .common)
-        }
-    }
-
-    func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
-    }
+    // The 1 Hz status poll that used to live here (`startPolling` /
+    // `stopPolling`) was retired by #433: the core now pushes state / track /
+    // queue changes through the `PlayerObserver` event stream, and the
+    // position advances via `AudioEngine`'s playing-only time observer. See
+    // `AppModel+PlayerEvents.swift` for the subscription + the transplanted
+    // tick body (`applyPlayerEvent`), including the rc11→rc13 history of why
+    // a state-gated poll was tried and reverted before events replaced it.
 }

--- a/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
+++ b/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
@@ -152,6 +152,7 @@ extension AppModel {
         let duration = max(0, status.durationSeconds)
         let target = status.positionSeconds + delta
         let clamped = max(0, duration > 0 ? min(target, duration) : target)
+        applySeekPosition(clamped)
         audio.seek(toSeconds: clamped)
     }
 
@@ -163,7 +164,24 @@ extension AppModel {
         guard status.currentTrack != nil else { return }
         let duration = max(0, status.durationSeconds)
         let clamped = max(0, duration > 0 ? min(target, duration) : target)
+        applySeekPosition(clamped)
         audio.seek(toSeconds: clamped)
+    }
+
+    /// Mirror a just-issued seek target onto the reactive surface and into
+    /// the core's position bookkeeping.
+    ///
+    /// While **playing**, the engine's next 1 Hz time-observer tick would do
+    /// both anyway; while **paused** that tick never fires (`rate == 0`), so
+    /// without this a paused scrub snapped the progress bar back to the
+    /// pre-seek position — and, with the status poll retired (#433), it
+    /// would stay wrong until resume rather than for one tick. Writing the
+    /// core via `markPosition` keeps `status()` snapshots and the 5 s
+    /// heartbeat's progress reports agreeing with what the user sees; it is
+    /// event-silent by design, so no push loops back from this.
+    private func applySeekPosition(_ seconds: Double) {
+        status.positionSeconds = seconds
+        core.markPosition(seconds: seconds)
     }
 
     func togglePlayPause() {

--- a/macos/Sources/Lyrebird/AppModel+PlayerEvents.swift
+++ b/macos/Sources/Lyrebird/AppModel+PlayerEvents.swift
@@ -1,0 +1,177 @@
+import Foundation
+@preconcurrency import LyrebirdCore
+
+/// Push-driven player status (#433).
+///
+/// The old `startPolling()` fired a repeating `Timer` whose tick re-read
+/// `core.status()` on the main actor — taking the Rust player mutex and
+/// republishing `@Observable` state once a second even while paused in the
+/// background (~3,600 wakes/hour at idle). The core now *pushes* on the
+/// mutations that can actually change what the UI shows — state transitions
+/// (`markState` / `markTrackStarted` / `stop`), current-track changes, and
+/// queue changes — through the `PlayerObserver` UniFFI callback interface,
+/// so an idle app does zero periodic status work.
+///
+/// Position is the one per-second quantity, and it keeps its existing owner:
+/// `AudioEngine`'s 1 Hz `periodicTimeObserver`, which already skips entirely
+/// at `rate == 0`, now also forwards each tick here (`handlePositionTick`)
+/// so the progress surfaces advance without any core FFI on the UI path.
+///
+/// Net wake budget: zero when idle or paused (no timer exists at all),
+/// 1 Hz position ticks only while audio is audibly advancing — strictly
+/// at-or-below the rc13 contract this replaces (see CLAUDE.md gap #2).
+///
+/// History, so nobody re-walks it: rc11/rc12 tried keeping the poll but
+/// gating its body on `status.state == .playing`. That froze the PlayerBar
+/// after the first pause — `pause()` / `resume()` delegate straight to
+/// `AudioEngine` and nothing else republished `status`, so the gate locked
+/// itself shut (rc12 regression). rc13 reverted to an ungated 1 s poll
+/// (~3,600 wakes/hour paused). Pushes solve the dilemma both ways: every
+/// `markState` transition publishes (no frozen UI), and the absence of
+/// transitions costs nothing (no wakes).
+extension AppModel {
+    /// Subscribe `status` to the core's player event stream. Called wherever
+    /// a session becomes live (login, Quick Connect, restore); replaces any
+    /// previous subscription, so repeated calls are safe.
+    ///
+    /// Seeds `status` with one synchronous snapshot first — pushes only
+    /// arrive on the *next* mutation, and a restored session may already
+    /// hold meaningful player state.
+    func startStatusEventStream() {
+        let bridge = PlayerEventBridge(model: self)
+        playerEventBridge = bridge
+        core.setPlayerObserver(observer: bridge)
+        status = core.status()
+    }
+
+    /// Tear down the event-stream subscription (logout, token forget, auth
+    /// expiry). Player mutations after this emit nothing.
+    func stopStatusEventStream() {
+        core.clearPlayerObserver()
+        playerEventBridge = nil
+    }
+
+    /// Apply one player push to the reactive surface. Runs on the main actor
+    /// (marshalled by `PlayerEventBridge`); `fresh` is the complete
+    /// post-mutation snapshot the core captured under its player lock.
+    ///
+    /// This is the old poll-tick body, fired on change instead of on a
+    /// timer: it republishes `status`, keeps the Dock tile + scrobble gate
+    /// fed, runs the track-change side effects (session history, credits +
+    /// lyrics refetch, notification banner), and nudges `MediaSession` when
+    /// the queue shape moved.
+    func applyPlayerEvent(seq: UInt64, kinds: [PlayerEventKind], status fresh: PlayerStatus) {
+        // Pushes are stamped in mutation order under the core's player lock,
+        // but each crosses to the main actor as its own `Task` hop — so a
+        // pair of rapid mutations could, in principle, land here reordered.
+        // Applying an older snapshot over a newer one would wedge the UI on
+        // stale state until the next event, so drop anything not strictly
+        // newer than the last applied push.
+        guard seq > lastPlayerEventSeq else { return }
+        lastPlayerEventSeq = seq
+
+        let beforeTrack = status.currentTrack
+        let before = beforeTrack?.id
+        status = fresh
+        let after = fresh.currentTrack?.id
+
+        // Keep the custom Dock tile in sync with state/track transitions —
+        // pause/resume flips the ring style, stop tears the tile down. The
+        // per-second ring fill while playing is driven by
+        // `handlePositionTick`; the controller throttles its own redraws to
+        // ≤1 Hz, so overlapping calls stay cheap.
+        AppDelegate.shared?.refreshDockTile()
+
+        // Feed the scrobble gate the fresh status. Fires a ListenBrainz
+        // `playing_now` on track change — both submit paths hop off the main
+        // actor inside `driveScrobble`.
+        driveScrobble()
+
+        // Track-change side effects. Diffed against the previously-applied
+        // snapshot (not just `kinds`) so an inline `status = core.status()`
+        // refresh that already mirrored this mutation can't double-fire
+        // them.
+        if before != after {
+            // Record the track we just left onto the in-session history
+            // (#81). Only push real outgoing tracks — a start-from-stopped
+            // transition (before == nil) has nothing to record.
+            if let outgoing = beforeTrack {
+                recordSessionPlay(outgoing)
+            }
+            if after == nil {
+                currentTrackPeople = []
+                currentTrackPeopleForId = nil
+                currentLyrics = nil
+                currentLyricsForId = nil
+            } else {
+                Task { await self.fetchCurrentTrackDetails() }
+                Task { await self.fetchCurrentTrackLyrics() }
+                // Notify on the new track. The manager no-ops when the
+                // banner toggle is off, so this is cheap on every change.
+                if let track = fresh.currentTrack {
+                    NotificationManager.shared.notifyTrackChange(
+                        title: track.name,
+                        artist: track.artistName,
+                        album: track.albumName
+                    )
+                }
+            }
+        }
+
+        // Keep MediaSession's queue index in sync when a skip or queue edit
+        // happens. `AudioEngine.play(track:)` already fires `trackChanged`
+        // for the new item; `queueChanged` covers shape changes that don't
+        // start a new track. Elapsed time is intentionally NOT pushed here
+        // (see issue #48 — the widget interpolates from
+        // `elapsed + wallclock * rate`).
+        if kinds.contains(.queueChanged) {
+            mediaSession.queueChanged()
+        }
+    }
+
+    /// 1 Hz position tick from `AudioEngine`'s periodic time observer,
+    /// forwarded only while audio is actually advancing (`rate != 0`) —
+    /// paused and idle states produce no ticks, preserving the zero-wake
+    /// contract. Mirrors the position the engine just wrote into the core
+    /// (`core.markPosition`) onto the reactive surface, with no extra FFI.
+    func handlePositionTick(seconds: Double) {
+        // A tick can race a teardown push (stop / track end) across the
+        // main-actor hop; never resurrect a position onto a stopped surface.
+        guard status.currentTrack != nil else { return }
+        status.positionSeconds = seconds
+        // Advance the Dock tile's progress ring in real time (≤1 Hz redraw
+        // throttle lives in the controller).
+        AppDelegate.shared?.refreshDockTile()
+        // Threshold check for the durable ListenBrainz listen — position-
+        // driven, so it belongs to the tick, not the event stream.
+        driveScrobble()
+    }
+}
+
+/// UniFFI callback bridge for the core's player event stream (#433).
+///
+/// The core invokes `playerChanged` synchronously on whatever thread
+/// performed the player mutation (the main thread for user actions, but the
+/// contract makes no promise); the bridge marshals onto the main actor
+/// before touching `AppModel` — the same shape as `LibrarySyncBridge`.
+/// No core lock is held during the callback, so the hop is the only
+/// scheduling this needs.
+///
+/// Holds the model weakly: a push outliving the model (quit, teardown) just
+/// drops. `@unchecked Sendable`: the only state is a `weak` reference
+/// assigned once in `init`; ARC weak loads are thread-safe, and all reads
+/// happen inside the main-actor hop.
+final class PlayerEventBridge: PlayerObserver, @unchecked Sendable {
+    private weak var model: AppModel?
+
+    init(model: AppModel) {
+        self.model = model
+    }
+
+    func playerChanged(seq: UInt64, kinds: [PlayerEventKind], status: PlayerStatus) {
+        let model = model
+        Task { @MainActor in
+            model?.applyPlayerEvent(seq: seq, kinds: kinds, status: status)
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -38,7 +38,7 @@ extension AppModel {
             self.serverURL = url
             self.username = username
             self.errorMessage = nil
-            startPolling()
+            startStatusEventStream()
             await refreshLibrary()
             await refreshDownloads()
         } catch {
@@ -122,7 +122,7 @@ extension AppModel {
             self.serverURL = session.server.url
             self.username = session.user.name
             self.errorMessage = nil
-            startPolling()
+            startStatusEventStream()
             await refreshLibrary()
             await refreshDownloads()
             return true
@@ -163,7 +163,7 @@ extension AppModel {
             self.serverURL = session.server.url
             self.username = session.user.name
             self.errorMessage = nil
-            startPolling()
+            startStatusEventStream()
             await refreshLibrary()
             await refreshDownloads()
         } catch {
@@ -249,7 +249,7 @@ extension AppModel {
         downloadStats = nil
         downloadsInFlight = []
         resetPaginationState()
-        stopPolling()
+        stopStatusEventStream()
     }
 
     /// Drop the stored access token (keychain + in-memory session) without
@@ -323,7 +323,7 @@ extension AppModel {
         currentLyricsForId = nil
         sessionPlayHistory = []
         resetPaginationState()
-        stopPolling()
+        stopStatusEventStream()
     }
 
     /// Clear all pagination counters and in-flight flags. Kept in one place
@@ -349,7 +349,7 @@ extension AppModel {
     func markAuthExpired() {
         guard !authExpired else { return }
         audio.stop()
-        stopPolling()
+        stopStatusEventStream()
         authExpired = true
     }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -469,12 +469,24 @@ final class AppModel {
 
     // MARK: - Player
     var status: PlayerStatus
-    var pollTimer: Timer?
+    /// UniFFI callback bridge feeding the core's player event stream into
+    /// `applyPlayerEvent` (#433) — the push-based replacement for the old
+    /// 1 Hz `core.status()` poll timer. Held strongly so the registered
+    /// observer outlives the subscription; managed by
+    /// `startStatusEventStream()` / `stopStatusEventStream()` in
+    /// `AppModel+PlayerEvents`.
+    var playerEventBridge: PlayerEventBridge?
+    /// Sequence number of the last player push applied to `status`. The core
+    /// stamps pushes in mutation order, so any push at or below this value is
+    /// a late-delivered stale snapshot and must be dropped — see
+    /// `applyPlayerEvent`.
+    var lastPlayerEventSeq: UInt64 = 0
 
     // MARK: - Scrobbling (#46)
     /// Decides when to fire a `playing_now` vs a durable `single` listen. Driven
-    /// from the 1 Hz status poll; the actual POSTs go to the Rust core off the
-    /// main actor. Pure value type — see `ScrobbleGate`.
+    /// from player push events and the 1 Hz playing-only position tick; the
+    /// actual POSTs go to the Rust core off the main actor. Pure value type —
+    /// see `ScrobbleGate`.
     var scrobbleGate = ScrobbleGate()
     /// Mirrors `core.isScrobbleConfigured()` for the Preferences pane to read
     /// without a per-render FFI. Refreshed when the token changes and at launch.
@@ -548,7 +560,7 @@ final class AppModel {
     /// they just heard. Distinct from `recentlyPlayed`, which is the server's
     /// cross-device listening history — this is purely in-memory and resets
     /// on sign-out. Capped at `sessionPlayHistoryLimit`; populated by the
-    /// status-poll track-change hook in `startPolling`.
+    /// track-change hook in `applyPlayerEvent`.
     var sessionPlayHistory: [Track] = []
 
     /// Hard cap on `sessionPlayHistory`. The acceptance criteria call for the
@@ -854,6 +866,13 @@ final class AppModel {
         self.status = core.status()
         self.audio.onTrackEnded = { [weak self] in
             self?.handleTrackEnded()
+        }
+        // 1 Hz position tick, fired only while audio is actually advancing
+        // (the engine skips it at `rate == 0`). With the status poll gone
+        // (#433) this is what moves `status.positionSeconds` — and the dock
+        // ring + scrobble threshold — between push events.
+        self.audio.onPositionTick = { [weak self] seconds in
+            self?.handlePositionTick(seconds: seconds)
         }
         // Hand the engine and the media session the things they need
         // from us *after* all stored properties are initialized. The
@@ -1417,9 +1436,10 @@ extension AppModel: AudioEngineDelegate {
 extension AppModel {
     /// Pull the latest `PlayerStatus` snapshot out of the core and hand it
     /// to `MediaSession` so the remote-control surface reflects any
-    /// just-applied change (shuffle, repeat, favorite). The polling timer
-    /// refreshes this on a cadence, but command handlers want the round-trip
-    /// to feel synchronous — without this, Control Center's shuffle toggle
+    /// just-applied change (shuffle, repeat, favorite). Shuffle / repeat /
+    /// volume setters are deliberately outside the core's push-event set
+    /// (#433), so command handlers refresh inline to make the round-trip
+    /// feel synchronous — without this, Control Center's shuffle toggle
     /// can flicker back to the previous state on the next redraw.
     fileprivate func refreshStatus() {
         self.status = core.status()

--- a/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
@@ -53,6 +53,10 @@ extension AudioEngine {
         pipeline.onPositionTick = { [weak self] seconds in
             guard let self, seconds.isFinite, seconds >= 0 else { return }
             self.core.markPosition(seconds: seconds)
+            // Reporting parity with the AVQueuePlayer path: forward the tick
+            // so the owner's progress surfaces advance on the DSP route too
+            // (#433 — `markPosition` is event-silent core-side).
+            self.onPositionTick?(seconds)
         }
         pipeline.onStreamError = { [weak self] message in
             guard let self else { return }

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -188,6 +188,16 @@ public final class AudioEngine: NSObject {
     /// owner (AppModel) can advance the queue.
     public var onTrackEnded: (() -> Void)?
 
+    /// Called at the 1 Hz position cadence, but **only while audio is
+    /// actually advancing** — the time observer skips entirely at
+    /// `rate == 0` (paused / stalled), so subscribers inherit the zero-wake
+    /// idle contract for free. Fired on the main queue right after the same
+    /// position is written into the core via `markPosition`. With the status
+    /// poll retired (#433) this is what advances the owner's progress
+    /// surfaces (PlayerBar elapsed, Dock ring, scrobble threshold) between
+    /// push events.
+    public var onPositionTick: ((Double) -> Void)?
+
     /// Single writer of `MPNowPlayingInfoCenter.nowPlayingInfo`. Held weakly
     /// because the session is owned by `AppModel` — the engine just notifies
     /// it of transport state transitions. See `MediaSession.swift` and
@@ -961,6 +971,11 @@ public final class AudioEngine: NSObject {
             guard player.rate != 0 else { return }
             let seconds = time.seconds.isFinite ? time.seconds : 0
             self.core.markPosition(seconds: seconds)
+            // Forward the tick to the owner (AppModel) so the UI position
+            // advances without polling — `markPosition` is deliberately
+            // event-silent core-side (#433), so this closure is the only
+            // way the per-second position reaches the reactive surface.
+            self.onPositionTick?(seconds)
         }
 
         // Wire the end-of-item notification to the first item. When

--- a/macos/Tests/LyrebirdTests/PlayerEventStreamTests.swift
+++ b/macos/Tests/LyrebirdTests/PlayerEventStreamTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+
+@preconcurrency import LyrebirdCore
+
+@testable import Lyrebird
+
+/// Coverage for the push-based player status surface (#433): the
+/// `PlayerEventBridge` subscription that replaced the 1 Hz `core.status()`
+/// poll, the stale-sequence drop rule, and the track-change side-effect
+/// bookkeeping that used to live in the poll tick.
+///
+/// `AppModel` is `@MainActor`, so the whole suite is main-actor isolated.
+/// Constructing it boots a live `LyrebirdCore`; the core's data directory is
+/// redirected to a throwaway temp dir via `XDG_DATA_HOME` (honoured by
+/// `storage::default_data_dir()`) so tests never touch the real app's
+/// database. No session is required — the player FFIs are local state.
+@MainActor
+final class PlayerEventStreamTests: XCTestCase {
+
+    /// Point the core at a unique temp data dir before the first `AppModel()`
+    /// in the process — same pattern as `AutoplayWhenQueueEndsTests`.
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func makeTrack(_ id: String) -> Track {
+        Track(
+            id: id,
+            name: "t-\(id)",
+            albumId: nil,
+            albumName: nil,
+            artistName: "Artist",
+            artistId: nil,
+            indexNumber: nil,
+            discNumber: nil,
+            year: nil,
+            runtimeTicks: 1_800_000_000,
+            isFavorite: false,
+            playCount: 0,
+            container: nil,
+            bitrate: nil,
+            imageTag: nil,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    private func makeStatus(
+        state: PlaybackState,
+        track: Track?,
+        position: Double = 0,
+        queuePosition: UInt32 = 0,
+        queueLength: UInt32 = 0
+    ) -> PlayerStatus {
+        PlayerStatus(
+            state: state,
+            currentTrack: track,
+            positionSeconds: position,
+            durationSeconds: 180,
+            volume: 1.0,
+            queuePosition: queuePosition,
+            queueLength: queueLength,
+            shuffle: false,
+            repeatMode: .off,
+            playSessionId: nil
+        )
+    }
+
+    /// Let the bridge's `Task { @MainActor in … }` hops run until `predicate`
+    /// holds (or the deadline passes). The test itself is main-actor bound,
+    /// so suspension via `Task.sleep` is what gives the queued hops a turn.
+    private func drainMainActor(
+        timeout: TimeInterval = 2,
+        until predicate: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !predicate(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    // MARK: - End-to-end: core mutation -> push -> status
+
+    /// A core-side player mutation must land on `model.status` with no
+    /// polling: the registered bridge receives the push and applies it on
+    /// the main actor.
+    func testCoreMutationIsPushedIntoStatus() async throws {
+        let model = try AppModel()
+        model.startStatusEventStream()
+        defer { model.stopStatusEventStream() }
+
+        XCTAssertNil(model.status.currentTrack, "fresh core starts trackless")
+
+        _ = try model.core.setQueue(tracks: [makeTrack("a"), makeTrack("b")], startIndex: 0)
+        model.core.markTrackStarted(track: makeTrack("a"))
+
+        await drainMainActor { model.status.currentTrack?.id == "a" }
+        XCTAssertEqual(model.status.currentTrack?.id, "a")
+        XCTAssertEqual(model.status.state, .playing)
+        XCTAssertEqual(model.status.queueLength, 2)
+
+        model.core.markState(state: .paused)
+        await drainMainActor { model.status.state == .paused }
+        XCTAssertEqual(
+            model.status.state, .paused,
+            "a state transition must be pushed without any poll"
+        )
+    }
+
+    /// After `stopStatusEventStream`, further core mutations must not move
+    /// the reactive surface.
+    func testStoppedStreamGoesSilent() async throws {
+        let model = try AppModel()
+        model.startStatusEventStream()
+
+        model.core.markState(state: .playing)
+        await drainMainActor { model.status.state == .playing }
+        XCTAssertEqual(model.status.state, .playing)
+
+        model.stopStatusEventStream()
+        model.core.markState(state: .paused)
+        // Deliberately give a (nonexistent) push time to arrive.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(
+            model.status.state, .playing,
+            "no pushes may arrive after the stream is stopped"
+        )
+        XCTAssertNil(model.playerEventBridge)
+    }
+
+    // MARK: - Stale-sequence drop rule
+
+    /// Pushes hop to the main actor as individual `Task`s, so delivery
+    /// order is not guaranteed even though sequence numbers are stamped in
+    /// mutation order. An older snapshot arriving late must be dropped, not
+    /// applied over newer state.
+    func testStaleSequenceIsDropped() throws {
+        let model = try AppModel()
+
+        model.applyPlayerEvent(
+            seq: 5,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .playing, track: makeTrack("a"))
+        )
+        XCTAssertEqual(model.status.state, .playing)
+
+        // Late-delivered older push: must be ignored entirely.
+        model.applyPlayerEvent(
+            seq: 3,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .paused, track: makeTrack("a"))
+        )
+        XCTAssertEqual(
+            model.status.state, .playing,
+            "an older seq must never overwrite newer state"
+        )
+
+        // Equal seq (duplicate delivery): also dropped.
+        model.applyPlayerEvent(
+            seq: 5,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .stopped, track: nil)
+        )
+        XCTAssertEqual(model.status.state, .playing)
+
+        // Strictly newer: applies.
+        model.applyPlayerEvent(
+            seq: 6,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .paused, track: makeTrack("a"))
+        )
+        XCTAssertEqual(model.status.state, .paused)
+    }
+
+    // MARK: - Track-change side effects (the old poll-tick body)
+
+    /// A push that drops the current track (stop / queue exhausted) must
+    /// clear the Now Playing detail state, exactly like the old poll's
+    /// track-change hook did.
+    func testTrackTeardownClearsNowPlayingDetails() throws {
+        let model = try AppModel()
+
+        model.applyPlayerEvent(
+            seq: 1,
+            kinds: [.stateChanged, .trackChanged],
+            status: makeStatus(state: .playing, track: makeTrack("a"))
+        )
+        // Simulate details fetched for the playing track.
+        model.currentTrackPeople = [Person(name: "P", type: "Composer", id: nil)]
+        model.currentTrackPeopleForId = "a"
+        model.currentLyrics = [LyricLine(id: 0, timestamp: nil, text: "la")]
+        model.currentLyricsForId = "a"
+
+        model.applyPlayerEvent(
+            seq: 2,
+            kinds: [.stateChanged, .trackChanged, .queueChanged],
+            status: makeStatus(state: .stopped, track: nil)
+        )
+
+        XCTAssertTrue(model.currentTrackPeople.isEmpty)
+        XCTAssertNil(model.currentTrackPeopleForId)
+        XCTAssertNil(model.currentLyrics)
+        XCTAssertNil(model.currentLyricsForId)
+    }
+
+    /// A track-to-track transition must record the *outgoing* track onto the
+    /// in-session history (#81) — and a same-track push must not.
+    func testTrackChangeRecordsSessionHistory() throws {
+        let model = try AppModel()
+
+        model.applyPlayerEvent(
+            seq: 1,
+            kinds: [.trackChanged],
+            status: makeStatus(state: .playing, track: makeTrack("a"))
+        )
+        XCTAssertTrue(
+            model.sessionPlayHistory.isEmpty,
+            "start-from-stopped has no outgoing track to record"
+        )
+
+        model.applyPlayerEvent(
+            seq: 2,
+            kinds: [.trackChanged],
+            status: makeStatus(state: .playing, track: makeTrack("b"))
+        )
+        XCTAssertEqual(model.sessionPlayHistory.map(\.id), ["a"])
+
+        // Same track again (e.g. an inline refresh raced the push): the
+        // before/after diff suppresses a duplicate history entry.
+        model.applyPlayerEvent(
+            seq: 3,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .paused, track: makeTrack("b"))
+        )
+        XCTAssertEqual(model.sessionPlayHistory.map(\.id), ["a"])
+    }
+
+    // MARK: - Position ticks
+
+    /// The 1 Hz engine tick must advance `status.positionSeconds` directly
+    /// (no FFI, no event) — and must not resurrect a position after the
+    /// track was torn down.
+    func testPositionTickAdvancesPositionOnlyWhileTrackLoaded() throws {
+        let model = try AppModel()
+
+        model.applyPlayerEvent(
+            seq: 1,
+            kinds: [.trackChanged, .stateChanged],
+            status: makeStatus(state: .playing, track: makeTrack("a"))
+        )
+        model.handlePositionTick(seconds: 42.5)
+        XCTAssertEqual(model.status.positionSeconds, 42.5)
+
+        model.applyPlayerEvent(
+            seq: 2,
+            kinds: [.stateChanged, .trackChanged],
+            status: makeStatus(state: .stopped, track: nil)
+        )
+        model.handlePositionTick(seconds: 99)
+        XCTAssertEqual(
+            model.status.positionSeconds, 0,
+            "a stale tick must not write onto a stopped surface"
+        )
+    }
+
+    /// Seeks mirror their target onto the reactive surface immediately —
+    /// while paused there is no time-observer tick to do it, and with the
+    /// poll gone nothing else would.
+    func testSeekMirrorsPositionWhilePaused() throws {
+        let model = try AppModel()
+
+        model.applyPlayerEvent(
+            seq: 1,
+            kinds: [.trackChanged, .stateChanged],
+            status: makeStatus(state: .playing, track: makeTrack("a"))
+        )
+        model.applyPlayerEvent(
+            seq: 2,
+            kinds: [.stateChanged],
+            status: makeStatus(state: .paused, track: makeTrack("a"), position: 10)
+        )
+
+        model.seek(toSeconds: 90)
+        XCTAssertEqual(
+            model.status.positionSeconds, 90,
+            "paused seek must update the UI position without waiting for a tick"
+        )
+        XCTAssertEqual(
+            model.core.status().positionSeconds, 90,
+            "the core's bookkeeping must agree with the surface after a seek"
+        )
+    }
+}


### PR DESCRIPTION
The 1 Hz `core.status()` poll re-took the Rust player mutex and republished `@Observable` state every second — even paused, even in the background — so the core now pushes the changes instead and the timer is gone entirely.

Closes #433

## Event set

`PlayerObserver.player_changed(seq, kinds, status)` — registered via `set_player_observer` / `clear_player_observer`, carrying the full post-mutation `PlayerStatus` snapshot plus the changed facets:

- `StateChanged` — `mark_state`, `set_current` (forces Playing), `clear`/`stop`
- `TrackChanged` — identity changes from `set_current`, skips, `set_queue`, playhead priming on a cold queue, `clear`/`stop`
- `QueueChanged` — `set_queue`, `play_next`, `add_to_queue`, `clear_queue`, cursor moves from skips / in-queue `set_current`

Deliberately silent: `mark_position` (the platform's 1 Hz AVPlayer time observer is the position source — echoing it back would reintroduce the wake storm), and volume / shuffle / repeat / play-session-id setters (their UI call sites already refresh `status()` inline, and Control Center wants that round-trip synchronous). No-op mutations (re-marking the same state/track, empty queue inserts, repeat-one "skips") don't emit.

## Deadlock safety

No lock is ever held while a callback runs: each mutation computes `(seq, kinds, snapshot)` inside the player-lock scope and emits after release; the observer-slot lock is held only to clone the `Arc`, never across the call. `seq` is stamped *under* the player lock so it is monotonic in mutation order — the Swift side drops any push not strictly newer than the last applied, which makes the per-push main-actor hops safe against reordered delivery. A core test re-enters `status()`, `set_volume`, and `clear_player_observer` from inside the callback to pin the contract (it hangs rather than passes if emission ever moves back under a lock).

## Energy Impact

- Idle / paused: **zero** periodic work — the poll `Timer` no longer exists (rc13 baseline was ~3,600 wakes/h paused). No `Timer` remains anywhere in the status path.
- Playing: unchanged 1 Hz — the pre-existing, `rate == 0`-gated AVPlayer time observer now also forwards each tick (`AudioEngine.onPositionTick`, wired on both the AVQueuePlayer and DSP paths for reporting parity) to advance `status.positionSeconds`, the Dock ring, and the scrobble threshold without any FFI on the UI path.
- Events fire only on user/track actions, so the rc11 contract strictly improves; this also structurally fixes the rc12 frozen-PlayerBar failure mode since every `markState` transition publishes.
- Bonus correctness: seeks now mirror their target into `status` + `core.markPosition`, so a paused scrub no longer snaps back to the pre-seek position.

The synchronous `status()` FFI stays for inline refreshes (shuffle/repeat handlers, SmokeTest, seeding the surface at subscription start).

## Tests

- `core/src/tests/status_events.rs` (16 new): per-mutation emission kinds + snapshots, no-op silence, `mark_position`/volume/shuffle/repeat silence, seq monotonicity, observer replacement + unregistration, and the re-entrancy/deadlock pin.
- `macos/Tests/LyrebirdTests/PlayerEventStreamTests.swift` (7 new): end-to-end core-mutation→push→`status` through a real `AppModel`, stream teardown silence, stale-seq drops, track-change side effects (session history, Now Playing detail teardown), position-tick gating, paused-seek mirroring.
- Gates: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (332), `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`, `./macos/Scripts/build-core.sh`, clean `swift build` + `swift test` (1014) — all green, re-run after rebasing onto `main`.