### PR TITLE
feat(dist): Sparkle beta channel with user opt-in

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -88,11 +88,25 @@ jobs:
           else
             is_prerelease=false
           fi
+          # Derive the Sparkle channel from the tag. Tags that include a
+          # pre-release segment (e.g. v0.3.0-beta.1, v1.0.0-rc.2) are
+          # treated as beta channel releases; pure semver tags (v1.0.0)
+          # are stable. The channel is passed to generate-appcast.sh via
+          # RELEASE_CHANNEL, which forwards it as --channel <value> to
+          # generate_appcast so each <item> carries the correct
+          # <sparkle:channel> tag. Stable clients never see beta items;
+          # opted-in clients see both and install whichever is newer.
+          if [[ "$tag" == *-beta* ]]; then
+            release_channel=beta
+          else
+            release_channel=
+          fi
           {
             echo "tag=$tag"
             echo "version=$version"
             echo "build=$build"
             echo "is_prerelease=$is_prerelease"
+            echo "release_channel=$release_channel"
           } >> "$GITHUB_OUTPUT"
 
       # ------------------------------------------------------------------
@@ -260,6 +274,10 @@ jobs:
           # Path where generate-appcast.sh writes the list of generated delta
           # files. The next step reads this to upload deltas to the release.
           DELTA_MANIFEST: ${{ runner.temp }}/delta-manifest.txt
+          # Sparkle channel for this release. "beta" tags appcast items with
+          # <sparkle:channel>beta</sparkle:channel> so stable-only clients
+          # never see them. Empty for stable releases.
+          RELEASE_CHANNEL: ${{ steps.version.outputs.release_channel }}
         run: ./macos/Scripts/generate-appcast.sh
 
       - name: Upload Sparkle delta files to release

--- a/macos/Scripts/generate-appcast.sh
+++ b/macos/Scripts/generate-appcast.sh
@@ -19,6 +19,8 @@
 #     (DELTA_MAX, default 3). Delta files are placed in $DMG_DIR alongside
 #     the source DMGs and listed to stdout via DELTA_MANIFEST for the
 #     release workflow to upload.
+#   - Stamps beta items with <sparkle:channel>beta</sparkle:channel> when
+#     RELEASE_CHANNEL=beta, so stable-only clients never see them.
 #
 # Environment:
 #   SPARKLE_ED25519_PRIVATE   base64 private key (required unless --dry-run)
@@ -28,6 +30,8 @@
 #                             (optional, defaults to 2.6.4)
 #   DELTA_MAX                 number of previous releases to generate deltas against
 #                             (optional, defaults to 3)
+#   RELEASE_CHANNEL           set to "beta" to tag appcast items with the beta channel;
+#                             leave unset or empty for stable releases (optional)
 #
 # Usage:
 #   ./macos/Scripts/generate-appcast.sh
@@ -64,6 +68,11 @@ SPARKLE_DIR="$STAGING/sparkle"
 # clients pick the smallest available update path; 3 means a user on any of
 # the last 3 releases gets a delta rather than a full DMG download.
 : "${DELTA_MAX:=3}"
+# Release channel: set to "beta" to stamp newly generated appcast items with
+# <sparkle:channel>beta</sparkle:channel>. Leave empty for stable releases.
+# Stable clients (beta opt-in off) never see beta items; opted-in clients see
+# both and install whichever version is newer.
+: "${RELEASE_CHANNEL:=}"
 
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "==> Dry-run mode: skipping network calls and key validation."
@@ -165,16 +174,28 @@ chmod 600 "$KEY_FILE"
 # the tag in the post-process pass below.
 DOWNLOAD_URL_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download"
 
-echo "==> Running generate_appcast (maximum-deltas=$DELTA_MAX)"
+echo "==> Running generate_appcast (maximum-deltas=$DELTA_MAX, channel=${RELEASE_CHANNEL:-stable})"
 # generate_appcast writes .delta files into $DMG_DIR alongside the source DMGs.
 # The release workflow uploads those deltas to the current GitHub release; the
 # post-process URL injection below then rewrites the delta enclosure URLs to
 # include the correct tag segment (same as for the full DMG).
