### PR TITLE
feat(macos): playlist public/private visibility toggle

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2261,7 +2261,12 @@ impl JellyfinClient {
     ///
     /// Requires an authenticated session; returns
     /// [`LyrebirdError::NotAuthenticated`] if no `user_id` is set.
-    pub async fn create_playlist(&self, name: &str, item_ids: &[&str]) -> Result<String> {
+    pub async fn create_playlist(
+        &self,
+        name: &str,
+        item_ids: &[&str],
+        is_public: bool,
+    ) -> Result<String> {
         let user_id = self
             .user_id
             .as_ref()
@@ -2272,6 +2277,7 @@ impl JellyfinClient {
             ids: item_ids.iter().map(|s| s.to_string()).collect(),
             user_id: user_id.clone(),
             media_type: "Audio".to_string(),
+            is_public,
         };
         let resp = self
             .send_mutation_no_retry(|| {
@@ -2284,6 +2290,34 @@ impl JellyfinClient {
             .await?;
         let result: CreatePlaylistResult = resp.json().await?;
         Ok(result.id)
+    }
+
+    /// Update a playlist's `IsPublic` visibility flag via
+    /// `POST /Playlists/{id}?userId={userId}`.
+    ///
+    /// Jellyfin's dedicated Playlists endpoint accepts a lightweight body
+    /// with just `IsPublic`; it does NOT require the full item round-trip
+    /// that `rename_playlist` uses. Responds 204 on success.
+    ///
+    /// Requires an authenticated session; returns
+    /// [`LyrebirdError::NotAuthenticated`] if no token is set.
+    pub async fn set_playlist_visibility(&self, playlist_id: &str, is_public: bool) -> Result<()> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(LyrebirdError::NotAuthenticated)?;
+        let mut url = self.endpoint(&format!("Playlists/{playlist_id}"))?;
+        url.query_pairs_mut().append_pair("userId", user_id);
+        let body = UpdatePlaylistBody { is_public };
+        self.send_with_retry(|| {
+            Ok(self
+                .http
+                .post(url.clone())
+                .headers(self.build_headers()?)
+                .json(&body))
+        })
+        .await?;
+        Ok(())
     }
 
     /// Report current playback progress to Jellyfin. Jellify calls this
@@ -3093,6 +3127,18 @@ struct CreatePlaylistBody {
     user_id: String,
     #[serde(rename = "MediaType")]
     media_type: String,
+    #[serde(rename = "IsPublic")]
+    is_public: bool,
+}
+
+/// Body for `POST /Playlists/{id}` (update visibility / name via the
+/// Playlists-specific endpoint). Only `IsPublic` is exposed here; name
+/// changes still go through the heavier `POST /Items/{id}` rename path
+/// so existing metadata is preserved in the round-trip.
+#[derive(Serialize)]
+struct UpdatePlaylistBody {
+    #[serde(rename = "IsPublic")]
+    is_public: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3375,6 +3421,11 @@ impl From<RawItem> for Playlist {
             runtime_ticks: r.runtime_ticks,
             image_tag: r.image_tags.get("Primary").cloned(),
             user_data,
+            // The standard Items list endpoint does not return OpenAccess;
+            // default to true (Jellyfin's server default) until the caller
+            // explicitly fetches the single-playlist detail via
+            // `GET /Playlists/{id}`.
+            is_public: true,
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1020,6 +1020,11 @@ impl LyrebirdCore {
     /// `item_ids` may be empty to create an empty playlist. Errors with
     /// [`LyrebirdError::NotAuthenticated`] if no session is active.
     ///
+    /// `is_public` maps to Jellyfin's `IsPublic` field in `POST /Playlists`;
+    /// pass `true` for a playlist visible to all server users, `false` to
+    /// restrict it to the creating user. Defaults to `true` on older server
+    /// versions that ignore the field.
+    ///
     /// There is no positional-insert parameter: `POST /Playlists` has no
     /// server-side `StartIndex` semantics, so the seed `item_ids` are
     /// appended in order. Positional insert is deferred to a dedicated
@@ -1028,10 +1033,27 @@ impl LyrebirdCore {
         &self,
         name: String,
         item_ids: Vec<String>,
+        is_public: bool,
     ) -> std::result::Result<String, LyrebirdError> {
         self.with_client(|c| {
             let id_refs: Vec<&str> = item_ids.iter().map(String::as_str).collect();
-            self.runtime.block_on(c.create_playlist(&name, &id_refs))
+            self.runtime
+                .block_on(c.create_playlist(&name, &id_refs, is_public))
+        })
+    }
+
+    /// Update a playlist's public / private visibility flag. Uses
+    /// `POST /Playlists/{id}?userId={userId}` with `{"IsPublic": bool}`.
+    /// Callers should update their local `Playlist.is_public` on success.
+    /// Errors with [`LyrebirdError::NotAuthenticated`] if no session is active.
+    pub fn set_playlist_visibility(
+        &self,
+        playlist_id: String,
+        is_public: bool,
+    ) -> std::result::Result<(), LyrebirdError> {
+        self.with_client(|c| {
+            self.runtime
+                .block_on(c.set_playlist_visibility(&playlist_id, is_public))
         })
     }
 

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -119,6 +119,11 @@ pub struct Playlist {
     /// favorite flag, play count, last-played date, etc. `None` when the
     /// caller did not request `Fields=UserData` or the server omitted it.
     pub user_data: Option<UserItemData>,
+    /// Whether this playlist is publicly visible to other server users.
+    /// Jellyfin reports this as `OpenAccess` on `GET /Playlists/{id}`;
+    /// the create / update body uses `IsPublic`. Defaults to `true` when
+    /// the server omits the field (pre-10.9 behaviour, public by default).
+    pub is_public: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]

--- a/core/src/tests/playlists.rs
+++ b/core/src/tests/playlists.rs
@@ -302,7 +302,7 @@ async fn create_playlist_posts_pascal_case_body_and_returns_id() {
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
     let id = client
-        .create_playlist("Road Trip", &["t1", "t2", "t3"])
+        .create_playlist("Road Trip", &["t1", "t2", "t3"], true)
         .await
         .unwrap();
     assert_eq!(id, "new-playlist-id");
@@ -388,7 +388,10 @@ async fn create_playlist_with_empty_ids_sends_empty_array() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client.create_playlist("Empty List", &[]).await.unwrap();
+    let id = client
+        .create_playlist("Empty List", &[], true)
+        .await
+        .unwrap();
     assert_eq!(id, "empty-playlist-id");
 
     let requests = server.received_requests().await.unwrap();
@@ -424,7 +427,7 @@ async fn create_playlist_propagates_server_errors() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let err = client.create_playlist("x", &[]).await.unwrap_err();
+    let err = client.create_playlist("x", &[], true).await.unwrap_err();
     match err {
         crate::error::LyrebirdError::Server { status, .. } => assert_eq!(status, 500),
         other => panic!("expected Server 500, got {other:?}"),
@@ -454,7 +457,7 @@ async fn create_playlist_requires_authenticated_session() {
     // a real host.
     let server = MockServer::start().await;
     let client = mock_client(&server.uri());
-    let err = client.create_playlist("x", &[]).await.unwrap_err();
+    let err = client.create_playlist("x", &[], true).await.unwrap_err();
     assert!(
         matches!(err, crate::error::LyrebirdError::NotAuthenticated),
         "expected NotAuthenticated, got {err:?}"
@@ -700,7 +703,10 @@ async fn create_playlist_never_sends_start_index() {
 
     let mut client = mock_client(&server.uri());
     client.authenticate_by_name("n", "pw").await.unwrap();
-    let id = client.create_playlist("Appended", &["t1"]).await.unwrap();
+    let id = client
+        .create_playlist("Appended", &["t1"], true)
+        .await
+        .unwrap();
     assert_eq!(id, "no-pos-pl-id");
 
     let requests = server.received_requests().await.unwrap();
@@ -1338,4 +1344,153 @@ async fn playlists_containing_artist_zero_limit_is_empty() {
         .await
         .unwrap();
     assert!(result.is_empty());
+}
+
+// ============================================================================
+// Playlist visibility — IsPublic in create + set_playlist_visibility
+// ============================================================================
+
+/// `create_playlist` must send `IsPublic` in the POST body.
+#[tokio::test]
+async fn create_playlist_sends_is_public_in_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "Id": "vis-pl-id" })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+
+    // Create a private playlist.
+    let id = client
+        .create_playlist("Private Mix", &[], false)
+        .await
+        .unwrap();
+    assert_eq!(id, "vis-pl-id");
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
+        .expect("expected POST to /Playlists");
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("body should be valid JSON");
+    // IsPublic=false must appear in the body so the server stores the playlist
+    // as private. Without this field the server defaults to public.
+    assert_eq!(
+        body.get("IsPublic").and_then(|v| v.as_bool()),
+        Some(false),
+        "IsPublic must be false in the body when creating a private playlist, got: {body}"
+    );
+}
+
+/// `create_playlist` with `is_public=true` must send `IsPublic: true`.
+#[tokio::test]
+async fn create_playlist_sends_is_public_true_for_public_playlist() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "Id": "pub-pl-id" })))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .create_playlist("Public Mix", &[], true)
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists")
+        .expect("expected POST to /Playlists");
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("body should be valid JSON");
+    assert_eq!(
+        body.get("IsPublic").and_then(|v| v.as_bool()),
+        Some(true),
+        "IsPublic must be true in the body when creating a public playlist, got: {body}"
+    );
+}
+
+/// `set_playlist_visibility` must POST to `/Playlists/{id}` with `IsPublic`
+/// in the body and `userId` in the query string.
+#[tokio::test]
+async fn set_playlist_visibility_posts_is_public_with_user_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/Users/AuthenticateByName"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "AccessToken": "t", "ServerId": "s", "ServerName": "S",
+            "User": { "Id": "u1", "Name": "n", "ServerId": "s", "PrimaryImageTag": null }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/Playlists/pl-55"))
+        .and(query_param("userId", "u1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let mut client = mock_client(&server.uri());
+    client.authenticate_by_name("n", "pw").await.unwrap();
+    client
+        .set_playlist_visibility("pl-55", false)
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let post = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/Playlists/pl-55")
+        .expect("expected POST to /Playlists/pl-55");
+
+    // Body must carry IsPublic=false.
+    let body: serde_json::Value =
+        serde_json::from_slice(&post.body).expect("body should be valid JSON");
+    assert_eq!(
+        body.get("IsPublic").and_then(|v| v.as_bool()),
+        Some(false),
+        "IsPublic must be false in the update body, got: {body}"
+    );
+
+    // UserId must appear in the query string.
+    let q = post.url.query().unwrap_or_default();
+    assert!(q.contains("userId=u1"), "userId must be in query: {q}");
+}
+
+/// `set_playlist_visibility` must require an authenticated session.
+#[tokio::test]
+async fn set_playlist_visibility_requires_authenticated_session() {
+    let server = MockServer::start().await;
+    let client = mock_client(&server.uri());
+    let err = client
+        .set_playlist_visibility("pl-1", true)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::error::LyrebirdError::NotAuthenticated),
+        "expected NotAuthenticated, got {err:?}"
+    );
 }

--- a/macos/Sources/Lyrebird/AppModel+PlaylistTracks.swift
+++ b/macos/Sources/Lyrebird/AppModel+PlaylistTracks.swift
@@ -137,7 +137,8 @@ extension AppModel {
                 trackCount: UInt32(newCount),
                 runtimeTicks: p.runtimeTicks,
                 imageTag: p.imageTag,
-                userData: p.userData
+                userData: p.userData,
+                isPublic: p.isPublic
             )
         }
         // Capture the optimistic state so we can roll back on server failure.
@@ -174,7 +175,8 @@ extension AppModel {
                         trackCount: p.trackCount + UInt32(removedSnapshot.count),
                         runtimeTicks: p.runtimeTicks,
                         imageTag: p.imageTag,
-                        userData: p.userData
+                        userData: p.userData,
+                        isPublic: p.isPublic
                     )
                 }
                 self.pendingPlaylistRemoval = nil
@@ -214,7 +216,8 @@ extension AppModel {
                 trackCount: p.trackCount + UInt32(reinserted.count),
                 runtimeTicks: p.runtimeTicks,
                 imageTag: p.imageTag,
-                userData: p.userData
+                userData: p.userData,
+                isPublic: p.isPublic
             )
         }
         // Capture the count of optimistically-reinserted tracks so we can