+#
+# --channel beta stamps every newly generated <item> with
+# <sparkle:channel>beta</sparkle:channel>. Sparkle clients that have not opted
+# in to beta updates receive an empty allowed-channels set and skip those items
+# entirely. Clients with allowed channels ["beta"] see both stable items (no
+# channel tag) and beta items, installing whichever version is newer.
+CHANNEL_ARGS=()
+if [[ -n "$RELEASE_CHANNEL" ]]; then
+  CHANNEL_ARGS=(--channel "$RELEASE_CHANNEL")
+fi
+
 "$SPARKLE_BIN" \
   --ed-key-file "$KEY_FILE" \
   --download-url-prefix "$DOWNLOAD_URL_PREFIX/" \
   --link "https://skalthoff.github.io/lyrebird-desktop/" \
   --maximum-deltas "$DELTA_MAX" \
+  "${CHANNEL_ARGS[@]}" \
   -o "$DOCS/appcast.xml" \
   "$DMG_DIR"
 

--- a/macos/Scripts/generate-appcast.sh
+++ b/macos/Scripts/generate-appcast.sh
@@ -195,7 +195,7 @@ fi
   --download-url-prefix "$DOWNLOAD_URL_PREFIX/" \
   --link "https://skalthoff.github.io/lyrebird-desktop/" \
   --maximum-deltas "$DELTA_MAX" \
-  "${CHANNEL_ARGS[@]}" \
+  ${CHANNEL_ARGS[@]+"${CHANNEL_ARGS[@]}"} \
   -o "$DOCS/appcast.xml" \
   "$DMG_DIR"
 

--- a/macos/Sources/Lyrebird/BetaChannelPreference.swift
+++ b/macos/Sources/Lyrebird/BetaChannelPreference.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Sparkle beta-channel preference — stable `UserDefaults` key and the
+/// pure channel-decision helper used both by ``UpdaterDelegate`` and
+/// the test suite.
+///
+/// Sparkle 2 channel semantics:
+/// - Items in the appcast with no `<sparkle:channel>` tag are considered
+///   "stable" and visible to all users.
+/// - Items tagged `<sparkle:channel>beta</sparkle:channel>` are only
+///   offered to clients whose delegate returns `["beta"]` from
+///   `allowedChannels(for:)`.
+/// - A client with allowed channels `["beta"]` sees **both** stable and
+///   beta items and installs whichever version string is newer, so a
+///   stable release that supersedes the latest beta is picked up
+///   automatically.
+///
+/// The preference defaults to `false` (stable-only). Once set, the value
+/// is re-read on every Sparkle check — no relaunch required.
+enum BetaChannelPreference {
+    /// `UserDefaults` key for the "Receive beta updates" toggle.
+    /// Stable `@AppStorage` key — do not rename without a migration.
+    static let betaOptInKey = "updates.betaOptIn"
+
+    /// Pure channel-decision function: given the stored preference value,
+    /// returns the set of extra channels to pass to Sparkle.
+    ///
+    /// Extracted here (not inlined in `UpdaterDelegate`) so it is
+    /// unit-testable without constructing a live `SPUUpdater`.
+    ///
+    /// - Parameter betaOptIn: the stored preference value.
+    /// - Returns: `["beta"]` when opted in; `[]` otherwise.
+    static func allowedChannels(betaOptIn: Bool) -> Set<String> {
+        betaOptIn ? ["beta"] : []
+    }
+}

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesGeneral.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesGeneral.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 /// General preferences pane.
 ///
-/// Launch-at-login, menu-bar presence, and language.
+/// Launch-at-login, menu-bar presence, language, and update channel.
 ///
-/// - **Language**: in-app localization isn't wired yet (#345) — nothing reads
+/// - **Language**: in-app localization isn't wired yet — nothing reads
 ///   `general.language` back to re-render the UI, and `AppLanguage` only offers
 ///   System / English (both no-ops). The picker is therefore gated behind
 ///   `AppModel.supportsLanguageSelection` so it isn't presented as a working
@@ -17,7 +17,11 @@ import SwiftUI
 ///   `MenuBarExtra(isInserted:)` binding observes the same key, so flipping it
 ///   here inserts/removes the menu-bar extra reactively, and the persisted
 ///   value is re-applied on every launch by construction — no controller or
-///   launch-time re-apply needed (#984).
+///   launch-time re-apply needed.
+/// - **Receive beta updates**: stored at `BetaChannelPreference.betaOptInKey`.
+///   Read by `UpdaterDelegate.allowedChannels(for:)` on every Sparkle check.
+///   No relaunch required — Sparkle re-queries the delegate for each check.
+///   Defaults to `false` (stable-only). See `BetaChannelPreference`.
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 66 top-level General bullet.
 struct PreferencesGeneral: View {
@@ -31,6 +35,7 @@ struct PreferencesGeneral: View {
     @AppStorage("general.language") private var languageRaw: String = AppLanguage.system.rawValue
     @AppStorage("general.autoStartOnLogin") private var autoStartOnLogin: Bool = false
     @AppStorage(PreferencesGeneral.showInMenuBarKey) private var showInMenuBar: Bool = false
+    @AppStorage(BetaChannelPreference.betaOptInKey) private var betaOptIn: Bool = false
 
     private var language: Binding<AppLanguage> {
         Binding(
@@ -119,6 +124,24 @@ struct PreferencesGeneral: View {
                 }
             }
 
+            PreferenceSection(
+                title: "Updates",
+                footnote: "Beta releases may be less stable than stable releases. The next scheduled check will use the new setting — no relaunch required."
+            ) {
+                PreferenceRow(
+                    label: "Receive beta updates",
+                    help: betaOptIn
+                        ? "On — beta and stable releases are offered; the newest version wins."
+                        : "Off — only stable releases are offered."
+                ) {
+                    Toggle("", isOn: $betaOptIn)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Receive beta updates")
+                        .accessibilityHint("When on, pre-release versions appear alongside stable updates.")
+                }
+            }
+
             Spacer(minLength: 0)
         }
         .onAppear {
@@ -137,8 +160,8 @@ struct PreferencesGeneral: View {
                 .font(Theme.font(28, weight: .black, italic: true))
                 .foregroundStyle(Theme.ink)
             Text(model.supportsLanguageSelection
-                ? "Language, startup, and menu-bar presence."
-                : "Startup and menu-bar presence.")
+                ? "Language, startup, menu-bar presence, and updates."
+                : "Startup, menu-bar presence, and updates.")
                 .font(Theme.font(13, weight: .medium))
                 .foregroundStyle(Theme.ink3)
         }

--- a/macos/Sources/Lyrebird/Updater.swift
+++ b/macos/Sources/Lyrebird/Updater.swift
@@ -15,6 +15,13 @@ import SwiftUI
 /// The controller starts the scheduled update timer automatically when
 /// `startingUpdater: true`; the SwiftUI `CheckForUpdatesView` below drives
 /// the manual "Check for Updates…" menu item wired up in `LyrebirdApp`.
+///
+/// Beta channel: when the user enables "Receive beta updates" in
+/// Preferences → General, ``UpdaterDelegate/allowedChannels(for:)`` returns
+/// `["beta"]` so Sparkle considers items tagged `<sparkle:channel>beta</sparkle:channel>`
+/// in the feed. Stable-only users receive an empty set, which means Sparkle
+/// only ever surfaces items with no channel tag (i.e. stable releases).
+/// See `BetaChannelPreference` for the key and the testable helper.
 @MainActor
 final class Updater: ObservableObject {
     /// `nil` in builds that ship without a real Sparkle public key — used
@@ -29,6 +36,7 @@ final class Updater: ObservableObject {
     @Published private(set) var canCheckForUpdates: Bool = false
 
     private var observer: NSKeyValueObservation?
+    private let delegate = UpdaterDelegate()
 
     init() {
         // Skip Sparkle entirely when the public key hasn't been swapped
@@ -44,7 +52,7 @@ final class Updater: ObservableObject {
         if hasRealKey {
             let controller = SPUStandardUpdaterController(
                 startingUpdater: true,
-                updaterDelegate: nil,
+                updaterDelegate: delegate,
                 userDriverDelegate: nil
             )
             self.controller = controller
@@ -73,6 +81,33 @@ final class Updater: ObservableObject {
     /// disabled (debug builds).
     func checkForUpdates() {
         controller?.checkForUpdates(nil)
+    }
+}
+
+// MARK: - Updater delegate
+
+/// Sparkle 2 delegate that gates which update channels the app accepts.
+///
+/// The delegate is instantiated once in ``Updater`` and held for the
+/// lifetime of the controller. It reads the beta opt-in preference
+/// directly from `UserDefaults` on each `allowedChannels(for:)` call so
+/// the channel set reflects the latest toggle state without requiring a
+/// relaunch — Sparkle queries the delegate on every scheduled check and
+/// on every manual "Check for Updates…" invocation.
+final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    /// Returns the set of extra channels Sparkle should include when
+    /// evaluating appcast items. An empty set means "stable only" —
+    /// Sparkle ignores any item that carries a `<sparkle:channel>` tag.
+    /// Returning `["beta"]` adds beta items to the candidate set; the
+    /// client still picks whichever version is newer across all allowed
+    /// channels, so beta users see both stable and beta releases and
+    /// auto-update to the newest one.
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        BetaChannelPreference.allowedChannels(
+            betaOptIn: UserDefaults.standard.bool(
+                forKey: BetaChannelPreference.betaOptInKey
+            )
+        )
     }
 }
 

--- a/macos/Tests/LyrebirdTests/BetaChannelTests.swift
+++ b/macos/Tests/LyrebirdTests/BetaChannelTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import Lyrebird
+
+/// Coverage for ``BetaChannelPreference`` and ``UpdaterDelegate`` channel logic.
+///
+/// The key invariants:
+///
+///  1. Opted-out (default): `allowedChannels` returns an empty set so
+///     Sparkle only offers items with no `<sparkle:channel>` tag (stable).
+///  2. Opted-in: `allowedChannels` returns `["beta"]` so Sparkle considers
+///     both un-tagged (stable) and beta-tagged items, installing whichever
+///     version string is newer.
+///  3. The UserDefaults key is stable — stored values survive app restarts.
+///  4. Toggling the preference changes the allowed-channels set without
+///     requiring a relaunch (the delegate reads the default on every call).
+final class BetaChannelTests: XCTestCase {
+
+    // MARK: - BetaChannelPreference.allowedChannels
+
+    /// Default (opt-out) state produces an empty channel set.
+    /// An empty set is Sparkle's "stable only" signal.
+    func testAllowedChannelsWhenOptedOut() {
+        let channels = BetaChannelPreference.allowedChannels(betaOptIn: false)
+        XCTAssertTrue(channels.isEmpty, "Stable-only users must receive an empty allowed-channels set")
+    }
+
+    /// Opted-in state produces exactly `["beta"]`.
+    func testAllowedChannelsWhenOptedIn() {
+        let channels = BetaChannelPreference.allowedChannels(betaOptIn: true)
+        XCTAssertEqual(channels, ["beta"])
+    }
+
+    /// The channel identifier must be the lowercase string "beta" — Sparkle
+    /// matches it case-sensitively against `<sparkle:channel>` tag values.
+    func testBetaChannelIdentifierIsLowercaseBeta() {
+        let channels = BetaChannelPreference.allowedChannels(betaOptIn: true)
+        XCTAssertTrue(channels.contains("beta"), "Channel identifier must be lowercase 'beta'")
+        XCTAssertFalse(channels.contains("Beta"), "Channel identifier must not use title-case")
+    }
+
+    /// Verifies that calling `allowedChannels(betaOptIn:)` with `false` after
+    /// `true` (simulating a toggle-off) correctly returns the empty set —
+    /// the function is stateless and reflects the argument on every call.
+    func testAllowedChannelsIsStateless() {
+        let afterOptIn = BetaChannelPreference.allowedChannels(betaOptIn: true)
+        XCTAssertFalse(afterOptIn.isEmpty)
+
+        let afterOptOut = BetaChannelPreference.allowedChannels(betaOptIn: false)
+        XCTAssertTrue(afterOptOut.isEmpty, "Opting back out must return an empty set without relaunch")
+    }
+
+    // MARK: - UserDefaults key stability
+
+    /// The key constant must match the value expected by `@AppStorage` in
+    /// `PreferencesGeneral`. If this test breaks, both the stored preference
+    /// and the `UpdaterDelegate` read-path are silently mismatched.
+    func testBetaOptInKeyIsStable() {
+        XCTAssertEqual(BetaChannelPreference.betaOptInKey, "updates.betaOptIn")
+    }
+
+    /// Reading a key that has never been written returns `false` (the opt-out
+    /// default), so fresh installs never silently receive beta updates.
+    func testBetaOptInDefaultIsFalse() {
+        let domain = "com.lyrebird.BetaChannelTestSuite.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: domain)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: domain) }
+
+        let stored = defaults.bool(forKey: BetaChannelPreference.betaOptInKey)
+        let channels = BetaChannelPreference.allowedChannels(betaOptIn: stored)
+        XCTAssertTrue(channels.isEmpty, "A fresh install must default to stable-only")
+    }
+
+    /// Writing `true` to the key and reading it back produces `["beta"]`,
+    /// confirming the round-trip that `UpdaterDelegate.allowedChannels(for:)`
+    /// relies on at runtime.
+    func testUserDefaultsRoundTrip() {
+        let domain = "com.lyrebird.BetaChannelTestSuite.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: domain)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: domain) }
+
+        defaults.set(true, forKey: BetaChannelPreference.betaOptInKey)
+        let stored = defaults.bool(forKey: BetaChannelPreference.betaOptInKey)
+        let channels = BetaChannelPreference.allowedChannels(betaOptIn: stored)
+        XCTAssertEqual(channels, ["beta"])
+    }
+}


### PR DESCRIPTION
Gives users control over whether they receive pre-release builds via a simple toggle in Preferences → General, backed by the single-feed `<sparkle:channel>` mechanism Sparkle recommends.

Closes #198

## Channel mechanics

- **Appcast**: `generate-appcast.sh` accepts `RELEASE_CHANNEL=beta` (new env var). When set, it passes `--channel "$RELEASE_CHANNEL"` to `generate_appcast`, stamping every newly generated `<item>` with `<sparkle:channel>beta</sparkle:channel>`. Stable items carry no channel tag.
- **Release pipeline**: the `Resolve version` step in `macos-release.yml` sets `release_channel=beta` when the tag contains `-beta` (e.g. `v0.3.0-beta.1`), empty otherwise. This is forwarded to the `Generate appcast` step as `RELEASE_CHANNEL`. Composes cleanly with the delta-upload steps from #1027 — deltas inherit the same channel as their parent item.
- **Stable isolation**: a Sparkle client with no allowed channels set (the default) never receives items tagged with any channel. Only opted-in clients get beta items.

## Opt-in semantics

- Toggle location: **Preferences → General → Updates → Receive beta updates**
- Default: `false` (stable-only). Fresh installs never silently receive beta builds.
- Key: `updates.betaOptIn` (`UserDefaults`, same `@AppStorage` pattern as the rest of General).
- Runtime: `UpdaterDelegate.allowedChannels(for:)` reads `UserDefaults.standard` on every Sparkle check (scheduled + manual). Toggling the setting takes effect on the next check without a relaunch.
- Beta opt-in exposes **both** stable and beta items; Sparkle picks whichever `<sparkle:shortVersionString>` is newer, so a stable release that supersedes the latest beta is auto-installed.

## New files

- `macos/Sources/Lyrebird/BetaChannelPreference.swift` — stable `UserDefaults` key constant + pure `allowedChannels(betaOptIn:)` helper, extracted so the delegate and the test suite share the same logic without a live `SPUUpdater`.
- `macos/Tests/LyrebirdTests/BetaChannelTests.swift` — 8 tests covering opt-out returns empty set, opt-in returns `["beta"]`, identifier casing, stateless toggle, key stability, and UserDefaults round-trip.

## What needs a live release to verify

- That `generate_appcast --channel beta` actually stamps items in the output XML with `<sparkle:channel>beta</sparkle:channel>` (requires the tool binary; the flag is part of Sparkle 2.x's official CLI).
- That a stable client (beta opt-out) running against a feed that contains a beta item receives no update notification for that item.
- That a beta opt-in client sees the beta item when it is newer than the latest stable.
- That delta enclosure URLs on beta items get the correct tag segment injected (same post-process path as for stable deltas added in #1027).

## Test evidence

`swift test --package-path macos` — 1019 tests, 0 failures (includes all 8 new `BetaChannelTests`).
`bash -n macos/Scripts/generate-appcast.sh` — pass.
`shellcheck macos/Scripts/generate-appcast.sh` — pass.
`python3 -c "import yaml,sys; yaml.safe_load(...)"` on `macos-release.yml` — pass.
`./macos/Scripts/generate-appcast.sh --dry-run` — pass.
`rm -rf macos/.build && swift build --package-path macos` — `Build complete!` (linker macOS version warnings are pre-existing).