@@ -250,7 +253,8 @@ extension AppModel {
                         trackCount: UInt32(newCount),
                         runtimeTicks: p.runtimeTicks,
                         imageTag: p.imageTag,
-                        userData: p.userData
+                        userData: p.userData,
+                        isPublic: p.isPublic
                     )
                 }
                 self.errorMessage = LyrebirdErrorPresenter.message(
@@ -291,7 +295,8 @@ extension AppModel {
                 trackCount: p.trackCount + UInt32(trackIds.count),
                 runtimeTicks: p.runtimeTicks,
                 imageTag: p.imageTag,
-                userData: p.userData
+                userData: p.userData,
+                isPublic: p.isPublic
             )
         }
         let bumpedCount = trackIds.count
@@ -326,7 +331,8 @@ extension AppModel {
                         trackCount: UInt32(newCount),
                         runtimeTicks: p.runtimeTicks,
                         imageTag: p.imageTag,
-                        userData: p.userData
+                        userData: p.userData,
+                        isPublic: p.isPublic
                     )
                 }
                 self.errorMessage = LyrebirdErrorPresenter.message(

--- a/macos/Sources/Lyrebird/AppModel+Playlists.swift
+++ b/macos/Sources/Lyrebird/AppModel+Playlists.swift
@@ -329,15 +329,13 @@ extension AppModel {
 
     // MARK: - Sidebar playlist CRUD (BATCH-06b, #71 / #73 / #75)
 
-    /// Drop a placeholder row into edit mode so Cmd+N feels instant. The
-    /// placeholder is identified by `sidebarNewPlaylistSentinel`; the
-    /// sidebar renders a single TextField in its slot. Committing via
-    /// `commitSidebarPlaylistEdit` turns this into a real `create_playlist`
-    /// call; Escape / empty-blur bails out via `cancelSidebarPlaylistEdit`.
-    /// See issue #71.
+    /// Present the New Playlist sheet. The sheet owns the name field and
+    /// the Public / Private visibility toggle; on confirm it calls
+    /// `createPlaylist(name:isPublic:)`. The ⌘N menu item and the sidebar
+    /// "+" button both funnel through this so the toggle is always reachable
+    /// at creation time.
     func beginNewPlaylist() {
-        sidebarEditingPlaylistId = Self.sidebarNewPlaylistSentinel
-        sidebarEditingDraft = ""
+        showingNewPlaylistSheet = true
     }
 
     /// Dismiss the inline TextField without saving. Used for Escape /
@@ -370,16 +368,19 @@ extension AppModel {
     }
 
     /// Create a new (empty) playlist on the server and prepend it to the
+    /// Create a new (empty) playlist on the server and prepend it to the
     /// in-memory `playlists` list so the sidebar surfaces it immediately.
-    /// Backed by `core.createPlaylist(name:, itemIds:)` — see #126.
-    /// A thin optimistic update: if the core call fails we fall back to
-    /// an `errorMessage` and do not insert the row.
-    func createPlaylist(name: String) async {
+    /// Backed by `core.createPlaylist(name:itemIds:isPublic:)` — see #126.
+    /// `isPublic` maps to Jellyfin's `IsPublic` field; `true` makes the
+    /// playlist visible to all server users, `false` restricts it to the
+    /// creating user. A thin optimistic update: if the core call fails we
+    /// fall back to an `errorMessage` and do not insert the row.
+    func createPlaylist(name: String, isPublic: Bool = true) async {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: trimmed, itemIds: [])
+                try core.createPlaylist(name: trimmed, itemIds: [], isPublic: isPublic)
             }.value
             // The core returns only the id; build a minimal `Playlist`
             // record client-side rather than refetching. An `imageTag` of
@@ -391,11 +392,50 @@ extension AppModel {
                 trackCount: 0,
                 runtimeTicks: 0,
                 imageTag: nil,
-                userData: nil
+                userData: nil,
+                isPublic: isPublic
             )
             playlists.insert(newPlaylist, at: 0)
         } catch {
             errorMessage = "Create playlist failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Set the public / private visibility of an existing playlist. Optimistically
+    /// updates the in-memory record for instant UI feedback, then persists via
+    /// `core.setPlaylistVisibility`. Rolls back and surfaces `errorMessage` on
+    /// failure, matching the rc12 playlist-mutation pattern.
+    func setPlaylistVisibility(playlist: Playlist, isPublic: Bool) {
+        guard let idx = playlists.firstIndex(where: { $0.id == playlist.id }) else { return }
+        let existing = playlists[idx]
+        guard isPublic != existing.isPublic else { return }
+        // Optimistic update.
+        playlists[idx] = Playlist(
+            id: existing.id,
+            name: existing.name,
+            trackCount: existing.trackCount,
+            runtimeTicks: existing.runtimeTicks,
+            imageTag: existing.imageTag,
+            userData: existing.userData,
+            isPublic: isPublic
+        )
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) { [core] in
+                    try core.setPlaylistVisibility(playlistId: playlist.id, isPublic: isPublic)
+                }.value
+                serverReachability.noteSuccess()
+            } catch {
+                if handleAuthError(error) { return }
+                // Rollback the optimistic visibility change on failure.
+                if let rollbackIdx = playlists.firstIndex(where: { $0.id == playlist.id }) {
+                    playlists[rollbackIdx] = existing
+                }
+                errorMessage = "Visibility update failed: \(error.localizedDescription)"
+                if ServerReachability.shouldCount(error: error) {
+                    serverReachability.noteFailure()
+                }
+            }
         }
     }
 
@@ -417,7 +457,8 @@ extension AppModel {
             trackCount: existing.trackCount,
             runtimeTicks: existing.runtimeTicks,
             imageTag: existing.imageTag,
-            userData: existing.userData
+            userData: existing.userData,
+            isPublic: existing.isPublic
         )
         Task {
             do {
@@ -457,9 +498,11 @@ extension AppModel {
         let tracks = await loadAllPlaylistTracks(playlistID: source.id)
         let trackIds = tracks.map(\.id)
         let copyName = "\(source.name) Copy"
+        // Duplicate inherits the source playlist's visibility.
+        let sourceIsPublic = source.isPublic
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: copyName, itemIds: trackIds)
+                try core.createPlaylist(name: copyName, itemIds: trackIds, isPublic: sourceIsPublic)
             }.value
             // Core's `create_playlist` can accept seed items directly; the
             // `itemIds` path above covers the common case. We still build a
@@ -470,7 +513,8 @@ extension AppModel {
                 trackCount: UInt32(trackIds.count),
                 runtimeTicks: source.runtimeTicks,
                 imageTag: nil,
-                userData: nil
+                userData: nil,
+                isPublic: sourceIsPublic
             )
             playlists.insert(newPlaylist, at: 0)
             // Prime the tracks cache so the detail view doesn't have to

--- a/macos/Sources/Lyrebird/AppModel+Queue.swift
+++ b/macos/Sources/Lyrebird/AppModel+Queue.swift
@@ -158,7 +158,7 @@ extension AppModel {
         guard !ids.isEmpty else { return }
         do {
             let newId = try await Task.detached(priority: .userInitiated) { [core] in
-                try core.createPlaylist(name: trimmed, itemIds: ids)
+                try core.createPlaylist(name: trimmed, itemIds: ids, isPublic: true)
             }.value
             // Some older Jellyfin builds ignore the initial `ItemIds` on
             // `create_playlist` and return an empty playlist. Follow up

--- a/macos/Sources/Lyrebird/AppModel+Resolvers.swift
+++ b/macos/Sources/Lyrebird/AppModel+Resolvers.swift
@@ -308,7 +308,10 @@ extension AppModel {
             trackCount: trackCount,
             runtimeTicks: runtimeTicks,
             imageTag: imageTag,
-            userData: nil
+            userData: nil,
+            // Resolver uses fetch_item (GET /Items?Ids=), which does not
+            // return OpenAccess; default to true (Jellyfin's default).
+            isPublic: true
         )
     }
 

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -691,6 +691,13 @@ final class AppModel {
     /// this set. Cleared on success or error. See `duplicatePlaylist`.
     var sidebarCopyingPlaylistIds: Set<String> = []
 
+    // MARK: - New Playlist sheet
+
+    /// When `true` the New Playlist sheet is presented. The sheet owns the
+    /// name field + Public/Private toggle; on confirm it calls
+    /// `createPlaylist(name:isPublic:)` and dismisses.
+    var showingNewPlaylistSheet: Bool = false
+
     // MARK: - Mini Player (⌘⌥P)
 
     /// UserDefaults key for the persisted always-on-top preference. AppModel is

--- a/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistContextMenu.swift
@@ -56,6 +56,17 @@ struct PlaylistContextMenu: View {
             model.requestDuplicate(playlist: playlist)
         }
         .disabled(isCopying)
+        // Visibility toggle — flips the playlist between Public (globe) and
+        // Private (lock). Optimistic with server rollback on failure.
+        if playlist.isPublic {
+            Button("Make Private", systemImage: "lock.fill") {
+                model.setPlaylistVisibility(playlist: playlist, isPublic: false)
+            }
+        } else {
+            Button("Make Public", systemImage: "globe") {
+                model.setPlaylistVisibility(playlist: playlist, isPublic: true)
+            }
+        }
         Button("Delete…", systemImage: "trash", role: .destructive) {
             model.confirmDelete(playlist: playlist)
         }

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -210,7 +210,6 @@ struct Sidebar: View {
 
     @ViewBuilder
     private var playlistsSection: some View {
-        let editingNew = model.sidebarEditingPlaylistId == AppModel.sidebarNewPlaylistSentinel
         // Sort the live playlists by the persisted manual order. New playlists
         // append; deleted ones prune — see `PlaylistSidebarOrder`.
         let orderedPlaylists = PlaylistSidebarOrder.order(
@@ -247,6 +246,7 @@ struct Sidebar: View {
                 .accessibilityAddTraits(.isButton)
 
                 Spacer()
+                // "+" opens the New Playlist sheet (name + Public/Private toggle).
                 Button { model.beginNewPlaylist() } label: {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .bold))
@@ -268,13 +268,6 @@ struct Sidebar: View {
                 // match the rest of the sidebar: plain rows, no separators, a
                 // clear background so the sidebar material shows through.
                 List {
-                    // In-progress new-playlist row, shown at the top so the
-                    // user sees where the new item will land. Not movable.
-                    if editingNew {
-                        newPlaylistEditRow
-                            .listRowSidebarStyling()
-                            .moveDisabled(true)
-                    }
                     ForEach(orderedPlaylists, id: \.id) { playlist in
                         playlistRow(playlist)
                             .listRowSidebarStyling()
@@ -296,8 +289,8 @@ struct Sidebar: View {
                 .frame(maxHeight: 280)
             }
         }
-        // #585: Allow space-bar input in the inline rename / new-playlist
-        // TextField even while the global Play/Pause ⎵ shortcut is active.
+        // #585: Allow space-bar input in the inline rename TextField even
+        // while the global Play/Pause ⎵ shortcut is active.
         .spaceKeyGuardForTextField()
     }
 
@@ -454,6 +447,15 @@ struct Sidebar: View {
                     .progressViewStyle(.circular)
                     .controlSize(.mini)
                     .tint(Theme.ink3)
+            } else if !playlist.isPublic {
+                // Lock icon — signals that this playlist is private (not
+                // visible to other server users). Hidden while a duplicate
+                // round trip is in flight to avoid icon overlap.
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(Theme.ink3)
+                    .accessibilityLabel("Private playlist")
+                    .help("Private — only visible to you")
             }
         }
         .padding(.horizontal, 10)
@@ -479,7 +481,7 @@ struct Sidebar: View {
             model.goToPlaylist(playlist)
         }
         .contextMenu { PlaylistContextMenu(playlist: playlist) }
-        .accessibilityLabel(playlist.name)
+        .accessibilityLabel(playlist.isPublic ? playlist.name : "\(playlist.name), Private")
         .accessibilityAddTraits(isActiveScreen ? .isSelected : [])
     }
 

--- a/macos/Sources/Lyrebird/Screens/MainShell.swift
+++ b/macos/Sources/Lyrebird/Screens/MainShell.swift
@@ -391,6 +391,13 @@ struct MainShell: View {
         .sheet(isPresented: $model.isShowingInstantMixPicker) {
             InstantMixSheet(model: model)
         }
+        // New Playlist sheet — presents the name field + Public/Private
+        // visibility toggle. Triggered from ⌘N / the sidebar "+" button
+        // via `AppModel.beginNewPlaylist()`.
+        .sheet(isPresented: $model.showingNewPlaylistSheet) {
+            NewPlaylistSheet()
+                .environment(model)
+        }
         // Playlist-delete confirmation — see #98 / #131. Triggered from
         // `PlaylistContextMenu` via `AppModel.confirmDelete(playlist:)`.
         .confirmationDialog(

--- a/macos/Sources/Lyrebird/Screens/NewPlaylistSheet.swift
+++ b/macos/Sources/Lyrebird/Screens/NewPlaylistSheet.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Sheet for creating a new playlist with a name field and a Public / Private
+/// visibility toggle. Presented via `AppModel.showingNewPlaylistSheet` when the
+/// user triggers ⌘N or taps the "+" button in the sidebar.
+///
+/// On confirm the sheet calls `AppModel.createPlaylist(name:isPublic:)` and
+/// dismisses. An empty name disables the Create button — matching Finder's
+/// inline-rename convention — so the sheet never sends a blank name to the
+/// server.
+struct NewPlaylistSheet: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @State private var isPublic: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("New Playlist")
+                .font(Theme.font(17, weight: .bold))
+                .foregroundStyle(Theme.ink)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Name")
+                    .font(Theme.font(11, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(0.5)
+                TextField("Playlist name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(Theme.font(13, weight: .regular))
+                    // Submit via Return key mirrors inline-edit commit.
+                    .onSubmit { commitIfValid() }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Visibility")
+                    .font(Theme.font(11, weight: .semibold))
+                    .foregroundStyle(Theme.ink3)
+                    .tracking(0.5)
+                Picker("Visibility", selection: $isPublic) {
+                    Label("Public", systemImage: "globe")
+                        .tag(true)
+                    Label("Private", systemImage: "lock.fill")
+                        .tag(false)
+                }
+                .pickerStyle(.segmented)
+                Text(isPublic
+                    ? "Visible to all users on this server."
+                    : "Only visible to you.")
+                    .font(Theme.font(11, weight: .regular))
+                    .foregroundStyle(Theme.ink3)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.escape, modifiers: [])
+                Button("Create") { commitIfValid() }
+                    .keyboardShortcut(.return, modifiers: [])
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+    }
+
+    private func commitIfValid() {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        dismiss()
+        Task { await model.createPlaylist(name: trimmed, isPublic: isPublic) }
+    }
+}

--- a/macos/Tests/LyrebirdTests/PlaylistSidebarOrderTests.swift
+++ b/macos/Tests/LyrebirdTests/PlaylistSidebarOrderTests.swift
@@ -174,7 +174,8 @@ final class PlaylistSidebarOrderTests: XCTestCase {
             trackCount: 0,
             runtimeTicks: 0,
             imageTag: nil,
-            userData: nil
+            userData: nil,
+            isPublic: true
         )
     }
 }

--- a/macos/Tests/LyrebirdTests/SidebarPlaylistRenameCommitTests.swift
+++ b/macos/Tests/LyrebirdTests/SidebarPlaylistRenameCommitTests.swift
@@ -36,7 +36,8 @@ final class SidebarPlaylistRenameCommitTests: XCTestCase {
             trackCount: 0,
             runtimeTicks: 0,
             imageTag: nil,
-            userData: nil
+            userData: nil,
+            isPublic: true
         )
     }
 


### PR DESCRIPTION
Jellyfin supports an `IsPublic` flag on playlists that controls whether they are visible to all server users or only the owner. This PR wires that flag all the way from the Jellyfin REST API through the Rust core to the SwiftUI layer.

## What changed

**Core (Rust)**
- `Playlist` model gains `is_public: bool` (defaults to `true` when the server omits the field — pre-10.9 behaviour and the `/Items` list endpoint both omit `OpenAccess`)
- `create_playlist` accepts `is_public` and sends `IsPublic` in the request body
- New `set_playlist_visibility(playlist_id, is_public)` method: `POST /Playlists/{id}?userId=…` with `{"IsPublic": bool}` — verified against `music.skalthoff.com` (204 response)
- FFI surface updated accordingly; 4 new tests in `core/src/tests/playlists.rs`

**SwiftUI (macOS)**
- ⌘N / sidebar "+" now opens `NewPlaylistSheet` — a focused modal with a name field and a Public/Private segmented picker — instead of the inline row (which had no room for a toggle)
- Sidebar rows show a `lock.fill` icon next to the name for private playlists; accessibility label includes "Private" for VoiceOver
- Playlist context menu gains "Make Private" / "Make Public" (toggles in place) with optimistic update + server rollback on failure, matching the rc12 mutation pattern
- All `Playlist(…)` constructors throughout the codebase updated to carry `isPublic` through mutations and resolve operations

## API contract

`GET /Playlists/{id}` returns `"OpenAccess": bool`. The `/Items` list endpoint does **not** return this field — all items from that path default to `is_public = true` (server default). Visibility is written via `POST /Playlists/{id}?userId=X` with `{"IsPublic": bool}`, which returns 204. Verified against the real server (`music.skalthoff.com`) before implementation.

## Test evidence

- `cargo test` — 324 tests pass (4 new playlist-visibility tests)
- `swift build` (clean, `rm -rf .build` first) — Build complete, 0 errors
- `swift test` — 1056 tests pass, 0 failures

Closes #78