### PR TITLE
feat(macos): seed translations for 8 first-wave locales

### DIFF
--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -35,7 +35,6 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
 
-    <!-- First-wave localizations. Keep in sync with Localizable.xcstrings. -->
     <key>CFBundleLocalizations</key>
     <array>
         <string>en</string>

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -35,7 +35,21 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
 
-    <!-- Version fields. These placeholders are overwritten by
+    <!-- First-wave localizations. Keep in sync with Localizable.xcstrings. -->
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>en</string>
+        <string>es</string>
+        <string>fr</string>
+        <string>de</string>
+        <string>ja</string>
+        <string>pt-BR</string>
+        <string>it</string>
+        <string>ru</string>
+        <string>zh-Hans</string>
+    </array>
+
+        <!-- Version fields. These placeholders are overwritten by
          make-bundle.sh via `plutil -replace` at build time. -->
     <key>CFBundleShortVersionString</key>
     <string>$VERSION</string>

--- a/macos/Sources/Lyrebird/Resources/InfoPlist.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/InfoPlist.xcstrings
@@ -1,42 +1,186 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "CFBundleDisplayName" : {
-      "comment" : "The user-visible app name shown in the Dock, Finder, and the menu bar. Mirrors CFBundleDisplayName in Info.plist (#359).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird"
+  "sourceLanguage": "en",
+  "strings": {
+    "CFBundleDisplayName": {
+      "comment": "The user-visible app name shown in the Dock, Finder, and the menu bar. Mirrors CFBundleDisplayName in Info.plist (#359).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
           }
         }
       }
     },
-    "CFBundleName" : {
-      "comment" : "The short app name (≤15 chars) used where CFBundleDisplayName is unavailable. Mirrors CFBundleName in Info.plist (#359).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird"
+    "CFBundleName": {
+      "comment": "The short app name (≤15 chars) used where CFBundleDisplayName is unavailable. Mirrors CFBundleName in Info.plist (#359).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
           }
         }
       }
     },
-    "NSHumanReadableCopyright" : {
-      "comment" : "Copyright notice shown in the About window and Get Info. Mirrors NSHumanReadableCopyright in Info.plist (#359).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "© 2026 Lyrebird. GPL-3.0-only."
+    "NSHumanReadableCopyright": {
+      "comment": "Copyright notice shown in the About window and Get Info. Mirrors NSHumanReadableCopyright in Info.plist (#359).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "© 2026 Lyrebird. GPL-3.0-only."
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -22,6 +22,12 @@
             "state": "needs_review",
             "value": "À propos de Lyrebird"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Über Lyrebird"
+          }
         }
       }
     },
@@ -42,6 +48,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -70,6 +82,12 @@
             "state": "needs_review",
             "value": "BUREAU"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "DESKTOP"
+          }
         }
       }
     },
@@ -93,6 +111,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Votre session a expiré"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ihre Sitzung ist abgelaufen"
           }
         }
       }
@@ -118,6 +142,12 @@
             "state": "needs_review",
             "value": "Veuillez vous reconnecter pour continuer à écouter."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bitte melden Sie sich erneut an, um weiter Musik zu hören."
+          }
         }
       }
     },
@@ -141,6 +171,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Se connecter"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anmelden"
           }
         }
       }
@@ -166,6 +202,12 @@
             "state": "needs_review",
             "value": "Se reconnecter"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erneut anmelden"
+          }
         }
       }
     },
@@ -189,6 +231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Connexion en cours…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anmeldung läuft…"
           }
         }
       }
@@ -214,6 +262,12 @@
             "state": "needs_review",
             "value": "Impossible d'atteindre votre serveur."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Server nicht erreichbar."
+          }
         }
       }
     },
@@ -237,6 +291,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible d'atteindre %@. Nouvelle tentative…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%@ nicht erreichbar. Neuer Versuch…"
           }
         }
       }
@@ -262,6 +322,12 @@
             "state": "needs_review",
             "value": "Réessayer la connexion au serveur"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Serververbindung erneut versuchen"
+          }
         }
       }
     },
@@ -282,6 +348,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
@@ -310,6 +382,12 @@
             "state": "needs_review",
             "value": "Artiste"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstler"
+          }
         }
       }
     },
@@ -333,6 +411,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabeliste"
           }
         }
       }
@@ -358,6 +442,12 @@
             "state": "needs_review",
             "value": "Annuler"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abbrechen"
+          }
         }
       }
     },
@@ -381,6 +471,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Supprimer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Löschen"
           }
         }
       }
@@ -406,6 +502,12 @@
             "state": "needs_review",
             "value": "Ignorer"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Schließen"
+          }
         }
       }
     },
@@ -430,6 +532,12 @@
             "state": "needs_review",
             "value": "Terminé"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fertig"
+          }
         }
       }
     },
@@ -453,6 +561,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Réessayer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erneut versuchen"
           }
         }
       }
@@ -510,6 +624,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld albums"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Album"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Alben"
                 }
               }
             }
@@ -574,6 +706,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Künstler"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Künstler"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -630,6 +780,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld éléments"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Element"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Elemente"
                 }
               }
             }
@@ -694,6 +862,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Wiedergabeliste"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Wiedergabelisten"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -750,6 +936,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld lectures"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Wiedergabe"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Wiedergaben"
                 }
               }
             }
@@ -814,6 +1018,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Ergebnis"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Ergebnisse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -870,6 +1092,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld sélectionnés"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld ausgewählt"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld ausgewählt"
                 }
               }
             }
@@ -934,6 +1174,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Song"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Songs"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -994,6 +1252,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Titel"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Titel"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1017,6 +1293,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pas encore de musique"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Noch keine Musik"
           }
         }
       }
@@ -1042,6 +1324,12 @@
             "state": "needs_review",
             "value": "Votre serveur Jellyfin ne contient pas de musique dans sa bibliothèque, ou elle est encore en cours d'indexation. Ajoutez une bibliothèque sur le serveur, puis actualisez."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ihr Jellyfin-Server hat keine Musik in seiner Bibliothek, oder sie wird noch indiziert. Fügen Sie eine Bibliothek auf dem Server hinzu und aktualisieren Sie dann."
+          }
         }
       }
     },
@@ -1065,6 +1353,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ouvrir Jellyfin web"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jellyfin Web öffnen"
           }
         }
       }
@@ -1090,6 +1384,12 @@
             "state": "needs_review",
             "value": "La file d'attente est vide"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Warteschlange ist leer"
+          }
         }
       }
     },
@@ -1113,6 +1413,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lisez quelque chose pour démarrer une file d'attente."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Geben Sie etwas wieder, um eine Warteschlange zu starten."
           }
         }
       }
@@ -1138,6 +1444,12 @@
             "state": "needs_review",
             "value": "Veuillez vous reconnecter."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bitte melden Sie sich erneut an."
+          }
         }
       }
     },
@@ -1161,6 +1473,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Vous n'avez pas la permission de faire cela."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sie haben keine Berechtigung dafür."
           }
         }
       }
@@ -1186,6 +1504,12 @@
             "state": "needs_review",
             "value": "Cet élément est introuvable."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dieses Element wurde nicht gefunden."
+          }
         }
       }
     },
@@ -1209,6 +1533,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Trop de requêtes. Veuillez réessayer dans un moment."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zu viele Anfragen. Bitte versuchen Sie es gleich noch einmal."
           }
         }
       }
@@ -1234,6 +1564,12 @@
             "state": "needs_review",
             "value": "Erreur réseau. Vérifiez votre connexion et réessayez."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Netzwerkfehler. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut."
+          }
         }
       }
     },
@@ -1257,6 +1593,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Le serveur a rencontré un problème. Veuillez réessayer."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Der Server ist auf ein Problem gestoßen. Bitte versuchen Sie es erneut."
           }
         }
       }
@@ -1282,6 +1624,12 @@
             "state": "needs_review",
             "value": "Impossible de lire la réponse du serveur."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Die Antwort des Servers konnte nicht gelesen werden."
+          }
         }
       }
     },
@@ -1305,6 +1653,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de télécharger pour la lecture hors ligne."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Herunterladen für die Offline-Wiedergabe fehlgeschlagen."
           }
         }
       }
@@ -1330,6 +1684,12 @@
             "state": "needs_review",
             "value": "Erreur de stockage local. Veuillez réessayer."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lokaler Speicherfehler. Bitte versuchen Sie es erneut."
+          }
         }
       }
     },
@@ -1353,6 +1713,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible d'accéder au trousseau système."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zugriff auf den Systemschlüsselbund nicht möglich."
           }
         }
       }
@@ -1378,6 +1744,12 @@
             "state": "needs_review",
             "value": "Erreur de lecture audio."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fehler bei der Audiowiedergabe."
+          }
         }
       }
     },
@@ -1401,6 +1773,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Le certificat du serveur n'a pas pu être vérifié. Vous devrez peut-être approuver ce serveur."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Das Zertifikat des Servers konnte nicht überprüft werden. Möglicherweise müssen Sie diesem Server vertrauen."
           }
         }
       }
@@ -1426,6 +1804,12 @@
             "state": "needs_review",
             "value": "Cette valeur n'est pas valide."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dieser Wert ist ungültig."
+          }
         }
       }
     },
@@ -1449,6 +1833,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Une erreur s'est produite."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ein Fehler ist aufgetreten."
           }
         }
       }
@@ -1474,6 +1864,12 @@
             "state": "needs_review",
             "value": "Impossible de démarrer la lecture."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe konnte nicht gestartet werden."
+          }
         }
       }
     },
@@ -1497,6 +1893,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de charger votre bibliothèque."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothek konnte nicht geladen werden."
           }
         }
       }
@@ -1522,6 +1924,12 @@
             "state": "needs_review",
             "value": "Impossible de charger les playlists."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabelisten konnten nicht geladen werden."
+          }
         }
       }
     },
@@ -1545,6 +1953,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de charger cette playlist."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diese Wiedergabeliste konnte nicht geladen werden."
           }
         }
       }
@@ -1570,6 +1984,12 @@
             "state": "needs_review",
             "value": "Impossible de charger les pistes de l'album."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Albumtitel konnten nicht geladen werden."
+          }
         }
       }
     },
@@ -1593,6 +2013,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de charger les pistes de la playlist."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel der Wiedergabeliste konnten nicht geladen werden."
           }
         }
       }
@@ -1618,6 +2044,12 @@
             "state": "needs_review",
             "value": "Échec de la recherche."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suche fehlgeschlagen."
+          }
         }
       }
     },
@@ -1641,6 +2073,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de mettre à jour le favori."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorit konnte nicht aktualisiert werden."
           }
         }
       }
@@ -1666,6 +2104,12 @@
             "state": "needs_review",
             "value": "Impossible de mettre à jour l'état de lecture."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabestatus konnte nicht aktualisiert werden."
+          }
         }
       }
     },
@@ -1689,6 +2133,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible d'ajouter à la playlist."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Konnte nicht zur Wiedergabeliste hinzugefügt werden."
           }
         }
       }
@@ -1714,6 +2164,12 @@
             "state": "needs_review",
             "value": "Échec de la connexion."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anmeldung fehlgeschlagen."
+          }
         }
       }
     },
@@ -1737,6 +2193,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nom d'utilisateur ou mot de passe incorrect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Falscher Benutzername oder falsches Passwort"
           }
         }
       }
@@ -1762,6 +2224,12 @@
             "state": "needs_review",
             "value": "Cette action n'est pas encore disponible."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diese Aktion ist noch nicht verfügbar."
+          }
         }
       }
     },
@@ -1785,6 +2253,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pas de réseau. Vérifiez votre connexion."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kein Netzwerk. Überprüfen Sie Ihre Verbindung."
           }
         }
       }
@@ -1810,6 +2284,12 @@
             "state": "needs_review",
             "value": "Vérification…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Prüfen…"
+          }
         }
       }
     },
@@ -1833,6 +2313,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "URL DU SERVEUR"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "SERVER-URL"
           }
         }
       }
@@ -1858,6 +2344,12 @@
             "state": "needs_review",
             "value": "NOM D'UTILISATEUR"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "BENUTZERNAME"
+          }
         }
       }
     },
@@ -1881,6 +2373,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "MOT DE PASSE"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PASSWORT"
           }
         }
       }
@@ -1906,6 +2404,12 @@
             "state": "needs_review",
             "value": "vous"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sie"
+          }
         }
       }
     },
@@ -1929,6 +2433,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "TROUVÉ SUR CE RÉSEAU"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "IN DIESEM NETZWERK GEFUNDEN"
           }
         }
       }
@@ -1954,6 +2464,12 @@
             "state": "needs_review",
             "value": "URL du serveur"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Server-URL"
+          }
         }
       }
     },
@@ -1977,6 +2493,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nom d'utilisateur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Benutzername"
           }
         }
       }
@@ -2002,6 +2524,12 @@
             "state": "needs_review",
             "value": "Mot de passe"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Passwort"
+          }
         }
       }
     },
@@ -2025,6 +2553,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Retour"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zurück"
           }
         }
       }
@@ -2050,6 +2584,12 @@
             "state": "needs_review",
             "value": "Bienvenue sur Lyrebird"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Willkommen bei Lyrebird"
+          }
         }
       }
     },
@@ -2073,6 +2613,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Votre musique, votre serveur, vos règles."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ihre Musik, Ihr Server, Ihre Regeln."
           }
         }
       }
@@ -2098,6 +2644,12 @@
             "state": "needs_review",
             "value": "Commencer"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Loslegen"
+          }
         }
       }
     },
@@ -2121,6 +2673,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "J'ai déjà un compte →"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ich habe bereits ein Konto →"
           }
         }
       }
@@ -2146,6 +2704,12 @@
             "state": "needs_review",
             "value": "J'ai déjà un compte"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ich habe bereits ein Konto"
+          }
         }
       }
     },
@@ -2169,6 +2733,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Connectez votre serveur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Server verbinden"
           }
         }
       }
@@ -2194,6 +2764,12 @@
             "state": "needs_review",
             "value": "L'URL Jellyfin est l'adresse que vous utilisez pour y accéder depuis un navigateur."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Die Jellyfin-URL ist die Adresse, über die Sie vom Browser aus darauf zugreifen."
+          }
         }
       }
     },
@@ -2217,6 +2793,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Continuer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Weiter"
           }
         }
       }
@@ -2242,6 +2824,12 @@
             "state": "needs_review",
             "value": "Connexion…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Verbindung wird hergestellt…"
+          }
         }
       }
     },
@@ -2265,6 +2853,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ignorer, explorer hors ligne →"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Überspringen, offline erkunden →"
           }
         }
       }
@@ -2290,6 +2884,12 @@
             "state": "needs_review",
             "value": "Chargement de votre bibliothèque"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothek wird geladen"
+          }
         }
       }
     },
@@ -2313,6 +2913,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Chargement des artistes…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstler werden geladen…"
           }
         }
       }
@@ -2338,6 +2944,12 @@
             "state": "needs_review",
             "value": "Chargement des albums…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alben werden geladen…"
+          }
         }
       }
     },
@@ -2361,6 +2973,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Chargement des pistes…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel werden geladen…"
           }
         }
       }
@@ -2386,6 +3004,12 @@
             "state": "needs_review",
             "value": "Récupération des pochettes…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cover werden abgerufen…"
+          }
         }
       }
     },
@@ -2409,6 +3033,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ pistes · %2$@ artistes · %3$@ albums"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ Titel · %2$@ Künstler · %3$@ Alben"
           }
         }
       }
@@ -2434,6 +3064,12 @@
             "state": "needs_review",
             "value": "Accéder à l'accueil"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zur Startseite"
+          }
         }
       }
     },
@@ -2457,6 +3093,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Synchronisation…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Synchronisierung…"
           }
         }
       }
@@ -2482,6 +3124,12 @@
             "state": "needs_review",
             "value": "Impossible de charger votre bibliothèque."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothek konnte nicht geladen werden."
+          }
         }
       }
     },
@@ -2505,6 +3153,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Réessayer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erneut versuchen"
           }
         }
       }
@@ -2530,6 +3184,12 @@
             "state": "needs_review",
             "value": "À propos de Lyrebird"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Über Lyrebird"
+          }
         }
       }
     },
@@ -2553,6 +3213,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nouvelle playlist…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Neue Wiedergabeliste…"
           }
         }
       }
@@ -2578,6 +3244,12 @@
             "state": "needs_review",
             "value": "Nouvelle fenêtre"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Neues Fenster"
+          }
         }
       }
     },
@@ -2601,6 +3273,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Afficher la barre latérale"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Seitenleiste einblenden"
           }
         }
       }
@@ -2626,6 +3304,12 @@
             "state": "needs_review",
             "value": "Afficher l'inspecteur de file d'attente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Warteschlangeninspektor einblenden"
+          }
         }
       }
     },
@@ -2649,6 +3333,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Accueil"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Startseite"
           }
         }
       }
@@ -2674,6 +3364,12 @@
             "state": "needs_review",
             "value": "Bibliothèque"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothek"
+          }
         }
       }
     },
@@ -2697,6 +3393,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Rechercher"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suchen"
           }
         }
       }
@@ -2722,6 +3424,12 @@
             "state": "needs_review",
             "value": "Rechercher…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suchen…"
+          }
         }
       }
     },
@@ -2745,6 +3453,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Rechercher dans la bibliothèque…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "In Bibliothek suchen…"
           }
         }
       }
@@ -2770,6 +3484,12 @@
             "state": "needs_review",
             "value": "Aller à la lecture en cours"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zu „Gerade wiedergegeben“ gehen"
+          }
         }
       }
     },
@@ -2793,6 +3513,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "File de lecture"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabewarteschlange"
           }
         }
       }
@@ -2818,6 +3544,12 @@
             "state": "needs_review",
             "value": "Palette de commandes…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Befehlspalette…"
+          }
         }
       }
     },
@@ -2841,6 +3573,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lecture"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe"
           }
         }
       }
@@ -2866,6 +3604,12 @@
             "state": "needs_review",
             "value": "Lire"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe"
+          }
         }
       }
     },
@@ -2886,6 +3630,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Pause"
@@ -2914,6 +3664,12 @@
             "state": "needs_review",
             "value": "Piste suivante"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nächster Titel"
+          }
         }
       }
     },
@@ -2937,6 +3693,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Piste précédente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vorheriger Titel"
           }
         }
       }
@@ -2962,6 +3724,12 @@
             "state": "needs_review",
             "value": "Augmenter le volume"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lautstärke erhöhen"
+          }
         }
       }
     },
@@ -2985,6 +3753,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Diminuer le volume"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lautstärke verringern"
           }
         }
       }
@@ -3010,6 +3784,12 @@
             "state": "needs_review",
             "value": "Avancer de 10s"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "10s vorspulen"
+          }
         }
       }
     },
@@ -3033,6 +3813,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reculer de 10s"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "10s zurückspulen"
           }
         }
       }
@@ -3058,6 +3844,12 @@
             "state": "needs_review",
             "value": "Arrêter"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Stopp"
+          }
         }
       }
     },
@@ -3081,6 +3873,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ancrer la fenêtre à gauche"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fenster links anordnen"
           }
         }
       }
@@ -3106,6 +3904,12 @@
             "state": "needs_review",
             "value": "Ancrer la fenêtre à droite"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fenster rechts anordnen"
+          }
         }
       }
     },
@@ -3129,6 +3933,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aide Lyrebird"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird-Hilfe"
           }
         }
       }
@@ -3154,6 +3964,12 @@
             "state": "needs_review",
             "value": "Basculer l'inspecteur de file d'attente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Warteschlangeninspektor ein-/ausblenden"
+          }
         }
       }
     },
@@ -3177,6 +3993,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Rien en lecture"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nichts wird wiedergegeben"
           }
         }
       }
@@ -3202,6 +4024,12 @@
             "state": "needs_review",
             "value": "Accueil"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Startseite"
+          }
         }
       }
     },
@@ -3226,6 +4054,12 @@
             "state": "needs_review",
             "value": "Découvrir"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Entdecken"
+          }
         }
       }
     },
@@ -3246,6 +4080,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Radio"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Radio"
@@ -3274,6 +4114,12 @@
             "state": "needs_review",
             "value": "Bibliothèque"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothek"
+          }
         }
       }
     },
@@ -3298,6 +4144,12 @@
             "state": "needs_review",
             "value": "Rechercher"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suchen"
+          }
         }
       }
     },
@@ -3321,6 +4173,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Votre bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Meine Bibliothek"
           }
         }
       }
@@ -3382,6 +4240,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Element"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Elemente"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3405,6 +4281,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Déconnecté"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Getrennt"
           }
         }
       }
@@ -3430,6 +4312,12 @@
             "state": "needs_review",
             "value": "Favoris"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favoriten"
+          }
         }
       }
     },
@@ -3453,6 +4341,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Albums"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alben"
           }
         }
       }
@@ -3478,6 +4372,12 @@
             "state": "needs_review",
             "value": "Artistes"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstler"
+          }
         }
       }
     },
@@ -3501,6 +4401,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlists"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabelisten"
           }
         }
       }
@@ -3526,6 +4432,12 @@
             "state": "needs_review",
             "value": "Modifier les règles de la playlist intelligente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regeln der intelligenten Wiedergabeliste bearbeiten"
+          }
         }
       }
     },
@@ -3549,6 +4461,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lire la playlist intelligente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste abspielen"
           }
         }
       }
@@ -3574,6 +4492,12 @@
             "state": "needs_review",
             "value": "Lecture aléatoire de la playlist intelligente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste zufällig abspielen"
+          }
         }
       }
     },
@@ -3597,6 +4521,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "PLAYLIST INTELLIGENTE"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "INTELLIGENTE WIEDERGABELISTE"
           }
         }
       }
@@ -3622,6 +4552,12 @@
             "state": "needs_review",
             "value": "Ajouter une règle"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regel hinzufügen"
+          }
         }
       }
     },
@@ -3645,6 +4581,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Champ de règle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regelfeld"
           }
         }
       }
@@ -3670,6 +4612,12 @@
             "state": "needs_review",
             "value": "Mode de correspondance"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Übereinstimmungsmodus"
+          }
         }
       }
     },
@@ -3693,6 +4641,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nom de la playlist intelligente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Name der intelligenten Wiedergabeliste"
           }
         }
       }
@@ -3718,6 +4672,12 @@
             "state": "needs_review",
             "value": "Opérateur de règle"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regeloperator"
+          }
         }
       }
     },
@@ -3741,6 +4701,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Supprimer la règle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regel entfernen"
           }
         }
       }
@@ -3766,6 +4732,12 @@
             "state": "needs_review",
             "value": "Enregistrer la playlist intelligente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste speichern"
+          }
         }
       }
     },
@@ -3789,6 +4761,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Valeur de règle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regelwert"
           }
         }
       }
@@ -3814,6 +4792,12 @@
             "state": "needs_review",
             "value": "Valeur de règle en jours"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regelwert in Tagen"
+          }
         }
       }
     },
@@ -3837,6 +4821,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ajouter une règle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regel hinzufügen"
           }
         }
       }
@@ -3862,6 +4852,12 @@
             "state": "needs_review",
             "value": "non"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "nein"
+          }
         }
       }
     },
@@ -3885,6 +4881,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "oui"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ja"
           }
         }
       }
@@ -3910,6 +4912,12 @@
             "state": "needs_review",
             "value": "Annuler"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abbrechen"
+          }
         }
       }
     },
@@ -3933,6 +4941,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Comptage…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wird gezählt…"
           }
         }
       }
@@ -3958,6 +4972,12 @@
             "state": "needs_review",
             "value": "jours"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tage"
+          }
         }
       }
     },
@@ -3981,6 +5001,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist intelligente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste"
           }
         }
       }
@@ -4042,6 +5068,24 @@
               }
             }
           }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Treffer"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld Treffer"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -4065,6 +5109,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Correspondre"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Übereinstimmen mit"
           }
         }
       }
@@ -4090,6 +5140,12 @@
             "state": "needs_review",
             "value": "aux règles suivantes :"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "der folgenden Regeln:"
+          }
         }
       }
     },
@@ -4113,6 +5169,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "NOM"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NAME"
           }
         }
       }
@@ -4138,6 +5200,12 @@
             "state": "needs_review",
             "value": "Nom de la playlist intelligente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Name der intelligenten Wiedergabeliste"
+          }
         }
       }
     },
@@ -4161,6 +5229,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Enregistrer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Speichern"
           }
         }
       }
@@ -4186,6 +5260,12 @@
             "state": "needs_review",
             "value": "Playlist intelligente"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste"
+          }
         }
       }
     },
@@ -4209,6 +5289,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "valeur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wert"
           }
         }
       }
@@ -4234,6 +5320,12 @@
             "state": "needs_review",
             "value": "Modifier les règles"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Regeln bearbeiten"
+          }
         }
       }
     },
@@ -4257,6 +5349,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld pistes chargées jusqu'ici. Essayez d'assouplir les règles ou ouvrez la Bibliothèque pour avoir plus de pistes en mémoire."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%lld Titel bisher geladen. Lockern Sie die Regeln oder öffnen Sie die Bibliothek, um mehr Titel im Speicher zu haben."
           }
         }
       }
@@ -4282,6 +5380,12 @@
             "state": "needs_review",
             "value": "Aucune piste ne correspond à ces règles"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kein Titel entspricht diesen Regeln"
+          }
         }
       }
     },
@@ -4302,6 +5406,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
@@ -4330,6 +5440,12 @@
             "state": "needs_review",
             "value": "Artiste"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstler"
+          }
         }
       }
     },
@@ -4354,6 +5470,12 @@
             "state": "needs_review",
             "value": "Favori"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorit"
+          }
         }
       }
     },
@@ -4374,6 +5496,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genre"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Genre"
@@ -4402,6 +5530,12 @@
             "state": "needs_review",
             "value": "Durée (sec)"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dauer (Sek.)"
+          }
         }
       }
     },
@@ -4425,6 +5559,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Dernière lecture"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zuletzt abgespielt"
           }
         }
       }
@@ -4450,6 +5590,12 @@
             "state": "needs_review",
             "value": "Nombre de lectures"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergaben"
+          }
         }
       }
     },
@@ -4473,6 +5619,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Année"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jahr"
           }
         }
       }
@@ -4498,6 +5650,12 @@
             "state": "needs_review",
             "value": "Filtrer les pistes"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel filtern"
+          }
         }
       }
     },
@@ -4521,6 +5679,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "toutes"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "alle"
           }
         }
       }
@@ -4546,6 +5710,12 @@
             "state": "needs_review",
             "value": "n'importe laquelle"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "beliebige"
+          }
         }
       }
     },
@@ -4569,6 +5739,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aucune piste ne correspond à \"%@\""
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kein Titel entspricht \"%@\""
           }
         }
       }
@@ -4594,6 +5770,12 @@
             "state": "needs_review",
             "value": "Playlist intelligente introuvable"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intelligente Wiedergabeliste nicht gefunden"
+          }
         }
       }
     },
@@ -4617,6 +5799,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "contient"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "enthält"
           }
         }
       }
@@ -4642,6 +5830,12 @@
             "state": "needs_review",
             "value": "supérieur à"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "größer als"
+          }
         }
       }
     },
@@ -4665,6 +5859,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "dans les derniers (jours)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "in den letzten (Tagen)"
           }
         }
       }
@@ -4690,6 +5890,12 @@
             "state": "needs_review",
             "value": "est"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ist"
+          }
         }
       }
     },
@@ -4713,6 +5919,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "n'est pas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ist nicht"
           }
         }
       }
@@ -4738,6 +5950,12 @@
             "state": "needs_review",
             "value": "inférieur à"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "kleiner als"
+          }
         }
       }
     },
@@ -4758,6 +5976,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": ", "
@@ -4786,6 +6010,12 @@
             "state": "needs_review",
             "value": "Correspond %1$@ parmi : %2$@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Stimmt überein mit %1$@ von: %2$@"
+          }
         }
       }
     },
@@ -4809,6 +6039,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Correspond à toutes les pistes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Stimmt mit allen Titeln überein."
           }
         }
       }
@@ -4834,6 +6070,12 @@
             "state": "needs_review",
             "value": "Réessayer de lire la piste en échec"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fehlgeschlagenen Titel erneut abspielen"
+          }
         }
       }
     },
@@ -4857,6 +6099,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aller à la piste"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zum Titel gehen"
           }
         }
       }
@@ -4882,6 +6130,12 @@
             "state": "needs_review",
             "value": "Impossible de lire \"%@\". Passage à la suivante."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "\"%@\" konnte nicht abgespielt werden. Wird übersprungen."
+          }
         }
       }
     },
@@ -4905,6 +6159,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Réessayer la connexion réseau"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Netzwerkverbindung erneut versuchen"
           }
         }
       }
@@ -4930,6 +6190,12 @@
             "state": "needs_review",
             "value": "Vous êtes hors ligne. Lecture uniquement depuis les pistes téléchargées."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sie sind offline. Nur heruntergeladene Titel werden abgespielt."
+          }
         }
       }
     },
@@ -4954,6 +6220,12 @@
             "state": "needs_review",
             "value": "Cette action supprimera définitivement cette playlist. Cette action est irréversible."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dadurch wird diese Wiedergabeliste dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
+          }
         }
       }
     },
@@ -4974,6 +6246,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
@@ -5002,6 +6280,12 @@
             "state": "needs_review",
             "value": "Disque"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CD"
+          }
         }
       }
     },
@@ -5026,6 +6310,12 @@
             "state": "needs_review",
             "value": "Durée"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dauer"
+          }
         }
       }
     },
@@ -5046,6 +6336,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Format"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Format"
@@ -5074,6 +6370,12 @@
             "state": "needs_review",
             "value": "Lectures"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergaben"
+          }
         }
       }
     },
@@ -5097,6 +6399,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Piste"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel"
           }
         }
       }
@@ -5122,6 +6430,12 @@
             "state": "needs_review",
             "value": "Année"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jahr"
+          }
         }
       }
     },
@@ -5145,6 +6459,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini-lecteur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player"
           }
         }
       }
@@ -5170,6 +6490,12 @@
             "state": "needs_review",
             "value": "En cours de lecture"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gerade gespielt"
+          }
         }
       }
     },
@@ -5193,6 +6519,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Suivant"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Weiter"
           }
         }
       }
@@ -5218,6 +6550,12 @@
             "state": "needs_review",
             "value": "Ouvrir Lyrebird"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird öffnen"
+          }
         }
       }
     },
@@ -5238,6 +6576,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Pause"
@@ -5266,6 +6610,12 @@
             "state": "needs_review",
             "value": "Lire"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe"
+          }
         }
       }
     },
@@ -5289,6 +6639,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Précédent"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zurück"
           }
         }
       }
@@ -5314,6 +6670,12 @@
             "state": "needs_review",
             "value": "Mini-lecteur"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player"
+          }
         }
       }
     },
@@ -5337,6 +6699,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini-lecteur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player"
           }
         }
       }
@@ -5362,6 +6730,12 @@
             "state": "needs_review",
             "value": "Pochette. Faites glisser pour déplacer le mini-lecteur."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cover. Ziehen Sie es, um den Mini-Player zu verschieben."
+          }
         }
       }
     },
@@ -5385,6 +6759,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Options du mini-lecteur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player-Optionen"
           }
         }
       }
@@ -5410,6 +6790,12 @@
             "state": "needs_review",
             "value": "Toujours au premier plan"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Immer im Vordergrund"
+          }
         }
       }
     },
@@ -5433,6 +6819,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Revenir à la fenêtre complète"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zum Vollbild zurückkehren"
           }
         }
       }
@@ -5458,6 +6850,12 @@
             "state": "needs_review",
             "value": "Transparent lorsqu'inactif"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Transparent wenn inaktiv"
+          }
         }
       }
     },
@@ -5481,6 +6879,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fermer le mini-lecteur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player schließen"
           }
         }
       }
@@ -5506,6 +6910,12 @@
             "state": "needs_review",
             "value": "Pochette. Appuyez pour ouvrir l'album ; faites glisser pour déplacer le mini-lecteur."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cover. Tippen Sie, um das Album zu öffnen; ziehen Sie, um den Mini-Player zu verschieben."
+          }
         }
       }
     },
@@ -5529,6 +6939,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ouvrir la page de l'artiste"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstlerseite öffnen"
           }
         }
       }
@@ -5554,6 +6970,12 @@
             "state": "needs_review",
             "value": "Agrandir à la fenêtre complète"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zum Vollbild erweitern"
+          }
         }
       }
     },
@@ -5577,6 +6999,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Favori"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorit"
           }
         }
       }
@@ -5602,6 +7030,12 @@
             "state": "needs_review",
             "value": "Retirer des favoris"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aus Favoriten entfernen"
+          }
         }
       }
     },
@@ -5625,6 +7059,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Piste précédente"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vorheriger Titel"
           }
         }
       }
@@ -5650,6 +7090,12 @@
             "state": "needs_review",
             "value": "Lire"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe"
+          }
         }
       }
     },
@@ -5670,6 +7116,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Pause"
@@ -5698,6 +7150,12 @@
             "state": "needs_review",
             "value": "Piste suivante"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nächster Titel"
+          }
         }
       }
     },
@@ -5721,6 +7179,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Revenir à la fenêtre complète"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zum Vollbild zurückkehren"
           }
         }
       }
@@ -5746,6 +7210,12 @@
             "state": "needs_review",
             "value": "Volume"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lautstärke"
+          }
         }
       }
     },
@@ -5769,6 +7239,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Position de lecture"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabeposition"
           }
         }
       }
@@ -5794,6 +7270,12 @@
             "state": "needs_review",
             "value": "Exporter le bundle de diagnostic…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnose-Bundle exportieren…"
+          }
         }
       }
     },
@@ -5816,6 +7298,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Raccourcis clavier"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tastaturkürzel"
           }
         }
       }
@@ -5840,6 +7328,12 @@
             "state": "needs_review",
             "value": "Lire / Pause"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe / Pause"
+          }
         }
       }
     },
@@ -5862,6 +7356,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Rechercher des raccourcis clavier"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tastaturkürzel durchsuchen"
           }
         }
       }
@@ -5886,6 +7386,12 @@
             "state": "needs_review",
             "value": "Effacer la recherche"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suche löschen"
+          }
         }
       }
     },
@@ -5908,6 +7414,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aucun raccourci ne correspond à votre recherche"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kein Kürzel entspricht Ihrer Suche"
           }
         }
       }
@@ -5932,6 +7444,12 @@
             "state": "needs_review",
             "value": "Rechercher des raccourcis"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kürzel suchen"
+          }
         }
       }
     },
@@ -5954,6 +7472,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fichier"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ablage"
           }
         }
       }
@@ -5978,6 +7502,12 @@
             "state": "needs_review",
             "value": "Lecture"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wiedergabe"
+          }
         }
       }
     },
@@ -6000,6 +7530,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Affichage"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Darstellung"
           }
         }
       }
@@ -6024,6 +7560,12 @@
             "state": "needs_review",
             "value": "Fenêtre"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fenster"
+          }
         }
       }
     },
@@ -6046,6 +7588,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Raccourcis clavier"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tastaturkürzel"
           }
         }
       }
@@ -6071,6 +7619,12 @@
             "state": "needs_review",
             "value": "Albums"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alben"
+          }
         }
       }
     },
@@ -6094,6 +7648,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tout"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alle"
           }
         }
       }
@@ -6119,6 +7679,12 @@
             "state": "needs_review",
             "value": "Artistes"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Künstler"
+          }
         }
       }
     },
@@ -6139,6 +7705,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genres"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Genres"
@@ -6167,6 +7739,12 @@
             "state": "needs_review",
             "value": "Pistes"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel"
+          }
         }
       }
     },
@@ -6190,6 +7768,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fermer le sélecteur de mix instantané"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sofort-Mix-Auswahl schließen"
           }
         }
       }
@@ -6215,6 +7799,12 @@
             "state": "needs_review",
             "value": "Recherchez quelque chose pour créer un mix."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suchen Sie nach etwas, um einen Mix zu erstellen."
+          }
         }
       }
     },
@@ -6238,6 +7828,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Générer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Generieren"
           }
         }
       }
@@ -6263,6 +7859,12 @@
             "state": "needs_review",
             "value": "Dernier mix :"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Letzter Mix:"
+          }
         }
       }
     },
@@ -6286,6 +7888,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aucun résultat"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Keine Treffer"
           }
         }
       }
@@ -6311,6 +7919,12 @@
             "state": "needs_review",
             "value": "Recherchez une piste, un album, un artiste ou un genre"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Titel, Album, Künstler oder Genre suchen"
+          }
         }
       }
     },
@@ -6334,6 +7948,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Origine :"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Basis:"
           }
         }
       }
@@ -6359,6 +7979,12 @@
             "state": "needs_review",
             "value": "Nouveau mix instantané"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Neuer Sofort-Mix"
+          }
         }
       }
     },
@@ -6382,6 +8008,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nouveau mix instantané…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Neuer Sofort-Mix…"
           }
         }
       }
@@ -6407,6 +8039,12 @@
             "state": "needs_review",
             "value": "Afficher la visite guidée"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tour anzeigen"
+          }
         }
       }
     },
@@ -6430,6 +8068,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Visite guidée des fonctionnalités"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Funktionsrundgang"
           }
         }
       }
@@ -6455,6 +8099,12 @@
             "state": "needs_review",
             "value": "Étape %1$lld sur %2$lld"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Schritt %1$lld von %2$lld"
+          }
         }
       }
     },
@@ -6478,6 +8128,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Raccourci clavier %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tastaturkürzel %@"
           }
         }
       }
@@ -6503,6 +8159,12 @@
             "state": "needs_review",
             "value": "Précédent"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Zurück"
+          }
         }
       }
     },
@@ -6526,6 +8188,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Terminé"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fertig"
           }
         }
       }
@@ -6551,6 +8219,12 @@
             "state": "needs_review",
             "value": "Appuyez sur ⌘⌥P pour un lecteur compact, toujours au premier plan, que vous pouvez placer dans un coin pendant que vous travaillez."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Drücken Sie ⌘⌥P für einen kompakten, immer sichtbaren Player, den Sie in eine Ecke verschieben können, während Sie arbeiten."
+          }
         }
       }
     },
@@ -6574,6 +8248,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ouvrez le mini-lecteur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-Player öffnen"
           }
         }
       }
@@ -6599,6 +8279,12 @@
             "state": "needs_review",
             "value": "Suivant"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Weiter"
+          }
         }
       }
     },
@@ -6622,6 +8308,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cliquez avec le bouton droit sur n'importe quelle piste, album, artiste ou playlist pour des actions rapides — lire ensuite, ajouter à une playlist, démarrer une station radio, et plus encore."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Klicken Sie mit der rechten Maustaste auf einen Titel, ein Album, einen Künstler oder eine Wiedergabeliste für Schnellaktionen — als nächstes abspielen, zu einer Wiedergabeliste hinzufügen, einen Radiosender starten und mehr."
           }
         }
       }
@@ -6647,6 +8339,12 @@
             "state": "needs_review",
             "value": "Clic droit pour plus d'options"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechtsklick für mehr Optionen"
+          }
         }
       }
     },
@@ -6670,6 +8368,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Appuyez sur ⌘F pour accéder directement à la recherche et trouver n'importe quelle chanson, album ou artiste dans votre bibliothèque."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Drücken Sie ⌘F, um direkt zur Suche zu gelangen und jeden Song, jedes Album oder jeden Künstler in Ihrer Bibliothek zu finden."
           }
         }
       }
@@ -6695,6 +8399,12 @@
             "state": "needs_review",
             "value": "Trouvez n'importe quoi rapidement"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alles schnell finden"
+          }
         }
       }
     },
@@ -6718,6 +8428,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Passer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Überspringen"
           }
         }
       }
@@ -6743,6 +8459,12 @@
             "state": "needs_review",
             "value": "Appuyez sur la barre d'espace n'importe où en dehors d'un champ de texte pour lire ou mettre en pause la piste en cours."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Drücken Sie die Leertaste außerhalb eines Textfelds, um den aktuellen Titel abzuspielen oder zu pausieren."
+          }
         }
       }
     },
@@ -6766,6 +8488,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lire et mettre en pause avec Espace"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mit Leertaste abspielen und pausieren"
           }
         }
       }
@@ -6791,6 +8519,12 @@
             "state": "needs_review",
             "value": "Les données locales de Lyrebird n'ont pas pu être ouvertes. Cela se résout généralement ainsi : réinitialisez les données locales pour repartir de zéro, ou exportez un bundle de diagnostic à joindre à un rapport de bug."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Die lokalen Daten von Lyrebird konnten nicht geöffnet werden. Meistens lässt sich das beheben: Setzen Sie die lokalen Daten zurück, um neu zu beginnen, oder exportieren Sie ein Diagnose-Bundle, um es einem Fehlerbericht beizufügen."
+          }
         }
       }
     },
@@ -6814,6 +8548,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Exporter le diagnostic…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnose exportieren…"
           }
         }
       }
@@ -6839,6 +8579,12 @@
             "state": "needs_review",
             "value": "Diagnostic exporté."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnose exportiert."
+          }
         }
       }
     },
@@ -6862,6 +8608,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible d'exporter le diagnostic : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnose konnte nicht exportiert werden: %@"
           }
         }
       }
@@ -6887,6 +8639,12 @@
             "state": "needs_review",
             "value": "Quitter"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Beenden"
+          }
         }
       }
     },
@@ -6910,6 +8668,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Réinitialiser les données locales"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lokale Daten zurücksetzen"
           }
         }
       }
@@ -6935,6 +8699,12 @@
             "state": "needs_review",
             "value": "Les données locales ont été déplacées vers :\n%@\nVeuillez quitter et relancer Lyrebird."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lokale Daten wurden verschoben nach:\n%@\nBitte beenden Sie Lyrebird und öffnen Sie es erneut."
+          }
         }
       }
     },
@@ -6958,6 +8728,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossible de réinitialiser les données locales : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lokale Daten konnten nicht zurückgesetzt werden: %@"
           }
         }
       }
@@ -6983,6 +8759,12 @@
             "state": "needs_review",
             "value": "Aucune donnée locale à réinitialiser. Essayez d'exporter le diagnostic."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Keine lokalen Daten zum Zurücksetzen gefunden. Versuchen Sie, die Diagnose zu exportieren."
+          }
         }
       }
     },
@@ -7006,6 +8788,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird n'a pas pu démarrer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird konnte nicht gestartet werden"
           }
         }
       }
@@ -7031,6 +8819,12 @@
             "state": "needs_review",
             "value": "Nom de l'appareil"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gerätename"
+          }
         }
       }
     },
@@ -7054,6 +8848,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nom de l'appareil : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gerätename: %@"
           }
         }
       }
@@ -7079,6 +8879,12 @@
             "state": "needs_review",
             "value": "Annuler"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abbrechen"
+          }
         }
       }
     },
@@ -7102,6 +8908,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Modifiez le nom que Jellyfin affiche pour cet appareil."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ändern Sie den Namen, den Jellyfin für dieses Gerät anzeigt."
           }
         }
       }
@@ -7127,6 +8939,12 @@
             "state": "needs_review",
             "value": "Mon Mac"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mein Mac"
+          }
         }
       }
     },
@@ -7150,6 +8968,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Enregistrer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Speichern"
           }
         }
       }
@@ -7175,6 +8999,12 @@
             "state": "needs_review",
             "value": "Affiché dans le tableau de bord de ce serveur et dans les autres clients Jellyfin."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wird im Dashboard dieses Servers und in anderen Jellyfin-Clients angezeigt."
+          }
         }
       }
     },
@@ -7198,6 +9028,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nom de l'appareil"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gerätename"
           }
         }
       }
@@ -7223,6 +9059,12 @@
             "state": "needs_review",
             "value": "Associez cet appareil en saisissant un code dans un autre client Jellyfin connecté."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Koppeln Sie dieses Gerät, indem Sie einen Code in einem anderen angemeldeten Jellyfin-Client eingeben."
+          }
         }
       }
     },
@@ -7247,6 +9089,12 @@
             "state": "needs_review",
             "value": "Annuler"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abbrechen"
+          }
         }
       }
     },
@@ -7267,6 +9115,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CODE"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "CODE"
@@ -7295,6 +9149,12 @@
             "state": "needs_review",
             "value": "Quick Connect n'a pas pu être finalisé. Veuillez réessayer."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut."
+          }
         }
       }
     },
@@ -7318,6 +9178,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Utiliser Jellyfin Quick Connect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jellyfin Quick Connect verwenden"
           }
         }
       }
@@ -7343,6 +9209,12 @@
             "state": "needs_review",
             "value": "Saisissez l'adresse de votre serveur sur l'écran de connexion d'abord, puis réessayez Quick Connect."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Geben Sie zuerst Ihre Serveradresse auf dem Anmeldebildschirm ein und versuchen Sie dann Quick Connect."
+          }
         }
       }
     },
@@ -7366,6 +9238,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Réessayer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erneut versuchen"
           }
         }
       }
@@ -7391,6 +9269,12 @@
             "state": "needs_review",
             "value": "Démarrage de Quick Connect…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect wird gestartet…"
+          }
         }
       }
     },
@@ -7415,6 +9299,12 @@
             "state": "needs_review",
             "value": "Saisissez ce code dans une autre app Jellyfin connectée pour associer cet appareil."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Geben Sie diesen Code in einer anderen angemeldeten Jellyfin-App ein, um dieses Gerät zu koppeln."
+          }
         }
       }
     },
@@ -7435,6 +9325,12 @@
           }
         },
         "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect"
@@ -7462,6 +9358,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "En attente d'approbation…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Warten auf Genehmigung…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -8501,13 +8501,13 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld elemento"
+                  "value": "Conectado · %lld álbum"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld elementos"
+                  "value": "Conectado · %lld álbumes"
                 }
               }
             }
@@ -8519,13 +8519,13 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld élément"
+                  "value": "Connecté · %lld album"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld éléments"
+                  "value": "Connecté · %lld albums"
                 }
               }
             }
@@ -8537,13 +8537,13 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld Element"
+                  "value": "Verbunden · %lld Album"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld Elemente"
+                  "value": "Verbunden · %lld Alben"
                 }
               }
             }
@@ -8555,7 +8555,7 @@
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld件"
+                  "value": "接続済み · %lld枚のアルバム"
                 }
               }
             }
@@ -8567,13 +8567,13 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld item"
+                  "value": "Conectado · %lld álbum"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld itens"
+                  "value": "Conectado · %lld álbuns"
                 }
               }
             }
@@ -8585,13 +8585,13 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld elemento"
+                  "value": "Connesso · %lld album"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld elementi"
+                  "value": "Connesso · %lld album"
                 }
               }
             }
@@ -8603,25 +8603,25 @@
               "one": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld элемент"
+                  "value": "Подключено · %lld альбом"
                 }
               },
               "few": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld элемента"
+                  "value": "Подключено · %lld альбома"
                 }
               },
               "many": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld элементов"
+                  "value": "Подключено · %lld альбомов"
                 }
               },
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld элемента"
+                  "value": "Подключено · %lld альбома"
                 }
               }
             }
@@ -8633,7 +8633,7 @@
               "other": {
                 "stringUnit": {
                   "state": "needs_review",
-                  "value": "%lld 个项目"
+                  "value": "已连接 · %lld 张专辑"
                 }
               }
             }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -52,6 +52,12 @@
             "state": "needs_review",
             "value": "О Lyrebird"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关于 Lyrebird"
+          }
         }
       }
     },
@@ -102,6 +108,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -160,6 +172,12 @@
             "state": "needs_review",
             "value": "РАБОЧИЙ СТОЛ"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "桌面版"
+          }
         }
       }
     },
@@ -213,6 +231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сеанс истёк"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "会话已过期"
           }
         }
       }
@@ -268,6 +292,12 @@
             "state": "needs_review",
             "value": "Войдите снова, чтобы продолжить прослушивание."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "请重新登录以继续收听音乐。"
+          }
         }
       }
     },
@@ -321,6 +351,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Войти"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "登录"
           }
         }
       }
@@ -376,6 +412,12 @@
             "state": "needs_review",
             "value": "Войти снова"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重新登录"
+          }
         }
       }
     },
@@ -429,6 +471,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Выполняется вход…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在登录…"
           }
         }
       }
@@ -484,6 +532,12 @@
             "state": "needs_review",
             "value": "Не удаётся достичь сервера."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法连接到您的服务器。"
+          }
         }
       }
     },
@@ -537,6 +591,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удаётся достичь %@. Повторная попытка…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法连接到 %@。正在重试…"
           }
         }
       }
@@ -592,6 +652,12 @@
             "state": "needs_review",
             "value": "Повторить подключение к серверу"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试服务器连接"
+          }
         }
       }
     },
@@ -645,6 +711,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Альбом"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑"
           }
         }
       }
@@ -700,6 +772,12 @@
             "state": "needs_review",
             "value": "Исполнитель"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "艺术家"
+          }
         }
       }
     },
@@ -753,6 +831,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Плейлист"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放列表"
           }
         }
       }
@@ -808,6 +892,12 @@
             "state": "needs_review",
             "value": "Отмена"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消"
+          }
         }
       }
     },
@@ -861,6 +951,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Удалить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "删除"
           }
         }
       }
@@ -916,6 +1012,12 @@
             "state": "needs_review",
             "value": "Закрыть"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关闭"
+          }
         }
       }
     },
@@ -970,6 +1072,12 @@
             "state": "needs_review",
             "value": "Готово"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "完成"
+          }
         }
       }
     },
@@ -1023,6 +1131,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Повторить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试"
           }
         }
       }
@@ -1176,6 +1290,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld альбома"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 张专辑"
                 }
               }
             }
@@ -1336,6 +1462,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 位艺术家"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1488,6 +1626,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld элемента"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 个项目"
                 }
               }
             }
@@ -1648,6 +1798,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 个播放列表"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1800,6 +1962,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld воспроизведения"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 次播放"
                 }
               }
             }
@@ -1960,6 +2134,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 个结果"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2112,6 +2298,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld выбрано"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "已选 %lld 个"
                 }
               }
             }
@@ -2272,6 +2470,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 首歌曲"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2428,6 +2638,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 首曲目"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2481,6 +2703,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Нет музыки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暂无音乐"
           }
         }
       }
@@ -2536,6 +2764,12 @@
             "state": "needs_review",
             "value": "На сервере Jellyfin нет музыки в библиотеке, либо она ещё индексируется. Добавьте библиотеку на сервере и обновите страницу."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "您的 Jellyfin 服务器媒体库中没有音乐，或仍在索引中。请在服务器上添加媒体库，然后刷新。"
+          }
         }
       }
     },
@@ -2589,6 +2823,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Открыть Jellyfin в браузере"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "打开 Jellyfin 网页"
           }
         }
       }
@@ -2644,6 +2884,12 @@
             "state": "needs_review",
             "value": "Очередь пуста"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "队列为空"
+          }
         }
       }
     },
@@ -2697,6 +2943,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизведите что-нибудь, чтобы начать очередь."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放内容以开始队列。"
           }
         }
       }
@@ -2752,6 +3004,12 @@
             "state": "needs_review",
             "value": "Войдите снова."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "请重新登录。"
+          }
         }
       }
     },
@@ -2805,6 +3063,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "У вас нет прав на это действие."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "您没有执行此操作的权限。"
           }
         }
       }
@@ -2860,6 +3124,12 @@
             "state": "needs_review",
             "value": "Элемент не найден."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "找不到该项目。"
+          }
         }
       }
     },
@@ -2913,6 +3183,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Слишком много запросов. Попробуйте снова через мгновение."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "请求过多。请稍后再试。"
           }
         }
       }
@@ -2968,6 +3244,12 @@
             "state": "needs_review",
             "value": "Ошибка сети. Проверьте подключение и попробуйте снова."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "网络错误。请检查连接后重试。"
+          }
         }
       }
     },
@@ -3021,6 +3303,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сервер столкнулся с проблемой. Попробуйте снова."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "服务器遇到问题。请重试。"
           }
         }
       }
@@ -3076,6 +3364,12 @@
             "state": "needs_review",
             "value": "Не удалось прочитать ответ сервера."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法读取服务器响应。"
+          }
         }
       }
     },
@@ -3129,6 +3423,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось загрузить для воспроизведения без подключения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法下载以供离线播放。"
           }
         }
       }
@@ -3184,6 +3484,12 @@
             "state": "needs_review",
             "value": "Ошибка локального хранилища. Попробуйте снова."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "本地存储错误。请重试。"
+          }
         }
       }
     },
@@ -3237,6 +3543,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось получить доступ к системному ключнице."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法访问系统钥匙串。"
           }
         }
       }
@@ -3292,6 +3604,12 @@
             "state": "needs_review",
             "value": "Ошибка воспроизведения аудио."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音频播放错误。"
+          }
         }
       }
     },
@@ -3345,6 +3663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось проверить сертификат сервера. Возможно, потребуется доверять этому серверу."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法验证服务器证书。您可能需要信任此服务器。"
           }
         }
       }
@@ -3400,6 +3724,12 @@
             "state": "needs_review",
             "value": "Это значение недействительно."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "该值无效。"
+          }
         }
       }
     },
@@ -3453,6 +3783,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Что-то пошло не так."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "出现了问题。"
           }
         }
       }
@@ -3508,6 +3844,12 @@
             "state": "needs_review",
             "value": "Не удалось начать воспроизведение."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法开始播放。"
+          }
         }
       }
     },
@@ -3561,6 +3903,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось загрузить библиотеку."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载您的媒体库。"
           }
         }
       }
@@ -3616,6 +3964,12 @@
             "state": "needs_review",
             "value": "Не удалось загрузить плейлисты."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载播放列表。"
+          }
         }
       }
     },
@@ -3669,6 +4023,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось загрузить этот плейлист."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载此播放列表。"
           }
         }
       }
@@ -3724,6 +4084,12 @@
             "state": "needs_review",
             "value": "Не удалось загрузить треки альбома."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载专辑曲目。"
+          }
         }
       }
     },
@@ -3777,6 +4143,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось загрузить треки плейлиста."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载播放列表曲目。"
           }
         }
       }
@@ -3832,6 +4204,12 @@
             "state": "needs_review",
             "value": "Поиск не выполнен."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索失败。"
+          }
         }
       }
     },
@@ -3885,6 +4263,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось обновить избранное."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法更新喜欢。"
           }
         }
       }
@@ -3940,6 +4324,12 @@
             "state": "needs_review",
             "value": "Не удалось обновить статус воспроизведения."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法更新播放状态。"
+          }
         }
       }
     },
@@ -3993,6 +4383,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось добавить в плейлист."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法添加到播放列表。"
           }
         }
       }
@@ -4048,6 +4444,12 @@
             "state": "needs_review",
             "value": "Ошибка входа."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "登录失败。"
+          }
         }
       }
     },
@@ -4101,6 +4503,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Неверное имя пользователя или пароль"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "用户名或密码错误"
           }
         }
       }
@@ -4156,6 +4564,12 @@
             "state": "needs_review",
             "value": "Это действие пока недоступно."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "此功能暂不可用。"
+          }
         }
       }
     },
@@ -4209,6 +4623,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Нет сети. Проверьте подключение."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无网络。请检查连接。"
           }
         }
       }
@@ -4264,6 +4684,12 @@
             "state": "needs_review",
             "value": "Проверка…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "检查中…"
+          }
         }
       }
     },
@@ -4317,6 +4743,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "АДРЕС СЕРВЕРА"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "服务器地址"
           }
         }
       }
@@ -4372,6 +4804,12 @@
             "state": "needs_review",
             "value": "ИМЯ ПОЛЬЗОВАТЕЛЯ"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "用户名"
+          }
         }
       }
     },
@@ -4425,6 +4863,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ПАРОЛЬ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "密码"
           }
         }
       }
@@ -4480,6 +4924,12 @@
             "state": "needs_review",
             "value": "вы"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "您"
+          }
         }
       }
     },
@@ -4533,6 +4983,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "НАЙДЕНО В ЭТОЙ СЕТИ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在此网络上发现"
           }
         }
       }
@@ -4588,6 +5044,12 @@
             "state": "needs_review",
             "value": "Адрес сервера"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "服务器地址"
+          }
         }
       }
     },
@@ -4641,6 +5103,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Имя пользователя"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "用户名"
           }
         }
       }
@@ -4696,6 +5164,12 @@
             "state": "needs_review",
             "value": "Пароль"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "密码"
+          }
         }
       }
     },
@@ -4749,6 +5223,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "返回"
           }
         }
       }
@@ -4804,6 +5284,12 @@
             "state": "needs_review",
             "value": "Добро пожаловать в Lyrebird"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "欢迎使用 Lyrebird"
+          }
         }
       }
     },
@@ -4857,6 +5343,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ваша музыка, ваш сервер, ваши правила."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "您的音乐，您的服务器，您的规则。"
           }
         }
       }
@@ -4912,6 +5404,12 @@
             "state": "needs_review",
             "value": "Начать"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "开始"
+          }
         }
       }
     },
@@ -4965,6 +5463,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "У меня уже есть аккаунт →"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "我已有账户 →"
           }
         }
       }
@@ -5020,6 +5524,12 @@
             "state": "needs_review",
             "value": "У меня уже есть аккаунт"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "我已有账户"
+          }
         }
       }
     },
@@ -5073,6 +5583,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Подключите сервер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "连接您的服务器"
           }
         }
       }
@@ -5128,6 +5644,12 @@
             "state": "needs_review",
             "value": "URL Jellyfin — это адрес, по которому вы заходите с браузера."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jellyfin 网址是您在浏览器中访问它的地址。"
+          }
         }
       }
     },
@@ -5181,6 +5703,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Продолжить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "继续"
           }
         }
       }
@@ -5236,6 +5764,12 @@
             "state": "needs_review",
             "value": "Подключение…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "连接中…"
+          }
         }
       }
     },
@@ -5289,6 +5823,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Пропустить, изучить без подключения →"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "跳过，离线探索 →"
           }
         }
       }
@@ -5344,6 +5884,12 @@
             "state": "needs_review",
             "value": "Загрузка библиотеки"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在加载媒体库"
+          }
         }
       }
     },
@@ -5397,6 +5943,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Загружаем исполнителей…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在加载艺术家…"
           }
         }
       }
@@ -5452,6 +6004,12 @@
             "state": "needs_review",
             "value": "Загружаем альбомы…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在加载专辑…"
+          }
         }
       }
     },
@@ -5505,6 +6063,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Загружаем треки…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在加载曲目…"
           }
         }
       }
@@ -5560,6 +6124,12 @@
             "state": "needs_review",
             "value": "Получаем обложки…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在获取封面…"
+          }
         }
       }
     },
@@ -5613,6 +6183,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ треков · %2$@ исполнителей · %3$@ альбомов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ 首曲目 · %2$@ 位艺术家 · %3$@ 张专辑"
           }
         }
       }
@@ -5668,6 +6244,12 @@
             "state": "needs_review",
             "value": "На главную"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前往首页"
+          }
         }
       }
     },
@@ -5721,6 +6303,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Синхронизация…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "同步中…"
           }
         }
       }
@@ -5776,6 +6364,12 @@
             "state": "needs_review",
             "value": "Не удалось загрузить библиотеку."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法加载您的媒体库。"
+          }
         }
       }
     },
@@ -5829,6 +6423,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Попробовать снова"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试"
           }
         }
       }
@@ -5884,6 +6484,12 @@
             "state": "needs_review",
             "value": "О Lyrebird"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关于 Lyrebird"
+          }
         }
       }
     },
@@ -5937,6 +6543,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Новый плейлист…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新建播放列表…"
           }
         }
       }
@@ -5992,6 +6604,12 @@
             "state": "needs_review",
             "value": "Новое окно"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新建窗口"
+          }
         }
       }
     },
@@ -6045,6 +6663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Показать боковую панель"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示侧边栏"
           }
         }
       }
@@ -6100,6 +6724,12 @@
             "state": "needs_review",
             "value": "Показать инспектор очереди"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示队列检查器"
+          }
         }
       }
     },
@@ -6153,6 +6783,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Главная"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "首页"
           }
         }
       }
@@ -6208,6 +6844,12 @@
             "state": "needs_review",
             "value": "Библиотека"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒体库"
+          }
         }
       }
     },
@@ -6261,6 +6903,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Поиск"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索"
           }
         }
       }
@@ -6316,6 +6964,12 @@
             "state": "needs_review",
             "value": "Найти…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "查找…"
+          }
         }
       }
     },
@@ -6369,6 +7023,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Найти в библиотеке…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在媒体库中查找…"
           }
         }
       }
@@ -6424,6 +7084,12 @@
             "state": "needs_review",
             "value": "Перейти к воспроизведению"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前往正在播放"
+          }
         }
       }
     },
@@ -6477,6 +7143,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Очередь воспроизведения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放队列"
           }
         }
       }
@@ -6532,6 +7204,12 @@
             "state": "needs_review",
             "value": "Палитра команд…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "命令面板…"
+          }
         }
       }
     },
@@ -6585,6 +7263,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизведение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放"
           }
         }
       }
@@ -6640,6 +7324,12 @@
             "state": "needs_review",
             "value": "Воспроизвести"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放"
+          }
         }
       }
     },
@@ -6693,6 +7383,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Пауза"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暂停"
           }
         }
       }
@@ -6748,6 +7444,12 @@
             "state": "needs_review",
             "value": "Следующий трек"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下一首"
+          }
         }
       }
     },
@@ -6801,6 +7503,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Предыдущий трек"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "上一首"
           }
         }
       }
@@ -6856,6 +7564,12 @@
             "state": "needs_review",
             "value": "Увеличить громкость"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "调高音量"
+          }
         }
       }
     },
@@ -6909,6 +7623,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Уменьшить громкость"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "调低音量"
           }
         }
       }
@@ -6964,6 +7684,12 @@
             "state": "needs_review",
             "value": "Перемотать вперёд на 10с"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "快进 10 秒"
+          }
         }
       }
     },
@@ -7017,6 +7743,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Перемотать назад на 10с"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "后退 10 秒"
           }
         }
       }
@@ -7072,6 +7804,12 @@
             "state": "needs_review",
             "value": "Стоп"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "停止"
+          }
         }
       }
     },
@@ -7125,6 +7863,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Прикрепить окно к левому краю"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "将窗口拼贴到屏幕左侧"
           }
         }
       }
@@ -7180,6 +7924,12 @@
             "state": "needs_review",
             "value": "Прикрепить окно к правому краю"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "将窗口拼贴到屏幕右侧"
+          }
         }
       }
     },
@@ -7233,6 +7983,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Справка Lyrebird"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird 帮助"
           }
         }
       }
@@ -7288,6 +8044,12 @@
             "state": "needs_review",
             "value": "Показать/скрыть инспектор очереди"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "切换队列检查器"
+          }
         }
       }
     },
@@ -7341,6 +8103,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ничего не воспроизводится"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "未播放内容"
           }
         }
       }
@@ -7396,6 +8164,12 @@
             "state": "needs_review",
             "value": "Главная"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "首页"
+          }
         }
       }
     },
@@ -7449,6 +8223,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Открытия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "发现"
           }
         }
       }
@@ -7504,6 +8284,12 @@
             "state": "needs_review",
             "value": "Радио"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "广播"
+          }
         }
       }
     },
@@ -7557,6 +8343,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Библиотека"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒体库"
           }
         }
       }
@@ -7612,6 +8404,12 @@
             "state": "needs_review",
             "value": "Поиск"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索"
+          }
         }
       }
     },
@@ -7665,6 +8463,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Моя библиотека"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "我的媒体库"
           }
         }
       }
@@ -7822,6 +8626,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 个项目"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -7875,6 +8691,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Отключено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已断开"
           }
         }
       }
@@ -7930,6 +8752,12 @@
             "state": "needs_review",
             "value": "Избранное"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "喜欢"
+          }
         }
       }
     },
@@ -7983,6 +8811,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Альбомы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑"
           }
         }
       }
@@ -8038,6 +8872,12 @@
             "state": "needs_review",
             "value": "Исполнители"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "艺术家"
+          }
         }
       }
     },
@@ -8091,6 +8931,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Плейлисты"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放列表"
           }
         }
       }
@@ -8146,6 +8992,12 @@
             "state": "needs_review",
             "value": "Редактировать правила умного плейлиста"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "编辑智能播放列表规则"
+          }
         }
       }
     },
@@ -8199,6 +9051,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизвести умный плейлист"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放智能播放列表"
           }
         }
       }
@@ -8254,6 +9112,12 @@
             "state": "needs_review",
             "value": "Перемешать умный плейлист"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "随机播放智能播放列表"
+          }
         }
       }
     },
@@ -8307,6 +9171,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "УМНЫЙ ПЛЕЙЛИСТ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "智能播放列表"
           }
         }
       }
@@ -8362,6 +9232,12 @@
             "state": "needs_review",
             "value": "Добавить правило"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "添加规则"
+          }
         }
       }
     },
@@ -8415,6 +9291,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Поле правила"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "规则字段"
           }
         }
       }
@@ -8470,6 +9352,12 @@
             "state": "needs_review",
             "value": "Режим совпадения"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配模式"
+          }
         }
       }
     },
@@ -8523,6 +9411,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Название умного плейлиста"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "智能播放列表名称"
           }
         }
       }
@@ -8578,6 +9472,12 @@
             "state": "needs_review",
             "value": "Оператор правила"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "规则运算符"
+          }
         }
       }
     },
@@ -8631,6 +9531,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Удалить правило"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "移除规则"
           }
         }
       }
@@ -8686,6 +9592,12 @@
             "state": "needs_review",
             "value": "Сохранить умный плейлист"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保存智能播放列表"
+          }
         }
       }
     },
@@ -8739,6 +9651,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Значение правила"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "规则值"
           }
         }
       }
@@ -8794,6 +9712,12 @@
             "state": "needs_review",
             "value": "Значение правила в днях"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "规则值（天数）"
+          }
         }
       }
     },
@@ -8847,6 +9771,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Добавить правило"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "添加规则"
           }
         }
       }
@@ -8902,6 +9832,12 @@
             "state": "needs_review",
             "value": "нет"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "否"
+          }
         }
       }
     },
@@ -8955,6 +9891,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "да"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "是"
           }
         }
       }
@@ -9010,6 +9952,12 @@
             "state": "needs_review",
             "value": "Отмена"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消"
+          }
         }
       }
     },
@@ -9063,6 +10011,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Подсчёт…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "计数中…"
           }
         }
       }
@@ -9118,6 +10072,12 @@
             "state": "needs_review",
             "value": "дней"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "天"
+          }
         }
       }
     },
@@ -9171,6 +10131,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Умный плейлист"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "智能播放列表"
           }
         }
       }
@@ -9328,6 +10294,18 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld 个匹配"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -9381,6 +10359,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Соответствовать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配"
           }
         }
       }
@@ -9436,6 +10420,12 @@
             "state": "needs_review",
             "value": "из следующих правил:"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "以下规则："
+          }
         }
       }
     },
@@ -9489,6 +10479,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "НАЗВАНИЕ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "名称"
           }
         }
       }
@@ -9544,6 +10540,12 @@
             "state": "needs_review",
             "value": "Название умного плейлиста"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "智能播放列表名称"
+          }
         }
       }
     },
@@ -9597,6 +10599,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сохранить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保存"
           }
         }
       }
@@ -9652,6 +10660,12 @@
             "state": "needs_review",
             "value": "Умный плейлист"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "智能播放列表"
+          }
         }
       }
     },
@@ -9705,6 +10719,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "значение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "值"
           }
         }
       }
@@ -9760,6 +10780,12 @@
             "state": "needs_review",
             "value": "Редактировать правила"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "编辑规则"
+          }
         }
       }
     },
@@ -9813,6 +10839,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Загружено %lld треков. Попробуйте ослабить правила или откройте Библиотеку, чтобы в памяти было больше треков."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已加载 %lld 首曲目。请尝试放宽规则，或打开媒体库以在内存中加载更多曲目。"
           }
         }
       }
@@ -9868,6 +10900,12 @@
             "state": "needs_review",
             "value": "Нет треков, соответствующих этим правилам"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "没有符合这些规则的曲目"
+          }
         }
       }
     },
@@ -9921,6 +10959,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Альбом"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑"
           }
         }
       }
@@ -9976,6 +11020,12 @@
             "state": "needs_review",
             "value": "Исполнитель"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "艺术家"
+          }
         }
       }
     },
@@ -10029,6 +11079,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Избранное"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "喜欢"
           }
         }
       }
@@ -10084,6 +11140,12 @@
             "state": "needs_review",
             "value": "Жанр"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "流派"
+          }
         }
       }
     },
@@ -10137,6 +11199,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Длительность (сек)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "时长（秒）"
           }
         }
       }
@@ -10192,6 +11260,12 @@
             "state": "needs_review",
             "value": "Последнее воспроизведение"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "上次播放"
+          }
         }
       }
     },
@@ -10245,6 +11319,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Количество воспроизведений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放次数"
           }
         }
       }
@@ -10300,6 +11380,12 @@
             "state": "needs_review",
             "value": "Год"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "年份"
+          }
         }
       }
     },
@@ -10353,6 +11439,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Фильтровать треки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "过滤曲目"
           }
         }
       }
@@ -10408,6 +11500,12 @@
             "state": "needs_review",
             "value": "все"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "全部"
+          }
         }
       }
     },
@@ -10461,6 +11559,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "любое"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "任意"
           }
         }
       }
@@ -10516,6 +11620,12 @@
             "state": "needs_review",
             "value": "Нет треков, соответствующих \"%@\""
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "没有曲目匹配「%@」"
+          }
         }
       }
     },
@@ -10569,6 +11679,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Умный плейлист не найден"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "找不到智能播放列表"
           }
         }
       }
@@ -10624,6 +11740,12 @@
             "state": "needs_review",
             "value": "содержит"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "包含"
+          }
         }
       }
     },
@@ -10677,6 +11799,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "больше чем"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "大于"
           }
         }
       }
@@ -10732,6 +11860,12 @@
             "state": "needs_review",
             "value": "за последние (дни)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "最近（天）"
+          }
         }
       }
     },
@@ -10785,6 +11919,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "равно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "是"
           }
         }
       }
@@ -10840,6 +11980,12 @@
             "state": "needs_review",
             "value": "не равно"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "不是"
+          }
         }
       }
     },
@@ -10893,6 +12039,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "меньше чем"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "小于"
           }
         }
       }
@@ -10948,6 +12100,12 @@
             "state": "needs_review",
             "value": ", "
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "、"
+          }
         }
       }
     },
@@ -11001,6 +12159,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Совпадает %1$@ из: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配 %2$@ 中的 %1$@"
           }
         }
       }
@@ -11056,6 +12220,12 @@
             "state": "needs_review",
             "value": "Совпадает со всеми треками."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配所有曲目。"
+          }
         }
       }
     },
@@ -11109,6 +12279,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Повторить воспроизведение неудавшегося трека"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试播放失败的曲目"
           }
         }
       }
@@ -11164,6 +12340,12 @@
             "state": "needs_review",
             "value": "Перейти к треку"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前往曲目"
+          }
         }
       }
     },
@@ -11217,6 +12399,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось воспроизвести «%@». Пропускаем."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法播放「%@」。正在跳过。"
           }
         }
       }
@@ -11272,6 +12460,12 @@
             "state": "needs_review",
             "value": "Повторить подключение к сети"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试网络连接"
+          }
         }
       }
     },
@@ -11325,6 +12519,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Вы не в сети. Воспроизведение только из загруженных треков."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "您已离线。仅播放已下载的曲目。"
           }
         }
       }
@@ -11380,6 +12580,12 @@
             "state": "needs_review",
             "value": "Это навсегда удалит плейлист. Это действие нельзя отменить."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "这将永久删除此播放列表。此操作无法撤销。"
+          }
         }
       }
     },
@@ -11433,6 +12639,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Альбом"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑"
           }
         }
       }
@@ -11488,6 +12700,12 @@
             "state": "needs_review",
             "value": "Диск"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "碟"
+          }
         }
       }
     },
@@ -11541,6 +12759,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Длительность"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "时长"
           }
         }
       }
@@ -11596,6 +12820,12 @@
             "state": "needs_review",
             "value": "Формат"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "格式"
+          }
         }
       }
     },
@@ -11649,6 +12879,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизведений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放次数"
           }
         }
       }
@@ -11704,6 +12940,12 @@
             "state": "needs_review",
             "value": "Трек"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "曲目"
+          }
         }
       }
     },
@@ -11757,6 +12999,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Год"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "年份"
           }
         }
       }
@@ -11812,6 +13060,12 @@
             "state": "needs_review",
             "value": "Мини-плеер"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "迷你播放器"
+          }
         }
       }
     },
@@ -11865,6 +13119,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сейчас играет"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在播放"
           }
         }
       }
@@ -11920,6 +13180,12 @@
             "state": "needs_review",
             "value": "Следующий"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下一首"
+          }
         }
       }
     },
@@ -11973,6 +13239,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Открыть Lyrebird"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "打开 Lyrebird"
           }
         }
       }
@@ -12028,6 +13300,12 @@
             "state": "needs_review",
             "value": "Пауза"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暂停"
+          }
         }
       }
     },
@@ -12081,6 +13359,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизвести"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放"
           }
         }
       }
@@ -12136,6 +13420,12 @@
             "state": "needs_review",
             "value": "Предыдущий"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "上一首"
+          }
         }
       }
     },
@@ -12189,6 +13479,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Мини-плеер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "迷你播放器"
           }
         }
       }
@@ -12244,6 +13540,12 @@
             "state": "needs_review",
             "value": "Мини-плеер"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "迷你播放器"
+          }
         }
       }
     },
@@ -12297,6 +13599,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Обложка альбома. Перетащите, чтобы переместить мини-плеер."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑封面。拖动以移动迷你播放器。"
           }
         }
       }
@@ -12352,6 +13660,12 @@
             "state": "needs_review",
             "value": "Параметры мини-плеера"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "迷你播放器选项"
+          }
         }
       }
     },
@@ -12405,6 +13719,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Всегда поверх"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "始终置顶"
           }
         }
       }
@@ -12460,6 +13780,12 @@
             "state": "needs_review",
             "value": "Вернуться к полному окну"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "返回完整窗口"
+          }
         }
       }
     },
@@ -12513,6 +13839,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Прозрачный при неактивности"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "非活动时透明"
           }
         }
       }
@@ -12568,6 +13900,12 @@
             "state": "needs_review",
             "value": "Закрыть мини-плеер"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关闭迷你播放器"
+          }
         }
       }
     },
@@ -12621,6 +13959,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Обложка альбома. Нажмите, чтобы открыть альбом; перетащите, чтобы переместить мини-плеер."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑封面。点击打开专辑；拖动以移动迷你播放器。"
           }
         }
       }
@@ -12676,6 +14020,12 @@
             "state": "needs_review",
             "value": "Открыть страницу исполнителя"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "打开艺术家页面"
+          }
         }
       }
     },
@@ -12729,6 +14079,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Развернуть на весь экран"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "展开到完整窗口"
           }
         }
       }
@@ -12784,6 +14140,12 @@
             "state": "needs_review",
             "value": "Избранное"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "喜欢"
+          }
         }
       }
     },
@@ -12837,6 +14199,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Убрать из избранного"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消喜欢"
           }
         }
       }
@@ -12892,6 +14260,12 @@
             "state": "needs_review",
             "value": "Предыдущий трек"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "上一首"
+          }
         }
       }
     },
@@ -12945,6 +14319,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Воспроизвести"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放"
           }
         }
       }
@@ -13000,6 +14380,12 @@
             "state": "needs_review",
             "value": "Пауза"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暂停"
+          }
         }
       }
     },
@@ -13053,6 +14439,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Следующий трек"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下一首"
           }
         }
       }
@@ -13108,6 +14500,12 @@
             "state": "needs_review",
             "value": "Вернуться к полному окну"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "返回完整窗口"
+          }
         }
       }
     },
@@ -13161,6 +14559,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Громкость"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音量"
           }
         }
       }
@@ -13216,6 +14620,12 @@
             "state": "needs_review",
             "value": "Позиция воспроизведения"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放位置"
+          }
         }
       }
     },
@@ -13270,6 +14680,12 @@
             "state": "needs_review",
             "value": "Экспортировать диагностический пакет…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "导出诊断包…"
+          }
         }
       }
     },
@@ -13322,6 +14738,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сочетания клавиш"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "键盘快捷键"
           }
         }
       }
@@ -13376,6 +14798,12 @@
             "state": "needs_review",
             "value": "Воспроизвести / Пауза"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放 / 暂停"
+          }
         }
       }
     },
@@ -13428,6 +14856,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Поиск сочетаний клавиш"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索键盘快捷键"
           }
         }
       }
@@ -13482,6 +14916,12 @@
             "state": "needs_review",
             "value": "Очистить поиск"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "清除搜索"
+          }
         }
       }
     },
@@ -13534,6 +14974,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Нет сочетаний клавиш, соответствующих поиску"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "没有与您搜索匹配的快捷键"
           }
         }
       }
@@ -13588,6 +15034,12 @@
             "state": "needs_review",
             "value": "Поиск сочетаний"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索快捷键"
+          }
         }
       }
     },
@@ -13640,6 +15092,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Файл"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "文件"
           }
         }
       }
@@ -13694,6 +15152,12 @@
             "state": "needs_review",
             "value": "Воспроизведение"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "播放"
+          }
         }
       }
     },
@@ -13746,6 +15210,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Вид"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示"
           }
         }
       }
@@ -13800,6 +15270,12 @@
             "state": "needs_review",
             "value": "Окно"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "窗口"
+          }
         }
       }
     },
@@ -13852,6 +15328,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сочетания клавиш"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "键盘快捷键"
           }
         }
       }
@@ -13907,6 +15389,12 @@
             "state": "needs_review",
             "value": "Альбомы"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "专辑"
+          }
         }
       }
     },
@@ -13960,6 +15448,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Всё"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "全部"
           }
         }
       }
@@ -14015,6 +15509,12 @@
             "state": "needs_review",
             "value": "Исполнители"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "艺术家"
+          }
         }
       }
     },
@@ -14068,6 +15568,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Жанры"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "流派"
           }
         }
       }
@@ -14123,6 +15629,12 @@
             "state": "needs_review",
             "value": "Треки"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "曲目"
+          }
         }
       }
     },
@@ -14176,6 +15688,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Закрыть выбор моментального микса"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关闭即时混音选择器"
           }
         }
       }
@@ -14231,6 +15749,12 @@
             "state": "needs_review",
             "value": "Найдите что-нибудь для создания микса."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索内容以建立混音。"
+          }
         }
       }
     },
@@ -14284,6 +15808,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Создать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "生成"
           }
         }
       }
@@ -14339,6 +15869,12 @@
             "state": "needs_review",
             "value": "Последний микс:"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "上次混音："
+          }
         }
       }
     },
@@ -14392,6 +15928,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Нет совпадений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无匹配"
           }
         }
       }
@@ -14447,6 +15989,12 @@
             "state": "needs_review",
             "value": "Найдите трек, альбом, исполнителя или жанр"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "搜索曲目、专辑、艺术家或流派"
+          }
         }
       }
     },
@@ -14500,6 +16048,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Основа:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "基于："
           }
         }
       }
@@ -14555,6 +16109,12 @@
             "state": "needs_review",
             "value": "Новый моментальный микс"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新建即时混音"
+          }
         }
       }
     },
@@ -14608,6 +16168,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Новый моментальный микс…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新建即时混音…"
           }
         }
       }
@@ -14663,6 +16229,12 @@
             "state": "needs_review",
             "value": "Показать тур"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示向导"
+          }
         }
       }
     },
@@ -14716,6 +16288,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Тур по функциям"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "功能导览"
           }
         }
       }
@@ -14771,6 +16349,12 @@
             "state": "needs_review",
             "value": "Шаг %1$lld из %2$lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "第 %1$lld 步，共 %2$lld 步"
+          }
         }
       }
     },
@@ -14824,6 +16408,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сочетание клавиш %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "键盘快捷键 %@"
           }
         }
       }
@@ -14879,6 +16469,12 @@
             "state": "needs_review",
             "value": "Назад"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "返回"
+          }
         }
       }
     },
@@ -14932,6 +16528,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Готово"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "完成"
           }
         }
       }
@@ -14987,6 +16589,12 @@
             "state": "needs_review",
             "value": "Нажмите ⌘⌥P, чтобы открыть компактный плеер, всегда поверх других окон, который можно убрать в угол во время работы."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "按 ⌘⌥P 打开一个紧凑的悬浮播放器，可以在工作时放到角落。"
+          }
         }
       }
     },
@@ -15040,6 +16648,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Откройте мини-плеер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "弹出迷你播放器"
           }
         }
       }
@@ -15095,6 +16709,12 @@
             "state": "needs_review",
             "value": "Далее"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下一步"
+          }
         }
       }
     },
@@ -15148,6 +16768,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Щёлкните правой кнопкой мыши по треку, альбому, исполнителю или плейлисту для быстрых действий — воспроизвести следующим, добавить в плейлист, запустить радиостанцию и многое другое."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "右键点击任意曲目、专辑、艺术家或播放列表，可快速操作——下一首播放、添加到播放列表、开始电台等。"
           }
         }
       }
@@ -15203,6 +16829,12 @@
             "state": "needs_review",
             "value": "Правая кнопка мыши для большего"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "右键查看更多"
+          }
         }
       }
     },
@@ -15256,6 +16888,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Нажмите ⌘F, чтобы сразу перейти к поиску и найти любую песню, альбом или исполнителя в библиотеке."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "按 ⌘F 直接跳转到搜索，快速找到媒体库中的任何歌曲、专辑或艺术家。"
           }
         }
       }
@@ -15311,6 +16949,12 @@
             "state": "needs_review",
             "value": "Найдите всё быстро"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "快速查找任何内容"
+          }
         }
       }
     },
@@ -15364,6 +17008,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Пропустить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "跳过"
           }
         }
       }
@@ -15419,6 +17069,12 @@
             "state": "needs_review",
             "value": "Нажмите пробел в любом месте вне текстового поля, чтобы воспроизвести или поставить на паузу текущий трек."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在文本框以外的任何地方按空格键，可播放或暂停当前曲目。"
+          }
         }
       }
     },
@@ -15472,6 +17128,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Пробел для воспроизведения и паузы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "用空格键播放和暂停"
           }
         }
       }
@@ -15527,6 +17189,12 @@
             "state": "needs_review",
             "value": "Локальные данные Lyrebird не удалось открыть. Обычно это можно исправить: сбросьте локальные данные для нового старта или экспортируйте диагностический пакет для отправки с отчётом об ошибке."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird 的本地数据无法打开。通常可以修复：重置本地数据重新开始，或导出诊断包附在错误报告中。"
+          }
         }
       }
     },
@@ -15580,6 +17248,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Экспортировать диагностику…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "导出诊断…"
           }
         }
       }
@@ -15635,6 +17309,12 @@
             "state": "needs_review",
             "value": "Диагностика экспортирована."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "诊断已导出。"
+          }
         }
       }
     },
@@ -15688,6 +17368,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось экспортировать диагностику: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法导出诊断：%@"
           }
         }
       }
@@ -15743,6 +17429,12 @@
             "state": "needs_review",
             "value": "Выйти"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出"
+          }
         }
       }
     },
@@ -15796,6 +17488,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сбросить локальные данные"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重置本地数据"
           }
         }
       }
@@ -15851,6 +17549,12 @@
             "state": "needs_review",
             "value": "Локальные данные перемещены в:\n%@\nПожалуйста, выйдите и снова откройте Lyrebird."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "本地数据已移动至：\n%@\n请退出并重新打开 Lyrebird。"
+          }
         }
       }
     },
@@ -15904,6 +17608,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось сбросить локальные данные: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无法重置本地数据：%@"
           }
         }
       }
@@ -15959,6 +17669,12 @@
             "state": "needs_review",
             "value": "Локальных данных для сброса не найдено. Попробуйте экспортировать диагностику."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "未找到可重置的本地数据。请尝试导出诊断。"
+          }
         }
       }
     },
@@ -16012,6 +17728,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird не удалось запустить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird 无法启动"
           }
         }
       }
@@ -16067,6 +17789,12 @@
             "state": "needs_review",
             "value": "Имя устройства"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "设备名称"
+          }
         }
       }
     },
@@ -16120,6 +17848,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Имя устройства: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "设备名称：%@"
           }
         }
       }
@@ -16175,6 +17909,12 @@
             "state": "needs_review",
             "value": "Отмена"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消"
+          }
         }
       }
     },
@@ -16228,6 +17968,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Измените имя, которое Jellyfin отображает для этого устройства."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "更改 Jellyfin 为此设备显示的名称。"
           }
         }
       }
@@ -16283,6 +18029,12 @@
             "state": "needs_review",
             "value": "Мой Mac"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "我的 Mac"
+          }
         }
       }
     },
@@ -16336,6 +18088,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сохранить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保存"
           }
         }
       }
@@ -16391,6 +18149,12 @@
             "state": "needs_review",
             "value": "Отображается на панели управления этого сервера и в других клиентах Jellyfin."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示在该服务器的控制台及其他 Jellyfin 客户端中。"
+          }
         }
       }
     },
@@ -16444,6 +18208,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Имя устройства"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "设备名称"
           }
         }
       }
@@ -16499,6 +18269,12 @@
             "state": "needs_review",
             "value": "Привяжите это устройство, введя код в другом подключённом клиенте Jellyfin."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在另一个已登录的 Jellyfin 客户端输入代码以配对此设备。"
+          }
         }
       }
     },
@@ -16552,6 +18328,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Отмена"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消"
           }
         }
       }
@@ -16607,6 +18389,12 @@
             "state": "needs_review",
             "value": "КОД"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "代码"
+          }
         }
       }
     },
@@ -16660,6 +18448,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Не удалось завершить Quick Connect. Попробуйте снова."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect 无法完成。请重试。"
           }
         }
       }
@@ -16715,6 +18509,12 @@
             "state": "needs_review",
             "value": "Использовать Jellyfin Quick Connect"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "使用 Jellyfin Quick Connect"
+          }
         }
       }
     },
@@ -16768,6 +18568,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Сначала введите адрес сервера на экране входа, затем попробуйте Quick Connect."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "请先在登录屏幕输入服务器地址，然后再尝试 Quick Connect。"
           }
         }
       }
@@ -16823,6 +18629,12 @@
             "state": "needs_review",
             "value": "Повторить"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重试"
+          }
         }
       }
     },
@@ -16876,6 +18688,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Запуск Quick Connect…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在启动 Quick Connect…"
           }
         }
       }
@@ -16931,6 +18749,12 @@
             "state": "needs_review",
             "value": "Введите этот код в другом подключённом приложении Jellyfin для привязки устройства."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在另一个已登录的 Jellyfin 应用中输入此代码以配对此设备。"
+          }
         }
       }
     },
@@ -16981,6 +18805,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect"
@@ -17038,6 +18868,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ожидание подтверждения…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "等待批准…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -16,6 +16,12 @@
             "state": "needs_review",
             "value": "Acerca de Lyrebird"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "À propos de Lyrebird"
+          }
         }
       }
     },
@@ -30,6 +36,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -52,6 +64,12 @@
             "state": "needs_review",
             "value": "ESCRITORIO"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "BUREAU"
+          }
         }
       }
     },
@@ -69,6 +87,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tu sesión ha expirado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Votre session a expiré"
           }
         }
       }
@@ -88,6 +112,12 @@
             "state": "needs_review",
             "value": "Inicia sesión de nuevo para continuar escuchando."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Veuillez vous reconnecter pour continuer à écouter."
+          }
         }
       }
     },
@@ -105,6 +135,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Iniciar sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Se connecter"
           }
         }
       }
@@ -124,6 +160,12 @@
             "state": "needs_review",
             "value": "Iniciar sesión de nuevo"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Se reconnecter"
+          }
         }
       }
     },
@@ -141,6 +183,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Iniciando sesión…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Connexion en cours…"
           }
         }
       }
@@ -160,6 +208,12 @@
             "state": "needs_review",
             "value": "No se puede alcanzar tu servidor."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible d'atteindre votre serveur."
+          }
         }
       }
     },
@@ -177,6 +231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se puede alcanzar %@. Volviendo a intentar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible d'atteindre %@. Nouvelle tentative…"
           }
         }
       }
@@ -196,6 +256,12 @@
             "state": "needs_review",
             "value": "Reintentar conexión con el servidor"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer la connexion au serveur"
+          }
         }
       }
     },
@@ -213,6 +279,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Álbum"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
           }
         }
       }
@@ -232,6 +304,12 @@
             "state": "needs_review",
             "value": "Artista"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artiste"
+          }
         }
       }
     },
@@ -249,6 +327,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lista de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist"
           }
         }
       }
@@ -268,6 +352,12 @@
             "state": "needs_review",
             "value": "Cancelar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annuler"
+          }
         }
       }
     },
@@ -285,6 +375,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Supprimer"
           }
         }
       }
@@ -304,6 +400,12 @@
             "state": "needs_review",
             "value": "Descartar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ignorer"
+          }
         }
       }
     },
@@ -322,6 +424,12 @@
             "state": "needs_review",
             "value": "Listo"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Terminé"
+          }
         }
       }
     },
@@ -339,6 +447,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reintentar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer"
           }
         }
       }
@@ -378,6 +492,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld álbumes"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld album"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld albums"
                 }
               }
             }
@@ -424,6 +556,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artiste"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artistes"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -462,6 +612,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld elementos"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld élément"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld éléments"
                 }
               }
             }
@@ -508,6 +676,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlist"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlists"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -546,6 +732,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld reproducciones"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld lecture"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld lectures"
                 }
               }
             }
@@ -592,6 +796,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld résultat"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld résultats"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -630,6 +852,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld seleccionados"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld sélectionné"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld sélectionnés"
                 }
               }
             }
@@ -676,6 +916,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld chanson"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld chansons"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -718,6 +976,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld piste"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld pistes"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -735,6 +1011,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aún no hay música"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pas encore de musique"
           }
         }
       }
@@ -754,6 +1036,12 @@
             "state": "needs_review",
             "value": "Tu servidor Jellyfin no tiene música en su biblioteca, o aún se está indexando. Añade una biblioteca en el servidor y actualiza."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Votre serveur Jellyfin ne contient pas de musique dans sa bibliothèque, ou elle est encore en cours d'indexation. Ajoutez une bibliothèque sur le serveur, puis actualisez."
+          }
         }
       }
     },
@@ -771,6 +1059,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abrir Jellyfin web"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ouvrir Jellyfin web"
           }
         }
       }
@@ -790,6 +1084,12 @@
             "state": "needs_review",
             "value": "La cola está vacía"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La file d'attente est vide"
+          }
         }
       }
     },
@@ -807,6 +1107,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproduce algo para iniciar una cola."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lisez quelque chose pour démarrer une file d'attente."
           }
         }
       }
@@ -826,6 +1132,12 @@
             "state": "needs_review",
             "value": "Inicia sesión de nuevo."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Veuillez vous reconnecter."
+          }
         }
       }
     },
@@ -843,6 +1155,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No tienes permiso para hacer eso."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vous n'avez pas la permission de faire cela."
           }
         }
       }
@@ -862,6 +1180,12 @@
             "state": "needs_review",
             "value": "No se encontró ese elemento."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cet élément est introuvable."
+          }
         }
       }
     },
@@ -879,6 +1203,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Demasiadas solicitudes. Vuelve a intentarlo en un momento."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Trop de requêtes. Veuillez réessayer dans un moment."
           }
         }
       }
@@ -898,6 +1228,12 @@
             "state": "needs_review",
             "value": "Error de red. Verifica tu conexión e inténtalo de nuevo."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erreur réseau. Vérifiez votre connexion et réessayez."
+          }
         }
       }
     },
@@ -915,6 +1251,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "El servidor encontró un problema. Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Le serveur a rencontré un problème. Veuillez réessayer."
           }
         }
       }
@@ -934,6 +1276,12 @@
             "state": "needs_review",
             "value": "No se pudo leer la respuesta del servidor."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de lire la réponse du serveur."
+          }
         }
       }
     },
@@ -951,6 +1299,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo descargar para reproducción sin conexión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de télécharger pour la lecture hors ligne."
           }
         }
       }
@@ -970,6 +1324,12 @@
             "state": "needs_review",
             "value": "Error de almacenamiento local. Inténtalo de nuevo."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erreur de stockage local. Veuillez réessayer."
+          }
         }
       }
     },
@@ -987,6 +1347,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo acceder al llavero del sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible d'accéder au trousseau système."
           }
         }
       }
@@ -1006,6 +1372,12 @@
             "state": "needs_review",
             "value": "Error de reproducción de audio."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erreur de lecture audio."
+          }
         }
       }
     },
@@ -1023,6 +1395,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo verificar el certificado del servidor. Es posible que debas confiar en este servidor."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Le certificat du serveur n'a pas pu être vérifié. Vous devrez peut-être approuver ce serveur."
           }
         }
       }
@@ -1042,6 +1420,12 @@
             "state": "needs_review",
             "value": "Ese valor no es válido."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cette valeur n'est pas valide."
+          }
         }
       }
     },
@@ -1059,6 +1443,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Algo salió mal."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Une erreur s'est produite."
           }
         }
       }
@@ -1078,6 +1468,12 @@
             "state": "needs_review",
             "value": "No se pudo iniciar la reproducción."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de démarrer la lecture."
+          }
         }
       }
     },
@@ -1095,6 +1491,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo cargar tu biblioteca."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger votre bibliothèque."
           }
         }
       }
@@ -1114,6 +1516,12 @@
             "state": "needs_review",
             "value": "No se pudieron cargar las listas de reproducción."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger les playlists."
+          }
         }
       }
     },
@@ -1131,6 +1539,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo cargar esta lista de reproducción."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger cette playlist."
           }
         }
       }
@@ -1150,6 +1564,12 @@
             "state": "needs_review",
             "value": "No se pudieron cargar las pistas del álbum."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger les pistes de l'album."
+          }
         }
       }
     },
@@ -1167,6 +1587,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudieron cargar las pistas de la lista de reproducción."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger les pistes de la playlist."
           }
         }
       }
@@ -1186,6 +1612,12 @@
             "state": "needs_review",
             "value": "Error al buscar."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Échec de la recherche."
+          }
         }
       }
     },
@@ -1203,6 +1635,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo actualizar favorito."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de mettre à jour le favori."
           }
         }
       }
@@ -1222,6 +1660,12 @@
             "state": "needs_review",
             "value": "No se pudo actualizar el estado de reproducción."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de mettre à jour l'état de lecture."
+          }
         }
       }
     },
@@ -1239,6 +1683,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo añadir a la lista de reproducción."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible d'ajouter à la playlist."
           }
         }
       }
@@ -1258,6 +1708,12 @@
             "state": "needs_review",
             "value": "Error al iniciar sesión."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Échec de la connexion."
+          }
         }
       }
     },
@@ -1275,6 +1731,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Usuario o contraseña incorrectos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom d'utilisateur ou mot de passe incorrect"
           }
         }
       }
@@ -1294,6 +1756,12 @@
             "state": "needs_review",
             "value": "Esta acción no está disponible aún."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cette action n'est pas encore disponible."
+          }
         }
       }
     },
@@ -1311,6 +1779,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sin red. Verifica tu conexión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pas de réseau. Vérifiez votre connexion."
           }
         }
       }
@@ -1330,6 +1804,12 @@
             "state": "needs_review",
             "value": "Verificando…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vérification…"
+          }
         }
       }
     },
@@ -1347,6 +1827,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "URL DEL SERVIDOR"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL DU SERVEUR"
           }
         }
       }
@@ -1366,6 +1852,12 @@
             "state": "needs_review",
             "value": "USUARIO"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOM D'UTILISATEUR"
+          }
         }
       }
     },
@@ -1383,6 +1875,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "CONTRASEÑA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "MOT DE PASSE"
           }
         }
       }
@@ -1402,6 +1900,12 @@
             "state": "needs_review",
             "value": "tú"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "vous"
+          }
         }
       }
     },
@@ -1419,6 +1923,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ENCONTRADO EN ESTA RED"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "TROUVÉ SUR CE RÉSEAU"
           }
         }
       }
@@ -1438,6 +1948,12 @@
             "state": "needs_review",
             "value": "URL del servidor"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL du serveur"
+          }
         }
       }
     },
@@ -1455,6 +1971,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Usuario"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom d'utilisateur"
           }
         }
       }
@@ -1474,6 +1996,12 @@
             "state": "needs_review",
             "value": "Contraseña"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mot de passe"
+          }
         }
       }
     },
@@ -1491,6 +2019,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atrás"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Retour"
           }
         }
       }
@@ -1510,6 +2044,12 @@
             "state": "needs_review",
             "value": "Bienvenido a Lyrebird"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bienvenue sur Lyrebird"
+          }
         }
       }
     },
@@ -1527,6 +2067,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tu música, tu servidor, tus reglas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Votre musique, votre serveur, vos règles."
           }
         }
       }
@@ -1546,6 +2092,12 @@
             "state": "needs_review",
             "value": "Comenzar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Commencer"
+          }
         }
       }
     },
@@ -1563,6 +2115,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ya tengo una cuenta →"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "J'ai déjà un compte →"
           }
         }
       }
@@ -1582,6 +2140,12 @@
             "state": "needs_review",
             "value": "Ya tengo una cuenta"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "J'ai déjà un compte"
+          }
         }
       }
     },
@@ -1599,6 +2163,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Conecta tu servidor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Connectez votre serveur"
           }
         }
       }
@@ -1618,6 +2188,12 @@
             "state": "needs_review",
             "value": "La URL de Jellyfin es la dirección que usas para acceder desde un navegador."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "L'URL Jellyfin est l'adresse que vous utilisez pour y accéder depuis un navigateur."
+          }
         }
       }
     },
@@ -1635,6 +2211,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Continuar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Continuer"
           }
         }
       }
@@ -1654,6 +2236,12 @@
             "state": "needs_review",
             "value": "Conectando…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Connexion…"
+          }
         }
       }
     },
@@ -1671,6 +2259,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Omitir, explorar sin conexión →"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ignorer, explorer hors ligne →"
           }
         }
       }
@@ -1690,6 +2284,12 @@
             "state": "needs_review",
             "value": "Cargando tu biblioteca"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chargement de votre bibliothèque"
+          }
         }
       }
     },
@@ -1707,6 +2307,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cargando artistas…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chargement des artistes…"
           }
         }
       }
@@ -1726,6 +2332,12 @@
             "state": "needs_review",
             "value": "Cargando álbumes…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chargement des albums…"
+          }
         }
       }
     },
@@ -1743,6 +2355,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cargando pistas…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chargement des pistes…"
           }
         }
       }
@@ -1762,6 +2380,12 @@
             "state": "needs_review",
             "value": "Obteniendo portadas…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Récupération des pochettes…"
+          }
         }
       }
     },
@@ -1779,6 +2403,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ pistas · %2$@ artistas · %3$@ álbumes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ pistes · %2$@ artistes · %3$@ albums"
           }
         }
       }
@@ -1798,6 +2428,12 @@
             "state": "needs_review",
             "value": "Ir a inicio"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accéder à l'accueil"
+          }
         }
       }
     },
@@ -1815,6 +2451,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sincronizando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Synchronisation…"
           }
         }
       }
@@ -1834,6 +2476,12 @@
             "state": "needs_review",
             "value": "No se pudo cargar tu biblioteca."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de charger votre bibliothèque."
+          }
         }
       }
     },
@@ -1851,6 +2499,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Intentar de nuevo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer"
           }
         }
       }
@@ -1870,6 +2524,12 @@
             "state": "needs_review",
             "value": "Acerca de Lyrebird"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "À propos de Lyrebird"
+          }
         }
       }
     },
@@ -1887,6 +2547,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nueva lista de reproducción…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nouvelle playlist…"
           }
         }
       }
@@ -1906,6 +2572,12 @@
             "state": "needs_review",
             "value": "Nueva ventana"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nouvelle fenêtre"
+          }
         }
       }
     },
@@ -1923,6 +2595,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mostrar barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Afficher la barre latérale"
           }
         }
       }
@@ -1942,6 +2620,12 @@
             "state": "needs_review",
             "value": "Mostrar inspector de cola"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Afficher l'inspecteur de file d'attente"
+          }
         }
       }
     },
@@ -1959,6 +2643,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Inicio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accueil"
           }
         }
       }
@@ -1978,6 +2668,12 @@
             "state": "needs_review",
             "value": "Biblioteca"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothèque"
+          }
         }
       }
     },
@@ -1995,6 +2691,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher"
           }
         }
       }
@@ -2014,6 +2716,12 @@
             "state": "needs_review",
             "value": "Buscar…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher…"
+          }
         }
       }
     },
@@ -2031,6 +2739,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar en la biblioteca…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher dans la bibliothèque…"
           }
         }
       }
@@ -2050,6 +2764,12 @@
             "state": "needs_review",
             "value": "Ir a reproducción actual"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aller à la lecture en cours"
+          }
         }
       }
     },
@@ -2067,6 +2787,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cola de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "File de lecture"
           }
         }
       }
@@ -2086,6 +2812,12 @@
             "state": "needs_review",
             "value": "Paleta de comandos…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Palette de commandes…"
+          }
         }
       }
     },
@@ -2103,6 +2835,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lecture"
           }
         }
       }
@@ -2122,6 +2860,12 @@
             "state": "needs_review",
             "value": "Reproducir"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire"
+          }
         }
       }
     },
@@ -2139,6 +2883,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
           }
         }
       }
@@ -2158,6 +2908,12 @@
             "state": "needs_review",
             "value": "Pista siguiente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Piste suivante"
+          }
         }
       }
     },
@@ -2175,6 +2931,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pista anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Piste précédente"
           }
         }
       }
@@ -2194,6 +2956,12 @@
             "state": "needs_review",
             "value": "Subir volumen"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Augmenter le volume"
+          }
         }
       }
     },
@@ -2211,6 +2979,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Bajar volumen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diminuer le volume"
           }
         }
       }
@@ -2230,6 +3004,12 @@
             "state": "needs_review",
             "value": "Avanzar 10s"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avancer de 10s"
+          }
         }
       }
     },
@@ -2247,6 +3027,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Retroceder 10s"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reculer de 10s"
           }
         }
       }
@@ -2266,6 +3052,12 @@
             "state": "needs_review",
             "value": "Detener"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Arrêter"
+          }
         }
       }
     },
@@ -2283,6 +3075,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ajustar ventana a la izquierda"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ancrer la fenêtre à gauche"
           }
         }
       }
@@ -2302,6 +3100,12 @@
             "state": "needs_review",
             "value": "Ajustar ventana a la derecha"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ancrer la fenêtre à droite"
+          }
         }
       }
     },
@@ -2319,6 +3123,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ayuda de Lyrebird"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aide Lyrebird"
           }
         }
       }
@@ -2338,6 +3148,12 @@
             "state": "needs_review",
             "value": "Alternar inspector de cola"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Basculer l'inspecteur de file d'attente"
+          }
         }
       }
     },
@@ -2355,6 +3171,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nada en reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rien en lecture"
           }
         }
       }
@@ -2374,6 +3196,12 @@
             "state": "needs_review",
             "value": "Inicio"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accueil"
+          }
         }
       }
     },
@@ -2392,6 +3220,12 @@
             "state": "needs_review",
             "value": "Descubrir"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Découvrir"
+          }
         }
       }
     },
@@ -2406,6 +3240,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Radio"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Radio"
@@ -2428,6 +3268,12 @@
             "state": "needs_review",
             "value": "Biblioteca"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bibliothèque"
+          }
         }
       }
     },
@@ -2446,6 +3292,12 @@
             "state": "needs_review",
             "value": "Buscar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher"
+          }
         }
       }
     },
@@ -2463,6 +3315,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tu biblioteca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Votre bibliothèque"
           }
         }
       }
@@ -2506,6 +3364,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld élément"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld éléments"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2523,6 +3399,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Desconectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Déconnecté"
           }
         }
       }
@@ -2542,6 +3424,12 @@
             "state": "needs_review",
             "value": "Favoritos"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favoris"
+          }
         }
       }
     },
@@ -2559,6 +3447,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Álbumes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Albums"
           }
         }
       }
@@ -2578,6 +3472,12 @@
             "state": "needs_review",
             "value": "Artistas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistes"
+          }
         }
       }
     },
@@ -2595,6 +3495,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Listas de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlists"
           }
         }
       }
@@ -2614,6 +3520,12 @@
             "state": "needs_review",
             "value": "Editar reglas de lista inteligente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modifier les règles de la playlist intelligente"
+          }
         }
       }
     },
@@ -2631,6 +3543,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproducir lista inteligente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire la playlist intelligente"
           }
         }
       }
@@ -2650,6 +3568,12 @@
             "state": "needs_review",
             "value": "Mezclar lista inteligente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lecture aléatoire de la playlist intelligente"
+          }
         }
       }
     },
@@ -2667,6 +3591,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "LISTA INTELIGENTE"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PLAYLIST INTELLIGENTE"
           }
         }
       }
@@ -2686,6 +3616,12 @@
             "state": "needs_review",
             "value": "Añadir regla"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ajouter une règle"
+          }
         }
       }
     },
@@ -2703,6 +3639,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Campo de regla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Champ de règle"
           }
         }
       }
@@ -2722,6 +3664,12 @@
             "state": "needs_review",
             "value": "Modo de coincidencia"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mode de correspondance"
+          }
         }
       }
     },
@@ -2739,6 +3687,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nombre de lista inteligente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom de la playlist intelligente"
           }
         }
       }
@@ -2758,6 +3712,12 @@
             "state": "needs_review",
             "value": "Operador de regla"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Opérateur de règle"
+          }
         }
       }
     },
@@ -2775,6 +3735,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Eliminar regla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Supprimer la règle"
           }
         }
       }
@@ -2794,6 +3760,12 @@
             "state": "needs_review",
             "value": "Guardar lista inteligente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Enregistrer la playlist intelligente"
+          }
         }
       }
     },
@@ -2811,6 +3783,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Valor de regla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valeur de règle"
           }
         }
       }
@@ -2830,6 +3808,12 @@
             "state": "needs_review",
             "value": "Valor de regla en días"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valeur de règle en jours"
+          }
         }
       }
     },
@@ -2847,6 +3831,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Añadir regla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ajouter une règle"
           }
         }
       }
@@ -2866,6 +3856,12 @@
             "state": "needs_review",
             "value": "no"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "non"
+          }
         }
       }
     },
@@ -2883,6 +3879,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "sí"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "oui"
           }
         }
       }
@@ -2902,6 +3904,12 @@
             "state": "needs_review",
             "value": "Cancelar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annuler"
+          }
         }
       }
     },
@@ -2919,6 +3927,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Contando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Comptage…"
           }
         }
       }
@@ -2938,6 +3952,12 @@
             "state": "needs_review",
             "value": "días"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "jours"
+          }
         }
       }
     },
@@ -2955,6 +3975,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lista inteligente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist intelligente"
           }
         }
       }
@@ -2998,6 +4024,24 @@
               }
             }
           }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld correspondance"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld correspondances"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3015,6 +4059,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Coincidir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Correspondre"
           }
         }
       }
@@ -3034,6 +4084,12 @@
             "state": "needs_review",
             "value": "de las siguientes reglas:"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "aux règles suivantes :"
+          }
         }
       }
     },
@@ -3051,6 +4107,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "NOMBRE"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOM"
           }
         }
       }
@@ -3070,6 +4132,12 @@
             "state": "needs_review",
             "value": "Nombre de la lista inteligente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom de la playlist intelligente"
+          }
         }
       }
     },
@@ -3087,6 +4155,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Enregistrer"
           }
         }
       }
@@ -3106,6 +4180,12 @@
             "state": "needs_review",
             "value": "Lista inteligente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist intelligente"
+          }
         }
       }
     },
@@ -3123,6 +4203,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "valor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "valeur"
           }
         }
       }
@@ -3142,6 +4228,12 @@
             "state": "needs_review",
             "value": "Editar reglas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modifier les règles"
+          }
         }
       }
     },
@@ -3159,6 +4251,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Se cargaron %lld pistas hasta ahora. Intenta relajar las reglas o abre la Biblioteca para tener más pistas en memoria."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%lld pistes chargées jusqu'ici. Essayez d'assouplir les règles ou ouvrez la Bibliothèque pour avoir plus de pistes en mémoire."
           }
         }
       }
@@ -3178,6 +4276,12 @@
             "state": "needs_review",
             "value": "Ninguna pista coincide con estas reglas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aucune piste ne correspond à ces règles"
+          }
         }
       }
     },
@@ -3195,6 +4299,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Álbum"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
           }
         }
       }
@@ -3214,6 +4324,12 @@
             "state": "needs_review",
             "value": "Artista"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artiste"
+          }
         }
       }
     },
@@ -3231,6 +4347,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Favorito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favori"
           }
         }
       }
@@ -3250,6 +4372,12 @@
             "state": "needs_review",
             "value": "Género"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genre"
+          }
         }
       }
     },
@@ -3267,6 +4395,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Duración (seg)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Durée (sec)"
           }
         }
       }
@@ -3286,6 +4420,12 @@
             "state": "needs_review",
             "value": "Última reproducción"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dernière lecture"
+          }
         }
       }
     },
@@ -3303,6 +4443,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproducciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre de lectures"
           }
         }
       }
@@ -3322,6 +4468,12 @@
             "state": "needs_review",
             "value": "Año"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Année"
+          }
         }
       }
     },
@@ -3339,6 +4491,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Filtrar pistas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Filtrer les pistes"
           }
         }
       }
@@ -3358,6 +4516,12 @@
             "state": "needs_review",
             "value": "todas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "toutes"
+          }
         }
       }
     },
@@ -3375,6 +4539,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "alguna"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "n'importe laquelle"
           }
         }
       }
@@ -3394,6 +4564,12 @@
             "state": "needs_review",
             "value": "Ninguna pista coincide con \"%@\""
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aucune piste ne correspond à \"%@\""
+          }
         }
       }
     },
@@ -3411,6 +4587,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lista inteligente no encontrada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist intelligente introuvable"
           }
         }
       }
@@ -3430,6 +4612,12 @@
             "state": "needs_review",
             "value": "contiene"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "contient"
+          }
         }
       }
     },
@@ -3447,6 +4635,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "mayor que"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "supérieur à"
           }
         }
       }
@@ -3466,6 +4660,12 @@
             "state": "needs_review",
             "value": "en los últimos (días)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "dans les derniers (jours)"
+          }
         }
       }
     },
@@ -3483,6 +4683,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "es"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "est"
           }
         }
       }
@@ -3502,6 +4708,12 @@
             "state": "needs_review",
             "value": "no es"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "n'est pas"
+          }
         }
       }
     },
@@ -3520,6 +4732,12 @@
             "state": "needs_review",
             "value": "menor que"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "inférieur à"
+          }
         }
       }
     },
@@ -3534,6 +4752,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "needs_review",
             "value": ", "
@@ -3556,6 +4780,12 @@
             "state": "needs_review",
             "value": "Coincide %1$@ de: %2$@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Correspond %1$@ parmi : %2$@"
+          }
         }
       }
     },
@@ -3573,6 +4803,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Coincide con todas las pistas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Correspond à toutes les pistes."
           }
         }
       }
@@ -3592,6 +4828,12 @@
             "state": "needs_review",
             "value": "Reintentar reproducir la pista fallida"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer de lire la piste en échec"
+          }
         }
       }
     },
@@ -3609,6 +4851,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ir a la pista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aller à la piste"
           }
         }
       }
@@ -3628,6 +4876,12 @@
             "state": "needs_review",
             "value": "No se pudo reproducir \"%@\". Omitiendo."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de lire \"%@\". Passage à la suivante."
+          }
         }
       }
     },
@@ -3645,6 +4899,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reintentar conexión de red"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer la connexion réseau"
           }
         }
       }
@@ -3664,6 +4924,12 @@
             "state": "needs_review",
             "value": "Estás sin conexión. Reproduciendo solo desde pistas descargadas."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vous êtes hors ligne. Lecture uniquement depuis les pistes téléchargées."
+          }
         }
       }
     },
@@ -3681,6 +4947,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Esto eliminará permanentemente esta lista de reproducción. Esta acción no se puede deshacer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cette action supprimera définitivement cette playlist. Cette action est irréversible."
           }
         }
       }
@@ -3700,6 +4972,12 @@
             "state": "needs_review",
             "value": "Álbum"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
         }
       }
     },
@@ -3717,6 +4995,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Disco"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Disque"
           }
         }
       }
@@ -3736,6 +5020,12 @@
             "state": "needs_review",
             "value": "Duración"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Durée"
+          }
         }
       }
     },
@@ -3753,6 +5043,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Formato"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Format"
           }
         }
       }
@@ -3772,6 +5068,12 @@
             "state": "needs_review",
             "value": "Reproducciones"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lectures"
+          }
         }
       }
     },
@@ -3789,6 +5091,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Piste"
           }
         }
       }
@@ -3808,6 +5116,12 @@
             "state": "needs_review",
             "value": "Año"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Année"
+          }
         }
       }
     },
@@ -3825,6 +5139,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproductor mini"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-lecteur"
           }
         }
       }
@@ -3844,6 +5164,12 @@
             "state": "needs_review",
             "value": "Reproduciendo ahora"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "En cours de lecture"
+          }
         }
       }
     },
@@ -3861,6 +5187,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Siguiente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suivant"
           }
         }
       }
@@ -3880,6 +5212,12 @@
             "state": "needs_review",
             "value": "Abrir Lyrebird"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ouvrir Lyrebird"
+          }
         }
       }
     },
@@ -3897,6 +5235,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
           }
         }
       }
@@ -3916,6 +5260,12 @@
             "state": "needs_review",
             "value": "Reproducir"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire"
+          }
         }
       }
     },
@@ -3933,6 +5283,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Précédent"
           }
         }
       }
@@ -3952,6 +5308,12 @@
             "state": "needs_review",
             "value": "Reproductor mini"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-lecteur"
+          }
         }
       }
     },
@@ -3969,6 +5331,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproductor mini"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini-lecteur"
           }
         }
       }
@@ -3988,6 +5356,12 @@
             "state": "needs_review",
             "value": "Portada. Arrastra para mover el reproductor mini."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pochette. Faites glisser pour déplacer le mini-lecteur."
+          }
         }
       }
     },
@@ -4005,6 +5379,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Opciones del reproductor mini"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Options du mini-lecteur"
           }
         }
       }
@@ -4024,6 +5404,12 @@
             "state": "needs_review",
             "value": "Siempre visible"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Toujours au premier plan"
+          }
         }
       }
     },
@@ -4041,6 +5427,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Volver a ventana completa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Revenir à la fenêtre complète"
           }
         }
       }
@@ -4060,6 +5452,12 @@
             "state": "needs_review",
             "value": "Transparente cuando está inactivo"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Transparent lorsqu'inactif"
+          }
         }
       }
     },
@@ -4077,6 +5475,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cerrar reproductor mini"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fermer le mini-lecteur"
           }
         }
       }
@@ -4096,6 +5500,12 @@
             "state": "needs_review",
             "value": "Portada. Toca para abrir el álbum; arrastra para mover el reproductor mini."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pochette. Appuyez pour ouvrir l'album ; faites glisser pour déplacer le mini-lecteur."
+          }
         }
       }
     },
@@ -4113,6 +5523,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abrir página del artista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ouvrir la page de l'artiste"
           }
         }
       }
@@ -4132,6 +5548,12 @@
             "state": "needs_review",
             "value": "Expandir a ventana completa"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Agrandir à la fenêtre complète"
+          }
         }
       }
     },
@@ -4149,6 +5571,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Favorito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favori"
           }
         }
       }
@@ -4168,6 +5596,12 @@
             "state": "needs_review",
             "value": "Quitar de favoritos"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Retirer des favoris"
+          }
         }
       }
     },
@@ -4185,6 +5619,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pista anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Piste précédente"
           }
         }
       }
@@ -4204,6 +5644,12 @@
             "state": "needs_review",
             "value": "Reproducir"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire"
+          }
         }
       }
     },
@@ -4221,6 +5667,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pause"
           }
         }
       }
@@ -4240,6 +5692,12 @@
             "state": "needs_review",
             "value": "Pista siguiente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Piste suivante"
+          }
         }
       }
     },
@@ -4257,6 +5715,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Volver a ventana completa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Revenir à la fenêtre complète"
           }
         }
       }
@@ -4276,6 +5740,12 @@
             "state": "needs_review",
             "value": "Volumen"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volume"
+          }
         }
       }
     },
@@ -4293,6 +5763,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Posición de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Position de lecture"
           }
         }
       }
@@ -4312,6 +5788,12 @@
             "state": "needs_review",
             "value": "Exportar paquete de diagnóstico…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exporter le bundle de diagnostic…"
+          }
         }
       }
     },
@@ -4328,6 +5810,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atajos de teclado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Raccourcis clavier"
           }
         }
       }
@@ -4346,6 +5834,12 @@
             "state": "needs_review",
             "value": "Reproducir / Pausar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire / Pause"
+          }
         }
       }
     },
@@ -4362,6 +5856,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar atajos de teclado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher des raccourcis clavier"
           }
         }
       }
@@ -4380,6 +5880,12 @@
             "state": "needs_review",
             "value": "Borrar búsqueda"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Effacer la recherche"
+          }
         }
       }
     },
@@ -4396,6 +5902,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ningún atajo coincide con tu búsqueda"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aucun raccourci ne correspond à votre recherche"
           }
         }
       }
@@ -4414,6 +5926,12 @@
             "state": "needs_review",
             "value": "Buscar atajos"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechercher des raccourcis"
+          }
         }
       }
     },
@@ -4430,6 +5948,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Archivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fichier"
           }
         }
       }
@@ -4448,6 +5972,12 @@
             "state": "needs_review",
             "value": "Reproducción"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lecture"
+          }
         }
       }
     },
@@ -4464,6 +5994,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Vista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Affichage"
           }
         }
       }
@@ -4482,6 +6018,12 @@
             "state": "needs_review",
             "value": "Ventana"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fenêtre"
+          }
         }
       }
     },
@@ -4498,6 +6040,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atajos de teclado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Raccourcis clavier"
           }
         }
       }
@@ -4517,6 +6065,12 @@
             "state": "needs_review",
             "value": "Álbumes"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Albums"
+          }
         }
       }
     },
@@ -4534,6 +6088,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tout"
           }
         }
       }
@@ -4553,6 +6113,12 @@
             "state": "needs_review",
             "value": "Artistas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistes"
+          }
         }
       }
     },
@@ -4570,6 +6136,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Géneros"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genres"
           }
         }
       }
@@ -4589,6 +6161,12 @@
             "state": "needs_review",
             "value": "Pistas"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pistes"
+          }
         }
       }
     },
@@ -4606,6 +6184,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cerrar selector de mezcla instantánea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fermer le sélecteur de mix instantané"
           }
         }
       }
@@ -4625,6 +6209,12 @@
             "state": "needs_review",
             "value": "Busca algo para crear una mezcla."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Recherchez quelque chose pour créer un mix."
+          }
         }
       }
     },
@@ -4642,6 +6232,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Generar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Générer"
           }
         }
       }
@@ -4661,6 +6257,12 @@
             "state": "needs_review",
             "value": "Última mezcla:"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dernier mix :"
+          }
         }
       }
     },
@@ -4678,6 +6280,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sin coincidencias"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aucun résultat"
           }
         }
       }
@@ -4697,6 +6305,12 @@
             "state": "needs_review",
             "value": "Busca una pista, álbum, artista o género"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Recherchez une piste, un album, un artiste ou un genre"
+          }
         }
       }
     },
@@ -4714,6 +6328,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Origen:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Origine :"
           }
         }
       }
@@ -4733,6 +6353,12 @@
             "state": "needs_review",
             "value": "Nueva mezcla instantánea"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nouveau mix instantané"
+          }
         }
       }
     },
@@ -4750,6 +6376,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nueva mezcla instantánea…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nouveau mix instantané…"
           }
         }
       }
@@ -4769,6 +6401,12 @@
             "state": "needs_review",
             "value": "Mostrar visita guiada"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Afficher la visite guidée"
+          }
         }
       }
     },
@@ -4786,6 +6424,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Visita guiada de funciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Visite guidée des fonctionnalités"
           }
         }
       }
@@ -4805,6 +6449,12 @@
             "state": "needs_review",
             "value": "Paso %1$lld de %2$lld"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Étape %1$lld sur %2$lld"
+          }
         }
       }
     },
@@ -4822,6 +6472,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atajo de teclado %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Raccourci clavier %@"
           }
         }
       }
@@ -4841,6 +6497,12 @@
             "state": "needs_review",
             "value": "Atrás"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Précédent"
+          }
         }
       }
     },
@@ -4858,6 +6520,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Listo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Terminé"
           }
         }
       }
@@ -4877,6 +6545,12 @@
             "state": "needs_review",
             "value": "Pulsa ⌘⌥P para un reproductor compacto, siempre visible, que puedes colocar en una esquina mientras trabajas."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Appuyez sur ⌘⌥P pour un lecteur compact, toujours au premier plan, que vous pouvez placer dans un coin pendant que vous travaillez."
+          }
         }
       }
     },
@@ -4894,6 +6568,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abre el reproductor mini"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ouvrez le mini-lecteur"
           }
         }
       }
@@ -4913,6 +6593,12 @@
             "state": "needs_review",
             "value": "Siguiente"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suivant"
+          }
         }
       }
     },
@@ -4930,6 +6616,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Haz clic derecho en cualquier pista, álbum, artista o lista de reproducción para acciones rápidas — reproducir a continuación, añadir a una lista, iniciar una radio y más."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cliquez avec le bouton droit sur n'importe quelle piste, album, artiste ou playlist pour des actions rapides — lire ensuite, ajouter à une playlist, démarrer une station radio, et plus encore."
           }
         }
       }
@@ -4949,6 +6641,12 @@
             "state": "needs_review",
             "value": "Clic derecho para más opciones"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Clic droit pour plus d'options"
+          }
         }
       }
     },
@@ -4966,6 +6664,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pulsa ⌘F para ir directamente a la búsqueda y encontrar cualquier canción, álbum o artista en tu biblioteca."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Appuyez sur ⌘F pour accéder directement à la recherche et trouver n'importe quelle chanson, album ou artiste dans votre bibliothèque."
           }
         }
       }
@@ -4985,6 +6689,12 @@
             "state": "needs_review",
             "value": "Encuentra cualquier cosa rápido"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Trouvez n'importe quoi rapidement"
+          }
         }
       }
     },
@@ -5002,6 +6712,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Omitir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Passer"
           }
         }
       }
@@ -5021,6 +6737,12 @@
             "state": "needs_review",
             "value": "Pulsa la barra espaciadora fuera de un campo de texto para reproducir o pausar la pista actual."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Appuyez sur la barre d'espace n'importe où en dehors d'un champ de texte pour lire ou mettre en pause la piste en cours."
+          }
         }
       }
     },
@@ -5038,6 +6760,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproducir y pausar con Espacio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lire et mettre en pause avec Espace"
           }
         }
       }
@@ -5057,6 +6785,12 @@
             "state": "needs_review",
             "value": "No se pudieron abrir los datos locales de Lyrebird. Normalmente se puede solucionar: restablece los datos locales para empezar de nuevo, o exporta un paquete de diagnóstico para compartir con un informe de error."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Les données locales de Lyrebird n'ont pas pu être ouvertes. Cela se résout généralement ainsi : réinitialisez les données locales pour repartir de zéro, ou exportez un bundle de diagnostic à joindre à un rapport de bug."
+          }
         }
       }
     },
@@ -5074,6 +6808,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Exportar diagnóstico…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exporter le diagnostic…"
           }
         }
       }
@@ -5093,6 +6833,12 @@
             "state": "needs_review",
             "value": "Diagnóstico exportado."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnostic exporté."
+          }
         }
       }
     },
@@ -5110,6 +6856,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo exportar el diagnóstico: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible d'exporter le diagnostic : %@"
           }
         }
       }
@@ -5129,6 +6881,12 @@
             "state": "needs_review",
             "value": "Salir"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quitter"
+          }
         }
       }
     },
@@ -5146,6 +6904,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Restablecer datos locales"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réinitialiser les données locales"
           }
         }
       }
@@ -5165,6 +6929,12 @@
             "state": "needs_review",
             "value": "Los datos locales se movieron a:\n%@\nSal y vuelve a abrir Lyrebird."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Les données locales ont été déplacées vers :\n%@\nVeuillez quitter et relancer Lyrebird."
+          }
         }
       }
     },
@@ -5182,6 +6952,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudieron restablecer los datos locales: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossible de réinitialiser les données locales : %@"
           }
         }
       }
@@ -5201,6 +6977,12 @@
             "state": "needs_review",
             "value": "No se encontraron datos locales para restablecer. Intenta exportar el diagnóstico."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aucune donnée locale à réinitialiser. Essayez d'exporter le diagnostic."
+          }
         }
       }
     },
@@ -5218,6 +7000,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird no pudo iniciarse"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird n'a pas pu démarrer"
           }
         }
       }
@@ -5237,6 +7025,12 @@
             "state": "needs_review",
             "value": "Nombre del dispositivo"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom de l'appareil"
+          }
         }
       }
     },
@@ -5254,6 +7048,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nombre del dispositivo: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom de l'appareil : %@"
           }
         }
       }
@@ -5273,6 +7073,12 @@
             "state": "needs_review",
             "value": "Cancelar"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annuler"
+          }
         }
       }
     },
@@ -5290,6 +7096,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cambia el nombre que Jellyfin muestra para este dispositivo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modifiez le nom que Jellyfin affiche pour cet appareil."
           }
         }
       }
@@ -5309,6 +7121,12 @@
             "state": "needs_review",
             "value": "Mi Mac"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mon Mac"
+          }
         }
       }
     },
@@ -5326,6 +7144,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Enregistrer"
           }
         }
       }
@@ -5345,6 +7169,12 @@
             "state": "needs_review",
             "value": "Se muestra en el panel de este servidor y en otros clientes de Jellyfin."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Affiché dans le tableau de bord de ce serveur et dans les autres clients Jellyfin."
+          }
         }
       }
     },
@@ -5362,6 +7192,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nombre del dispositivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nom de l'appareil"
           }
         }
       }
@@ -5381,6 +7217,12 @@
             "state": "needs_review",
             "value": "Empareja este dispositivo introduciendo un código en otro cliente de Jellyfin con sesión iniciada."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Associez cet appareil en saisissant un code dans un autre client Jellyfin connecté."
+          }
         }
       }
     },
@@ -5398,6 +7240,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cancelar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annuler"
           }
         }
       }
@@ -5417,6 +7265,12 @@
             "state": "needs_review",
             "value": "CÓDIGO"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CODE"
+          }
         }
       }
     },
@@ -5434,6 +7288,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "No se pudo completar Quick Connect. Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect n'a pas pu être finalisé. Veuillez réessayer."
           }
         }
       }
@@ -5453,6 +7313,12 @@
             "state": "needs_review",
             "value": "Usar Jellyfin Quick Connect"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Utiliser Jellyfin Quick Connect"
+          }
         }
       }
     },
@@ -5470,6 +7336,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Introduce la dirección de tu servidor en la pantalla de inicio de sesión primero, luego prueba Quick Connect."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Saisissez l'adresse de votre serveur sur l'écran de connexion d'abord, puis réessayez Quick Connect."
           }
         }
       }
@@ -5489,6 +7361,12 @@
             "state": "needs_review",
             "value": "Intentar de nuevo"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Réessayer"
+          }
         }
       }
     },
@@ -5506,6 +7384,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Iniciando Quick Connect…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Démarrage de Quick Connect…"
           }
         }
       }
@@ -5525,6 +7409,12 @@
             "state": "needs_review",
             "value": "Introduce este código en otra app de Jellyfin con sesión iniciada para emparejar este dispositivo."
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Saisissez ce code dans une autre app Jellyfin connectée pour associer cet appareil."
+          }
         }
       }
     },
@@ -5539,6 +7429,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect"
@@ -5560,6 +7456,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Esperando aprobación…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "En attente d'approbation…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -40,6 +40,12 @@
             "state": "needs_review",
             "value": "Sobre o Lyrebird"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Informazioni su Lyrebird"
+          }
         }
       }
     },
@@ -78,6 +84,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -124,6 +136,12 @@
             "state": "needs_review",
             "value": "DESKTOP"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "DESKTOP"
+          }
         }
       }
     },
@@ -165,6 +183,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sua sessão expirou"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La sessione è scaduta"
           }
         }
       }
@@ -208,6 +232,12 @@
             "state": "needs_review",
             "value": "Faça login novamente para continuar ouvindo."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accedi di nuovo per continuare ad ascoltare."
+          }
         }
       }
     },
@@ -249,6 +279,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Entrar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accedi"
           }
         }
       }
@@ -292,6 +328,12 @@
             "state": "needs_review",
             "value": "Entrar novamente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accedi di nuovo"
+          }
         }
       }
     },
@@ -333,6 +375,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Entrando…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accesso in corso…"
           }
         }
       }
@@ -376,6 +424,12 @@
             "state": "needs_review",
             "value": "Não foi possível alcançar o seu servidor."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile raggiungere il server."
+          }
         }
       }
     },
@@ -417,6 +471,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível alcançar %@. Tentando novamente…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile raggiungere %@. Nuovo tentativo…"
           }
         }
       }
@@ -460,6 +520,12 @@
             "state": "needs_review",
             "value": "Tentar reconectar ao servidor"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova la connessione al server"
+          }
         }
       }
     },
@@ -502,6 +568,12 @@
             "state": "needs_review",
             "value": "Álbum"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
         }
       }
     },
@@ -540,6 +612,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Artista"
@@ -586,6 +664,12 @@
             "state": "needs_review",
             "value": "Playlist"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist"
+          }
         }
       }
     },
@@ -627,6 +711,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cancelar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annulla"
           }
         }
       }
@@ -670,6 +760,12 @@
             "state": "needs_review",
             "value": "Excluir"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Elimina"
+          }
         }
       }
     },
@@ -711,6 +807,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Dispensar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ignora"
           }
         }
       }
@@ -754,6 +856,12 @@
             "state": "needs_review",
             "value": "Concluído"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fine"
+          }
         }
       }
     },
@@ -795,6 +903,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tentar novamente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova"
           }
         }
       }
@@ -900,6 +1014,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld álbuns"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld album"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld album"
                 }
               }
             }
@@ -1012,6 +1144,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artista"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artisti"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1116,6 +1266,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld itens"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elemento"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elementi"
                 }
               }
             }
@@ -1228,6 +1396,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlist"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlist"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1332,6 +1518,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld reproduções"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld riproduzione"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld riproduzioni"
                 }
               }
             }
@@ -1444,6 +1648,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld risultato"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld risultati"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1548,6 +1770,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld selecionados"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld selezionato"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld selezionati"
                 }
               }
             }
@@ -1660,6 +1900,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld canzone"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld canzoni"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1768,6 +2026,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld brano"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld brani"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1809,6 +2085,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nenhuma música ainda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessuna musica ancora"
           }
         }
       }
@@ -1852,6 +2134,12 @@
             "state": "needs_review",
             "value": "Seu servidor Jellyfin não tem música na biblioteca, ou ela ainda está sendo indexada. Adicione uma biblioteca no servidor e atualize."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Il server Jellyfin non ha musica nella libreria, o è ancora in fase di indicizzazione. Aggiungi una libreria sul server, poi aggiorna."
+          }
         }
       }
     },
@@ -1893,6 +2181,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abrir Jellyfin web"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Apri Jellyfin web"
           }
         }
       }
@@ -1936,6 +2230,12 @@
             "state": "needs_review",
             "value": "A fila está vazia"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La coda è vuota"
+          }
         }
       }
     },
@@ -1977,6 +2277,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproduza algo para iniciar uma fila."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci qualcosa per avviare una coda."
           }
         }
       }
@@ -2020,6 +2326,12 @@
             "state": "needs_review",
             "value": "Faça login novamente."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accedi di nuovo."
+          }
         }
       }
     },
@@ -2061,6 +2373,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Você não tem permissão para fazer isso."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Non hai il permesso di farlo."
           }
         }
       }
@@ -2104,6 +2422,12 @@
             "state": "needs_review",
             "value": "Esse item não foi encontrado."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quell'elemento non è stato trovato."
+          }
         }
       }
     },
@@ -2145,6 +2469,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Muitas solicitações. Tente novamente em um momento."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Troppe richieste. Riprova tra un momento."
           }
         }
       }
@@ -2188,6 +2518,12 @@
             "state": "needs_review",
             "value": "Erro de rede. Verifique sua conexão e tente novamente."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Errore di rete. Controlla la connessione e riprova."
+          }
         }
       }
     },
@@ -2229,6 +2565,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "O servidor encontrou um problema. Tente novamente."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Il server ha riscontrato un problema. Riprova."
           }
         }
       }
@@ -2272,6 +2614,12 @@
             "state": "needs_review",
             "value": "Não foi possível ler a resposta do servidor."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile leggere la risposta del server."
+          }
         }
       }
     },
@@ -2313,6 +2661,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível baixar para reprodução offline."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile scaricare per la riproduzione offline."
           }
         }
       }
@@ -2356,6 +2710,12 @@
             "state": "needs_review",
             "value": "Erro de armazenamento local. Tente novamente."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Errore di archiviazione locale. Riprova."
+          }
         }
       }
     },
@@ -2397,6 +2757,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível acessar o chaveiro do sistema."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile accedere al portachiavi di sistema."
           }
         }
       }
@@ -2440,6 +2806,12 @@
             "state": "needs_review",
             "value": "Erro de reprodução de áudio."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Errore di riproduzione audio."
+          }
         }
       }
     },
@@ -2481,6 +2853,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível verificar o certificado do servidor. Talvez seja necessário confiar neste servidor."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile verificare il certificato del server. Potrebbe essere necessario approvare questo server."
           }
         }
       }
@@ -2524,6 +2902,12 @@
             "state": "needs_review",
             "value": "Esse valor não é válido."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Questo valore non è valido."
+          }
         }
       }
     },
@@ -2565,6 +2949,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Algo deu errado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Qualcosa è andato storto."
           }
         }
       }
@@ -2608,6 +2998,12 @@
             "state": "needs_review",
             "value": "Não foi possível iniciar a reprodução."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile avviare la riproduzione."
+          }
         }
       }
     },
@@ -2649,6 +3045,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível carregar sua biblioteca."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare la libreria."
           }
         }
       }
@@ -2692,6 +3094,12 @@
             "state": "needs_review",
             "value": "Não foi possível carregar as playlists."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare le playlist."
+          }
         }
       }
     },
@@ -2733,6 +3141,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível carregar esta playlist."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare questa playlist."
           }
         }
       }
@@ -2776,6 +3190,12 @@
             "state": "needs_review",
             "value": "Não foi possível carregar as faixas do álbum."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare i brani dell'album."
+          }
         }
       }
     },
@@ -2817,6 +3237,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível carregar as faixas da playlist."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare i brani della playlist."
           }
         }
       }
@@ -2860,6 +3286,12 @@
             "state": "needs_review",
             "value": "A busca falhou."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ricerca non riuscita."
+          }
         }
       }
     },
@@ -2901,6 +3333,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível atualizar o favorito."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile aggiornare il preferito."
           }
         }
       }
@@ -2944,6 +3382,12 @@
             "state": "needs_review",
             "value": "Não foi possível atualizar o status de reprodução."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile aggiornare lo stato di riproduzione."
+          }
         }
       }
     },
@@ -2985,6 +3429,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível adicionar à playlist."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile aggiungere alla playlist."
           }
         }
       }
@@ -3028,6 +3478,12 @@
             "state": "needs_review",
             "value": "Falha ao entrar."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Accesso non riuscito."
+          }
         }
       }
     },
@@ -3069,6 +3525,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Usuário ou senha incorretos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome utente o password errati"
           }
         }
       }
@@ -3112,6 +3574,12 @@
             "state": "needs_review",
             "value": "Esta ação ainda não está disponível."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Questa azione non è ancora disponibile."
+          }
         }
       }
     },
@@ -3153,6 +3621,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sem rede. Verifique sua conexão."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessuna rete. Controlla la connessione."
           }
         }
       }
@@ -3196,6 +3670,12 @@
             "state": "needs_review",
             "value": "Verificando…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Verifica…"
+          }
         }
       }
     },
@@ -3237,6 +3717,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "URL DO SERVIDOR"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL SERVER"
           }
         }
       }
@@ -3280,6 +3766,12 @@
             "state": "needs_review",
             "value": "USUÁRIO"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOME UTENTE"
+          }
         }
       }
     },
@@ -3321,6 +3813,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "SENHA"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PASSWORD"
           }
         }
       }
@@ -3364,6 +3862,12 @@
             "state": "needs_review",
             "value": "você"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "tu"
+          }
         }
       }
     },
@@ -3405,6 +3909,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ENCONTRADO NESTA REDE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "TROVATO IN QUESTA RETE"
           }
         }
       }
@@ -3448,6 +3958,12 @@
             "state": "needs_review",
             "value": "URL do servidor"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL server"
+          }
         }
       }
     },
@@ -3489,6 +4005,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Usuário"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome utente"
           }
         }
       }
@@ -3532,6 +4054,12 @@
             "state": "needs_review",
             "value": "Senha"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Password"
+          }
         }
       }
     },
@@ -3573,6 +4101,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Voltar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Indietro"
           }
         }
       }
@@ -3616,6 +4150,12 @@
             "state": "needs_review",
             "value": "Bem-vindo ao Lyrebird"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Benvenuto in Lyrebird"
+          }
         }
       }
     },
@@ -3657,6 +4197,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sua música, seu servidor, suas regras."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La tua musica, il tuo server, le tue regole."
           }
         }
       }
@@ -3700,6 +4246,12 @@
             "state": "needs_review",
             "value": "Começar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inizia"
+          }
         }
       }
     },
@@ -3741,6 +4293,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Já tenho uma conta →"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ho già un account →"
           }
         }
       }
@@ -3784,6 +4342,12 @@
             "state": "needs_review",
             "value": "Já tenho uma conta"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ho già un account"
+          }
         }
       }
     },
@@ -3825,6 +4389,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Conecte seu servidor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Connetti il tuo server"
           }
         }
       }
@@ -3868,6 +4438,12 @@
             "state": "needs_review",
             "value": "A URL do Jellyfin é o endereço que você usa para acessá-lo pelo navegador."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "L'URL di Jellyfin è l'indirizzo che usi per accedervi dal browser."
+          }
         }
       }
     },
@@ -3909,6 +4485,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Continuar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Continua"
           }
         }
       }
@@ -3952,6 +4534,12 @@
             "state": "needs_review",
             "value": "Conectando…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Connessione…"
+          }
         }
       }
     },
@@ -3993,6 +4581,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pular, explorar offline →"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salta, esplora offline →"
           }
         }
       }
@@ -4036,6 +4630,12 @@
             "state": "needs_review",
             "value": "Carregando sua biblioteca"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Caricamento libreria"
+          }
         }
       }
     },
@@ -4077,6 +4677,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carregando artistas…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Caricamento artisti…"
           }
         }
       }
@@ -4120,6 +4726,12 @@
             "state": "needs_review",
             "value": "Carregando álbuns…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Caricamento album…"
+          }
         }
       }
     },
@@ -4161,6 +4773,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carregando faixas…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Caricamento brani…"
           }
         }
       }
@@ -4204,6 +4822,12 @@
             "state": "needs_review",
             "value": "Buscando capas…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Recupero copertine…"
+          }
         }
       }
     },
@@ -4245,6 +4869,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ faixas · %2$@ artistas · %3$@ álbuns"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ brani · %2$@ artisti · %3$@ album"
           }
         }
       }
@@ -4288,6 +4918,12 @@
             "state": "needs_review",
             "value": "Ir para o início"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vai alla home"
+          }
         }
       }
     },
@@ -4329,6 +4965,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sincronizando…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sincronizzazione…"
           }
         }
       }
@@ -4372,6 +5014,12 @@
             "state": "needs_review",
             "value": "Não foi possível carregar sua biblioteca."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile caricare la libreria."
+          }
         }
       }
     },
@@ -4413,6 +5061,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tentar novamente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova"
           }
         }
       }
@@ -4456,6 +5110,12 @@
             "state": "needs_review",
             "value": "Sobre o Lyrebird"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Informazioni su Lyrebird"
+          }
         }
       }
     },
@@ -4497,6 +5157,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nova Playlist…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nuova Playlist…"
           }
         }
       }
@@ -4540,6 +5206,12 @@
             "state": "needs_review",
             "value": "Nova Janela"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nuova Finestra"
+          }
         }
       }
     },
@@ -4581,6 +5253,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mostrar Barra Lateral"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostra Barra Laterale"
           }
         }
       }
@@ -4624,6 +5302,12 @@
             "state": "needs_review",
             "value": "Mostrar Inspetor de Fila"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostra Ispettore Coda"
+          }
         }
       }
     },
@@ -4665,6 +5349,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Início"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Home"
           }
         }
       }
@@ -4708,6 +5398,12 @@
             "state": "needs_review",
             "value": "Biblioteca"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Libreria"
+          }
         }
       }
     },
@@ -4749,6 +5445,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca"
           }
         }
       }
@@ -4792,6 +5494,12 @@
             "state": "needs_review",
             "value": "Buscar…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca…"
+          }
         }
       }
     },
@@ -4833,6 +5541,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar na Biblioteca…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca nella Libreria…"
           }
         }
       }
@@ -4876,6 +5590,12 @@
             "state": "needs_review",
             "value": "Ir para Reproduzindo Agora"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vai a In Riproduzione"
+          }
         }
       }
     },
@@ -4917,6 +5637,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fila de Reprodução"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Coda di Riproduzione"
           }
         }
       }
@@ -4960,6 +5686,12 @@
             "state": "needs_review",
             "value": "Paleta de Comandos…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tavolozza Comandi…"
+          }
         }
       }
     },
@@ -5001,6 +5733,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reprodução"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduzione"
           }
         }
       }
@@ -5044,6 +5782,12 @@
             "state": "needs_review",
             "value": "Reproduzir"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci"
+          }
         }
       }
     },
@@ -5085,6 +5829,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausa"
           }
         }
       }
@@ -5128,6 +5878,12 @@
             "state": "needs_review",
             "value": "Próxima Faixa"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brano Successivo"
+          }
         }
       }
     },
@@ -5169,6 +5925,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Faixa Anterior"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brano Precedente"
           }
         }
       }
@@ -5212,6 +5974,12 @@
             "state": "needs_review",
             "value": "Aumentar Volume"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alza Volume"
+          }
         }
       }
     },
@@ -5253,6 +6021,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Diminuir Volume"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abbassa Volume"
           }
         }
       }
@@ -5296,6 +6070,12 @@
             "state": "needs_review",
             "value": "Avançar 10s"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avanza 10s"
+          }
         }
       }
     },
@@ -5337,6 +6117,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Retroceder 10s"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Indietro 10s"
           }
         }
       }
@@ -5380,6 +6166,12 @@
             "state": "needs_review",
             "value": "Parar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ferma"
+          }
         }
       }
     },
@@ -5421,6 +6213,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Organizar Janela à Esquerda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Affianca Finestra a Sinistra"
           }
         }
       }
@@ -5464,6 +6262,12 @@
             "state": "needs_review",
             "value": "Organizar Janela à Direita"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Affianca Finestra a Destra"
+          }
         }
       }
     },
@@ -5505,6 +6309,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ajuda do Lyrebird"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Guida Lyrebird"
           }
         }
       }
@@ -5548,6 +6358,12 @@
             "state": "needs_review",
             "value": "Alternar Inspetor de Fila"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Attiva/Disattiva Ispettore Coda"
+          }
         }
       }
     },
@@ -5589,6 +6405,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nada sendo reproduzido"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessuna riproduzione"
           }
         }
       }
@@ -5632,6 +6454,12 @@
             "state": "needs_review",
             "value": "Início"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Home"
+          }
         }
       }
     },
@@ -5673,6 +6501,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Descobrir"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Scopri"
           }
         }
       }
@@ -5716,6 +6550,12 @@
             "state": "needs_review",
             "value": "Rádio"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Radio"
+          }
         }
       }
     },
@@ -5757,6 +6597,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Biblioteca"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Libreria"
           }
         }
       }
@@ -5800,6 +6646,12 @@
             "state": "needs_review",
             "value": "Buscar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca"
+          }
         }
       }
     },
@@ -5841,6 +6693,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Minha Biblioteca"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La Mia Libreria"
           }
         }
       }
@@ -5950,6 +6808,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elemento"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elementi"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -5991,6 +6867,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Desconectado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Disconnesso"
           }
         }
       }
@@ -6034,6 +6916,12 @@
             "state": "needs_review",
             "value": "Favoritos"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Preferiti"
+          }
         }
       }
     },
@@ -6075,6 +6963,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Álbuns"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
           }
         }
       }
@@ -6118,6 +7012,12 @@
             "state": "needs_review",
             "value": "Artistas"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artisti"
+          }
         }
       }
     },
@@ -6159,6 +7059,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlists"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist"
           }
         }
       }
@@ -6202,6 +7108,12 @@
             "state": "needs_review",
             "value": "Editar regras da playlist inteligente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modifica regole playlist intelligente"
+          }
         }
       }
     },
@@ -6243,6 +7155,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproduzir playlist inteligente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci playlist intelligente"
           }
         }
       }
@@ -6286,6 +7204,12 @@
             "state": "needs_review",
             "value": "Embaralhar playlist inteligente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduzione casuale playlist intelligente"
+          }
         }
       }
     },
@@ -6327,6 +7251,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "PLAYLIST INTELIGENTE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PLAYLIST INTELLIGENTE"
           }
         }
       }
@@ -6370,6 +7300,12 @@
             "state": "needs_review",
             "value": "Adicionar regra"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aggiungi regola"
+          }
         }
       }
     },
@@ -6411,6 +7347,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Campo da regra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Campo regola"
           }
         }
       }
@@ -6454,6 +7396,12 @@
             "state": "needs_review",
             "value": "Modo de correspondência"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modalità corrispondenza"
+          }
         }
       }
     },
@@ -6495,6 +7443,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome da playlist inteligente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome playlist intelligente"
           }
         }
       }
@@ -6538,6 +7492,12 @@
             "state": "needs_review",
             "value": "Operador da regra"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Operatore regola"
+          }
         }
       }
     },
@@ -6579,6 +7539,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Remover regra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rimuovi regola"
           }
         }
       }
@@ -6622,6 +7588,12 @@
             "state": "needs_review",
             "value": "Salvar playlist inteligente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salva playlist intelligente"
+          }
         }
       }
     },
@@ -6663,6 +7635,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Valor da regra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valore regola"
           }
         }
       }
@@ -6706,6 +7684,12 @@
             "state": "needs_review",
             "value": "Valor da regra em dias"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valore regola in giorni"
+          }
         }
       }
     },
@@ -6747,6 +7731,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Adicionar Regra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aggiungi Regola"
           }
         }
       }
@@ -6790,6 +7780,12 @@
             "state": "needs_review",
             "value": "não"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "no"
+          }
         }
       }
     },
@@ -6831,6 +7827,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "sim"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "sì"
           }
         }
       }
@@ -6874,6 +7876,12 @@
             "state": "needs_review",
             "value": "Cancelar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annulla"
+          }
         }
       }
     },
@@ -6915,6 +7923,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Contando…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Conteggio…"
           }
         }
       }
@@ -6958,6 +7972,12 @@
             "state": "needs_review",
             "value": "dias"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "giorni"
+          }
         }
       }
     },
@@ -6999,6 +8019,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist Inteligente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist Intelligente"
           }
         }
       }
@@ -7108,6 +8134,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld corrispondenza"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld corrispondenze"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -7149,6 +8193,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Corresponder"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corrisponde"
           }
         }
       }
@@ -7192,6 +8242,12 @@
             "state": "needs_review",
             "value": "das seguintes regras:"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "delle seguenti regole:"
+          }
         }
       }
     },
@@ -7230,6 +8286,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOME"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "NOME"
@@ -7276,6 +8338,12 @@
             "state": "needs_review",
             "value": "Nome da Playlist Inteligente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome Playlist Intelligente"
+          }
         }
       }
     },
@@ -7317,6 +8385,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salvar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salva"
           }
         }
       }
@@ -7360,6 +8434,12 @@
             "state": "needs_review",
             "value": "Playlist Inteligente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist Intelligente"
+          }
         }
       }
     },
@@ -7401,6 +8481,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "valor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "valore"
           }
         }
       }
@@ -7444,6 +8530,12 @@
             "state": "needs_review",
             "value": "Editar Regras"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modifica Regole"
+          }
         }
       }
     },
@@ -7485,6 +8577,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld faixas carregadas até agora. Tente relaxar as regras ou abra a Biblioteca para ter mais faixas na memória."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%lld brani caricati finora. Prova ad allentare le regole o apri la Libreria per avere più brani in memoria."
           }
         }
       }
@@ -7528,6 +8626,12 @@
             "state": "needs_review",
             "value": "Nenhuma faixa corresponde a essas regras"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessun brano corrisponde a queste regole"
+          }
         }
       }
     },
@@ -7570,6 +8674,12 @@
             "state": "needs_review",
             "value": "Álbum"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
         }
       }
     },
@@ -7608,6 +8718,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Artista"
@@ -7654,6 +8770,12 @@
             "state": "needs_review",
             "value": "Favorito"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Preferito"
+          }
         }
       }
     },
@@ -7695,6 +8817,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gênero"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genere"
           }
         }
       }
@@ -7738,6 +8866,12 @@
             "state": "needs_review",
             "value": "Duração (seg)"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Durata (sec)"
+          }
         }
       }
     },
@@ -7779,6 +8913,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Última Reprodução"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ultima Riproduzione"
           }
         }
       }
@@ -7822,6 +8962,12 @@
             "state": "needs_review",
             "value": "Reproduções"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduzioni"
+          }
         }
       }
     },
@@ -7863,6 +9009,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ano"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anno"
           }
         }
       }
@@ -7906,6 +9058,12 @@
             "state": "needs_review",
             "value": "Filtrar faixas"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Filtra brani"
+          }
         }
       }
     },
@@ -7947,6 +9105,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "todas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "tutte"
           }
         }
       }
@@ -7990,6 +9154,12 @@
             "state": "needs_review",
             "value": "qualquer"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "qualsiasi"
+          }
         }
       }
     },
@@ -8031,6 +9201,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nenhuma faixa corresponde a \"%@\""
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessun brano corrisponde a \"%@\""
           }
         }
       }
@@ -8074,6 +9250,12 @@
             "state": "needs_review",
             "value": "Playlist inteligente não encontrada"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist intelligente non trovata"
+          }
         }
       }
     },
@@ -8115,6 +9297,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "contém"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "contiene"
           }
         }
       }
@@ -8158,6 +9346,12 @@
             "state": "needs_review",
             "value": "maior que"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "maggiore di"
+          }
         }
       }
     },
@@ -8199,6 +9393,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "nos últimos (dias)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "negli ultimi (giorni)"
           }
         }
       }
@@ -8242,6 +9442,12 @@
             "state": "needs_review",
             "value": "é"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "è"
+          }
         }
       }
     },
@@ -8283,6 +9489,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "não é"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "non è"
           }
         }
       }
@@ -8326,6 +9538,12 @@
             "state": "needs_review",
             "value": "menor que"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "minore di"
+          }
         }
       }
     },
@@ -8364,6 +9582,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": ", "
@@ -8410,6 +9634,12 @@
             "state": "needs_review",
             "value": "Corresponde %1$@ de: %2$@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corrisponde a %1$@ di: %2$@"
+          }
         }
       }
     },
@@ -8451,6 +9681,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Corresponde a todas as faixas."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corrisponde a tutti i brani."
           }
         }
       }
@@ -8494,6 +9730,12 @@
             "state": "needs_review",
             "value": "Tentar reproduzir a faixa com falha novamente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova il brano che ha avuto un errore"
+          }
         }
       }
     },
@@ -8535,6 +9777,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ir para a faixa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vai al brano"
           }
         }
       }
@@ -8578,6 +9826,12 @@
             "state": "needs_review",
             "value": "Não foi possível reproduzir \"%@\". Pulando."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile riprodurre \"%@\". Salto."
+          }
         }
       }
     },
@@ -8619,6 +9873,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tentar reconectar à rede"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova la connessione di rete"
           }
         }
       }
@@ -8662,6 +9922,12 @@
             "state": "needs_review",
             "value": "Você está offline. Reproduzindo apenas faixas baixadas."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sei offline. Riproduzione solo dai brani scaricati."
+          }
         }
       }
     },
@@ -8703,6 +9969,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Isso excluirá permanentemente esta playlist. Esta ação não pode ser desfeita."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Questa azione eliminerà definitivamente questa playlist. Non è possibile annullare."
           }
         }
       }
@@ -8746,6 +10018,12 @@
             "state": "needs_review",
             "value": "Álbum"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
         }
       }
     },
@@ -8784,6 +10062,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Disco"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Disco"
@@ -8830,6 +10114,12 @@
             "state": "needs_review",
             "value": "Duração"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Durata"
+          }
         }
       }
     },
@@ -8868,6 +10158,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Formato"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Formato"
@@ -8914,6 +10210,12 @@
             "state": "needs_review",
             "value": "Reproduções"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduzioni"
+          }
         }
       }
     },
@@ -8955,6 +10257,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Faixa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brano"
           }
         }
       }
@@ -8998,6 +10306,12 @@
             "state": "needs_review",
             "value": "Ano"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anno"
+          }
         }
       }
     },
@@ -9036,6 +10350,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini Player"
@@ -9082,6 +10402,12 @@
             "state": "needs_review",
             "value": "Reproduzindo Agora"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "In Riproduzione"
+          }
         }
       }
     },
@@ -9123,6 +10449,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Próximo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avanti"
           }
         }
       }
@@ -9166,6 +10498,12 @@
             "state": "needs_review",
             "value": "Abrir Lyrebird"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Apri Lyrebird"
+          }
         }
       }
     },
@@ -9207,6 +10545,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausa"
           }
         }
       }
@@ -9250,6 +10594,12 @@
             "state": "needs_review",
             "value": "Reproduzir"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci"
+          }
         }
       }
     },
@@ -9292,6 +10642,12 @@
             "state": "needs_review",
             "value": "Anterior"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Indietro"
+          }
         }
       }
     },
@@ -9330,6 +10686,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini Player"
@@ -9376,6 +10738,12 @@
             "state": "needs_review",
             "value": "Mini Player"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
+          }
         }
       }
     },
@@ -9417,6 +10785,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Capa do álbum. Arraste para mover o mini player."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Copertina album. Trascina per spostare il mini player."
           }
         }
       }
@@ -9460,6 +10834,12 @@
             "state": "needs_review",
             "value": "Opções do mini player"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Opzioni mini player"
+          }
         }
       }
     },
@@ -9501,6 +10881,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sempre Visível"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sempre in Primo Piano"
           }
         }
       }
@@ -9544,6 +10930,12 @@
             "state": "needs_review",
             "value": "Voltar à Janela Completa"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Torna alla Finestra Completa"
+          }
         }
       }
     },
@@ -9585,6 +10977,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Transparente quando Inativo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Trasparente quando Inattivo"
           }
         }
       }
@@ -9628,6 +11026,12 @@
             "state": "needs_review",
             "value": "Fechar Mini Player"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chiudi Mini Player"
+          }
         }
       }
     },
@@ -9669,6 +11073,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Capa do álbum. Toque para abrir o álbum; arraste para mover o mini player."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Copertina album. Tocca per aprire l'album; trascina per spostare il mini player."
           }
         }
       }
@@ -9712,6 +11122,12 @@
             "state": "needs_review",
             "value": "Abrir página do artista"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Apri pagina artista"
+          }
         }
       }
     },
@@ -9753,6 +11169,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Expandir para Janela Completa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Espandi a Finestra Completa"
           }
         }
       }
@@ -9796,6 +11218,12 @@
             "state": "needs_review",
             "value": "Favorito"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Preferito"
+          }
         }
       }
     },
@@ -9837,6 +11265,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Remover dos Favoritos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rimuovi dai Preferiti"
           }
         }
       }
@@ -9880,6 +11314,12 @@
             "state": "needs_review",
             "value": "Faixa anterior"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brano precedente"
+          }
         }
       }
     },
@@ -9921,6 +11361,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproduzir"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci"
           }
         }
       }
@@ -9964,6 +11410,12 @@
             "state": "needs_review",
             "value": "Pausar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausa"
+          }
         }
       }
     },
@@ -10005,6 +11457,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Próxima faixa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brano successivo"
           }
         }
       }
@@ -10048,6 +11506,12 @@
             "state": "needs_review",
             "value": "Voltar à janela completa"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Torna alla finestra completa"
+          }
         }
       }
     },
@@ -10086,6 +11550,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volume"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Volume"
@@ -10132,6 +11602,12 @@
             "state": "needs_review",
             "value": "Posição de reprodução"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Posizione di riproduzione"
+          }
         }
       }
     },
@@ -10174,6 +11650,12 @@
             "state": "needs_review",
             "value": "Exportar Pacote de Diagnóstico…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esporta Bundle Diagnostica…"
+          }
         }
       }
     },
@@ -10214,6 +11696,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atalhos de Teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Scorciatoie da Tastiera"
           }
         }
       }
@@ -10256,6 +11744,12 @@
             "state": "needs_review",
             "value": "Reproduzir / Pausar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci / Pausa"
+          }
         }
       }
     },
@@ -10296,6 +11790,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Buscar atalhos de teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca scorciatoie da tastiera"
           }
         }
       }
@@ -10338,6 +11838,12 @@
             "state": "needs_review",
             "value": "Limpar busca"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancella ricerca"
+          }
         }
       }
     },
@@ -10378,6 +11884,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nenhum atalho corresponde à sua busca"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessuna scorciatoia corrisponde alla ricerca"
           }
         }
       }
@@ -10420,6 +11932,12 @@
             "state": "needs_review",
             "value": "Buscar atalhos"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca scorciatoie"
+          }
         }
       }
     },
@@ -10460,6 +11978,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Arquivo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Archivio"
           }
         }
       }
@@ -10502,6 +12026,12 @@
             "state": "needs_review",
             "value": "Reprodução"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduzione"
+          }
         }
       }
     },
@@ -10542,6 +12072,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Visualizar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Visualizza"
           }
         }
       }
@@ -10584,6 +12120,12 @@
             "state": "needs_review",
             "value": "Janela"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Finestra"
+          }
         }
       }
     },
@@ -10624,6 +12166,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atalhos de Teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Scorciatoie da Tastiera"
           }
         }
       }
@@ -10667,6 +12215,12 @@
             "state": "needs_review",
             "value": "Álbuns"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Album"
+          }
         }
       }
     },
@@ -10708,6 +12262,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Todos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tutto"
           }
         }
       }
@@ -10751,6 +12311,12 @@
             "state": "needs_review",
             "value": "Artistas"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artisti"
+          }
         }
       }
     },
@@ -10792,6 +12358,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gêneros"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Generi"
           }
         }
       }
@@ -10835,6 +12407,12 @@
             "state": "needs_review",
             "value": "Faixas"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Brani"
+          }
         }
       }
     },
@@ -10876,6 +12454,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fechar seletor de mix instantâneo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chiudi selettore mix istantaneo"
           }
         }
       }
@@ -10919,6 +12503,12 @@
             "state": "needs_review",
             "value": "Pesquise algo para criar um mix."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca qualcosa per creare un mix."
+          }
         }
       }
     },
@@ -10960,6 +12550,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gerar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Genera"
           }
         }
       }
@@ -11003,6 +12599,12 @@
             "state": "needs_review",
             "value": "Último mix:"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ultimo mix:"
+          }
         }
       }
     },
@@ -11044,6 +12646,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sem correspondências"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessun risultato"
           }
         }
       }
@@ -11087,6 +12695,12 @@
             "state": "needs_review",
             "value": "Busque uma faixa, álbum, artista ou gênero"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerca un brano, album, artista o genere"
+          }
         }
       }
     },
@@ -11128,6 +12742,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Base:"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Origine:"
           }
         }
       }
@@ -11171,6 +12791,12 @@
             "state": "needs_review",
             "value": "Novo Mix Instantâneo"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nuovo Mix Istantaneo"
+          }
         }
       }
     },
@@ -11212,6 +12838,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Novo Mix Instantâneo…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nuovo Mix Istantaneo…"
           }
         }
       }
@@ -11255,6 +12887,12 @@
             "state": "needs_review",
             "value": "Mostrar Tour"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostra Tour"
+          }
         }
       }
     },
@@ -11296,6 +12934,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tour de recursos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tour delle funzionalità"
           }
         }
       }
@@ -11339,6 +12983,12 @@
             "state": "needs_review",
             "value": "Etapa %1$lld de %2$lld"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Passo %1$lld di %2$lld"
+          }
         }
       }
     },
@@ -11380,6 +13030,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Atalho de teclado %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Scorciatoia da tastiera %@"
           }
         }
       }
@@ -11423,6 +13079,12 @@
             "state": "needs_review",
             "value": "Voltar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Indietro"
+          }
         }
       }
     },
@@ -11464,6 +13126,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Concluído"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fine"
           }
         }
       }
@@ -11507,6 +13175,12 @@
             "state": "needs_review",
             "value": "Pressione ⌘⌥P para um player compacto, sempre visível, que você pode colocar em um canto enquanto trabalha."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Premi ⌘⌥P per un player compatto, sempre in primo piano, che puoi mettere in un angolo mentre lavori."
+          }
         }
       }
     },
@@ -11548,6 +13222,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abra o mini player"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Apri il mini player"
           }
         }
       }
@@ -11591,6 +13271,12 @@
             "state": "needs_review",
             "value": "Próximo"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avanti"
+          }
         }
       }
     },
@@ -11632,6 +13318,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Clique com o botão direito em qualquer faixa, álbum, artista ou playlist para ações rápidas — reproduzir a seguir, adicionar a uma playlist, iniciar uma rádio e mais."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fai clic destro su qualsiasi brano, album, artista o playlist per azioni rapide — riproduci successivo, aggiungi a playlist, avvia una stazione radio e altro."
           }
         }
       }
@@ -11675,6 +13367,12 @@
             "state": "needs_review",
             "value": "Clique direito para mais"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Clic destro per altro"
+          }
         }
       }
     },
@@ -11716,6 +13414,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pressione ⌘F para ir direto à busca e encontrar qualquer música, álbum ou artista na sua biblioteca."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Premi ⌘F per andare direttamente alla ricerca e trovare qualsiasi canzone, album o artista nella tua libreria."
           }
         }
       }
@@ -11759,6 +13463,12 @@
             "state": "needs_review",
             "value": "Encontre qualquer coisa rapidamente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Trova qualsiasi cosa velocemente"
+          }
         }
       }
     },
@@ -11800,6 +13510,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pular"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salta"
           }
         }
       }
@@ -11843,6 +13559,12 @@
             "state": "needs_review",
             "value": "Pressione a barra de espaço em qualquer lugar fora de um campo de texto para reproduzir ou pausar a faixa atual."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Premi la barra spazio ovunque al di fuori di un campo di testo per riprodurre o mettere in pausa il brano corrente."
+          }
         }
       }
     },
@@ -11884,6 +13606,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Reproduza e pause com Espaço"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riproduci e metti in pausa con Spazio"
           }
         }
       }
@@ -11927,6 +13655,12 @@
             "state": "needs_review",
             "value": "Os dados locais do Lyrebird não puderam ser abertos. Geralmente é solucionável: redefina os dados locais para começar do zero, ou exporte um pacote de diagnóstico para compartilhar com um relatório de bug."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "I dati locali di Lyrebird non possono essere aperti. Di solito si risolve: ripristina i dati locali per ricominciare, o esporta un bundle di diagnostica da allegare a un segnalazione di bug."
+          }
         }
       }
     },
@@ -11968,6 +13702,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Exportar Diagnóstico…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esporta Diagnostica…"
           }
         }
       }
@@ -12011,6 +13751,12 @@
             "state": "needs_review",
             "value": "Diagnóstico exportado."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnostica esportata."
+          }
         }
       }
     },
@@ -12052,6 +13798,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível exportar o diagnóstico: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile esportare la diagnostica: %@"
           }
         }
       }
@@ -12095,6 +13847,12 @@
             "state": "needs_review",
             "value": "Sair"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esci"
+          }
         }
       }
     },
@@ -12136,6 +13894,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Redefinir Dados Locais"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ripristina Dati Locali"
           }
         }
       }
@@ -12179,6 +13943,12 @@
             "state": "needs_review",
             "value": "Os dados locais foram movidos para:\n%@\nPor favor, saia e reabra o Lyrebird."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "I dati locali sono stati spostati in:\n%@\nEsci e riapri Lyrebird."
+          }
         }
       }
     },
@@ -12220,6 +13990,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Não foi possível redefinir os dados locais: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Impossibile ripristinare i dati locali: %@"
           }
         }
       }
@@ -12263,6 +14039,12 @@
             "state": "needs_review",
             "value": "Nenhum dado local encontrado para redefinir. Tente exportar o diagnóstico."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nessun dato locale trovato da ripristinare. Prova a esportare la diagnostica."
+          }
         }
       }
     },
@@ -12304,6 +14086,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "O Lyrebird não pôde iniciar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird non ha potuto avviarsi"
           }
         }
       }
@@ -12347,6 +14135,12 @@
             "state": "needs_review",
             "value": "Nome do dispositivo"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome dispositivo"
+          }
         }
       }
     },
@@ -12388,6 +14182,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome do dispositivo: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome dispositivo: %@"
           }
         }
       }
@@ -12431,6 +14231,12 @@
             "state": "needs_review",
             "value": "Cancelar"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annulla"
+          }
         }
       }
     },
@@ -12472,6 +14278,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Altere o nome que o Jellyfin exibe para este dispositivo."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cambia il nome che Jellyfin mostra per questo dispositivo."
           }
         }
       }
@@ -12515,6 +14327,12 @@
             "state": "needs_review",
             "value": "Meu Mac"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Il mio Mac"
+          }
         }
       }
     },
@@ -12556,6 +14374,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salvar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salva"
           }
         }
       }
@@ -12599,6 +14423,12 @@
             "state": "needs_review",
             "value": "Exibido no painel deste servidor e em outros clientes Jellyfin."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrato nel pannello di questo server e in altri client Jellyfin."
+          }
         }
       }
     },
@@ -12640,6 +14470,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome do dispositivo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome dispositivo"
           }
         }
       }
@@ -12683,6 +14519,12 @@
             "state": "needs_review",
             "value": "Emparelhe este dispositivo inserindo um código em outro cliente Jellyfin conectado."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Associa questo dispositivo inserendo un codice in un altro client Jellyfin connesso."
+          }
         }
       }
     },
@@ -12724,6 +14566,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cancelar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Annulla"
           }
         }
       }
@@ -12767,6 +14615,12 @@
             "state": "needs_review",
             "value": "CÓDIGO"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CODICE"
+          }
         }
       }
     },
@@ -12808,6 +14662,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "O Quick Connect não pôde ser concluído. Tente novamente."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect non ha potuto completarsi. Riprova."
           }
         }
       }
@@ -12851,6 +14711,12 @@
             "state": "needs_review",
             "value": "Usar Jellyfin Quick Connect"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usa Jellyfin Quick Connect"
+          }
         }
       }
     },
@@ -12892,6 +14758,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Insira o endereço do servidor na tela de login primeiro, depois tente o Quick Connect."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inserisci l'indirizzo del server nella schermata di accesso prima, poi prova Quick Connect."
           }
         }
       }
@@ -12935,6 +14807,12 @@
             "state": "needs_review",
             "value": "Tentar novamente"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Riprova"
+          }
         }
       }
     },
@@ -12976,6 +14854,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Iniciando Quick Connect…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avvio Quick Connect…"
           }
         }
       }
@@ -13019,6 +14903,12 @@
             "state": "needs_review",
             "value": "Insira este código em outro aplicativo Jellyfin conectado para emparelhar este dispositivo."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inserisci questo codice in un'altra app Jellyfin connessa per associare questo dispositivo."
+          }
         }
       }
     },
@@ -13057,6 +14947,12 @@
           }
         },
         "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect"
@@ -13102,6 +14998,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aguardando aprovação…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "In attesa di approvazione…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -28,6 +28,12 @@
             "state": "needs_review",
             "value": "Über Lyrebird"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdについて"
+          }
         }
       }
     },
@@ -54,6 +60,12 @@
           }
         },
         "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ja": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -88,6 +100,12 @@
             "state": "needs_review",
             "value": "DESKTOP"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "デスクトップ"
+          }
         }
       }
     },
@@ -117,6 +135,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ihre Sitzung ist abgelaufen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "セッションが期限切れです"
           }
         }
       }
@@ -148,6 +172,12 @@
             "state": "needs_review",
             "value": "Bitte melden Sie sich erneut an, um weiter Musik zu hören."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再度サインインして、音楽を聴き続けてください。"
+          }
         }
       }
     },
@@ -177,6 +207,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Anmelden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サインイン"
           }
         }
       }
@@ -208,6 +244,12 @@
             "state": "needs_review",
             "value": "Erneut anmelden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再度サインイン"
+          }
         }
       }
     },
@@ -237,6 +279,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Anmeldung läuft…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サインイン中…"
           }
         }
       }
@@ -268,6 +316,12 @@
             "state": "needs_review",
             "value": "Server nicht erreichbar."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーに接続できません。"
+          }
         }
       }
     },
@@ -297,6 +351,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%@ nicht erreichbar. Neuer Versuch…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%@に接続できません。再試行中…"
           }
         }
       }
@@ -328,6 +388,12 @@
             "state": "needs_review",
             "value": "Serververbindung erneut versuchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバー接続を再試行"
+          }
         }
       }
     },
@@ -357,6 +423,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバム"
           }
         }
       }
@@ -388,6 +460,12 @@
             "state": "needs_review",
             "value": "Künstler"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティスト"
+          }
         }
       }
     },
@@ -417,6 +495,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabeliste"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "プレイリスト"
           }
         }
       }
@@ -448,6 +532,12 @@
             "state": "needs_review",
             "value": "Abbrechen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キャンセル"
+          }
         }
       }
     },
@@ -477,6 +567,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Löschen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "削除"
           }
         }
       }
@@ -508,6 +604,12 @@
             "state": "needs_review",
             "value": "Schließen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "閉じる"
+          }
         }
       }
     },
@@ -538,6 +640,12 @@
             "state": "needs_review",
             "value": "Fertig"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "完了"
+          }
         }
       }
     },
@@ -567,6 +675,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Erneut versuchen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再試行"
           }
         }
       }
@@ -642,6 +756,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld Alben"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lldアルバム"
                 }
               }
             }
@@ -724,6 +850,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lldアーティスト"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -798,6 +936,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld Elemente"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld件"
                 }
               }
             }
@@ -880,6 +1030,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lldプレイリスト"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -954,6 +1116,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld Wiedergaben"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld回再生"
                 }
               }
             }
@@ -1036,6 +1210,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld件"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1110,6 +1296,18 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld ausgewählt"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld件選択"
                 }
               }
             }
@@ -1192,6 +1390,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld曲"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1270,6 +1480,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lldトラック"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1299,6 +1521,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Noch keine Musik"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音楽がありません"
           }
         }
       }
@@ -1330,6 +1558,12 @@
             "state": "needs_review",
             "value": "Ihr Jellyfin-Server hat keine Musik in seiner Bibliothek, oder sie wird noch indiziert. Fügen Sie eine Bibliothek auf dem Server hinzu und aktualisieren Sie dann."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "JellyfinサーバーのライブラリにまだまMusicがないか、インデックス作成中です。サーバーにライブラリを追加して更新してください。"
+          }
         }
       }
     },
@@ -1359,6 +1593,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Jellyfin Web öffnen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jellyfin Webを開く"
           }
         }
       }
@@ -1390,6 +1630,12 @@
             "state": "needs_review",
             "value": "Warteschlange ist leer"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キューが空です"
+          }
         }
       }
     },
@@ -1419,6 +1665,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Geben Sie etwas wieder, um eine Warteschlange zu starten."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "何かを再生してキューを開始してください。"
           }
         }
       }
@@ -1450,6 +1702,12 @@
             "state": "needs_review",
             "value": "Bitte melden Sie sich erneut an."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再度サインインしてください。"
+          }
         }
       }
     },
@@ -1479,6 +1737,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sie haben keine Berechtigung dafür."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "この操作を行う権限がありません。"
           }
         }
       }
@@ -1510,6 +1774,12 @@
             "state": "needs_review",
             "value": "Dieses Element wurde nicht gefunden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "そのアイテムが見つかりませんでした。"
+          }
         }
       }
     },
@@ -1539,6 +1809,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Zu viele Anfragen. Bitte versuchen Sie es gleich noch einmal."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "リクエストが多すぎます。しばらくしてから再試行してください。"
           }
         }
       }
@@ -1570,6 +1846,12 @@
             "state": "needs_review",
             "value": "Netzwerkfehler. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ネットワークエラー。接続を確認して再試行してください。"
+          }
         }
       }
     },
@@ -1599,6 +1881,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Der Server ist auf ein Problem gestoßen. Bitte versuchen Sie es erneut."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーで問題が発生しました。再試行してください。"
           }
         }
       }
@@ -1630,6 +1918,12 @@
             "state": "needs_review",
             "value": "Die Antwort des Servers konnte nicht gelesen werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーの応答を読み取れませんでした。"
+          }
         }
       }
     },
@@ -1659,6 +1953,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Herunterladen für die Offline-Wiedergabe fehlgeschlagen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "オフライン再生用にダウンロードできませんでした。"
           }
         }
       }
@@ -1690,6 +1990,12 @@
             "state": "needs_review",
             "value": "Lokaler Speicherfehler. Bitte versuchen Sie es erneut."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ローカルストレージエラー。再試行してください。"
+          }
         }
       }
     },
@@ -1719,6 +2025,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Zugriff auf den Systemschlüsselbund nicht möglich."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "システムキーチェーンにアクセスできませんでした。"
           }
         }
       }
@@ -1750,6 +2062,12 @@
             "state": "needs_review",
             "value": "Fehler bei der Audiowiedergabe."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音声再生エラー。"
+          }
         }
       }
     },
@@ -1779,6 +2097,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Das Zertifikat des Servers konnte nicht überprüft werden. Möglicherweise müssen Sie diesem Server vertrauen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーの証明書を確認できませんでした。このサーバーを信頼する必要があるかもしれません。"
           }
         }
       }
@@ -1810,6 +2134,12 @@
             "state": "needs_review",
             "value": "Dieser Wert ist ungültig."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "その値は無効です。"
+          }
         }
       }
     },
@@ -1839,6 +2169,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ein Fehler ist aufgetreten."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "問題が発生しました。"
           }
         }
       }
@@ -1870,6 +2206,12 @@
             "state": "needs_review",
             "value": "Wiedergabe konnte nicht gestartet werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生を開始できませんでした。"
+          }
         }
       }
     },
@@ -1899,6 +2241,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Bibliothek konnte nicht geladen werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリを読み込めませんでした。"
           }
         }
       }
@@ -1930,6 +2278,12 @@
             "state": "needs_review",
             "value": "Wiedergabelisten konnten nicht geladen werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "プレイリストを読み込めませんでした。"
+          }
         }
       }
     },
@@ -1959,6 +2313,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Diese Wiedergabeliste konnte nicht geladen werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "このプレイリストを読み込めませんでした。"
           }
         }
       }
@@ -1990,6 +2350,12 @@
             "state": "needs_review",
             "value": "Albumtitel konnten nicht geladen werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバムのトラックを読み込めませんでした。"
+          }
         }
       }
     },
@@ -2019,6 +2385,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Titel der Wiedergabeliste konnten nicht geladen werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "プレイリストのトラックを読み込めませんでした。"
           }
         }
       }
@@ -2050,6 +2422,12 @@
             "state": "needs_review",
             "value": "Suche fehlgeschlagen."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索に失敗しました。"
+          }
         }
       }
     },
@@ -2079,6 +2457,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Favorit konnte nicht aktualisiert werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "お気に入りを更新できませんでした。"
           }
         }
       }
@@ -2110,6 +2494,12 @@
             "state": "needs_review",
             "value": "Wiedergabestatus konnte nicht aktualisiert werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生状態を更新できませんでした。"
+          }
         }
       }
     },
@@ -2139,6 +2529,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Konnte nicht zur Wiedergabeliste hinzugefügt werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "プレイリストに追加できませんでした。"
           }
         }
       }
@@ -2170,6 +2566,12 @@
             "state": "needs_review",
             "value": "Anmeldung fehlgeschlagen."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サインインに失敗しました。"
+          }
         }
       }
     },
@@ -2199,6 +2601,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Falscher Benutzername oder falsches Passwort"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ユーザー名またはパスワードが間違っています"
           }
         }
       }
@@ -2230,6 +2638,12 @@
             "state": "needs_review",
             "value": "Diese Aktion ist noch nicht verfügbar."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "この機能はまだ利用できません。"
+          }
         }
       }
     },
@@ -2259,6 +2673,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Kein Netzwerk. Überprüfen Sie Ihre Verbindung."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ネットワークがありません。接続を確認してください。"
           }
         }
       }
@@ -2290,6 +2710,12 @@
             "state": "needs_review",
             "value": "Prüfen…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "確認中…"
+          }
         }
       }
     },
@@ -2319,6 +2745,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "SERVER-URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーURL"
           }
         }
       }
@@ -2350,6 +2782,12 @@
             "state": "needs_review",
             "value": "BENUTZERNAME"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ユーザー名"
+          }
         }
       }
     },
@@ -2379,6 +2817,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "PASSWORT"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "パスワード"
           }
         }
       }
@@ -2410,6 +2854,12 @@
             "state": "needs_review",
             "value": "Sie"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "あなた"
+          }
         }
       }
     },
@@ -2439,6 +2889,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "IN DIESEM NETZWERK GEFUNDEN"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "このネットワーク上に見つかりました"
           }
         }
       }
@@ -2470,6 +2926,12 @@
             "state": "needs_review",
             "value": "Server-URL"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーURL"
+          }
         }
       }
     },
@@ -2499,6 +2961,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Benutzername"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ユーザー名"
           }
         }
       }
@@ -2530,6 +2998,12 @@
             "state": "needs_review",
             "value": "Passwort"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "パスワード"
+          }
         }
       }
     },
@@ -2559,6 +3033,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Zurück"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "戻る"
           }
         }
       }
@@ -2590,6 +3070,12 @@
             "state": "needs_review",
             "value": "Willkommen bei Lyrebird"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdへようこそ"
+          }
         }
       }
     },
@@ -2619,6 +3105,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ihre Musik, Ihr Server, Ihre Regeln."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "あなたの音楽、あなたのサーバー、あなたのルール。"
           }
         }
       }
@@ -2650,6 +3142,12 @@
             "state": "needs_review",
             "value": "Loslegen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "始める"
+          }
         }
       }
     },
@@ -2679,6 +3177,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ich habe bereits ein Konto →"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "すでにアカウントがあります →"
           }
         }
       }
@@ -2710,6 +3214,12 @@
             "state": "needs_review",
             "value": "Ich habe bereits ein Konto"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "すでにアカウントがあります"
+          }
         }
       }
     },
@@ -2739,6 +3249,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Server verbinden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サーバーを接続"
           }
         }
       }
@@ -2770,6 +3286,12 @@
             "state": "needs_review",
             "value": "Die Jellyfin-URL ist die Adresse, über die Sie vom Browser aus darauf zugreifen."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "JellyfinのURLは、ブラウザからアクセスするために使用するアドレスです。"
+          }
         }
       }
     },
@@ -2799,6 +3321,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Weiter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "続ける"
           }
         }
       }
@@ -2830,6 +3358,12 @@
             "state": "needs_review",
             "value": "Verbindung wird hergestellt…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "接続中…"
+          }
         }
       }
     },
@@ -2859,6 +3393,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Überspringen, offline erkunden →"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スキップして、オフラインで探索 →"
           }
         }
       }
@@ -2890,6 +3430,12 @@
             "state": "needs_review",
             "value": "Bibliothek wird geladen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリを読み込み中"
+          }
         }
       }
     },
@@ -2919,6 +3465,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Künstler werden geladen…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティストを読み込み中…"
           }
         }
       }
@@ -2950,6 +3502,12 @@
             "state": "needs_review",
             "value": "Alben werden geladen…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバムを読み込み中…"
+          }
         }
       }
     },
@@ -2979,6 +3537,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Titel werden geladen…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラックを読み込み中…"
           }
         }
       }
@@ -3010,6 +3574,12 @@
             "state": "needs_review",
             "value": "Cover werden abgerufen…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アートワークを取得中…"
+          }
         }
       }
     },
@@ -3039,6 +3609,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ Titel · %2$@ Künstler · %3$@ Alben"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ トラック · %2$@ アーティスト · %3$@ アルバム"
           }
         }
       }
@@ -3070,6 +3646,12 @@
             "state": "needs_review",
             "value": "Zur Startseite"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ホームへ"
+          }
         }
       }
     },
@@ -3099,6 +3681,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Synchronisierung…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "同期中…"
           }
         }
       }
@@ -3130,6 +3718,12 @@
             "state": "needs_review",
             "value": "Bibliothek konnte nicht geladen werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリを読み込めませんでした。"
+          }
         }
       }
     },
@@ -3159,6 +3753,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Erneut versuchen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再試行"
           }
         }
       }
@@ -3190,6 +3790,12 @@
             "state": "needs_review",
             "value": "Über Lyrebird"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdについて"
+          }
         }
       }
     },
@@ -3219,6 +3825,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Neue Wiedergabeliste…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新規プレイリスト…"
           }
         }
       }
@@ -3250,6 +3862,12 @@
             "state": "needs_review",
             "value": "Neues Fenster"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新規ウィンドウ"
+          }
         }
       }
     },
@@ -3279,6 +3897,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Seitenleiste einblenden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "サイドバーを表示"
           }
         }
       }
@@ -3310,6 +3934,12 @@
             "state": "needs_review",
             "value": "Warteschlangeninspektor einblenden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キューインスペクタを表示"
+          }
         }
       }
     },
@@ -3339,6 +3969,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Startseite"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ホーム"
           }
         }
       }
@@ -3370,6 +4006,12 @@
             "state": "needs_review",
             "value": "Bibliothek"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリ"
+          }
         }
       }
     },
@@ -3399,6 +4041,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Suchen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索"
           }
         }
       }
@@ -3430,6 +4078,12 @@
             "state": "needs_review",
             "value": "Suchen…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索…"
+          }
         }
       }
     },
@@ -3459,6 +4113,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "In Bibliothek suchen…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリで検索…"
           }
         }
       }
@@ -3490,6 +4150,12 @@
             "state": "needs_review",
             "value": "Zu „Gerade wiedergegeben“ gehen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生中へ移動"
+          }
         }
       }
     },
@@ -3519,6 +4185,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabewarteschlange"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生キュー"
           }
         }
       }
@@ -3550,6 +4222,12 @@
             "state": "needs_review",
             "value": "Befehlspalette…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "コマンドパレット…"
+          }
         }
       }
     },
@@ -3579,6 +4257,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生"
           }
         }
       }
@@ -3610,6 +4294,12 @@
             "state": "needs_review",
             "value": "Wiedergabe"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生"
+          }
         }
       }
     },
@@ -3639,6 +4329,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pause"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一時停止"
           }
         }
       }
@@ -3670,6 +4366,12 @@
             "state": "needs_review",
             "value": "Nächster Titel"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "次のトラック"
+          }
         }
       }
     },
@@ -3699,6 +4401,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Vorheriger Titel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前のトラック"
           }
         }
       }
@@ -3730,6 +4438,12 @@
             "state": "needs_review",
             "value": "Lautstärke erhöhen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音量を上げる"
+          }
         }
       }
     },
@@ -3759,6 +4473,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lautstärke verringern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音量を下げる"
           }
         }
       }
@@ -3790,6 +4510,12 @@
             "state": "needs_review",
             "value": "10s vorspulen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "10秒進む"
+          }
         }
       }
     },
@@ -3819,6 +4545,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "10s zurückspulen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "10秒戻る"
           }
         }
       }
@@ -3850,6 +4582,12 @@
             "state": "needs_review",
             "value": "Stopp"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "停止"
+          }
         }
       }
     },
@@ -3879,6 +4617,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fenster links anordnen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ウィンドウを左に並べる"
           }
         }
       }
@@ -3910,6 +4654,12 @@
             "state": "needs_review",
             "value": "Fenster rechts anordnen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ウィンドウを右に並べる"
+          }
         }
       }
     },
@@ -3939,6 +4689,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird-Hilfe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdヘルプ"
           }
         }
       }
@@ -3970,6 +4726,12 @@
             "state": "needs_review",
             "value": "Warteschlangeninspektor ein-/ausblenden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キューインスペクタを切り替え"
+          }
         }
       }
     },
@@ -3999,6 +4761,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nichts wird wiedergegeben"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生中のものはありません"
           }
         }
       }
@@ -4030,6 +4798,12 @@
             "state": "needs_review",
             "value": "Startseite"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ホーム"
+          }
         }
       }
     },
@@ -4059,6 +4833,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Entdecken"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "見つける"
           }
         }
       }
@@ -4090,6 +4870,12 @@
             "state": "needs_review",
             "value": "Radio"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ラジオ"
+          }
         }
       }
     },
@@ -4119,6 +4905,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Bibliothek"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ライブラリ"
           }
         }
       }
@@ -4150,6 +4942,12 @@
             "state": "needs_review",
             "value": "Suchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索"
+          }
         }
       }
     },
@@ -4179,6 +4977,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Meine Bibliothek"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "マイライブラリ"
           }
         }
       }
@@ -4258,6 +5062,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld件"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -4287,6 +5103,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Getrennt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "切断中"
           }
         }
       }
@@ -4318,6 +5140,12 @@
             "state": "needs_review",
             "value": "Favoriten"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "お気に入り"
+          }
         }
       }
     },
@@ -4347,6 +5175,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Alben"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバム"
           }
         }
       }
@@ -4378,6 +5212,12 @@
             "state": "needs_review",
             "value": "Künstler"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティスト"
+          }
         }
       }
     },
@@ -4407,6 +5247,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabelisten"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "プレイリスト"
           }
         }
       }
@@ -4438,6 +5284,12 @@
             "state": "needs_review",
             "value": "Regeln der intelligenten Wiedergabeliste bearbeiten"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリストのルールを編集"
+          }
         }
       }
     },
@@ -4467,6 +5319,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste abspielen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリストを再生"
           }
         }
       }
@@ -4498,6 +5356,12 @@
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste zufällig abspielen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリストをシャッフル"
+          }
         }
       }
     },
@@ -4527,6 +5391,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "INTELLIGENTE WIEDERGABELISTE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリスト"
           }
         }
       }
@@ -4558,6 +5428,12 @@
             "state": "needs_review",
             "value": "Regel hinzufügen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルールを追加"
+          }
         }
       }
     },
@@ -4587,6 +5463,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Regelfeld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルールフィールド"
           }
         }
       }
@@ -4618,6 +5500,12 @@
             "state": "needs_review",
             "value": "Übereinstimmungsmodus"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一致モード"
+          }
         }
       }
     },
@@ -4647,6 +5535,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Name der intelligenten Wiedergabeliste"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリスト名"
           }
         }
       }
@@ -4678,6 +5572,12 @@
             "state": "needs_review",
             "value": "Regeloperator"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルール演算子"
+          }
         }
       }
     },
@@ -4707,6 +5607,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Regel entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルールを削除"
           }
         }
       }
@@ -4738,6 +5644,12 @@
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste speichern"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリストを保存"
+          }
         }
       }
     },
@@ -4767,6 +5679,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Regelwert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルール値"
           }
         }
       }
@@ -4798,6 +5716,12 @@
             "state": "needs_review",
             "value": "Regelwert in Tagen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルール値（日数）"
+          }
         }
       }
     },
@@ -4827,6 +5751,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Regel hinzufügen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルールを追加"
           }
         }
       }
@@ -4858,6 +5788,12 @@
             "state": "needs_review",
             "value": "nein"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "いいえ"
+          }
         }
       }
     },
@@ -4887,6 +5823,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ja"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "はい"
           }
         }
       }
@@ -4918,6 +5860,12 @@
             "state": "needs_review",
             "value": "Abbrechen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キャンセル"
+          }
         }
       }
     },
@@ -4947,6 +5895,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wird gezählt…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "カウント中…"
           }
         }
       }
@@ -4978,6 +5932,12 @@
             "state": "needs_review",
             "value": "Tage"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "日"
+          }
         }
       }
     },
@@ -5007,6 +5967,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリスト"
           }
         }
       }
@@ -5086,6 +6052,18 @@
               }
             }
           }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld件一致"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -5115,6 +6093,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Übereinstimmen mit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一致条件："
           }
         }
       }
@@ -5146,6 +6130,12 @@
             "state": "needs_review",
             "value": "der folgenden Regeln:"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "のルール："
+          }
         }
       }
     },
@@ -5175,6 +6165,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "NAME"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "名前"
           }
         }
       }
@@ -5206,6 +6202,12 @@
             "state": "needs_review",
             "value": "Name der intelligenten Wiedergabeliste"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリスト名"
+          }
         }
       }
     },
@@ -5235,6 +6237,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Speichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保存"
           }
         }
       }
@@ -5266,6 +6274,12 @@
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリスト"
+          }
         }
       }
     },
@@ -5295,6 +6309,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "値"
           }
         }
       }
@@ -5326,6 +6346,12 @@
             "state": "needs_review",
             "value": "Regeln bearbeiten"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ルールを編集"
+          }
         }
       }
     },
@@ -5355,6 +6381,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld Titel bisher geladen. Lockern Sie die Regeln oder öffnen Sie die Bibliothek, um mehr Titel im Speicher zu haben."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "現在%lldトラックを読み込み済み。ルールを緩めるか、ライブラリを開いてメモリにより多くのトラックを載せてください。"
           }
         }
       }
@@ -5386,6 +6418,12 @@
             "state": "needs_review",
             "value": "Kein Titel entspricht diesen Regeln"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "このルールに一致するトラックがありません"
+          }
         }
       }
     },
@@ -5415,6 +6453,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバム"
           }
         }
       }
@@ -5446,6 +6490,12 @@
             "state": "needs_review",
             "value": "Künstler"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティスト"
+          }
         }
       }
     },
@@ -5475,6 +6525,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Favorit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "お気に入り"
           }
         }
       }
@@ -5506,6 +6562,12 @@
             "state": "needs_review",
             "value": "Genre"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ジャンル"
+          }
         }
       }
     },
@@ -5535,6 +6597,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Dauer (Sek.)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "時間（秒）"
           }
         }
       }
@@ -5566,6 +6634,12 @@
             "state": "needs_review",
             "value": "Zuletzt abgespielt"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "最後に再生"
+          }
         }
       }
     },
@@ -5595,6 +6669,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergaben"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生回数"
           }
         }
       }
@@ -5626,6 +6706,12 @@
             "state": "needs_review",
             "value": "Jahr"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "年"
+          }
         }
       }
     },
@@ -5655,6 +6741,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Titel filtern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラックをフィルタ"
           }
         }
       }
@@ -5686,6 +6778,12 @@
             "state": "needs_review",
             "value": "alle"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "すべて"
+          }
         }
       }
     },
@@ -5715,6 +6813,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "beliebige"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "いずれか"
           }
         }
       }
@@ -5746,6 +6850,12 @@
             "state": "needs_review",
             "value": "Kein Titel entspricht \"%@\""
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "\"%@\"に一致するトラックがありません"
+          }
         }
       }
     },
@@ -5775,6 +6885,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Intelligente Wiedergabeliste nicht gefunden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スマートプレイリストが見つかりません"
           }
         }
       }
@@ -5806,6 +6922,12 @@
             "state": "needs_review",
             "value": "enthält"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "含む"
+          }
         }
       }
     },
@@ -5835,6 +6957,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "größer als"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "より大きい"
           }
         }
       }
@@ -5866,6 +6994,12 @@
             "state": "needs_review",
             "value": "in den letzten (Tagen)"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "直近（日数）"
+          }
         }
       }
     },
@@ -5895,6 +7029,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ist"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "が"
           }
         }
       }
@@ -5926,6 +7066,12 @@
             "state": "needs_review",
             "value": "ist nicht"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "でない"
+          }
         }
       }
     },
@@ -5955,6 +7101,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "kleiner als"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "より小さい"
           }
         }
       }
@@ -5986,6 +7138,12 @@
             "state": "needs_review",
             "value": ", "
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "、"
+          }
         }
       }
     },
@@ -6015,6 +7173,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Stimmt überein mit %1$@ von: %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%2$@の%1$@に一致"
           }
         }
       }
@@ -6046,6 +7210,12 @@
             "state": "needs_review",
             "value": "Stimmt mit allen Titeln überein."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "すべてのトラックに一致。"
+          }
         }
       }
     },
@@ -6075,6 +7245,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fehlgeschlagenen Titel erneut abspielen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "失敗したトラックを再試行"
           }
         }
       }
@@ -6106,6 +7282,12 @@
             "state": "needs_review",
             "value": "Zum Titel gehen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラックに移動"
+          }
         }
       }
     },
@@ -6135,6 +7317,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "\"%@\" konnte nicht abgespielt werden. Wird übersprungen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "\"%@\"を再生できませんでした。スキップします。"
           }
         }
       }
@@ -6166,6 +7354,12 @@
             "state": "needs_review",
             "value": "Netzwerkverbindung erneut versuchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ネットワーク接続を再試行"
+          }
         }
       }
     },
@@ -6195,6 +7389,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sie sind offline. Nur heruntergeladene Titel werden abgespielt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "オフラインです。ダウンロード済みのトラックのみ再生します。"
           }
         }
       }
@@ -6226,6 +7426,12 @@
             "state": "needs_review",
             "value": "Dadurch wird diese Wiedergabeliste dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "このプレイリストを完全に削除します。この操作は取り消せません。"
+          }
         }
       }
     },
@@ -6255,6 +7461,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバム"
           }
         }
       }
@@ -6286,6 +7498,12 @@
             "state": "needs_review",
             "value": "CD"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ディスク"
+          }
         }
       }
     },
@@ -6315,6 +7533,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Dauer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "時間"
           }
         }
       }
@@ -6346,6 +7570,12 @@
             "state": "needs_review",
             "value": "Format"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "形式"
+          }
         }
       }
     },
@@ -6375,6 +7605,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergaben"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生回数"
           }
         }
       }
@@ -6406,6 +7642,12 @@
             "state": "needs_review",
             "value": "Titel"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラック"
+          }
         }
       }
     },
@@ -6435,6 +7677,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Jahr"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "年"
           }
         }
       }
@@ -6466,6 +7714,12 @@
             "state": "needs_review",
             "value": "Mini-Player"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤー"
+          }
         }
       }
     },
@@ -6495,6 +7749,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gerade gespielt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生中"
           }
         }
       }
@@ -6526,6 +7786,12 @@
             "state": "needs_review",
             "value": "Weiter"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "次へ"
+          }
         }
       }
     },
@@ -6555,6 +7821,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird öffnen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdを開く"
           }
         }
       }
@@ -6586,6 +7858,12 @@
             "state": "needs_review",
             "value": "Pause"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一時停止"
+          }
         }
       }
     },
@@ -6615,6 +7893,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生"
           }
         }
       }
@@ -6646,6 +7930,12 @@
             "state": "needs_review",
             "value": "Zurück"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前へ"
+          }
         }
       }
     },
@@ -6675,6 +7965,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini-Player"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤー"
           }
         }
       }
@@ -6706,6 +8002,12 @@
             "state": "needs_review",
             "value": "Mini-Player"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤー"
+          }
         }
       }
     },
@@ -6735,6 +8037,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cover. Ziehen Sie es, um den Mini-Player zu verschieben."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバムアート。ドラッグしてミニプレーヤーを移動。"
           }
         }
       }
@@ -6766,6 +8074,12 @@
             "state": "needs_review",
             "value": "Mini-Player-Optionen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤーオプション"
+          }
         }
       }
     },
@@ -6795,6 +8109,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Immer im Vordergrund"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "常に前面表示"
           }
         }
       }
@@ -6826,6 +8146,12 @@
             "state": "needs_review",
             "value": "Zum Vollbild zurückkehren"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "フルウィンドウに戻る"
+          }
         }
       }
     },
@@ -6855,6 +8181,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Transparent wenn inaktiv"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "非アクティブ時は透明"
           }
         }
       }
@@ -6886,6 +8218,12 @@
             "state": "needs_review",
             "value": "Mini-Player schließen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤーを閉じる"
+          }
         }
       }
     },
@@ -6915,6 +8253,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cover. Tippen Sie, um das Album zu öffnen; ziehen Sie, um den Mini-Player zu verschieben."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバムアート。タップしてアルバムを開く。ドラッグしてミニプレーヤーを移動。"
           }
         }
       }
@@ -6946,6 +8290,12 @@
             "state": "needs_review",
             "value": "Künstlerseite öffnen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティストページを開く"
+          }
         }
       }
     },
@@ -6975,6 +8325,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Zum Vollbild erweitern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "フルウィンドウに展開"
           }
         }
       }
@@ -7006,6 +8362,12 @@
             "state": "needs_review",
             "value": "Favorit"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "お気に入り"
+          }
         }
       }
     },
@@ -7035,6 +8397,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aus Favoriten entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "お気に入りから削除"
           }
         }
       }
@@ -7066,6 +8434,12 @@
             "state": "needs_review",
             "value": "Vorheriger Titel"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前のトラック"
+          }
         }
       }
     },
@@ -7095,6 +8469,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Wiedergabe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生"
           }
         }
       }
@@ -7126,6 +8506,12 @@
             "state": "needs_review",
             "value": "Pause"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一時停止"
+          }
         }
       }
     },
@@ -7155,6 +8541,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nächster Titel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "次のトラック"
           }
         }
       }
@@ -7186,6 +8578,12 @@
             "state": "needs_review",
             "value": "Zum Vollbild zurückkehren"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "フルウィンドウに戻る"
+          }
         }
       }
     },
@@ -7215,6 +8613,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lautstärke"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音量"
           }
         }
       }
@@ -7246,6 +8650,12 @@
             "state": "needs_review",
             "value": "Wiedergabeposition"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生位置"
+          }
         }
       }
     },
@@ -7276,6 +8686,12 @@
             "state": "needs_review",
             "value": "Diagnose-Bundle exportieren…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "診断バンドルをエクスポート…"
+          }
         }
       }
     },
@@ -7304,6 +8720,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tastaturkürzel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キーボードショートカット"
           }
         }
       }
@@ -7334,6 +8756,12 @@
             "state": "needs_review",
             "value": "Wiedergabe / Pause"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生 / 一時停止"
+          }
         }
       }
     },
@@ -7362,6 +8790,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tastaturkürzel durchsuchen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キーボードショートカットを検索"
           }
         }
       }
@@ -7392,6 +8826,12 @@
             "state": "needs_review",
             "value": "Suche löschen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索をクリア"
+          }
         }
       }
     },
@@ -7420,6 +8860,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Kein Kürzel entspricht Ihrer Suche"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "検索に一致するショートカットがありません"
           }
         }
       }
@@ -7450,6 +8896,12 @@
             "state": "needs_review",
             "value": "Kürzel suchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ショートカットを検索"
+          }
         }
       }
     },
@@ -7478,6 +8930,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ablage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ファイル"
           }
         }
       }
@@ -7508,6 +8966,12 @@
             "state": "needs_review",
             "value": "Wiedergabe"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再生"
+          }
         }
       }
     },
@@ -7536,6 +9000,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Darstellung"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "表示"
           }
         }
       }
@@ -7566,6 +9036,12 @@
             "state": "needs_review",
             "value": "Fenster"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ウィンドウ"
+          }
         }
       }
     },
@@ -7594,6 +9070,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tastaturkürzel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キーボードショートカット"
           }
         }
       }
@@ -7625,6 +9107,12 @@
             "state": "needs_review",
             "value": "Alben"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アルバム"
+          }
         }
       }
     },
@@ -7654,6 +9142,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Alle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "すべて"
           }
         }
       }
@@ -7685,6 +9179,12 @@
             "state": "needs_review",
             "value": "Künstler"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "アーティスト"
+          }
         }
       }
     },
@@ -7714,6 +9214,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Genres"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ジャンル"
           }
         }
       }
@@ -7745,6 +9251,12 @@
             "state": "needs_review",
             "value": "Titel"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラック"
+          }
         }
       }
     },
@@ -7774,6 +9286,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sofort-Mix-Auswahl schließen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "インスタントミックスピッカーを閉じる"
           }
         }
       }
@@ -7805,6 +9323,12 @@
             "state": "needs_review",
             "value": "Suchen Sie nach etwas, um einen Mix zu erstellen."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミックスの基にするものを検索してください。"
+          }
         }
       }
     },
@@ -7834,6 +9358,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Generieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "生成"
           }
         }
       }
@@ -7865,6 +9395,12 @@
             "state": "needs_review",
             "value": "Letzter Mix:"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "前回のミックス："
+          }
         }
       }
     },
@@ -7894,6 +9430,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Keine Treffer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一致なし"
           }
         }
       }
@@ -7925,6 +9467,12 @@
             "state": "needs_review",
             "value": "Titel, Album, Künstler oder Genre suchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラック、アルバム、アーティスト、またはジャンルを検索"
+          }
         }
       }
     },
@@ -7954,6 +9502,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Basis:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "元："
           }
         }
       }
@@ -7985,6 +9539,12 @@
             "state": "needs_review",
             "value": "Neuer Sofort-Mix"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新規インスタントミックス"
+          }
         }
       }
     },
@@ -8014,6 +9574,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Neuer Sofort-Mix…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新規インスタントミックス…"
           }
         }
       }
@@ -8045,6 +9611,12 @@
             "state": "needs_review",
             "value": "Tour anzeigen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ツアーを表示"
+          }
         }
       }
     },
@@ -8074,6 +9646,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Funktionsrundgang"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "機能ツアー"
           }
         }
       }
@@ -8105,6 +9683,12 @@
             "state": "needs_review",
             "value": "Schritt %1$lld von %2$lld"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$lld / %2$lld ステップ"
+          }
         }
       }
     },
@@ -8134,6 +9718,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tastaturkürzel %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キーボードショートカット %@"
           }
         }
       }
@@ -8165,6 +9755,12 @@
             "state": "needs_review",
             "value": "Zurück"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "戻る"
+          }
         }
       }
     },
@@ -8194,6 +9790,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fertig"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "完了"
           }
         }
       }
@@ -8225,6 +9827,12 @@
             "state": "needs_review",
             "value": "Drücken Sie ⌘⌥P für einen kompakten, immer sichtbaren Player, den Sie in eine Ecke verschieben können, während Sie arbeiten."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "⌘⌥Pを押すと、作業中にコーナーに置けるコンパクトな常時表示プレーヤーが開きます。"
+          }
         }
       }
     },
@@ -8254,6 +9862,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini-Player öffnen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレーヤーを開く"
           }
         }
       }
@@ -8285,6 +9899,12 @@
             "state": "needs_review",
             "value": "Weiter"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "次へ"
+          }
         }
       }
     },
@@ -8314,6 +9934,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Klicken Sie mit der rechten Maustaste auf einen Titel, ein Album, einen Künstler oder eine Wiedergabeliste für Schnellaktionen — als nächstes abspielen, zu einer Wiedergabeliste hinzufügen, einen Radiosender starten und mehr."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "トラック、アルバム、アーティスト、またはプレイリストを右クリックすると、次に再生、プレイリストへ追加、ラジオ局を開始などのクイックアクションが使えます。"
           }
         }
       }
@@ -8345,6 +9971,12 @@
             "state": "needs_review",
             "value": "Rechtsklick für mehr Optionen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "右クリックでさらに"
+          }
         }
       }
     },
@@ -8374,6 +10006,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Drücken Sie ⌘F, um direkt zur Suche zu gelangen und jeden Song, jedes Album oder jeden Künstler in Ihrer Bibliothek zu finden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "⌘Fを押すと、すぐに検索に移動し、ライブラリ内の曲、アルバム、アーティストを検索できます。"
           }
         }
       }
@@ -8405,6 +10043,12 @@
             "state": "needs_review",
             "value": "Alles schnell finden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "素早く何でも検索"
+          }
         }
       }
     },
@@ -8434,6 +10078,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Überspringen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スキップ"
           }
         }
       }
@@ -8465,6 +10115,12 @@
             "state": "needs_review",
             "value": "Drücken Sie die Leertaste außerhalb eines Textfelds, um den aktuellen Titel abzuspielen oder zu pausieren."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "テキストフィールドの外でスペースバーを押すと、現在のトラックを再生または一時停止できます。"
+          }
         }
       }
     },
@@ -8494,6 +10150,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mit Leertaste abspielen und pausieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "スペースで再生・一時停止"
           }
         }
       }
@@ -8525,6 +10187,12 @@
             "state": "needs_review",
             "value": "Die lokalen Daten von Lyrebird konnten nicht geöffnet werden. Meistens lässt sich das beheben: Setzen Sie die lokalen Daten zurück, um neu zu beginnen, oder exportieren Sie ein Diagnose-Bundle, um es einem Fehlerbericht beizufügen."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdのローカルデータを開けませんでした。通常は修正できます：新しく始めるにはローカルデータをリセットするか、バグレポートに添付するために診断バンドルをエクスポートしてください。"
+          }
         }
       }
     },
@@ -8554,6 +10222,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Diagnose exportieren…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "診断をエクスポート…"
           }
         }
       }
@@ -8585,6 +10259,12 @@
             "state": "needs_review",
             "value": "Diagnose exportiert."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "診断をエクスポートしました。"
+          }
         }
       }
     },
@@ -8614,6 +10294,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Diagnose konnte nicht exportiert werden: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "診断をエクスポートできませんでした：%@"
           }
         }
       }
@@ -8645,6 +10331,12 @@
             "state": "needs_review",
             "value": "Beenden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "終了"
+          }
         }
       }
     },
@@ -8674,6 +10366,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lokale Daten zurücksetzen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ローカルデータをリセット"
           }
         }
       }
@@ -8705,6 +10403,12 @@
             "state": "needs_review",
             "value": "Lokale Daten wurden verschoben nach:\n%@\nBitte beenden Sie Lyrebird und öffnen Sie es erneut."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ローカルデータを次の場所に移動しました：\n%@\nLyrebirdを終了して再度開いてください。"
+          }
         }
       }
     },
@@ -8734,6 +10438,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lokale Daten konnten nicht zurückgesetzt werden: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ローカルデータをリセットできませんでした：%@"
           }
         }
       }
@@ -8765,6 +10475,12 @@
             "state": "needs_review",
             "value": "Keine lokalen Daten zum Zurücksetzen gefunden. Versuchen Sie, die Diagnose zu exportieren."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "リセットするローカルデータが見つかりませんでした。代わりに診断をエクスポートしてみてください。"
+          }
         }
       }
     },
@@ -8794,6 +10510,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird konnte nicht gestartet werden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebirdを起動できませんでした"
           }
         }
       }
@@ -8825,6 +10547,12 @@
             "state": "needs_review",
             "value": "Gerätename"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "デバイス名"
+          }
         }
       }
     },
@@ -8854,6 +10582,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gerätename: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "デバイス名：%@"
           }
         }
       }
@@ -8885,6 +10619,12 @@
             "state": "needs_review",
             "value": "Abbrechen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キャンセル"
+          }
         }
       }
     },
@@ -8914,6 +10654,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ändern Sie den Namen, den Jellyfin für dieses Gerät anzeigt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "JellyfinがこのデバイスのJellyfinダッシュボードに表示する名前を変更します。"
           }
         }
       }
@@ -8945,6 +10691,12 @@
             "state": "needs_review",
             "value": "Mein Mac"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "マイMac"
+          }
         }
       }
     },
@@ -8974,6 +10726,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Speichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保存"
           }
         }
       }
@@ -9005,6 +10763,12 @@
             "state": "needs_review",
             "value": "Wird im Dashboard dieses Servers und in anderen Jellyfin-Clients angezeigt."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "このサーバーのダッシュボードおよび他のJellyfinクライアントに表示されます。"
+          }
         }
       }
     },
@@ -9034,6 +10798,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Gerätename"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "デバイス名"
           }
         }
       }
@@ -9065,6 +10835,12 @@
             "state": "needs_review",
             "value": "Koppeln Sie dieses Gerät, indem Sie einen Code in einem anderen angemeldeten Jellyfin-Client eingeben."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "別のサインイン済みJellyfinクライアントでコードを入力してこのデバイスをペアリング。"
+          }
         }
       }
     },
@@ -9094,6 +10870,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abbrechen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "キャンセル"
           }
         }
       }
@@ -9125,6 +10907,12 @@
             "state": "needs_review",
             "value": "CODE"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "コード"
+          }
         }
       }
     },
@@ -9154,6 +10942,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "クイックコネクトを完了できませんでした。再試行してください。"
           }
         }
       }
@@ -9185,6 +10979,12 @@
             "state": "needs_review",
             "value": "Jellyfin Quick Connect verwenden"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jellyfinクイックコネクトを使用"
+          }
         }
       }
     },
@@ -9214,6 +11014,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Geben Sie zuerst Ihre Serveradresse auf dem Anmeldebildschirm ein und versuchen Sie dann Quick Connect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "最初にログイン画面でサーバーアドレスを入力してから、クイックコネクトをお試しください。"
           }
         }
       }
@@ -9245,6 +11051,12 @@
             "state": "needs_review",
             "value": "Erneut versuchen"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "再試行"
+          }
         }
       }
     },
@@ -9274,6 +11086,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect wird gestartet…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "クイックコネクトを開始中…"
           }
         }
       }
@@ -9305,6 +11123,12 @@
             "state": "needs_review",
             "value": "Geben Sie diesen Code in einer anderen angemeldeten Jellyfin-App ein, um dieses Gerät zu koppeln."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "別のサインイン済みJellyfinアプリにこのコードを入力してデバイスをペアリングします。"
+          }
         }
       }
     },
@@ -9335,6 +11159,12 @@
             "state": "needs_review",
             "value": "Quick Connect"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "クイックコネクト"
+          }
         }
       }
     },
@@ -9364,6 +11194,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Warten auf Genehmigung…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "承認を待っています…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -46,6 +46,12 @@
             "state": "needs_review",
             "value": "Informazioni su Lyrebird"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "О Lyrebird"
+          }
         }
       }
     },
@@ -90,6 +96,12 @@
           }
         },
         "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -142,6 +154,12 @@
             "state": "needs_review",
             "value": "DESKTOP"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "РАБОЧИЙ СТОЛ"
+          }
         }
       }
     },
@@ -189,6 +207,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "La sessione è scaduta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сеанс истёк"
           }
         }
       }
@@ -238,6 +262,12 @@
             "state": "needs_review",
             "value": "Accedi di nuovo per continuare ad ascoltare."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Войдите снова, чтобы продолжить прослушивание."
+          }
         }
       }
     },
@@ -285,6 +315,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Accedi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Войти"
           }
         }
       }
@@ -334,6 +370,12 @@
             "state": "needs_review",
             "value": "Accedi di nuovo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Войти снова"
+          }
         }
       }
     },
@@ -381,6 +423,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Accesso in corso…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Выполняется вход…"
           }
         }
       }
@@ -430,6 +478,12 @@
             "state": "needs_review",
             "value": "Impossibile raggiungere il server."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удаётся достичь сервера."
+          }
         }
       }
     },
@@ -477,6 +531,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile raggiungere %@. Nuovo tentativo…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удаётся достичь %@. Повторная попытка…"
           }
         }
       }
@@ -526,6 +586,12 @@
             "state": "needs_review",
             "value": "Riprova la connessione al server"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Повторить подключение к серверу"
+          }
         }
       }
     },
@@ -573,6 +639,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Альбом"
           }
         }
       }
@@ -622,6 +694,12 @@
             "state": "needs_review",
             "value": "Artista"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Исполнитель"
+          }
         }
       }
     },
@@ -669,6 +747,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Плейлист"
           }
         }
       }
@@ -718,6 +802,12 @@
             "state": "needs_review",
             "value": "Annulla"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отмена"
+          }
         }
       }
     },
@@ -765,6 +855,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Elimina"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Удалить"
           }
         }
       }
@@ -814,6 +910,12 @@
             "state": "needs_review",
             "value": "Ignora"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Закрыть"
+          }
         }
       }
     },
@@ -862,6 +964,12 @@
             "state": "needs_review",
             "value": "Fine"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Готово"
+          }
         }
       }
     },
@@ -909,6 +1017,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riprova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Повторить"
           }
         }
       }
@@ -1032,6 +1146,36 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld album"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld альбом"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld альбома"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld альбомов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld альбома"
                 }
               }
             }
@@ -1162,6 +1306,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld исполнитель"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld исполнителя"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld исполнителей"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld исполнителя"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1284,6 +1458,36 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld elementi"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемент"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемента"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элементов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемента"
                 }
               }
             }
@@ -1414,6 +1618,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld плейлист"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld плейлиста"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld плейлистов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld плейлиста"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1536,6 +1770,36 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld riproduzioni"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld воспроизведение"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld воспроизведения"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld воспроизведений"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld воспроизведения"
                 }
               }
             }
@@ -1666,6 +1930,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld результат"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld результата"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld результатов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld результата"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1788,6 +2082,36 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld selezionati"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld выбран"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld выбрано"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld выбрано"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld выбрано"
                 }
               }
             }
@@ -1918,6 +2242,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld песня"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld песни"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld песен"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld песни"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2044,6 +2398,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld трек"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld трека"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld треков"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld трека"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2091,6 +2475,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nessuna musica ancora"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет музыки"
           }
         }
       }
@@ -2140,6 +2530,12 @@
             "state": "needs_review",
             "value": "Il server Jellyfin non ha musica nella libreria, o è ancora in fase di indicizzazione. Aggiungi una libreria sul server, poi aggiorna."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "На сервере Jellyfin нет музыки в библиотеке, либо она ещё индексируется. Добавьте библиотеку на сервере и обновите страницу."
+          }
         }
       }
     },
@@ -2187,6 +2583,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Apri Jellyfin web"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Открыть Jellyfin в браузере"
           }
         }
       }
@@ -2236,6 +2638,12 @@
             "state": "needs_review",
             "value": "La coda è vuota"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Очередь пуста"
+          }
         }
       }
     },
@@ -2283,6 +2691,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riproduci qualcosa per avviare una coda."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизведите что-нибудь, чтобы начать очередь."
           }
         }
       }
@@ -2332,6 +2746,12 @@
             "state": "needs_review",
             "value": "Accedi di nuovo."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Войдите снова."
+          }
         }
       }
     },
@@ -2379,6 +2799,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Non hai il permesso di farlo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "У вас нет прав на это действие."
           }
         }
       }
@@ -2428,6 +2854,12 @@
             "state": "needs_review",
             "value": "Quell'elemento non è stato trovato."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Элемент не найден."
+          }
         }
       }
     },
@@ -2475,6 +2907,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Troppe richieste. Riprova tra un momento."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Слишком много запросов. Попробуйте снова через мгновение."
           }
         }
       }
@@ -2524,6 +2962,12 @@
             "state": "needs_review",
             "value": "Errore di rete. Controlla la connessione e riprova."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ошибка сети. Проверьте подключение и попробуйте снова."
+          }
         }
       }
     },
@@ -2571,6 +3015,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Il server ha riscontrato un problema. Riprova."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сервер столкнулся с проблемой. Попробуйте снова."
           }
         }
       }
@@ -2620,6 +3070,12 @@
             "state": "needs_review",
             "value": "Impossibile leggere la risposta del server."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось прочитать ответ сервера."
+          }
         }
       }
     },
@@ -2667,6 +3123,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile scaricare per la riproduzione offline."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить для воспроизведения без подключения."
           }
         }
       }
@@ -2716,6 +3178,12 @@
             "state": "needs_review",
             "value": "Errore di archiviazione locale. Riprova."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ошибка локального хранилища. Попробуйте снова."
+          }
         }
       }
     },
@@ -2763,6 +3231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile accedere al portachiavi di sistema."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось получить доступ к системному ключнице."
           }
         }
       }
@@ -2812,6 +3286,12 @@
             "state": "needs_review",
             "value": "Errore di riproduzione audio."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ошибка воспроизведения аудио."
+          }
         }
       }
     },
@@ -2859,6 +3339,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile verificare il certificato del server. Potrebbe essere necessario approvare questo server."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось проверить сертификат сервера. Возможно, потребуется доверять этому серверу."
           }
         }
       }
@@ -2908,6 +3394,12 @@
             "state": "needs_review",
             "value": "Questo valore non è valido."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Это значение недействительно."
+          }
         }
       }
     },
@@ -2955,6 +3447,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Qualcosa è andato storto."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Что-то пошло не так."
           }
         }
       }
@@ -3004,6 +3502,12 @@
             "state": "needs_review",
             "value": "Impossibile avviare la riproduzione."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось начать воспроизведение."
+          }
         }
       }
     },
@@ -3051,6 +3555,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile caricare la libreria."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить библиотеку."
           }
         }
       }
@@ -3100,6 +3610,12 @@
             "state": "needs_review",
             "value": "Impossibile caricare le playlist."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить плейлисты."
+          }
         }
       }
     },
@@ -3147,6 +3663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile caricare questa playlist."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить этот плейлист."
           }
         }
       }
@@ -3196,6 +3718,12 @@
             "state": "needs_review",
             "value": "Impossibile caricare i brani dell'album."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить треки альбома."
+          }
         }
       }
     },
@@ -3243,6 +3771,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile caricare i brani della playlist."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить треки плейлиста."
           }
         }
       }
@@ -3292,6 +3826,12 @@
             "state": "needs_review",
             "value": "Ricerca non riuscita."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск не выполнен."
+          }
         }
       }
     },
@@ -3339,6 +3879,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile aggiornare il preferito."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось обновить избранное."
           }
         }
       }
@@ -3388,6 +3934,12 @@
             "state": "needs_review",
             "value": "Impossibile aggiornare lo stato di riproduzione."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось обновить статус воспроизведения."
+          }
         }
       }
     },
@@ -3435,6 +3987,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile aggiungere alla playlist."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось добавить в плейлист."
           }
         }
       }
@@ -3484,6 +4042,12 @@
             "state": "needs_review",
             "value": "Accesso non riuscito."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ошибка входа."
+          }
         }
       }
     },
@@ -3531,6 +4095,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome utente o password errati"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Неверное имя пользователя или пароль"
           }
         }
       }
@@ -3580,6 +4150,12 @@
             "state": "needs_review",
             "value": "Questa azione non è ancora disponibile."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Это действие пока недоступно."
+          }
         }
       }
     },
@@ -3627,6 +4203,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nessuna rete. Controlla la connessione."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет сети. Проверьте подключение."
           }
         }
       }
@@ -3676,6 +4258,12 @@
             "state": "needs_review",
             "value": "Verifica…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Проверка…"
+          }
         }
       }
     },
@@ -3723,6 +4311,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "URL SERVER"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "АДРЕС СЕРВЕРА"
           }
         }
       }
@@ -3772,6 +4366,12 @@
             "state": "needs_review",
             "value": "NOME UTENTE"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ИМЯ ПОЛЬЗОВАТЕЛЯ"
+          }
         }
       }
     },
@@ -3819,6 +4419,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "PASSWORD"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ПАРОЛЬ"
           }
         }
       }
@@ -3868,6 +4474,12 @@
             "state": "needs_review",
             "value": "tu"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "вы"
+          }
         }
       }
     },
@@ -3915,6 +4527,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "TROVATO IN QUESTA RETE"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "НАЙДЕНО В ЭТОЙ СЕТИ"
           }
         }
       }
@@ -3964,6 +4582,12 @@
             "state": "needs_review",
             "value": "URL server"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Адрес сервера"
+          }
         }
       }
     },
@@ -4011,6 +4635,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome utente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Имя пользователя"
           }
         }
       }
@@ -4060,6 +4690,12 @@
             "state": "needs_review",
             "value": "Password"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пароль"
+          }
         }
       }
     },
@@ -4107,6 +4743,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Indietro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Назад"
           }
         }
       }
@@ -4156,6 +4798,12 @@
             "state": "needs_review",
             "value": "Benvenuto in Lyrebird"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Добро пожаловать в Lyrebird"
+          }
         }
       }
     },
@@ -4203,6 +4851,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "La tua musica, il tuo server, le tue regole."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ваша музыка, ваш сервер, ваши правила."
           }
         }
       }
@@ -4252,6 +4906,12 @@
             "state": "needs_review",
             "value": "Inizia"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Начать"
+          }
         }
       }
     },
@@ -4299,6 +4959,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ho già un account →"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "У меня уже есть аккаунт →"
           }
         }
       }
@@ -4348,6 +5014,12 @@
             "state": "needs_review",
             "value": "Ho già un account"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "У меня уже есть аккаунт"
+          }
         }
       }
     },
@@ -4395,6 +5067,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Connetti il tuo server"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Подключите сервер"
           }
         }
       }
@@ -4444,6 +5122,12 @@
             "state": "needs_review",
             "value": "L'URL di Jellyfin è l'indirizzo che usi per accedervi dal browser."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL Jellyfin — это адрес, по которому вы заходите с браузера."
+          }
         }
       }
     },
@@ -4491,6 +5175,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Continua"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Продолжить"
           }
         }
       }
@@ -4540,6 +5230,12 @@
             "state": "needs_review",
             "value": "Connessione…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Подключение…"
+          }
         }
       }
     },
@@ -4587,6 +5283,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salta, esplora offline →"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пропустить, изучить без подключения →"
           }
         }
       }
@@ -4636,6 +5338,12 @@
             "state": "needs_review",
             "value": "Caricamento libreria"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загрузка библиотеки"
+          }
         }
       }
     },
@@ -4683,6 +5391,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Caricamento artisti…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загружаем исполнителей…"
           }
         }
       }
@@ -4732,6 +5446,12 @@
             "state": "needs_review",
             "value": "Caricamento album…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загружаем альбомы…"
+          }
         }
       }
     },
@@ -4779,6 +5499,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Caricamento brani…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загружаем треки…"
           }
         }
       }
@@ -4828,6 +5554,12 @@
             "state": "needs_review",
             "value": "Recupero copertine…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Получаем обложки…"
+          }
         }
       }
     },
@@ -4875,6 +5607,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ brani · %2$@ artisti · %3$@ album"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ треков · %2$@ исполнителей · %3$@ альбомов"
           }
         }
       }
@@ -4924,6 +5662,12 @@
             "state": "needs_review",
             "value": "Vai alla home"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "На главную"
+          }
         }
       }
     },
@@ -4971,6 +5715,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sincronizzazione…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Синхронизация…"
           }
         }
       }
@@ -5020,6 +5770,12 @@
             "state": "needs_review",
             "value": "Impossibile caricare la libreria."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось загрузить библиотеку."
+          }
         }
       }
     },
@@ -5067,6 +5823,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riprova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Попробовать снова"
           }
         }
       }
@@ -5116,6 +5878,12 @@
             "state": "needs_review",
             "value": "Informazioni su Lyrebird"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "О Lyrebird"
+          }
         }
       }
     },
@@ -5163,6 +5931,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nuova Playlist…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Новый плейлист…"
           }
         }
       }
@@ -5212,6 +5986,12 @@
             "state": "needs_review",
             "value": "Nuova Finestra"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Новое окно"
+          }
         }
       }
     },
@@ -5259,6 +6039,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mostra Barra Laterale"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Показать боковую панель"
           }
         }
       }
@@ -5308,6 +6094,12 @@
             "state": "needs_review",
             "value": "Mostra Ispettore Coda"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Показать инспектор очереди"
+          }
         }
       }
     },
@@ -5355,6 +6147,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Home"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Главная"
           }
         }
       }
@@ -5404,6 +6202,12 @@
             "state": "needs_review",
             "value": "Libreria"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Библиотека"
+          }
         }
       }
     },
@@ -5451,6 +6255,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cerca"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск"
           }
         }
       }
@@ -5500,6 +6310,12 @@
             "state": "needs_review",
             "value": "Cerca…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Найти…"
+          }
         }
       }
     },
@@ -5547,6 +6363,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cerca nella Libreria…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Найти в библиотеке…"
           }
         }
       }
@@ -5596,6 +6418,12 @@
             "state": "needs_review",
             "value": "Vai a In Riproduzione"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Перейти к воспроизведению"
+          }
         }
       }
     },
@@ -5643,6 +6471,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Coda di Riproduzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Очередь воспроизведения"
           }
         }
       }
@@ -5692,6 +6526,12 @@
             "state": "needs_review",
             "value": "Tavolozza Comandi…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Палитра команд…"
+          }
         }
       }
     },
@@ -5739,6 +6579,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riproduzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизведение"
           }
         }
       }
@@ -5788,6 +6634,12 @@
             "state": "needs_review",
             "value": "Riproduci"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизвести"
+          }
         }
       }
     },
@@ -5835,6 +6687,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пауза"
           }
         }
       }
@@ -5884,6 +6742,12 @@
             "state": "needs_review",
             "value": "Brano Successivo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Следующий трек"
+          }
         }
       }
     },
@@ -5931,6 +6795,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Brano Precedente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Предыдущий трек"
           }
         }
       }
@@ -5980,6 +6850,12 @@
             "state": "needs_review",
             "value": "Alza Volume"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Увеличить громкость"
+          }
         }
       }
     },
@@ -6027,6 +6903,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abbassa Volume"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Уменьшить громкость"
           }
         }
       }
@@ -6076,6 +6958,12 @@
             "state": "needs_review",
             "value": "Avanza 10s"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Перемотать вперёд на 10с"
+          }
         }
       }
     },
@@ -6123,6 +7011,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Indietro 10s"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Перемотать назад на 10с"
           }
         }
       }
@@ -6172,6 +7066,12 @@
             "state": "needs_review",
             "value": "Ferma"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Стоп"
+          }
         }
       }
     },
@@ -6219,6 +7119,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Affianca Finestra a Sinistra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Прикрепить окно к левому краю"
           }
         }
       }
@@ -6268,6 +7174,12 @@
             "state": "needs_review",
             "value": "Affianca Finestra a Destra"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Прикрепить окно к правому краю"
+          }
         }
       }
     },
@@ -6315,6 +7227,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Guida Lyrebird"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Справка Lyrebird"
           }
         }
       }
@@ -6364,6 +7282,12 @@
             "state": "needs_review",
             "value": "Attiva/Disattiva Ispettore Coda"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Показать/скрыть инспектор очереди"
+          }
         }
       }
     },
@@ -6411,6 +7335,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nessuna riproduzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ничего не воспроизводится"
           }
         }
       }
@@ -6460,6 +7390,12 @@
             "state": "needs_review",
             "value": "Home"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Главная"
+          }
         }
       }
     },
@@ -6507,6 +7443,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Scopri"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Открытия"
           }
         }
       }
@@ -6556,6 +7498,12 @@
             "state": "needs_review",
             "value": "Radio"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Радио"
+          }
         }
       }
     },
@@ -6603,6 +7551,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Libreria"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Библиотека"
           }
         }
       }
@@ -6652,6 +7606,12 @@
             "state": "needs_review",
             "value": "Cerca"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск"
+          }
         }
       }
     },
@@ -6699,6 +7659,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "La Mia Libreria"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Моя библиотека"
           }
         }
       }
@@ -6826,6 +7792,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемент"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемента"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элементов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld элемента"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -6873,6 +7869,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Disconnesso"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отключено"
           }
         }
       }
@@ -6922,6 +7924,12 @@
             "state": "needs_review",
             "value": "Preferiti"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Избранное"
+          }
         }
       }
     },
@@ -6969,6 +7977,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Альбомы"
           }
         }
       }
@@ -7018,6 +8032,12 @@
             "state": "needs_review",
             "value": "Artisti"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Исполнители"
+          }
         }
       }
     },
@@ -7065,6 +8085,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Плейлисты"
           }
         }
       }
@@ -7114,6 +8140,12 @@
             "state": "needs_review",
             "value": "Modifica regole playlist intelligente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Редактировать правила умного плейлиста"
+          }
         }
       }
     },
@@ -7161,6 +8193,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riproduci playlist intelligente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизвести умный плейлист"
           }
         }
       }
@@ -7210,6 +8248,12 @@
             "state": "needs_review",
             "value": "Riproduzione casuale playlist intelligente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Перемешать умный плейлист"
+          }
         }
       }
     },
@@ -7257,6 +8301,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "PLAYLIST INTELLIGENTE"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "УМНЫЙ ПЛЕЙЛИСТ"
           }
         }
       }
@@ -7306,6 +8356,12 @@
             "state": "needs_review",
             "value": "Aggiungi regola"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Добавить правило"
+          }
         }
       }
     },
@@ -7353,6 +8409,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Campo regola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поле правила"
           }
         }
       }
@@ -7402,6 +8464,12 @@
             "state": "needs_review",
             "value": "Modalità corrispondenza"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Режим совпадения"
+          }
         }
       }
     },
@@ -7449,6 +8517,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome playlist intelligente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Название умного плейлиста"
           }
         }
       }
@@ -7498,6 +8572,12 @@
             "state": "needs_review",
             "value": "Operatore regola"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Оператор правила"
+          }
         }
       }
     },
@@ -7545,6 +8625,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Rimuovi regola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Удалить правило"
           }
         }
       }
@@ -7594,6 +8680,12 @@
             "state": "needs_review",
             "value": "Salva playlist intelligente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сохранить умный плейлист"
+          }
         }
       }
     },
@@ -7641,6 +8733,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Valore regola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Значение правила"
           }
         }
       }
@@ -7690,6 +8788,12 @@
             "state": "needs_review",
             "value": "Valore regola in giorni"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Значение правила в днях"
+          }
         }
       }
     },
@@ -7737,6 +8841,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Aggiungi Regola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Добавить правило"
           }
         }
       }
@@ -7786,6 +8896,12 @@
             "state": "needs_review",
             "value": "no"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "нет"
+          }
         }
       }
     },
@@ -7833,6 +8949,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "sì"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "да"
           }
         }
       }
@@ -7882,6 +9004,12 @@
             "state": "needs_review",
             "value": "Annulla"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отмена"
+          }
         }
       }
     },
@@ -7929,6 +9057,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Conteggio…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Подсчёт…"
           }
         }
       }
@@ -7978,6 +9112,12 @@
             "state": "needs_review",
             "value": "giorni"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "дней"
+          }
         }
       }
     },
@@ -8025,6 +9165,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist Intelligente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Умный плейлист"
           }
         }
       }
@@ -8152,6 +9298,36 @@
               }
             }
           }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld совпадение"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld совпадения"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld совпадений"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld совпадения"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -8199,6 +9375,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Corrisponde"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Соответствовать"
           }
         }
       }
@@ -8248,6 +9430,12 @@
             "state": "needs_review",
             "value": "delle seguenti regole:"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "из следующих правил:"
+          }
         }
       }
     },
@@ -8295,6 +9483,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "NOME"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "НАЗВАНИЕ"
           }
         }
       }
@@ -8344,6 +9538,12 @@
             "state": "needs_review",
             "value": "Nome Playlist Intelligente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Название умного плейлиста"
+          }
         }
       }
     },
@@ -8391,6 +9591,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сохранить"
           }
         }
       }
@@ -8440,6 +9646,12 @@
             "state": "needs_review",
             "value": "Playlist Intelligente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Умный плейлист"
+          }
         }
       }
     },
@@ -8487,6 +9699,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "valore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "значение"
           }
         }
       }
@@ -8536,6 +9754,12 @@
             "state": "needs_review",
             "value": "Modifica Regole"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Редактировать правила"
+          }
         }
       }
     },
@@ -8583,6 +9807,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld brani caricati finora. Prova ad allentare le regole o apri la Libreria per avere più brani in memoria."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загружено %lld треков. Попробуйте ослабить правила или откройте Библиотеку, чтобы в памяти было больше треков."
           }
         }
       }
@@ -8632,6 +9862,12 @@
             "state": "needs_review",
             "value": "Nessun brano corrisponde a queste regole"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет треков, соответствующих этим правилам"
+          }
         }
       }
     },
@@ -8679,6 +9915,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Album"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Альбом"
           }
         }
       }
@@ -8728,6 +9970,12 @@
             "state": "needs_review",
             "value": "Artista"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Исполнитель"
+          }
         }
       }
     },
@@ -8775,6 +10023,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Preferito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Избранное"
           }
         }
       }
@@ -8824,6 +10078,12 @@
             "state": "needs_review",
             "value": "Genere"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Жанр"
+          }
         }
       }
     },
@@ -8871,6 +10131,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Durata (sec)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Длительность (сек)"
           }
         }
       }
@@ -8920,6 +10186,12 @@
             "state": "needs_review",
             "value": "Ultima Riproduzione"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Последнее воспроизведение"
+          }
         }
       }
     },
@@ -8967,6 +10239,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riproduzioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Количество воспроизведений"
           }
         }
       }
@@ -9016,6 +10294,12 @@
             "state": "needs_review",
             "value": "Anno"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Год"
+          }
         }
       }
     },
@@ -9063,6 +10347,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Filtra brani"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Фильтровать треки"
           }
         }
       }
@@ -9112,6 +10402,12 @@
             "state": "needs_review",
             "value": "tutte"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "все"
+          }
         }
       }
     },
@@ -9159,6 +10455,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "qualsiasi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "любое"
           }
         }
       }
@@ -9208,6 +10510,12 @@
             "state": "needs_review",
             "value": "Nessun brano corrisponde a \"%@\""
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет треков, соответствующих \"%@\""
+          }
         }
       }
     },
@@ -9255,6 +10563,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Playlist intelligente non trovata"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Умный плейлист не найден"
           }
         }
       }
@@ -9304,6 +10618,12 @@
             "state": "needs_review",
             "value": "contiene"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "содержит"
+          }
         }
       }
     },
@@ -9351,6 +10671,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "maggiore di"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "больше чем"
           }
         }
       }
@@ -9400,6 +10726,12 @@
             "state": "needs_review",
             "value": "negli ultimi (giorni)"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "за последние (дни)"
+          }
         }
       }
     },
@@ -9447,6 +10779,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "è"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "равно"
           }
         }
       }
@@ -9496,6 +10834,12 @@
             "state": "needs_review",
             "value": "non è"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "не равно"
+          }
         }
       }
     },
@@ -9544,6 +10888,12 @@
             "state": "needs_review",
             "value": "minore di"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "меньше чем"
+          }
         }
       }
     },
@@ -9588,6 +10938,12 @@
           }
         },
         "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "needs_review",
             "value": ", "
@@ -9640,6 +10996,12 @@
             "state": "needs_review",
             "value": "Corrisponde a %1$@ di: %2$@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Совпадает %1$@ из: %2$@"
+          }
         }
       }
     },
@@ -9687,6 +11049,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Corrisponde a tutti i brani."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Совпадает со всеми треками."
           }
         }
       }
@@ -9736,6 +11104,12 @@
             "state": "needs_review",
             "value": "Riprova il brano che ha avuto un errore"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Повторить воспроизведение неудавшегося трека"
+          }
         }
       }
     },
@@ -9783,6 +11157,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Vai al brano"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Перейти к треку"
           }
         }
       }
@@ -9832,6 +11212,12 @@
             "state": "needs_review",
             "value": "Impossibile riprodurre \"%@\". Salto."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось воспроизвести «%@». Пропускаем."
+          }
         }
       }
     },
@@ -9879,6 +11265,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riprova la connessione di rete"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Повторить подключение к сети"
           }
         }
       }
@@ -9928,6 +11320,12 @@
             "state": "needs_review",
             "value": "Sei offline. Riproduzione solo dai brani scaricati."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Вы не в сети. Воспроизведение только из загруженных треков."
+          }
         }
       }
     },
@@ -9975,6 +11373,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Questa azione eliminerà definitivamente questa playlist. Non è possibile annullare."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Это навсегда удалит плейлист. Это действие нельзя отменить."
           }
         }
       }
@@ -10024,6 +11428,12 @@
             "state": "needs_review",
             "value": "Album"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Альбом"
+          }
         }
       }
     },
@@ -10071,6 +11481,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Disco"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Диск"
           }
         }
       }
@@ -10120,6 +11536,12 @@
             "state": "needs_review",
             "value": "Durata"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Длительность"
+          }
         }
       }
     },
@@ -10167,6 +11589,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Formato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Формат"
           }
         }
       }
@@ -10216,6 +11644,12 @@
             "state": "needs_review",
             "value": "Riproduzioni"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизведений"
+          }
         }
       }
     },
@@ -10263,6 +11697,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Brano"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Трек"
           }
         }
       }
@@ -10312,6 +11752,12 @@
             "state": "needs_review",
             "value": "Anno"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Год"
+          }
         }
       }
     },
@@ -10359,6 +11805,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini Player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Мини-плеер"
           }
         }
       }
@@ -10408,6 +11860,12 @@
             "state": "needs_review",
             "value": "In Riproduzione"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сейчас играет"
+          }
         }
       }
     },
@@ -10455,6 +11913,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Avanti"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Следующий"
           }
         }
       }
@@ -10504,6 +11968,12 @@
             "state": "needs_review",
             "value": "Apri Lyrebird"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Открыть Lyrebird"
+          }
         }
       }
     },
@@ -10551,6 +12021,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пауза"
           }
         }
       }
@@ -10600,6 +12076,12 @@
             "state": "needs_review",
             "value": "Riproduci"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизвести"
+          }
         }
       }
     },
@@ -10647,6 +12129,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Indietro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Предыдущий"
           }
         }
       }
@@ -10696,6 +12184,12 @@
             "state": "needs_review",
             "value": "Mini Player"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Мини-плеер"
+          }
         }
       }
     },
@@ -10743,6 +12237,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Mini Player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Мини-плеер"
           }
         }
       }
@@ -10792,6 +12292,12 @@
             "state": "needs_review",
             "value": "Copertina album. Trascina per spostare il mini player."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Обложка альбома. Перетащите, чтобы переместить мини-плеер."
+          }
         }
       }
     },
@@ -10839,6 +12345,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Opzioni mini player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Параметры мини-плеера"
           }
         }
       }
@@ -10888,6 +12400,12 @@
             "state": "needs_review",
             "value": "Sempre in Primo Piano"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Всегда поверх"
+          }
         }
       }
     },
@@ -10935,6 +12453,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Torna alla Finestra Completa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Вернуться к полному окну"
           }
         }
       }
@@ -10984,6 +12508,12 @@
             "state": "needs_review",
             "value": "Trasparente quando Inattivo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Прозрачный при неактивности"
+          }
         }
       }
     },
@@ -11031,6 +12561,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Chiudi Mini Player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Закрыть мини-плеер"
           }
         }
       }
@@ -11080,6 +12616,12 @@
             "state": "needs_review",
             "value": "Copertina album. Tocca per aprire l'album; trascina per spostare il mini player."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Обложка альбома. Нажмите, чтобы открыть альбом; перетащите, чтобы переместить мини-плеер."
+          }
         }
       }
     },
@@ -11127,6 +12669,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Apri pagina artista"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Открыть страницу исполнителя"
           }
         }
       }
@@ -11176,6 +12724,12 @@
             "state": "needs_review",
             "value": "Espandi a Finestra Completa"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Развернуть на весь экран"
+          }
         }
       }
     },
@@ -11223,6 +12777,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Preferito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Избранное"
           }
         }
       }
@@ -11272,6 +12832,12 @@
             "state": "needs_review",
             "value": "Rimuovi dai Preferiti"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Убрать из избранного"
+          }
         }
       }
     },
@@ -11319,6 +12885,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Brano precedente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Предыдущий трек"
           }
         }
       }
@@ -11368,6 +12940,12 @@
             "state": "needs_review",
             "value": "Riproduci"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизвести"
+          }
         }
       }
     },
@@ -11415,6 +12993,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Pausa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пауза"
           }
         }
       }
@@ -11464,6 +13048,12 @@
             "state": "needs_review",
             "value": "Brano successivo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Следующий трек"
+          }
         }
       }
     },
@@ -11511,6 +13101,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Torna alla finestra completa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Вернуться к полному окну"
           }
         }
       }
@@ -11560,6 +13156,12 @@
             "state": "needs_review",
             "value": "Volume"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Громкость"
+          }
         }
       }
     },
@@ -11607,6 +13209,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Posizione di riproduzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Позиция воспроизведения"
           }
         }
       }
@@ -11656,6 +13264,12 @@
             "state": "needs_review",
             "value": "Esporta Bundle Diagnostica…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Экспортировать диагностический пакет…"
+          }
         }
       }
     },
@@ -11702,6 +13316,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Scorciatoie da Tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сочетания клавиш"
           }
         }
       }
@@ -11750,6 +13370,12 @@
             "state": "needs_review",
             "value": "Riproduci / Pausa"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизвести / Пауза"
+          }
         }
       }
     },
@@ -11796,6 +13422,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cerca scorciatoie da tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск сочетаний клавиш"
           }
         }
       }
@@ -11844,6 +13476,12 @@
             "state": "needs_review",
             "value": "Cancella ricerca"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Очистить поиск"
+          }
         }
       }
     },
@@ -11890,6 +13528,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nessuna scorciatoia corrisponde alla ricerca"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет сочетаний клавиш, соответствующих поиску"
           }
         }
       }
@@ -11938,6 +13582,12 @@
             "state": "needs_review",
             "value": "Cerca scorciatoie"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск сочетаний"
+          }
         }
       }
     },
@@ -11984,6 +13634,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Archivio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Файл"
           }
         }
       }
@@ -12032,6 +13688,12 @@
             "state": "needs_review",
             "value": "Riproduzione"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Воспроизведение"
+          }
         }
       }
     },
@@ -12078,6 +13740,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Visualizza"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Вид"
           }
         }
       }
@@ -12126,6 +13794,12 @@
             "state": "needs_review",
             "value": "Finestra"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Окно"
+          }
         }
       }
     },
@@ -12172,6 +13846,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Scorciatoie da Tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сочетания клавиш"
           }
         }
       }
@@ -12221,6 +13901,12 @@
             "state": "needs_review",
             "value": "Album"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Альбомы"
+          }
         }
       }
     },
@@ -12268,6 +13954,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tutto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Всё"
           }
         }
       }
@@ -12317,6 +14009,12 @@
             "state": "needs_review",
             "value": "Artisti"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Исполнители"
+          }
         }
       }
     },
@@ -12364,6 +14062,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Generi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Жанры"
           }
         }
       }
@@ -12413,6 +14117,12 @@
             "state": "needs_review",
             "value": "Brani"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Треки"
+          }
         }
       }
     },
@@ -12460,6 +14170,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Chiudi selettore mix istantaneo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Закрыть выбор моментального микса"
           }
         }
       }
@@ -12509,6 +14225,12 @@
             "state": "needs_review",
             "value": "Cerca qualcosa per creare un mix."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Найдите что-нибудь для создания микса."
+          }
         }
       }
     },
@@ -12556,6 +14278,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Genera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Создать"
           }
         }
       }
@@ -12605,6 +14333,12 @@
             "state": "needs_review",
             "value": "Ultimo mix:"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Последний микс:"
+          }
         }
       }
     },
@@ -12652,6 +14386,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nessun risultato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нет совпадений"
           }
         }
       }
@@ -12701,6 +14441,12 @@
             "state": "needs_review",
             "value": "Cerca un brano, album, artista o genere"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Найдите трек, альбом, исполнителя или жанр"
+          }
         }
       }
     },
@@ -12748,6 +14494,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Origine:"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Основа:"
           }
         }
       }
@@ -12797,6 +14549,12 @@
             "state": "needs_review",
             "value": "Nuovo Mix Istantaneo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Новый моментальный микс"
+          }
         }
       }
     },
@@ -12844,6 +14602,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nuovo Mix Istantaneo…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Новый моментальный микс…"
           }
         }
       }
@@ -12893,6 +14657,12 @@
             "state": "needs_review",
             "value": "Mostra Tour"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Показать тур"
+          }
         }
       }
     },
@@ -12940,6 +14710,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Tour delle funzionalità"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Тур по функциям"
           }
         }
       }
@@ -12989,6 +14765,12 @@
             "state": "needs_review",
             "value": "Passo %1$lld di %2$lld"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Шаг %1$lld из %2$lld"
+          }
         }
       }
     },
@@ -13036,6 +14818,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Scorciatoia da tastiera %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сочетание клавиш %@"
           }
         }
       }
@@ -13085,6 +14873,12 @@
             "state": "needs_review",
             "value": "Indietro"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Назад"
+          }
         }
       }
     },
@@ -13132,6 +14926,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fine"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Готово"
           }
         }
       }
@@ -13181,6 +14981,12 @@
             "state": "needs_review",
             "value": "Premi ⌘⌥P per un player compatto, sempre in primo piano, che puoi mettere in un angolo mentre lavori."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нажмите ⌘⌥P, чтобы открыть компактный плеер, всегда поверх других окон, который можно убрать в угол во время работы."
+          }
         }
       }
     },
@@ -13228,6 +15034,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Apri il mini player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Откройте мини-плеер"
           }
         }
       }
@@ -13277,6 +15089,12 @@
             "state": "needs_review",
             "value": "Avanti"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Далее"
+          }
         }
       }
     },
@@ -13324,6 +15142,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Fai clic destro su qualsiasi brano, album, artista o playlist per azioni rapide — riproduci successivo, aggiungi a playlist, avvia una stazione radio e altro."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Щёлкните правой кнопкой мыши по треку, альбому, исполнителю или плейлисту для быстрых действий — воспроизвести следующим, добавить в плейлист, запустить радиостанцию и многое другое."
           }
         }
       }
@@ -13373,6 +15197,12 @@
             "state": "needs_review",
             "value": "Clic destro per altro"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Правая кнопка мыши для большего"
+          }
         }
       }
     },
@@ -13420,6 +15250,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Premi ⌘F per andare direttamente alla ricerca e trovare qualsiasi canzone, album o artista nella tua libreria."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нажмите ⌘F, чтобы сразу перейти к поиску и найти любую песню, альбом или исполнителя в библиотеке."
           }
         }
       }
@@ -13469,6 +15305,12 @@
             "state": "needs_review",
             "value": "Trova qualsiasi cosa velocemente"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Найдите всё быстро"
+          }
         }
       }
     },
@@ -13516,6 +15358,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пропустить"
           }
         }
       }
@@ -13565,6 +15413,12 @@
             "state": "needs_review",
             "value": "Premi la barra spazio ovunque al di fuori di un campo di testo per riprodurre o mettere in pausa il brano corrente."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Нажмите пробел в любом месте вне текстового поля, чтобы воспроизвести или поставить на паузу текущий трек."
+          }
         }
       }
     },
@@ -13612,6 +15466,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Riproduci e metti in pausa con Spazio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Пробел для воспроизведения и паузы"
           }
         }
       }
@@ -13661,6 +15521,12 @@
             "state": "needs_review",
             "value": "I dati locali di Lyrebird non possono essere aperti. Di solito si risolve: ripristina i dati locali per ricominciare, o esporta un bundle di diagnostica da allegare a un segnalazione di bug."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Локальные данные Lyrebird не удалось открыть. Обычно это можно исправить: сбросьте локальные данные для нового старта или экспортируйте диагностический пакет для отправки с отчётом об ошибке."
+          }
         }
       }
     },
@@ -13708,6 +15574,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Esporta Diagnostica…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Экспортировать диагностику…"
           }
         }
       }
@@ -13757,6 +15629,12 @@
             "state": "needs_review",
             "value": "Diagnostica esportata."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Диагностика экспортирована."
+          }
         }
       }
     },
@@ -13804,6 +15682,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile esportare la diagnostica: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось экспортировать диагностику: %@"
           }
         }
       }
@@ -13853,6 +15737,12 @@
             "state": "needs_review",
             "value": "Esci"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Выйти"
+          }
         }
       }
     },
@@ -13900,6 +15790,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ripristina Dati Locali"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сбросить локальные данные"
           }
         }
       }
@@ -13949,6 +15845,12 @@
             "state": "needs_review",
             "value": "I dati locali sono stati spostati in:\n%@\nEsci e riapri Lyrebird."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Локальные данные перемещены в:\n%@\nПожалуйста, выйдите и снова откройте Lyrebird."
+          }
         }
       }
     },
@@ -13996,6 +15898,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Impossibile ripristinare i dati locali: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось сбросить локальные данные: %@"
           }
         }
       }
@@ -14045,6 +15953,12 @@
             "state": "needs_review",
             "value": "Nessun dato locale trovato da ripristinare. Prova a esportare la diagnostica."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Локальных данных для сброса не найдено. Попробуйте экспортировать диагностику."
+          }
         }
       }
     },
@@ -14092,6 +16006,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird non ha potuto avviarsi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird не удалось запустить"
           }
         }
       }
@@ -14141,6 +16061,12 @@
             "state": "needs_review",
             "value": "Nome dispositivo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Имя устройства"
+          }
         }
       }
     },
@@ -14188,6 +16114,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome dispositivo: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Имя устройства: %@"
           }
         }
       }
@@ -14237,6 +16169,12 @@
             "state": "needs_review",
             "value": "Annulla"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отмена"
+          }
         }
       }
     },
@@ -14284,6 +16222,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Cambia il nome che Jellyfin mostra per questo dispositivo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Измените имя, которое Jellyfin отображает для этого устройства."
           }
         }
       }
@@ -14333,6 +16277,12 @@
             "state": "needs_review",
             "value": "Il mio Mac"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Мой Mac"
+          }
         }
       }
     },
@@ -14380,6 +16330,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Salva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сохранить"
           }
         }
       }
@@ -14429,6 +16385,12 @@
             "state": "needs_review",
             "value": "Mostrato nel pannello di questo server e in altri client Jellyfin."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отображается на панели управления этого сервера и в других клиентах Jellyfin."
+          }
         }
       }
     },
@@ -14476,6 +16438,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Nome dispositivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Имя устройства"
           }
         }
       }
@@ -14525,6 +16493,12 @@
             "state": "needs_review",
             "value": "Associa questo dispositivo inserendo un codice in un altro client Jellyfin connesso."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Привяжите это устройство, введя код в другом подключённом клиенте Jellyfin."
+          }
         }
       }
     },
@@ -14572,6 +16546,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Annulla"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отмена"
           }
         }
       }
@@ -14621,6 +16601,12 @@
             "state": "needs_review",
             "value": "CODICE"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "КОД"
+          }
         }
       }
     },
@@ -14668,6 +16654,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect non ha potuto completarsi. Riprova."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Не удалось завершить Quick Connect. Попробуйте снова."
           }
         }
       }
@@ -14717,6 +16709,12 @@
             "state": "needs_review",
             "value": "Usa Jellyfin Quick Connect"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Использовать Jellyfin Quick Connect"
+          }
         }
       }
     },
@@ -14764,6 +16762,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Inserisci l'indirizzo del server nella schermata di accesso prima, poi prova Quick Connect."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Сначала введите адрес сервера на экране входа, затем попробуйте Quick Connect."
           }
         }
       }
@@ -14813,6 +16817,12 @@
             "state": "needs_review",
             "value": "Riprova"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Повторить"
+          }
         }
       }
     },
@@ -14860,6 +16870,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Avvio Quick Connect…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Запуск Quick Connect…"
           }
         }
       }
@@ -14909,6 +16925,12 @@
             "state": "needs_review",
             "value": "Inserisci questo codice in un'altra app Jellyfin connessa per associare questo dispositivo."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Введите этот код в другом подключённом приложении Jellyfin для привязки устройства."
+          }
         }
       }
     },
@@ -14953,6 +16975,12 @@
           }
         },
         "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Quick Connect"
@@ -15004,6 +17032,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "In attesa di approvazione…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ожидание подтверждения…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -34,6 +34,12 @@
             "state": "needs_review",
             "value": "Lyrebirdについて"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sobre o Lyrebird"
+          }
         }
       }
     },
@@ -66,6 +72,12 @@
           }
         },
         "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
+          }
+        },
+        "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebird"
@@ -106,6 +118,12 @@
             "state": "needs_review",
             "value": "デスクトップ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "DESKTOP"
+          }
         }
       }
     },
@@ -141,6 +159,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "セッションが期限切れです"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sua sessão expirou"
           }
         }
       }
@@ -178,6 +202,12 @@
             "state": "needs_review",
             "value": "再度サインインして、音楽を聴き続けてください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faça login novamente para continuar ouvindo."
+          }
         }
       }
     },
@@ -213,6 +243,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サインイン"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Entrar"
           }
         }
       }
@@ -250,6 +286,12 @@
             "state": "needs_review",
             "value": "再度サインイン"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Entrar novamente"
+          }
         }
       }
     },
@@ -285,6 +327,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サインイン中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Entrando…"
           }
         }
       }
@@ -322,6 +370,12 @@
             "state": "needs_review",
             "value": "サーバーに接続できません。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível alcançar o seu servidor."
+          }
         }
       }
     },
@@ -357,6 +411,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%@に接続できません。再試行中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível alcançar %@. Tentando novamente…"
           }
         }
       }
@@ -394,6 +454,12 @@
             "state": "needs_review",
             "value": "サーバー接続を再試行"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar reconectar ao servidor"
+          }
         }
       }
     },
@@ -429,6 +495,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
           }
         }
       }
@@ -466,6 +538,12 @@
             "state": "needs_review",
             "value": "アーティスト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
+          }
         }
       }
     },
@@ -501,6 +579,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "プレイリスト"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist"
           }
         }
       }
@@ -538,6 +622,12 @@
             "state": "needs_review",
             "value": "キャンセル"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
+          }
         }
       }
     },
@@ -573,6 +663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "削除"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Excluir"
           }
         }
       }
@@ -610,6 +706,12 @@
             "state": "needs_review",
             "value": "閉じる"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dispensar"
+          }
         }
       }
     },
@@ -646,6 +748,12 @@
             "state": "needs_review",
             "value": "完了"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Concluído"
+          }
         }
       }
     },
@@ -681,6 +789,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再試行"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar novamente"
           }
         }
       }
@@ -768,6 +882,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lldアルバム"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld álbum"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld álbuns"
                 }
               }
             }
@@ -862,6 +994,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artista"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artistas"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -948,6 +1098,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld件"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld item"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld itens"
                 }
               }
             }
@@ -1042,6 +1210,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlist"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld playlists"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1128,6 +1314,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld回再生"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld reprodução"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld reproduções"
                 }
               }
             }
@@ -1222,6 +1426,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld resultado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld resultados"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1308,6 +1530,24 @@
                 "stringUnit": {
                   "state": "needs_review",
                   "value": "%lld件選択"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld selecionado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld selecionados"
                 }
               }
             }
@@ -1402,6 +1642,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld música"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld músicas"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1492,6 +1750,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld faixa"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld faixas"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1527,6 +1803,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "音楽がありません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nenhuma música ainda"
           }
         }
       }
@@ -1564,6 +1846,12 @@
             "state": "needs_review",
             "value": "JellyfinサーバーのライブラリにまだまMusicがないか、インデックス作成中です。サーバーにライブラリを追加して更新してください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Seu servidor Jellyfin não tem música na biblioteca, ou ela ainda está sendo indexada. Adicione uma biblioteca no servidor e atualize."
+          }
         }
       }
     },
@@ -1599,6 +1887,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Jellyfin Webを開く"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Jellyfin web"
           }
         }
       }
@@ -1636,6 +1930,12 @@
             "state": "needs_review",
             "value": "キューが空です"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "A fila está vazia"
+          }
         }
       }
     },
@@ -1671,6 +1971,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "何かを再生してキューを開始してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduza algo para iniciar uma fila."
           }
         }
       }
@@ -1708,6 +2014,12 @@
             "state": "needs_review",
             "value": "再度サインインしてください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faça login novamente."
+          }
         }
       }
     },
@@ -1743,6 +2055,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "この操作を行う権限がありません。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Você não tem permissão para fazer isso."
           }
         }
       }
@@ -1780,6 +2098,12 @@
             "state": "needs_review",
             "value": "そのアイテムが見つかりませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esse item não foi encontrado."
+          }
         }
       }
     },
@@ -1815,6 +2139,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "リクエストが多すぎます。しばらくしてから再試行してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Muitas solicitações. Tente novamente em um momento."
           }
         }
       }
@@ -1852,6 +2182,12 @@
             "state": "needs_review",
             "value": "ネットワークエラー。接続を確認して再試行してください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erro de rede. Verifique sua conexão e tente novamente."
+          }
         }
       }
     },
@@ -1887,6 +2223,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サーバーで問題が発生しました。再試行してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "O servidor encontrou um problema. Tente novamente."
           }
         }
       }
@@ -1924,6 +2266,12 @@
             "state": "needs_review",
             "value": "サーバーの応答を読み取れませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível ler a resposta do servidor."
+          }
         }
       }
     },
@@ -1959,6 +2307,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "オフライン再生用にダウンロードできませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível baixar para reprodução offline."
           }
         }
       }
@@ -1996,6 +2350,12 @@
             "state": "needs_review",
             "value": "ローカルストレージエラー。再試行してください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erro de armazenamento local. Tente novamente."
+          }
         }
       }
     },
@@ -2031,6 +2391,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "システムキーチェーンにアクセスできませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível acessar o chaveiro do sistema."
           }
         }
       }
@@ -2068,6 +2434,12 @@
             "state": "needs_review",
             "value": "音声再生エラー。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Erro de reprodução de áudio."
+          }
         }
       }
     },
@@ -2103,6 +2475,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サーバーの証明書を確認できませんでした。このサーバーを信頼する必要があるかもしれません。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível verificar o certificado do servidor. Talvez seja necessário confiar neste servidor."
           }
         }
       }
@@ -2140,6 +2518,12 @@
             "state": "needs_review",
             "value": "その値は無効です。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esse valor não é válido."
+          }
         }
       }
     },
@@ -2175,6 +2559,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "問題が発生しました。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Algo deu errado."
           }
         }
       }
@@ -2212,6 +2602,12 @@
             "state": "needs_review",
             "value": "再生を開始できませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível iniciar a reprodução."
+          }
         }
       }
     },
@@ -2247,6 +2643,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ライブラリを読み込めませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar sua biblioteca."
           }
         }
       }
@@ -2284,6 +2686,12 @@
             "state": "needs_review",
             "value": "プレイリストを読み込めませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar as playlists."
+          }
         }
       }
     },
@@ -2319,6 +2727,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "このプレイリストを読み込めませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar esta playlist."
           }
         }
       }
@@ -2356,6 +2770,12 @@
             "state": "needs_review",
             "value": "アルバムのトラックを読み込めませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar as faixas do álbum."
+          }
         }
       }
     },
@@ -2391,6 +2811,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "プレイリストのトラックを読み込めませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar as faixas da playlist."
           }
         }
       }
@@ -2428,6 +2854,12 @@
             "state": "needs_review",
             "value": "検索に失敗しました。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "A busca falhou."
+          }
         }
       }
     },
@@ -2463,6 +2895,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "お気に入りを更新できませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível atualizar o favorito."
           }
         }
       }
@@ -2500,6 +2938,12 @@
             "state": "needs_review",
             "value": "再生状態を更新できませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível atualizar o status de reprodução."
+          }
         }
       }
     },
@@ -2535,6 +2979,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "プレイリストに追加できませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível adicionar à playlist."
           }
         }
       }
@@ -2572,6 +3022,12 @@
             "state": "needs_review",
             "value": "サインインに失敗しました。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Falha ao entrar."
+          }
         }
       }
     },
@@ -2607,6 +3063,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ユーザー名またはパスワードが間違っています"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usuário ou senha incorretos"
           }
         }
       }
@@ -2644,6 +3106,12 @@
             "state": "needs_review",
             "value": "この機能はまだ利用できません。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esta ação ainda não está disponível."
+          }
         }
       }
     },
@@ -2679,6 +3147,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ネットワークがありません。接続を確認してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sem rede. Verifique sua conexão."
           }
         }
       }
@@ -2716,6 +3190,12 @@
             "state": "needs_review",
             "value": "確認中…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Verificando…"
+          }
         }
       }
     },
@@ -2751,6 +3231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サーバーURL"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL DO SERVIDOR"
           }
         }
       }
@@ -2788,6 +3274,12 @@
             "state": "needs_review",
             "value": "ユーザー名"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "USUÁRIO"
+          }
         }
       }
     },
@@ -2823,6 +3315,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "パスワード"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "SENHA"
           }
         }
       }
@@ -2860,6 +3358,12 @@
             "state": "needs_review",
             "value": "あなた"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "você"
+          }
         }
       }
     },
@@ -2895,6 +3399,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "このネットワーク上に見つかりました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ENCONTRADO NESTA REDE"
           }
         }
       }
@@ -2932,6 +3442,12 @@
             "state": "needs_review",
             "value": "サーバーURL"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL do servidor"
+          }
         }
       }
     },
@@ -2967,6 +3483,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ユーザー名"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usuário"
           }
         }
       }
@@ -3004,6 +3526,12 @@
             "state": "needs_review",
             "value": "パスワード"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Senha"
+          }
         }
       }
     },
@@ -3039,6 +3567,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "戻る"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Voltar"
           }
         }
       }
@@ -3076,6 +3610,12 @@
             "state": "needs_review",
             "value": "Lyrebirdへようこそ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bem-vindo ao Lyrebird"
+          }
         }
       }
     },
@@ -3111,6 +3651,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "あなたの音楽、あなたのサーバー、あなたのルール。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sua música, seu servidor, suas regras."
           }
         }
       }
@@ -3148,6 +3694,12 @@
             "state": "needs_review",
             "value": "始める"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Começar"
+          }
         }
       }
     },
@@ -3183,6 +3735,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "すでにアカウントがあります →"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Já tenho uma conta →"
           }
         }
       }
@@ -3220,6 +3778,12 @@
             "state": "needs_review",
             "value": "すでにアカウントがあります"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Já tenho uma conta"
+          }
         }
       }
     },
@@ -3255,6 +3819,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サーバーを接続"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Conecte seu servidor"
           }
         }
       }
@@ -3292,6 +3862,12 @@
             "state": "needs_review",
             "value": "JellyfinのURLは、ブラウザからアクセスするために使用するアドレスです。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "A URL do Jellyfin é o endereço que você usa para acessá-lo pelo navegador."
+          }
         }
       }
     },
@@ -3327,6 +3903,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "続ける"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Continuar"
           }
         }
       }
@@ -3364,6 +3946,12 @@
             "state": "needs_review",
             "value": "接続中…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Conectando…"
+          }
         }
       }
     },
@@ -3399,6 +3987,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スキップして、オフラインで探索 →"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pular, explorar offline →"
           }
         }
       }
@@ -3436,6 +4030,12 @@
             "state": "needs_review",
             "value": "ライブラリを読み込み中"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Carregando sua biblioteca"
+          }
         }
       }
     },
@@ -3471,6 +4071,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アーティストを読み込み中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Carregando artistas…"
           }
         }
       }
@@ -3508,6 +4114,12 @@
             "state": "needs_review",
             "value": "アルバムを読み込み中…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Carregando álbuns…"
+          }
         }
       }
     },
@@ -3543,6 +4155,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "トラックを読み込み中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Carregando faixas…"
           }
         }
       }
@@ -3580,6 +4198,12 @@
             "state": "needs_review",
             "value": "アートワークを取得中…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscando capas…"
+          }
         }
       }
     },
@@ -3615,6 +4239,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$@ トラック · %2$@ アーティスト · %3$@ アルバム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ faixas · %2$@ artistas · %3$@ álbuns"
           }
         }
       }
@@ -3652,6 +4282,12 @@
             "state": "needs_review",
             "value": "ホームへ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir para o início"
+          }
         }
       }
     },
@@ -3687,6 +4323,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "同期中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sincronizando…"
           }
         }
       }
@@ -3724,6 +4366,12 @@
             "state": "needs_review",
             "value": "ライブラリを読み込めませんでした。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível carregar sua biblioteca."
+          }
         }
       }
     },
@@ -3759,6 +4407,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再試行"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar novamente"
           }
         }
       }
@@ -3796,6 +4450,12 @@
             "state": "needs_review",
             "value": "Lyrebirdについて"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sobre o Lyrebird"
+          }
         }
       }
     },
@@ -3831,6 +4491,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "新規プレイリスト…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nova Playlist…"
           }
         }
       }
@@ -3868,6 +4534,12 @@
             "state": "needs_review",
             "value": "新規ウィンドウ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nova Janela"
+          }
         }
       }
     },
@@ -3903,6 +4575,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "サイドバーを表示"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar Barra Lateral"
           }
         }
       }
@@ -3940,6 +4618,12 @@
             "state": "needs_review",
             "value": "キューインスペクタを表示"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar Inspetor de Fila"
+          }
         }
       }
     },
@@ -3975,6 +4659,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ホーム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Início"
           }
         }
       }
@@ -4012,6 +4702,12 @@
             "state": "needs_review",
             "value": "ライブラリ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Biblioteca"
+          }
         }
       }
     },
@@ -4047,6 +4743,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "検索"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar"
           }
         }
       }
@@ -4084,6 +4786,12 @@
             "state": "needs_review",
             "value": "検索…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar…"
+          }
         }
       }
     },
@@ -4119,6 +4827,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ライブラリで検索…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar na Biblioteca…"
           }
         }
       }
@@ -4156,6 +4870,12 @@
             "state": "needs_review",
             "value": "再生中へ移動"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir para Reproduzindo Agora"
+          }
         }
       }
     },
@@ -4191,6 +4911,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生キュー"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fila de Reprodução"
           }
         }
       }
@@ -4228,6 +4954,12 @@
             "state": "needs_review",
             "value": "コマンドパレット…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Paleta de Comandos…"
+          }
         }
       }
     },
@@ -4263,6 +4995,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reprodução"
           }
         }
       }
@@ -4300,6 +5038,12 @@
             "state": "needs_review",
             "value": "再生"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzir"
+          }
         }
       }
     },
@@ -4335,6 +5079,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "一時停止"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
           }
         }
       }
@@ -4372,6 +5122,12 @@
             "state": "needs_review",
             "value": "次のトラック"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Próxima Faixa"
+          }
         }
       }
     },
@@ -4407,6 +5163,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "前のトラック"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faixa Anterior"
           }
         }
       }
@@ -4444,6 +5206,12 @@
             "state": "needs_review",
             "value": "音量を上げる"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aumentar Volume"
+          }
         }
       }
     },
@@ -4479,6 +5247,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "音量を下げる"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diminuir Volume"
           }
         }
       }
@@ -4516,6 +5290,12 @@
             "state": "needs_review",
             "value": "10秒進む"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avançar 10s"
+          }
         }
       }
     },
@@ -4551,6 +5331,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "10秒戻る"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Retroceder 10s"
           }
         }
       }
@@ -4588,6 +5374,12 @@
             "state": "needs_review",
             "value": "停止"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Parar"
+          }
         }
       }
     },
@@ -4623,6 +5415,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ウィンドウを左に並べる"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Organizar Janela à Esquerda"
           }
         }
       }
@@ -4660,6 +5458,12 @@
             "state": "needs_review",
             "value": "ウィンドウを右に並べる"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Organizar Janela à Direita"
+          }
         }
       }
     },
@@ -4695,6 +5499,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebirdヘルプ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ajuda do Lyrebird"
           }
         }
       }
@@ -4732,6 +5542,12 @@
             "state": "needs_review",
             "value": "キューインスペクタを切り替え"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alternar Inspetor de Fila"
+          }
         }
       }
     },
@@ -4767,6 +5583,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生中のものはありません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nada sendo reproduzido"
           }
         }
       }
@@ -4804,6 +5626,12 @@
             "state": "needs_review",
             "value": "ホーム"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Início"
+          }
         }
       }
     },
@@ -4839,6 +5667,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "見つける"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Descobrir"
           }
         }
       }
@@ -4876,6 +5710,12 @@
             "state": "needs_review",
             "value": "ラジオ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rádio"
+          }
         }
       }
     },
@@ -4911,6 +5751,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ライブラリ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Biblioteca"
           }
         }
       }
@@ -4948,6 +5794,12 @@
             "state": "needs_review",
             "value": "検索"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar"
+          }
         }
       }
     },
@@ -4983,6 +5835,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "マイライブラリ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Minha Biblioteca"
           }
         }
       }
@@ -5074,6 +5932,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld item"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld itens"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -5109,6 +5985,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "切断中"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Desconectado"
           }
         }
       }
@@ -5146,6 +6028,12 @@
             "state": "needs_review",
             "value": "お気に入り"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favoritos"
+          }
         }
       }
     },
@@ -5181,6 +6069,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbuns"
           }
         }
       }
@@ -5218,6 +6112,12 @@
             "state": "needs_review",
             "value": "アーティスト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistas"
+          }
         }
       }
     },
@@ -5253,6 +6153,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "プレイリスト"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlists"
           }
         }
       }
@@ -5290,6 +6196,12 @@
             "state": "needs_review",
             "value": "スマートプレイリストのルールを編集"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Editar regras da playlist inteligente"
+          }
         }
       }
     },
@@ -5325,6 +6237,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スマートプレイリストを再生"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzir playlist inteligente"
           }
         }
       }
@@ -5362,6 +6280,12 @@
             "state": "needs_review",
             "value": "スマートプレイリストをシャッフル"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Embaralhar playlist inteligente"
+          }
         }
       }
     },
@@ -5397,6 +6321,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スマートプレイリスト"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PLAYLIST INTELIGENTE"
           }
         }
       }
@@ -5434,6 +6364,12 @@
             "state": "needs_review",
             "value": "ルールを追加"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Adicionar regra"
+          }
         }
       }
     },
@@ -5469,6 +6405,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ルールフィールド"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Campo da regra"
           }
         }
       }
@@ -5506,6 +6448,12 @@
             "state": "needs_review",
             "value": "一致モード"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modo de correspondência"
+          }
         }
       }
     },
@@ -5541,6 +6489,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スマートプレイリスト名"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome da playlist inteligente"
           }
         }
       }
@@ -5578,6 +6532,12 @@
             "state": "needs_review",
             "value": "ルール演算子"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Operador da regra"
+          }
         }
       }
     },
@@ -5613,6 +6573,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ルールを削除"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Remover regra"
           }
         }
       }
@@ -5650,6 +6616,12 @@
             "state": "needs_review",
             "value": "スマートプレイリストを保存"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salvar playlist inteligente"
+          }
         }
       }
     },
@@ -5685,6 +6657,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ルール値"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valor da regra"
           }
         }
       }
@@ -5722,6 +6700,12 @@
             "state": "needs_review",
             "value": "ルール値（日数）"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valor da regra em dias"
+          }
         }
       }
     },
@@ -5757,6 +6741,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ルールを追加"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Adicionar Regra"
           }
         }
       }
@@ -5794,6 +6784,12 @@
             "state": "needs_review",
             "value": "いいえ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "não"
+          }
         }
       }
     },
@@ -5829,6 +6825,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "はい"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "sim"
           }
         }
       }
@@ -5866,6 +6868,12 @@
             "state": "needs_review",
             "value": "キャンセル"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
+          }
         }
       }
     },
@@ -5901,6 +6909,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "カウント中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Contando…"
           }
         }
       }
@@ -5938,6 +6952,12 @@
             "state": "needs_review",
             "value": "日"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "dias"
+          }
         }
       }
     },
@@ -5973,6 +6993,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スマートプレイリスト"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist Inteligente"
           }
         }
       }
@@ -6064,6 +7090,24 @@
               }
             }
           }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld correspondência"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld correspondências"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -6099,6 +7143,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "一致条件："
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corresponder"
           }
         }
       }
@@ -6136,6 +7186,12 @@
             "state": "needs_review",
             "value": "のルール："
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "das seguintes regras:"
+          }
         }
       }
     },
@@ -6171,6 +7227,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "名前"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOME"
           }
         }
       }
@@ -6208,6 +7270,12 @@
             "state": "needs_review",
             "value": "スマートプレイリスト名"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome da Playlist Inteligente"
+          }
         }
       }
     },
@@ -6243,6 +7311,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "保存"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salvar"
           }
         }
       }
@@ -6280,6 +7354,12 @@
             "state": "needs_review",
             "value": "スマートプレイリスト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist Inteligente"
+          }
         }
       }
     },
@@ -6315,6 +7395,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "値"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "valor"
           }
         }
       }
@@ -6352,6 +7438,12 @@
             "state": "needs_review",
             "value": "ルールを編集"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Editar Regras"
+          }
         }
       }
     },
@@ -6387,6 +7479,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "現在%lldトラックを読み込み済み。ルールを緩めるか、ライブラリを開いてメモリにより多くのトラックを載せてください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%lld faixas carregadas até agora. Tente relaxar as regras ou abra a Biblioteca para ter mais faixas na memória."
           }
         }
       }
@@ -6424,6 +7522,12 @@
             "state": "needs_review",
             "value": "このルールに一致するトラックがありません"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nenhuma faixa corresponde a essas regras"
+          }
         }
       }
     },
@@ -6459,6 +7563,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
           }
         }
       }
@@ -6496,6 +7606,12 @@
             "state": "needs_review",
             "value": "アーティスト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
+          }
         }
       }
     },
@@ -6531,6 +7647,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "お気に入り"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorito"
           }
         }
       }
@@ -6568,6 +7690,12 @@
             "state": "needs_review",
             "value": "ジャンル"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gênero"
+          }
         }
       }
     },
@@ -6603,6 +7731,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "時間（秒）"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Duração (seg)"
           }
         }
       }
@@ -6640,6 +7774,12 @@
             "state": "needs_review",
             "value": "最後に再生"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Última Reprodução"
+          }
         }
       }
     },
@@ -6675,6 +7815,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生回数"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduções"
           }
         }
       }
@@ -6712,6 +7858,12 @@
             "state": "needs_review",
             "value": "年"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ano"
+          }
         }
       }
     },
@@ -6747,6 +7899,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "トラックをフィルタ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Filtrar faixas"
           }
         }
       }
@@ -6784,6 +7942,12 @@
             "state": "needs_review",
             "value": "すべて"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "todas"
+          }
         }
       }
     },
@@ -6819,6 +7983,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "いずれか"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "qualquer"
           }
         }
       }
@@ -6856,6 +8026,12 @@
             "state": "needs_review",
             "value": "\"%@\"に一致するトラックがありません"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nenhuma faixa corresponde a \"%@\""
+          }
         }
       }
     },
@@ -6891,6 +8067,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スマートプレイリストが見つかりません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Playlist inteligente não encontrada"
           }
         }
       }
@@ -6928,6 +8110,12 @@
             "state": "needs_review",
             "value": "含む"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "contém"
+          }
         }
       }
     },
@@ -6963,6 +8151,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "より大きい"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "maior que"
           }
         }
       }
@@ -7000,6 +8194,12 @@
             "state": "needs_review",
             "value": "直近（日数）"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "nos últimos (dias)"
+          }
         }
       }
     },
@@ -7035,6 +8235,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "が"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "é"
           }
         }
       }
@@ -7072,6 +8278,12 @@
             "state": "needs_review",
             "value": "でない"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "não é"
+          }
         }
       }
     },
@@ -7107,6 +8319,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "より小さい"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "menor que"
           }
         }
       }
@@ -7144,6 +8362,12 @@
             "state": "needs_review",
             "value": "、"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
+          }
         }
       }
     },
@@ -7179,6 +8403,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%2$@の%1$@に一致"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corresponde %1$@ de: %2$@"
           }
         }
       }
@@ -7216,6 +8446,12 @@
             "state": "needs_review",
             "value": "すべてのトラックに一致。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Corresponde a todas as faixas."
+          }
         }
       }
     },
@@ -7251,6 +8487,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "失敗したトラックを再試行"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar reproduzir a faixa com falha novamente"
           }
         }
       }
@@ -7288,6 +8530,12 @@
             "state": "needs_review",
             "value": "トラックに移動"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir para a faixa"
+          }
         }
       }
     },
@@ -7323,6 +8571,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "\"%@\"を再生できませんでした。スキップします。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível reproduzir \"%@\". Pulando."
           }
         }
       }
@@ -7360,6 +8614,12 @@
             "state": "needs_review",
             "value": "ネットワーク接続を再試行"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar reconectar à rede"
+          }
         }
       }
     },
@@ -7395,6 +8655,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "オフラインです。ダウンロード済みのトラックのみ再生します。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Você está offline. Reproduzindo apenas faixas baixadas."
           }
         }
       }
@@ -7432,6 +8698,12 @@
             "state": "needs_review",
             "value": "このプレイリストを完全に削除します。この操作は取り消せません。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Isso excluirá permanentemente esta playlist. Esta ação não pode ser desfeita."
+          }
         }
       }
     },
@@ -7467,6 +8739,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバム"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
           }
         }
       }
@@ -7504,6 +8782,12 @@
             "state": "needs_review",
             "value": "ディスク"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Disco"
+          }
         }
       }
     },
@@ -7539,6 +8823,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "時間"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Duração"
           }
         }
       }
@@ -7576,6 +8866,12 @@
             "state": "needs_review",
             "value": "形式"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Formato"
+          }
         }
       }
     },
@@ -7611,6 +8907,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生回数"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduções"
           }
         }
       }
@@ -7648,6 +8950,12 @@
             "state": "needs_review",
             "value": "トラック"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faixa"
+          }
         }
       }
     },
@@ -7683,6 +8991,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "年"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ano"
           }
         }
       }
@@ -7720,6 +9034,12 @@
             "state": "needs_review",
             "value": "ミニプレーヤー"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
+          }
         }
       }
     },
@@ -7755,6 +9075,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生中"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzindo Agora"
           }
         }
       }
@@ -7792,6 +9118,12 @@
             "state": "needs_review",
             "value": "次へ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Próximo"
+          }
         }
       }
     },
@@ -7827,6 +9159,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebirdを開く"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Lyrebird"
           }
         }
       }
@@ -7864,6 +9202,12 @@
             "state": "needs_review",
             "value": "一時停止"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
+          }
         }
       }
     },
@@ -7899,6 +9243,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzir"
           }
         }
       }
@@ -7936,6 +9286,12 @@
             "state": "needs_review",
             "value": "前へ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anterior"
+          }
         }
       }
     },
@@ -7971,6 +9327,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ミニプレーヤー"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
           }
         }
       }
@@ -8008,6 +9370,12 @@
             "state": "needs_review",
             "value": "ミニプレーヤー"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player"
+          }
         }
       }
     },
@@ -8043,6 +9411,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバムアート。ドラッグしてミニプレーヤーを移動。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Capa do álbum. Arraste para mover o mini player."
           }
         }
       }
@@ -8080,6 +9454,12 @@
             "state": "needs_review",
             "value": "ミニプレーヤーオプション"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Opções do mini player"
+          }
         }
       }
     },
@@ -8115,6 +9495,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "常に前面表示"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sempre Visível"
           }
         }
       }
@@ -8152,6 +9538,12 @@
             "state": "needs_review",
             "value": "フルウィンドウに戻る"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Voltar à Janela Completa"
+          }
         }
       }
     },
@@ -8187,6 +9579,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "非アクティブ時は透明"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Transparente quando Inativo"
           }
         }
       }
@@ -8224,6 +9622,12 @@
             "state": "needs_review",
             "value": "ミニプレーヤーを閉じる"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fechar Mini Player"
+          }
         }
       }
     },
@@ -8259,6 +9663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "アルバムアート。タップしてアルバムを開く。ドラッグしてミニプレーヤーを移動。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Capa do álbum. Toque para abrir o álbum; arraste para mover o mini player."
           }
         }
       }
@@ -8296,6 +9706,12 @@
             "state": "needs_review",
             "value": "アーティストページを開く"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir página do artista"
+          }
         }
       }
     },
@@ -8331,6 +9747,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "フルウィンドウに展開"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Expandir para Janela Completa"
           }
         }
       }
@@ -8368,6 +9790,12 @@
             "state": "needs_review",
             "value": "お気に入り"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorito"
+          }
         }
       }
     },
@@ -8403,6 +9831,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "お気に入りから削除"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Remover dos Favoritos"
           }
         }
       }
@@ -8440,6 +9874,12 @@
             "state": "needs_review",
             "value": "前のトラック"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faixa anterior"
+          }
         }
       }
     },
@@ -8475,6 +9915,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "再生"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzir"
           }
         }
       }
@@ -8512,6 +9958,12 @@
             "state": "needs_review",
             "value": "一時停止"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
+          }
         }
       }
     },
@@ -8547,6 +9999,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "次のトラック"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Próxima faixa"
           }
         }
       }
@@ -8584,6 +10042,12 @@
             "state": "needs_review",
             "value": "フルウィンドウに戻る"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Voltar à janela completa"
+          }
         }
       }
     },
@@ -8619,6 +10083,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "音量"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volume"
           }
         }
       }
@@ -8656,6 +10126,12 @@
             "state": "needs_review",
             "value": "再生位置"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Posição de reprodução"
+          }
         }
       }
     },
@@ -8692,6 +10168,12 @@
             "state": "needs_review",
             "value": "診断バンドルをエクスポート…"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exportar Pacote de Diagnóstico…"
+          }
         }
       }
     },
@@ -8726,6 +10208,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "キーボードショートカット"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atalhos de Teclado"
           }
         }
       }
@@ -8762,6 +10250,12 @@
             "state": "needs_review",
             "value": "再生 / 一時停止"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduzir / Pausar"
+          }
         }
       }
     },
@@ -8796,6 +10290,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "キーボードショートカットを検索"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar atalhos de teclado"
           }
         }
       }
@@ -8832,6 +10332,12 @@
             "state": "needs_review",
             "value": "検索をクリア"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Limpar busca"
+          }
         }
       }
     },
@@ -8866,6 +10372,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "検索に一致するショートカットがありません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nenhum atalho corresponde à sua busca"
           }
         }
       }
@@ -8902,6 +10414,12 @@
             "state": "needs_review",
             "value": "ショートカットを検索"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar atalhos"
+          }
         }
       }
     },
@@ -8936,6 +10454,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ファイル"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Arquivo"
           }
         }
       }
@@ -8972,6 +10496,12 @@
             "state": "needs_review",
             "value": "再生"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reprodução"
+          }
         }
       }
     },
@@ -9006,6 +10536,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "表示"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Visualizar"
           }
         }
       }
@@ -9042,6 +10578,12 @@
             "state": "needs_review",
             "value": "ウィンドウ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Janela"
+          }
         }
       }
     },
@@ -9076,6 +10618,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "キーボードショートカット"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atalhos de Teclado"
           }
         }
       }
@@ -9113,6 +10661,12 @@
             "state": "needs_review",
             "value": "アルバム"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbuns"
+          }
         }
       }
     },
@@ -9148,6 +10702,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "すべて"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Todos"
           }
         }
       }
@@ -9185,6 +10745,12 @@
             "state": "needs_review",
             "value": "アーティスト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistas"
+          }
         }
       }
     },
@@ -9220,6 +10786,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ジャンル"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gêneros"
           }
         }
       }
@@ -9257,6 +10829,12 @@
             "state": "needs_review",
             "value": "トラック"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Faixas"
+          }
         }
       }
     },
@@ -9292,6 +10870,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "インスタントミックスピッカーを閉じる"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fechar seletor de mix instantâneo"
           }
         }
       }
@@ -9329,6 +10913,12 @@
             "state": "needs_review",
             "value": "ミックスの基にするものを検索してください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pesquise algo para criar um mix."
+          }
         }
       }
     },
@@ -9364,6 +10954,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "生成"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Gerar"
           }
         }
       }
@@ -9401,6 +10997,12 @@
             "state": "needs_review",
             "value": "前回のミックス："
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Último mix:"
+          }
         }
       }
     },
@@ -9436,6 +11038,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "一致なし"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sem correspondências"
           }
         }
       }
@@ -9473,6 +11081,12 @@
             "state": "needs_review",
             "value": "トラック、アルバム、アーティスト、またはジャンルを検索"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Busque uma faixa, álbum, artista ou gênero"
+          }
         }
       }
     },
@@ -9508,6 +11122,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "元："
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Base:"
           }
         }
       }
@@ -9545,6 +11165,12 @@
             "state": "needs_review",
             "value": "新規インスタントミックス"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Novo Mix Instantâneo"
+          }
         }
       }
     },
@@ -9580,6 +11206,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "新規インスタントミックス…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Novo Mix Instantâneo…"
           }
         }
       }
@@ -9617,6 +11249,12 @@
             "state": "needs_review",
             "value": "ツアーを表示"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar Tour"
+          }
         }
       }
     },
@@ -9652,6 +11290,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "機能ツアー"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tour de recursos"
           }
         }
       }
@@ -9689,6 +11333,12 @@
             "state": "needs_review",
             "value": "%1$lld / %2$lld ステップ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Etapa %1$lld de %2$lld"
+          }
         }
       }
     },
@@ -9724,6 +11374,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "キーボードショートカット %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atalho de teclado %@"
           }
         }
       }
@@ -9761,6 +11417,12 @@
             "state": "needs_review",
             "value": "戻る"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Voltar"
+          }
         }
       }
     },
@@ -9796,6 +11458,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "完了"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Concluído"
           }
         }
       }
@@ -9833,6 +11501,12 @@
             "state": "needs_review",
             "value": "⌘⌥Pを押すと、作業中にコーナーに置けるコンパクトな常時表示プレーヤーが開きます。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pressione ⌘⌥P para um player compacto, sempre visível, que você pode colocar em um canto enquanto trabalha."
+          }
         }
       }
     },
@@ -9868,6 +11542,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ミニプレーヤーを開く"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abra o mini player"
           }
         }
       }
@@ -9905,6 +11585,12 @@
             "state": "needs_review",
             "value": "次へ"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Próximo"
+          }
         }
       }
     },
@@ -9940,6 +11626,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "トラック、アルバム、アーティスト、またはプレイリストを右クリックすると、次に再生、プレイリストへ追加、ラジオ局を開始などのクイックアクションが使えます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Clique com o botão direito em qualquer faixa, álbum, artista ou playlist para ações rápidas — reproduzir a seguir, adicionar a uma playlist, iniciar uma rádio e mais."
           }
         }
       }
@@ -9977,6 +11669,12 @@
             "state": "needs_review",
             "value": "右クリックでさらに"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Clique direito para mais"
+          }
         }
       }
     },
@@ -10012,6 +11710,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "⌘Fを押すと、すぐに検索に移動し、ライブラリ内の曲、アルバム、アーティストを検索できます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pressione ⌘F para ir direto à busca e encontrar qualquer música, álbum ou artista na sua biblioteca."
           }
         }
       }
@@ -10049,6 +11753,12 @@
             "state": "needs_review",
             "value": "素早く何でも検索"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Encontre qualquer coisa rapidamente"
+          }
         }
       }
     },
@@ -10084,6 +11794,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スキップ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pular"
           }
         }
       }
@@ -10121,6 +11837,12 @@
             "state": "needs_review",
             "value": "テキストフィールドの外でスペースバーを押すと、現在のトラックを再生または一時停止できます。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pressione a barra de espaço em qualquer lugar fora de um campo de texto para reproduzir ou pausar a faixa atual."
+          }
         }
       }
     },
@@ -10156,6 +11878,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "スペースで再生・一時停止"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduza e pause com Espaço"
           }
         }
       }
@@ -10193,6 +11921,12 @@
             "state": "needs_review",
             "value": "Lyrebirdのローカルデータを開けませんでした。通常は修正できます：新しく始めるにはローカルデータをリセットするか、バグレポートに添付するために診断バンドルをエクスポートしてください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Os dados locais do Lyrebird não puderam ser abertos. Geralmente é solucionável: redefina os dados locais para começar do zero, ou exporte um pacote de diagnóstico para compartilhar com um relatório de bug."
+          }
         }
       }
     },
@@ -10228,6 +11962,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "診断をエクスポート…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exportar Diagnóstico…"
           }
         }
       }
@@ -10265,6 +12005,12 @@
             "state": "needs_review",
             "value": "診断をエクスポートしました。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnóstico exportado."
+          }
         }
       }
     },
@@ -10300,6 +12046,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "診断をエクスポートできませんでした：%@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível exportar o diagnóstico: %@"
           }
         }
       }
@@ -10337,6 +12089,12 @@
             "state": "needs_review",
             "value": "終了"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sair"
+          }
         }
       }
     },
@@ -10372,6 +12130,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ローカルデータをリセット"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Redefinir Dados Locais"
           }
         }
       }
@@ -10409,6 +12173,12 @@
             "state": "needs_review",
             "value": "ローカルデータを次の場所に移動しました：\n%@\nLyrebirdを終了して再度開いてください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Os dados locais foram movidos para:\n%@\nPor favor, saia e reabra o Lyrebird."
+          }
         }
       }
     },
@@ -10444,6 +12214,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ローカルデータをリセットできませんでした：%@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Não foi possível redefinir os dados locais: %@"
           }
         }
       }
@@ -10481,6 +12257,12 @@
             "state": "needs_review",
             "value": "リセットするローカルデータが見つかりませんでした。代わりに診断をエクスポートしてみてください。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nenhum dado local encontrado para redefinir. Tente exportar o diagnóstico."
+          }
         }
       }
     },
@@ -10516,6 +12298,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Lyrebirdを起動できませんでした"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "O Lyrebird não pôde iniciar"
           }
         }
       }
@@ -10553,6 +12341,12 @@
             "state": "needs_review",
             "value": "デバイス名"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome do dispositivo"
+          }
         }
       }
     },
@@ -10588,6 +12382,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "デバイス名：%@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome do dispositivo: %@"
           }
         }
       }
@@ -10625,6 +12425,12 @@
             "state": "needs_review",
             "value": "キャンセル"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
+          }
         }
       }
     },
@@ -10660,6 +12466,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "JellyfinがこのデバイスのJellyfinダッシュボードに表示する名前を変更します。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Altere o nome que o Jellyfin exibe para este dispositivo."
           }
         }
       }
@@ -10697,6 +12509,12 @@
             "state": "needs_review",
             "value": "マイMac"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Meu Mac"
+          }
         }
       }
     },
@@ -10732,6 +12550,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "保存"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salvar"
           }
         }
       }
@@ -10769,6 +12593,12 @@
             "state": "needs_review",
             "value": "このサーバーのダッシュボードおよび他のJellyfinクライアントに表示されます。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exibido no painel deste servidor e em outros clientes Jellyfin."
+          }
         }
       }
     },
@@ -10804,6 +12634,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "デバイス名"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nome do dispositivo"
           }
         }
       }
@@ -10841,6 +12677,12 @@
             "state": "needs_review",
             "value": "別のサインイン済みJellyfinクライアントでコードを入力してこのデバイスをペアリング。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Emparelhe este dispositivo inserindo um código em outro cliente Jellyfin conectado."
+          }
         }
       }
     },
@@ -10876,6 +12718,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "キャンセル"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
           }
         }
       }
@@ -10913,6 +12761,12 @@
             "state": "needs_review",
             "value": "コード"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CÓDIGO"
+          }
         }
       }
     },
@@ -10948,6 +12802,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "クイックコネクトを完了できませんでした。再試行してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "O Quick Connect não pôde ser concluído. Tente novamente."
           }
         }
       }
@@ -10985,6 +12845,12 @@
             "state": "needs_review",
             "value": "Jellyfinクイックコネクトを使用"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usar Jellyfin Quick Connect"
+          }
         }
       }
     },
@@ -11020,6 +12886,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "最初にログイン画面でサーバーアドレスを入力してから、クイックコネクトをお試しください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Insira o endereço do servidor na tela de login primeiro, depois tente o Quick Connect."
           }
         }
       }
@@ -11057,6 +12929,12 @@
             "state": "needs_review",
             "value": "再試行"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tentar novamente"
+          }
         }
       }
     },
@@ -11092,6 +12970,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "クイックコネクトを開始中…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Iniciando Quick Connect…"
           }
         }
       }
@@ -11129,6 +13013,12 @@
             "state": "needs_review",
             "value": "別のサインイン済みJellyfinアプリにこのコードを入力してデバイスをペアリングします。"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Insira este código em outro aplicativo Jellyfin conectado para emparelhar este dispositivo."
+          }
         }
       }
     },
@@ -11165,6 +13055,12 @@
             "state": "needs_review",
             "value": "クイックコネクト"
           }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
         }
       }
     },
@@ -11200,6 +13096,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "承認を待っています…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aguardando aprovação…"
           }
         }
       }

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -1,251 +1,383 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "about.window.title" : {
-      "comment" : "Window title for the dedicated About Lyrebird window (#25).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About Lyrebird"
+  "sourceLanguage": "en",
+  "strings": {
+    "about.window.title": {
+      "comment": "Window title for the dedicated About Lyrebird window (#25).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About Lyrebird"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Acerca de Lyrebird"
           }
         }
       }
     },
-    "app.name" : {
-      "comment" : "Brand name shown in the sidebar header and splash screens.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird"
+    "app.name": {
+      "comment": "Brand name shown in the sidebar header and splash screens.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird"
           }
         }
       }
     },
-    "app.subtitle.desktop" : {
-      "comment" : "Small tracking-uppercase label shown below the wordmark on brand lockups.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DESKTOP"
+    "app.subtitle.desktop": {
+      "comment": "Small tracking-uppercase label shown below the wordmark on brand lockups.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DESKTOP"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ESCRITORIO"
           }
         }
       }
     },
-    "auth.session.expired.title" : {
-      "comment" : "Modal sheet title when the server rejects a stored access token (HTTP 401).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your session expired"
+    "auth.session.expired.title": {
+      "comment": "Modal sheet title when the server rejects a stored access token (HTTP 401).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session expired"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tu sesión ha expirado"
           }
         }
       }
     },
-    "auth.session.expired.body" : {
-      "comment" : "Modal sheet body message explaining the user needs to re-authenticate.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please sign in again to continue listening."
+    "auth.session.expired.body": {
+      "comment": "Modal sheet body message explaining the user needs to re-authenticate.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please sign in again to continue listening."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inicia sesión de nuevo para continuar escuchando."
           }
         }
       }
     },
-    "auth.sign_in" : {
-      "comment" : "Primary sign-in button on LoginView and the auth-expired sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in"
+    "auth.sign_in": {
+      "comment": "Primary sign-in button on LoginView and the auth-expired sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Iniciar sesión"
           }
         }
       }
     },
-    "auth.sign_in.again.a11y" : {
-      "comment" : "Accessibility label for the sign-in button on the auth-expired sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in again"
+    "auth.sign_in.again.a11y": {
+      "comment": "Accessibility label for the sign-in button on the auth-expired sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Iniciar sesión de nuevo"
           }
         }
       }
     },
-    "auth.signing_in" : {
-      "comment" : "Button label shown while a sign-in request is in flight.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signing in\u2026"
+    "auth.signing_in": {
+      "comment": "Button label shown while a sign-in request is in flight.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing in…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Iniciando sesión…"
           }
         }
       }
     },
-    "banner.server_unreachable.generic" : {
-      "comment" : "ServerUnreachableBanner message when the configured server is failing to answer and no host is available to name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can't reach your server."
+    "banner.server_unreachable.generic": {
+      "comment": "ServerUnreachableBanner message when the configured server is failing to answer and no host is available to name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't reach your server."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se puede alcanzar tu servidor."
           }
         }
       }
     },
-    "banner.server_unreachable.named %@" : {
-      "comment" : "ServerUnreachableBanner message naming the configured host. %@ is the user's server host (or host:port) and is interpolated verbatim as user data.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can't reach %@. Trying again\u2026"
+    "banner.server_unreachable.named %@": {
+      "comment": "ServerUnreachableBanner message naming the configured host. %@ is the user's server host (or host:port) and is interpolated verbatim as user data.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't reach %@. Trying again…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se puede alcanzar %@. Volviendo a intentar…"
           }
         }
       }
     },
-    "banner.server_unreachable.retry.a11y" : {
-      "comment" : "VoiceOver label for the Retry button on the server-unreachable banner.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry server connection"
+    "banner.server_unreachable.retry.a11y": {
+      "comment": "VoiceOver label for the Retry button on the server-unreachable banner.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry server connection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reintentar conexión con el servidor"
           }
         }
       }
     },
-    "breadcrumb.album.fallback" : {
-      "comment" : "Breadcrumb segment when the current album hasn't resolved its name yet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album"
+    "breadcrumb.album.fallback": {
+      "comment": "Breadcrumb segment when the current album hasn't resolved its name yet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
           }
         }
       }
     },
-    "breadcrumb.artist.fallback" : {
-      "comment" : "Breadcrumb segment when the current artist hasn't resolved its name yet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Artist"
+    "breadcrumb.artist.fallback": {
+      "comment": "Breadcrumb segment when the current artist hasn't resolved its name yet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
           }
         }
       }
     },
-    "breadcrumb.playlist.fallback" : {
-      "comment" : "Breadcrumb segment when the current playlist hasn't resolved its name yet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Playlist"
+    "breadcrumb.playlist.fallback": {
+      "comment": "Breadcrumb segment when the current playlist hasn't resolved its name yet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lista de reproducción"
           }
         }
       }
     },
-    "common.cancel" : {
-      "comment" : "Generic Cancel action label.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "common.cancel": {
+      "comment": "Generic Cancel action label.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "common.delete" : {
-      "comment" : "Generic Delete action label.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+    "common.delete": {
+      "comment": "Generic Delete action label.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Eliminar"
           }
         }
       }
     },
-    "common.dismiss.a11y" : {
-      "comment" : "Accessibility label for a close/dismiss button on toasts and banners.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+    "common.dismiss.a11y": {
+      "comment": "Accessibility label for a close/dismiss button on toasts and banners.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Descartar"
           }
         }
       }
     },
-    "common.done" : {
-      "comment" : "Generic Done action label, used to dismiss read-only sheets.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "common.done": {
+      "comment": "Generic Done action label, used to dismiss read-only sheets.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Listo"
           }
         }
       }
     },
-    "common.retry" : {
-      "comment" : "Retry action label — shared between offline and stream-error toasts/banners.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+    "common.retry": {
+      "comment": "Retry action label — shared between offline and stream-error toasts/banners.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reintentar"
           }
         }
       }
     },
-    "count.albums %lld" : {
-      "comment" : "Standalone album count, e.g. an artist or genre subtitle. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld album"
+    "count.albums %lld": {
+      "comment": "Standalone album count, e.g. an artist or genre subtitle. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld album"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld albums"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld albums"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld álbum"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld álbumes"
                 }
               }
             }
@@ -253,23 +385,41 @@
         }
       }
     },
-    "count.artists %lld" : {
-      "comment" : "Standalone artist count, e.g. a Favorites subtitle. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld artist"
+    "count.artists %lld": {
+      "comment": "Standalone artist count, e.g. a Favorites subtitle. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld artist"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld artists"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld artists"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artista"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld artistas"
                 }
               }
             }
@@ -277,23 +427,41 @@
         }
       }
     },
-    "count.items %lld" : {
-      "comment" : "Generic queue or list item count, e.g. \"Clear N items?\". %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld item"
+    "count.items %lld": {
+      "comment": "Generic queue or list item count, e.g. \"Clear N items?\". %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld item"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld items"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld items"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elemento"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elementos"
                 }
               }
             }
@@ -301,23 +469,41 @@
         }
       }
     },
-    "count.playlists %lld" : {
-      "comment" : "Standalone playlist count. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld playlist"
+    "count.playlists %lld": {
+      "comment": "Standalone playlist count. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld playlist"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld playlists"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld playlists"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld lista de reproducción"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld listas de reproducción"
                 }
               }
             }
@@ -325,23 +511,41 @@
         }
       }
     },
-    "count.plays %lld" : {
-      "comment" : "Lifetime play-count for a track. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld play"
+    "count.plays %lld": {
+      "comment": "Lifetime play-count for a track. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld play"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld plays"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld plays"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld reproducción"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld reproducciones"
                 }
               }
             }
@@ -349,23 +553,41 @@
         }
       }
     },
-    "count.results %lld" : {
-      "comment" : "Search result count. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld result"
+    "count.results %lld": {
+      "comment": "Search result count. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld result"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld results"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld results"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld resultado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld resultados"
                 }
               }
             }
@@ -373,23 +595,41 @@
         }
       }
     },
-    "count.selected %lld" : {
-      "comment" : "Multiselect tally, e.g. \"N selected\" in a selection banner. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld selected"
+    "count.selected %lld": {
+      "comment": "Multiselect tally, e.g. \"N selected\" in a selection banner. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld selected"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld selected"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld selected"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld seleccionado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld seleccionados"
                 }
               }
             }
@@ -397,23 +637,41 @@
         }
       }
     },
-    "count.songs %lld" : {
-      "comment" : "Standalone song count, e.g. an artist or genre subtitle. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld song"
+    "count.songs %lld": {
+      "comment": "Standalone song count, e.g. an artist or genre subtitle. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld song"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld songs"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld songs"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld canción"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld canciones"
                 }
               }
             }
@@ -421,23 +679,41 @@
         }
       }
     },
-    "count.tracks %lld" : {
-      "comment" : "Standalone track count, e.g. a playlist or album subtitle. %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld track"
+    "count.tracks %lld": {
+      "comment": "Standalone track count, e.g. a playlist or album subtitle. %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld track"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld tracks"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld pista"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld pistas"
                 }
               }
             }
@@ -445,1187 +721,1787 @@
         }
       }
     },
-    "empty.library.title" : {
-      "comment" : "Headline on the empty-library state shown when the server has no music yet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No music yet"
+    "empty.library.title": {
+      "comment": "Headline on the empty-library state shown when the server has no music yet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No music yet"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Aún no hay música"
+          }
         }
       }
     },
-    "empty.library.subtitle" : {
-      "comment" : "Body copy on the empty-library state explaining that the server is empty or still indexing.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Jellyfin server doesn't have any music in its library, or it's still being indexed. Add a library on the server, then refresh."
+    "empty.library.subtitle": {
+      "comment": "Body copy on the empty-library state explaining that the server is empty or still indexing.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Jellyfin server doesn't have any music in its library, or it's still being indexed. Add a library on the server, then refresh."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tu servidor Jellyfin no tiene música en su biblioteca, o aún se está indexando. Añade una biblioteca en el servidor y actualiza."
+          }
         }
       }
     },
-    "empty.library.open_web" : {
-      "comment" : "CTA on the empty-library state that opens the Jellyfin web admin UI.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Jellyfin web"
+    "empty.library.open_web": {
+      "comment": "CTA on the empty-library state that opens the Jellyfin web admin UI.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Jellyfin web"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Jellyfin web"
           }
         }
       }
     },
-    "empty.queue.title" : {
-      "comment" : "Empty state title inside the queue inspector panel.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queue is empty"
+    "empty.queue.title": {
+      "comment": "Empty state title inside the queue inspector panel.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queue is empty"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La cola está vacía"
+          }
         }
       }
     },
-    "empty.queue.subtitle" : {
-      "comment" : "Empty state subtitle inside the queue inspector panel.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play something to start a queue."
+    "empty.queue.subtitle": {
+      "comment": "Empty state subtitle inside the queue inspector panel.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play something to start a queue."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduce algo para iniciar una cola."
+          }
         }
       }
     },
-    "error.auth.expired" : {
-      "comment" : "Banner copy for LyrebirdError.AuthExpired / Auth — surfaced by LyrebirdErrorPresenter.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please sign in again."
+    "error.auth.expired": {
+      "comment": "Banner copy for LyrebirdError.AuthExpired / Auth — surfaced by LyrebirdErrorPresenter.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please sign in again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inicia sesión de nuevo."
           }
         }
       }
     },
-    "error.forbidden" : {
-      "comment" : "Banner copy when a core call returns HTTP 403.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You don't have permission to do that."
+    "error.forbidden": {
+      "comment": "Banner copy when a core call returns HTTP 403.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You don't have permission to do that."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No tienes permiso para hacer eso."
+          }
         }
       }
     },
-    "error.not_found" : {
-      "comment" : "Banner copy when a core call returns HTTP 404.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That item couldn't be found."
+    "error.not_found": {
+      "comment": "Banner copy when a core call returns HTTP 404.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That item couldn't be found."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se encontró ese elemento."
+          }
         }
       }
     },
-    "error.rate_limit" : {
-      "comment" : "Banner copy when the server throttles us (HTTP 429).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Too many requests. Please try again in a moment."
+    "error.rate_limit": {
+      "comment": "Banner copy when the server throttles us (HTTP 429).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Too many requests. Please try again in a moment."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Demasiadas solicitudes. Vuelve a intentarlo en un momento."
           }
         }
       }
     },
-    "error.network" : {
-      "comment" : "Banner copy for transport-level failures (LyrebirdError.Network).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network error. Check your connection and try again."
+    "error.network": {
+      "comment": "Banner copy for transport-level failures (LyrebirdError.Network).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network error. Check your connection and try again."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Error de red. Verifica tu conexión e inténtalo de nuevo."
+          }
         }
       }
     },
-    "error.server" : {
-      "comment" : "Banner copy for HTTP 5xx responses (LyrebirdError.Server non-auth).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The server ran into a problem. Please try again."
+    "error.server": {
+      "comment": "Banner copy for HTTP 5xx responses (LyrebirdError.Server non-auth).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The server ran into a problem. Please try again."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "El servidor encontró un problema. Inténtalo de nuevo."
+          }
         }
       }
     },
-    "error.decode" : {
-      "comment" : "Banner copy for LyrebirdError.Decode — the server response couldn't be parsed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't read the server's response."
+    "error.decode": {
+      "comment": "Banner copy for LyrebirdError.Decode — the server response couldn't be parsed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't read the server's response."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo leer la respuesta del servidor."
           }
         }
       }
     },
-    "error.download" : {
-      "comment" : "Banner copy when downloading a track for offline playback fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't download for offline playback."
+    "error.download": {
+      "comment": "Banner copy when downloading a track for offline playback fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't download for offline playback."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo descargar para reproducción sin conexión."
+          }
         }
       }
     },
-    "error.storage" : {
-      "comment" : "Banner copy for LyrebirdError.Storage — local SQLite or cache failure.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local storage error. Please try again."
+    "error.storage": {
+      "comment": "Banner copy for LyrebirdError.Storage — local SQLite or cache failure.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local storage error. Please try again."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Error de almacenamiento local. Inténtalo de nuevo."
+          }
         }
       }
     },
-    "error.credentials" : {
-      "comment" : "Banner copy for LyrebirdError.Credentials — keychain access failed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't access the system keychain."
+    "error.credentials": {
+      "comment": "Banner copy for LyrebirdError.Credentials — keychain access failed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't access the system keychain."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo acceder al llavero del sistema."
           }
         }
       }
     },
-    "error.audio" : {
-      "comment" : "Banner copy for LyrebirdError.Audio — the audio engine failed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio playback error."
+    "error.audio": {
+      "comment": "Banner copy for LyrebirdError.Audio — the audio engine failed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio playback error."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Error de reproducción de audio."
+          }
         }
       }
     },
-    "error.certificate" : {
-      "comment" : "Banner copy for LyrebirdError.SelfSignedCertificate — the server's TLS certificate couldn't be verified (e.g. self-signed). The user may need to trust the server.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The server's certificate couldn't be verified. You may need to trust this server."
+    "error.certificate": {
+      "comment": "Banner copy for LyrebirdError.SelfSignedCertificate — the server's TLS certificate couldn't be verified (e.g. self-signed). The user may need to trust the server.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The server's certificate couldn't be verified. You may need to trust this server."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo verificar el certificado del servidor. Es posible que debas confiar en este servidor."
+          }
         }
       }
     },
-    "error.invalid_input" : {
-      "comment" : "Banner copy for LyrebirdError.InvalidInput — user-supplied value was rejected.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That value isn't valid."
+    "error.invalid_input": {
+      "comment": "Banner copy for LyrebirdError.InvalidInput — user-supplied value was rejected.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That value isn't valid."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ese valor no es válido."
           }
         }
       }
     },
-    "error.other" : {
-      "comment" : "Banner copy for LyrebirdError.Other — catch-all fallback.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something went wrong."
+    "error.other": {
+      "comment": "Banner copy for LyrebirdError.Other — catch-all fallback.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Algo salió mal."
+          }
         }
       }
     },
-    "error.playback" : {
-      "comment" : "Banner copy when the audio engine fails to start a track.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't start playback."
+    "error.playback": {
+      "comment": "Banner copy when the audio engine fails to start a track.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't start playback."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo iniciar la reproducción."
+          }
         }
       }
     },
-    "error.library.load" : {
-      "comment" : "Banner prefix when the library refresh pipeline fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load your library."
+    "error.library.load": {
+      "comment": "Banner prefix when the library refresh pipeline fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load your library."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo cargar tu biblioteca."
           }
         }
       }
     },
-    "error.playlists.load" : {
-      "comment" : "Banner copy when refreshing playlists fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load playlists."
+    "error.playlists.load": {
+      "comment": "Banner copy when refreshing playlists fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load playlists."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudieron cargar las listas de reproducción."
+          }
         }
       }
     },
-    "error.playlist.load" : {
-      "comment" : "Banner copy when loading a single playlist fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load this playlist."
+    "error.playlist.load": {
+      "comment": "Banner copy when loading a single playlist fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load this playlist."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo cargar esta lista de reproducción."
+          }
         }
       }
     },
-    "error.album.tracks" : {
-      "comment" : "Banner copy when loading album tracks fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load album tracks."
+    "error.album.tracks": {
+      "comment": "Banner copy when loading album tracks fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load album tracks."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudieron cargar las pistas del álbum."
           }
         }
       }
     },
-    "error.playlist.tracks" : {
-      "comment" : "Banner copy when loading playlist tracks fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load playlist tracks."
+    "error.playlist.tracks": {
+      "comment": "Banner copy when loading playlist tracks fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load playlist tracks."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudieron cargar las pistas de la lista de reproducción."
+          }
         }
       }
     },
-    "error.search" : {
-      "comment" : "Banner copy when a search query fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search failed."
+    "error.search": {
+      "comment": "Banner copy when a search query fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search failed."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Error al buscar."
+          }
         }
       }
     },
-    "error.favorite" : {
-      "comment" : "Banner copy when toggling a favorite fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't update favorite."
+    "error.favorite": {
+      "comment": "Banner copy when toggling a favorite fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't update favorite."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo actualizar favorito."
           }
         }
       }
     },
-    "error.markPlayed" : {
-      "comment" : "Banner copy when marking an item played / unplayed fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't update played status."
+    "error.markPlayed": {
+      "comment": "Banner copy when marking an item played / unplayed fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't update played status."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo actualizar el estado de reproducción."
+          }
         }
       }
     },
-    "error.playlist.add" : {
-      "comment" : "Banner copy when adding a track to a playlist fails.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't add to playlist."
+    "error.playlist.add": {
+      "comment": "Banner copy when adding a track to a playlist fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't add to playlist."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo añadir a la lista de reproducción."
+          }
         }
       }
     },
-    "error.login.failed" : {
-      "comment" : "Banner copy when login fails for a generic reason.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in failed."
+    "error.login.failed": {
+      "comment": "Banner copy when login fails for a generic reason.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in failed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Error al iniciar sesión."
           }
         }
       }
     },
-    "error.wrong_credentials" : {
-      "comment" : "Inline error on LoginView when the server returns 401 on submit.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wrong username or password"
+    "error.wrong_credentials": {
+      "comment": "Inline error on LoginView when the server returns 401 on submit.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wrong username or password"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usuario o contraseña incorrectos"
+          }
         }
       }
     },
-    "login.placeholder.not_wired" : {
-      "comment" : "Placeholder banner when a menu action is temporarily unavailable.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This action is not available yet."
+    "login.placeholder.not_wired": {
+      "comment": "Placeholder banner when a menu action is temporarily unavailable.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This action is not available yet."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esta acción no está disponible aún."
+          }
         }
       }
     },
-    "login.network_banner" : {
-      "comment" : "Top-of-column banner on LoginView when the system is offline.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No network. Check your connection."
+    "login.network_banner": {
+      "comment": "Top-of-column banner on LoginView when the system is offline.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No network. Check your connection."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sin red. Verifica tu conexión."
           }
         }
       }
     },
-    "login.probe.checking" : {
-      "comment" : "Status row under the server URL field while probing.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking\u2026"
+    "login.probe.checking": {
+      "comment": "Status row under the server URL field while probing.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Verificando…"
+          }
         }
       }
     },
-    "login.field.url" : {
-      "comment" : "Uppercase field label above the server URL input.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SERVER URL"
+    "login.field.url": {
+      "comment": "Uppercase field label above the server URL input.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SERVER URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL DEL SERVIDOR"
+          }
         }
       }
     },
-    "login.field.username" : {
-      "comment" : "Uppercase field label above the username input.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USERNAME"
+    "login.field.username": {
+      "comment": "Uppercase field label above the username input.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USERNAME"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "USUARIO"
           }
         }
       }
     },
-    "login.field.password" : {
-      "comment" : "Uppercase field label above the password input.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PASSWORD"
+    "login.field.password": {
+      "comment": "Uppercase field label above the password input.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PASSWORD"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CONTRASEÑA"
+          }
         }
       }
     },
-    "login.username.placeholder" : {
-      "comment" : "TextField prompt for the username input.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "you"
+    "login.username.placeholder": {
+      "comment": "TextField prompt for the username input.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "you"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "tú"
+          }
         }
       }
     },
-    "login.discovered_servers" : {
-      "comment" : "Heading above the LAN-discovered server chip row.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FOUND ON THIS NETWORK"
+    "login.discovered_servers": {
+      "comment": "Heading above the LAN-discovered server chip row.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FOUND ON THIS NETWORK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ENCONTRADO EN ESTA RED"
           }
         }
       }
     },
-    "login.a11y.server_url" : {
-      "comment" : "Accessibility label for the server URL field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server URL"
+    "login.a11y.server_url": {
+      "comment": "Accessibility label for the server URL field.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "URL del servidor"
+          }
         }
       }
     },
-    "login.a11y.username" : {
-      "comment" : "Accessibility label for the username field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+    "login.a11y.username": {
+      "comment": "Accessibility label for the username field.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usuario"
+          }
         }
       }
     },
-    "login.a11y.password" : {
-      "comment" : "Accessibility label for the password field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+    "login.a11y.password": {
+      "comment": "Accessibility label for the password field.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Contraseña"
           }
         }
       }
     },
-    "onboarding.back" : {
-      "comment" : "Back button on the onboarding connect step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+    "onboarding.back": {
+      "comment": "Back button on the onboarding connect step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atrás"
+          }
         }
       }
     },
-    "onboarding.welcome.title" : {
-      "comment" : "Hero headline on the first onboarding screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welcome to Lyrebird"
+    "onboarding.welcome.title": {
+      "comment": "Hero headline on the first onboarding screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to Lyrebird"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bienvenido a Lyrebird"
+          }
         }
       }
     },
-    "onboarding.welcome.subtitle" : {
-      "comment" : "Tagline under the welcome headline.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your music, your server, your rules."
+    "onboarding.welcome.subtitle": {
+      "comment": "Tagline under the welcome headline.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your music, your server, your rules."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tu música, tu servidor, tus reglas."
           }
         }
       }
     },
-    "onboarding.welcome.get_started" : {
-      "comment" : "Primary CTA on the welcome screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get started"
+    "onboarding.welcome.get_started": {
+      "comment": "Primary CTA on the welcome screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get started"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Comenzar"
+          }
         }
       }
     },
-    "onboarding.welcome.existing_account" : {
-      "comment" : "Secondary link on the welcome screen for returning users.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I already have an account →"
+    "onboarding.welcome.existing_account": {
+      "comment": "Secondary link on the welcome screen for returning users.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I already have an account →"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ya tengo una cuenta →"
+          }
         }
       }
     },
-    "onboarding.welcome.existing_account.a11y" : {
-      "comment" : "Accessibility label for the returning-user link on the welcome screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I already have an account"
+    "onboarding.welcome.existing_account.a11y": {
+      "comment": "Accessibility label for the returning-user link on the welcome screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I already have an account"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ya tengo una cuenta"
           }
         }
       }
     },
-    "onboarding.connect.title" : {
-      "comment" : "Heading on the onboarding connect-server step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect your server"
+    "onboarding.connect.title": {
+      "comment": "Heading on the onboarding connect-server step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect your server"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Conecta tu servidor"
+          }
         }
       }
     },
-    "onboarding.connect.subtitle" : {
-      "comment" : "Helper copy under the connect-server heading.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Jellyfin URL is the address you use to reach it from a browser."
+    "onboarding.connect.subtitle": {
+      "comment": "Helper copy under the connect-server heading.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Jellyfin URL is the address you use to reach it from a browser."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "La URL de Jellyfin es la dirección que usas para acceder desde un navegador."
+          }
         }
       }
     },
-    "onboarding.connect.continue" : {
-      "comment" : "Primary submit button on the connect step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "onboarding.connect.continue": {
+      "comment": "Primary submit button on the connect step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Continuar"
           }
         }
       }
     },
-    "onboarding.connect.connecting" : {
-      "comment" : "Submit button label while a sign-in request is in flight.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting…"
+    "onboarding.connect.connecting": {
+      "comment": "Submit button label while a sign-in request is in flight.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Conectando…"
+          }
         }
       }
     },
-    "onboarding.connect.skip_offline" : {
-      "comment" : "Link that skips sign-in and lets the user explore offline.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip, explore offline →"
+    "onboarding.connect.skip_offline": {
+      "comment": "Link that skips sign-in and lets the user explore offline.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip, explore offline →"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Omitir, explorar sin conexión →"
+          }
         }
       }
     },
-    "onboarding.sync.title" : {
-      "comment" : "Heading on the first-sync step that shows library loading progress.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading your library"
+    "onboarding.sync.title": {
+      "comment": "Heading on the first-sync step that shows library loading progress.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cargando tu biblioteca"
           }
         }
       }
     },
-    "onboarding.sync.phase.artists" : {
-      "comment" : "Progress line while artists are loading on the first-sync step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading artists…"
+    "onboarding.sync.phase.artists": {
+      "comment": "Progress line while artists are loading on the first-sync step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading artists…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cargando artistas…"
+          }
         }
       }
     },
-    "onboarding.sync.phase.albums" : {
-      "comment" : "Progress line while albums are loading on the first-sync step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading albums…"
+    "onboarding.sync.phase.albums": {
+      "comment": "Progress line while albums are loading on the first-sync step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading albums…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cargando álbumes…"
+          }
         }
       }
     },
-    "onboarding.sync.phase.tracks" : {
-      "comment" : "Progress line while tracks are loading on the first-sync step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading tracks…"
+    "onboarding.sync.phase.tracks": {
+      "comment": "Progress line while tracks are loading on the first-sync step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading tracks…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cargando pistas…"
           }
         }
       }
     },
-    "onboarding.sync.phase.artwork" : {
-      "comment" : "Progress line while artwork is loading on the first-sync step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching artwork…"
+    "onboarding.sync.phase.artwork": {
+      "comment": "Progress line while artwork is loading on the first-sync step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetching artwork…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Obteniendo portadas…"
+          }
         }
       }
     },
-    "onboarding.sync.counter" : {
-      "comment" : "Library totals counter on the first-sync step. %1$@ is the track count, %2$@ the artist count, %3$@ the album count, each pre-formatted with grouping separators.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ tracks · %2$@ artists · %3$@ albums"
+    "onboarding.sync.counter": {
+      "comment": "Library totals counter on the first-sync step. %1$@ is the track count, %2$@ the artist count, %3$@ the album count, each pre-formatted with grouping separators.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ tracks · %2$@ artists · %3$@ albums"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%1$@ pistas · %2$@ artistas · %3$@ álbumes"
+          }
         }
       }
     },
-    "onboarding.sync.continue" : {
-      "comment" : "CTA that leaves onboarding for the Home screen once the library has loaded.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue to Home"
+    "onboarding.sync.continue": {
+      "comment": "CTA that leaves onboarding for the Home screen once the library has loaded.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue to Home"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir a inicio"
           }
         }
       }
     },
-    "onboarding.sync.syncing" : {
-      "comment" : "Disabled CTA label shown while the library is still loading.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing…"
+    "onboarding.sync.syncing": {
+      "comment": "Disabled CTA label shown while the library is still loading.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sincronizando…"
+          }
         }
       }
     },
-    "onboarding.sync.error" : {
-      "comment" : "Status line on the first-sync step when the library failed to load; offers a retry.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn’t load your library."
+    "onboarding.sync.error": {
+      "comment": "Status line on the first-sync step when the library failed to load; offers a retry.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t load your library."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo cargar tu biblioteca."
+          }
         }
       }
     },
-    "onboarding.sync.retry" : {
-      "comment" : "Button that re-attempts the library load after a failure on the first-sync step.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    "onboarding.sync.retry": {
+      "comment": "Button that re-attempts the library load after a failure on the first-sync step.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intentar de nuevo"
           }
         }
       }
     },
-    "menu.app.about" : {
-      "comment" : "App menu \u201cAbout Lyrebird\u201d item that opens the dedicated About window (#25).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About Lyrebird"
+    "menu.app.about": {
+      "comment": "App menu “About Lyrebird” item that opens the dedicated About window (#25).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About Lyrebird"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Acerca de Lyrebird"
+          }
         }
       }
     },
-    "menu.file.new_playlist" : {
-      "comment" : "File > New > New Playlist\u2026 menu item.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Playlist\u2026"
+    "menu.file.new_playlist": {
+      "comment": "File > New > New Playlist… menu item.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Playlist…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nueva lista de reproducción…"
+          }
         }
       }
     },
-    "menu.file.new_window" : {
-      "comment" : "File > New Window menu item. Opens an additional main app window (\u21e7\u2318N). Playback and library are shared across windows.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Window"
+    "menu.file.new_window": {
+      "comment": "File > New Window menu item. Opens an additional main app window (⇧⌘N). Playback and library are shared across windows.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Window"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nueva ventana"
           }
         }
       }
     },
-    "menu.view.show_sidebar" : {
-      "comment" : "View menu item to toggle the sidebar visibility (placeholder until #5 lands).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Sidebar"
+    "menu.view.show_sidebar": {
+      "comment": "View menu item to toggle the sidebar visibility (placeholder until #5 lands).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Sidebar"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar barra lateral"
+          }
         }
       }
     },
-    "menu.view.show_queue" : {
-      "comment" : "View menu item to toggle the queue inspector.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Queue Inspector"
+    "menu.view.show_queue": {
+      "comment": "View menu item to toggle the queue inspector.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Queue Inspector"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar inspector de cola"
+          }
         }
       }
     },
-    "menu.nav.home" : {
-      "comment" : "View menu navigation entry for the Home screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Home"
+    "menu.nav.home": {
+      "comment": "View menu navigation entry for the Home screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inicio"
           }
         }
       }
     },
-    "menu.nav.library" : {
-      "comment" : "View menu navigation entry for the Library screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Library"
+    "menu.nav.library": {
+      "comment": "View menu navigation entry for the Library screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Biblioteca"
+          }
         }
       }
     },
-    "menu.nav.search" : {
-      "comment" : "View menu navigation entry for the Search screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+    "menu.nav.search": {
+      "comment": "View menu navigation entry for the Search screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar"
+          }
         }
       }
     },
-    "menu.nav.find" : {
-      "comment" : "View > Find\u2026 menu item (\u2318F).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Find\u2026"
+    "menu.nav.find": {
+      "comment": "View > Find… menu item (⌘F).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar…"
           }
         }
       }
     },
-    "menu.nav.find_global" : {
-      "comment" : "View > Find in Library\u2026 menu item (\u2318\u21e7F): focuses the global Search surface.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Find in Library\u2026"
+    "menu.nav.find_global": {
+      "comment": "View > Find in Library… menu item (⌘⇧F): focuses the global Search surface.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find in Library…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar en la biblioteca…"
+          }
         }
       }
     },
-    "menu.nav.now_playing" : {
-      "comment" : "View menu item: \"Go to Now Playing\" (\u2318L).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to Now Playing"
+    "menu.nav.now_playing": {
+      "comment": "View menu item: \"Go to Now Playing\" (⌘L).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to Now Playing"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir a reproducción actual"
+          }
         }
       }
     },
-    "menu.nav.play_queue" : {
-      "comment" : "View menu item: \"Play Queue\" (\u2318U) \u2014 opens the full-page Play Queue view.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play Queue"
+    "menu.nav.play_queue": {
+      "comment": "View menu item: \"Play Queue\" (⌘U) — opens the full-page Play Queue view.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play Queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cola de reproducción"
           }
         }
       }
     },
-    "menu.nav.command_palette" : {
-      "comment" : "View menu item that opens the \u2318K Command Palette.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command Palette\u2026"
+    "menu.nav.command_palette": {
+      "comment": "View menu item that opens the ⌘K Command Palette.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Palette…"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Paleta de comandos…"
+          }
         }
       }
     },
-    "menu.playback" : {
-      "comment" : "Top-level Playback menu name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Playback"
+    "menu.playback": {
+      "comment": "Top-level Playback menu name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducción"
+          }
         }
       }
     },
-    "menu.playback.play" : {
-      "comment" : "Playback menu item: Play.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play"
+    "menu.playback.play": {
+      "comment": "Playback menu item: Play.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir"
           }
         }
       }
     },
-    "menu.playback.pause" : {
-      "comment" : "Playback menu item: Pause.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+    "menu.playback.pause": {
+      "comment": "Playback menu item: Pause.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
+          }
         }
       }
     },
-    "menu.playback.next" : {
-      "comment" : "Playback menu item: Next Track.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next Track"
+    "menu.playback.next": {
+      "comment": "Playback menu item: Next Track.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pista siguiente"
+          }
         }
       }
     },
-    "menu.playback.previous" : {
-      "comment" : "Playback menu item: Previous Track.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous Track"
+    "menu.playback.previous": {
+      "comment": "Playback menu item: Previous Track.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pista anterior"
           }
         }
       }
     },
-    "menu.playback.volume_up" : {
-      "comment" : "Playback menu item: Volume Up.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volume Up"
+    "menu.playback.volume_up": {
+      "comment": "Playback menu item: Volume Up.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volume Up"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Subir volumen"
+          }
         }
       }
     },
-    "menu.playback.volume_down" : {
-      "comment" : "Playback menu item: Volume Down.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volume Down"
+    "menu.playback.volume_down": {
+      "comment": "Playback menu item: Volume Down.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volume Down"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bajar volumen"
+          }
         }
       }
     },
-    "menu.playback.seek_forward" : {
-      "comment" : "Playback menu item: Seek Forward 10s.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seek Forward 10s"
+    "menu.playback.seek_forward": {
+      "comment": "Playback menu item: Seek Forward 10s.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seek Forward 10s"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Avanzar 10s"
           }
         }
       }
     },
-    "menu.playback.seek_back" : {
-      "comment" : "Playback menu item: Seek Back 10s.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seek Back 10s"
+    "menu.playback.seek_back": {
+      "comment": "Playback menu item: Seek Back 10s.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seek Back 10s"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Retroceder 10s"
+          }
         }
       }
     },
-    "menu.playback.stop" : {
-      "comment" : "Playback menu item: Stop.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+    "menu.playback.stop": {
+      "comment": "Playback menu item: Stop.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Detener"
+          }
         }
       }
     },
-    "menu.window.tile_left" : {
-      "comment" : "Window menu item: tile current window to left half of screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tile Window to Left of Screen"
+    "menu.window.tile_left": {
+      "comment": "Window menu item: tile current window to left half of screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tile Window to Left of Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ajustar ventana a la izquierda"
           }
         }
       }
     },
-    "menu.window.tile_right" : {
-      "comment" : "Window menu item: tile current window to right half of screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tile Window to Right of Screen"
+    "menu.window.tile_right": {
+      "comment": "Window menu item: tile current window to right half of screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tile Window to Right of Screen"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ajustar ventana a la derecha"
+          }
         }
       }
     },
-    "menu.help.lyrebird" : {
-      "comment" : "Help menu entry that opens the repo in a browser.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird Help"
+    "menu.help.lyrebird": {
+      "comment": "Help menu entry that opens the repo in a browser.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird Help"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ayuda de Lyrebird"
+          }
         }
       }
     },
-    "menu.view.toggle_queue" : {
-      "comment" : "Invisible \u2318\u2325Q button label used to register the Queue Inspector shortcut inside MainShell.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toggle Queue Inspector"
+    "menu.view.toggle_queue": {
+      "comment": "Invisible ⌘⌥Q button label used to register the Queue Inspector shortcut inside MainShell.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Queue Inspector"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Alternar inspector de cola"
           }
         }
       }
     },
-    "player.nothing_playing" : {
-      "comment" : "PlayerBar left-meta label when no track is loaded.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nothing playing"
+    "player.nothing_playing": {
+      "comment": "PlayerBar left-meta label when no track is loaded.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing playing"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nada en reproducción"
+          }
         }
       }
     },
-    "sidebar.nav.home" : {
-      "comment" : "Sidebar primary nav item: Home.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Home"
+    "sidebar.nav.home": {
+      "comment": "Sidebar primary nav item: Home.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Inicio"
+          }
         }
       }
     },
-    "sidebar.nav.discover" : {
-      "comment" : "Sidebar primary nav item: Discover.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discover"
+    "sidebar.nav.discover": {
+      "comment": "Sidebar primary nav item: Discover.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discover"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Descubrir"
           }
         }
       }
     },
-    "sidebar.nav.radio" : {
-      "comment" : "Sidebar primary nav item: Radio.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Radio"
+    "sidebar.nav.radio": {
+      "comment": "Sidebar primary nav item: Radio.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radio"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Radio"
+          }
         }
       }
     },
-    "sidebar.nav.library" : {
-      "comment" : "Sidebar primary nav item: Library.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Library"
+    "sidebar.nav.library": {
+      "comment": "Sidebar primary nav item: Library.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Biblioteca"
           }
         }
       }
     },
-    "sidebar.nav.search" : {
-      "comment" : "Sidebar primary nav item: Search.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+    "sidebar.nav.search": {
+      "comment": "Sidebar primary nav item: Search.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar"
+          }
         }
       }
     },
-    "sidebar.section.your_library" : {
-      "comment" : "Sidebar section header above the stats rows.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Library"
+    "sidebar.section.your_library": {
+      "comment": "Sidebar section header above the stats rows.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tu biblioteca"
           }
         }
       }
     },
-    "sidebar.server.connected %lld" : {
-      "comment" : "Sidebar footer status line when the server is reachable; %lld is the total album count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Connected · %lld album"
+    "sidebar.server.connected %lld": {
+      "comment": "Sidebar footer status line when the server is reachable; %lld is the total album count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Connected · %lld album"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Connected · %lld albums"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Connected · %lld albums"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elemento"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld elementos"
                 }
               }
             }
@@ -1633,323 +2509,491 @@
         }
       }
     },
-    "sidebar.server.disconnected" : {
-      "comment" : "Sidebar footer status line when there is no session or the server is unreachable.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnected"
+    "sidebar.server.disconnected": {
+      "comment": "Sidebar footer status line when there is no session or the server is unreachable.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Desconectado"
           }
         }
       }
     },
-    "sidebar.stats.favorites" : {
-      "comment" : "Sidebar stats row: Favorites.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorites"
+    "sidebar.stats.favorites": {
+      "comment": "Sidebar stats row: Favorites.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorites"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favoritos"
           }
         }
       }
     },
-    "sidebar.stats.albums" : {
-      "comment" : "Sidebar stats row: Albums.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Albums"
+    "sidebar.stats.albums": {
+      "comment": "Sidebar stats row: Albums.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albums"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbumes"
           }
         }
       }
     },
-    "sidebar.stats.artists" : {
-      "comment" : "Sidebar stats row: Artists.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Artists"
+    "sidebar.stats.artists": {
+      "comment": "Sidebar stats row: Artists.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistas"
           }
         }
       }
     },
-    "sidebar.stats.playlists" : {
-      "comment" : "Sidebar stats row: Playlists.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Playlists"
+    "sidebar.stats.playlists": {
+      "comment": "Sidebar stats row: Playlists.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playlists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Listas de reproducción"
           }
         }
       }
     },
-    "smart_playlist.a11y.edit_rules" : {
-      "comment" : "Accessibility label for the Edit Rules button on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit smart playlist rules"
+    "smart_playlist.a11y.edit_rules": {
+      "comment": "Accessibility label for the Edit Rules button on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit smart playlist rules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Editar reglas de lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.a11y.play" : {
-      "comment" : "Accessibility label for the Play button on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play smart playlist"
+    "smart_playlist.a11y.play": {
+      "comment": "Accessibility label for the Play button on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play smart playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.a11y.shuffle" : {
-      "comment" : "Accessibility label for the Shuffle button on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuffle smart playlist"
+    "smart_playlist.a11y.shuffle": {
+      "comment": "Accessibility label for the Shuffle button on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffle smart playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mezclar lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.badge" : {
-      "comment" : "Small uppercase badge above the title on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SMART PLAYLIST"
+    "smart_playlist.badge": {
+      "comment": "Small uppercase badge above the title on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SMART PLAYLIST"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "LISTA INTELIGENTE"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.add_rule" : {
-      "comment" : "Accessibility label for the Add Rule button in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add rule"
+    "smart_playlist.builder.a11y.add_rule": {
+      "comment": "Accessibility label for the Add Rule button in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add rule"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Añadir regla"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.field" : {
-      "comment" : "Accessibility label for a rule's field picker in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rule field"
+    "smart_playlist.builder.a11y.field": {
+      "comment": "Accessibility label for a rule's field picker in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rule field"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Campo de regla"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.match_mode" : {
-      "comment" : "Accessibility label for the match-mode (all/any) picker in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Match mode"
+    "smart_playlist.builder.a11y.match_mode": {
+      "comment": "Accessibility label for the match-mode (all/any) picker in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Match mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Modo de coincidencia"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.name" : {
-      "comment" : "Accessibility label for the name field in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart playlist name"
+    "smart_playlist.builder.a11y.name": {
+      "comment": "Accessibility label for the name field in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart playlist name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre de lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.operator" : {
-      "comment" : "Accessibility label for a rule's operator picker in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rule operator"
+    "smart_playlist.builder.a11y.operator": {
+      "comment": "Accessibility label for a rule's operator picker in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rule operator"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Operador de regla"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.remove_rule" : {
-      "comment" : "Accessibility label for the per-row Remove Rule button in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove rule"
+    "smart_playlist.builder.a11y.remove_rule": {
+      "comment": "Accessibility label for the per-row Remove Rule button in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove rule"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Eliminar regla"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.save" : {
-      "comment" : "Accessibility label for the Save button in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save smart playlist"
+    "smart_playlist.builder.a11y.save": {
+      "comment": "Accessibility label for the Save button in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save smart playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Guardar lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.value" : {
-      "comment" : "Accessibility label for a rule's value editor in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rule value"
+    "smart_playlist.builder.a11y.value": {
+      "comment": "Accessibility label for a rule's value editor in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rule value"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valor de regla"
           }
         }
       }
     },
-    "smart_playlist.builder.a11y.value_days" : {
-      "comment" : "Accessibility label for a date rule's day-count value editor in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rule value in days"
+    "smart_playlist.builder.a11y.value_days": {
+      "comment": "Accessibility label for a date rule's day-count value editor in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rule value in days"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Valor de regla en días"
           }
         }
       }
     },
-    "smart_playlist.builder.add_rule" : {
-      "comment" : "Button that appends a new rule row in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Rule"
+    "smart_playlist.builder.add_rule": {
+      "comment": "Button that appends a new rule row in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Rule"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Añadir regla"
           }
         }
       }
     },
-    "smart_playlist.builder.bool_no" : {
-      "comment" : "The \"no\" / false option in a boolean (Favorite) rule's value picker.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no"
+    "smart_playlist.builder.bool_no": {
+      "comment": "The \"no\" / false option in a boolean (Favorite) rule's value picker.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "no"
           }
         }
       }
     },
-    "smart_playlist.builder.bool_yes" : {
-      "comment" : "The \"yes\" / true option in a boolean (Favorite) rule's value picker.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "yes"
+    "smart_playlist.builder.bool_yes": {
+      "comment": "The \"yes\" / true option in a boolean (Favorite) rule's value picker.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "sí"
           }
         }
       }
     },
-    "smart_playlist.builder.cancel" : {
-      "comment" : "Cancel button in the smart playlist builder footer.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "smart_playlist.builder.cancel": {
+      "comment": "Cancel button in the smart playlist builder footer.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "smart_playlist.builder.counting" : {
-      "comment" : "Placeholder shown in the builder footer while the live match count is still being computed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Counting…"
+    "smart_playlist.builder.counting": {
+      "comment": "Placeholder shown in the builder footer while the live match count is still being computed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Counting…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Contando…"
           }
         }
       }
     },
-    "smart_playlist.builder.days_suffix" : {
-      "comment" : "Unit label after a date rule's day-count field, e.g. \"30 days\".",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "days"
+    "smart_playlist.builder.days_suffix": {
+      "comment": "Unit label after a date rule's day-count field, e.g. \"30 days\".",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "days"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "días"
           }
         }
       }
     },
-    "smart_playlist.builder.default_name" : {
-      "comment" : "Fallback name applied when a smart playlist is saved with a blank name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Playlist"
+    "smart_playlist.builder.default_name": {
+      "comment": "Fallback name applied when a smart playlist is saved with a blank name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.builder.match_count %lld" : {
-      "comment" : "Live result count in the builder footer, e.g. \"12 match\". %lld is the count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld match"
+    "smart_playlist.builder.match_count %lld": {
+      "comment": "Live result count in the builder footer, e.g. \"12 match\". %lld is the count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld match"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld match"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld match"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld coincidencia"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "needs_review",
+                  "value": "%lld coincidencias"
                 }
               }
             }
@@ -1957,1711 +3001,2569 @@
         }
       }
     },
-    "smart_playlist.builder.match_prefix" : {
-      "comment" : "Leading word of the \"Match [all/any] of the following rules:\" sentence in the builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Match"
+    "smart_playlist.builder.match_prefix": {
+      "comment": "Leading word of the \"Match [all/any] of the following rules:\" sentence in the builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Match"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Coincidir"
+          }
         }
       }
     },
-    "smart_playlist.builder.match_suffix" : {
-      "comment" : "Trailing clause of the \"Match [all/any] of the following rules:\" sentence in the builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "of the following rules:"
+    "smart_playlist.builder.match_suffix": {
+      "comment": "Trailing clause of the \"Match [all/any] of the following rules:\" sentence in the builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "of the following rules:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "de las siguientes reglas:"
           }
         }
       }
     },
-    "smart_playlist.builder.name_label" : {
-      "comment" : "Uppercase field label above the name input in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NAME"
+    "smart_playlist.builder.name_label": {
+      "comment": "Uppercase field label above the name input in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NAME"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "NOMBRE"
+          }
         }
       }
     },
-    "smart_playlist.builder.name_placeholder" : {
-      "comment" : "Placeholder text for the name input in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Playlist Name"
+    "smart_playlist.builder.name_placeholder": {
+      "comment": "Placeholder text for the name input in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Playlist Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre de la lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.builder.save" : {
-      "comment" : "Save button in the smart playlist builder footer.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "smart_playlist.builder.save": {
+      "comment": "Save button in the smart playlist builder footer.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Guardar"
+          }
         }
       }
     },
-    "smart_playlist.builder.title" : {
-      "comment" : "Header title of the smart playlist builder sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Playlist"
+    "smart_playlist.builder.title": {
+      "comment": "Header title of the smart playlist builder sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Playlist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lista inteligente"
           }
         }
       }
     },
-    "smart_playlist.builder.value_placeholder" : {
-      "comment" : "Placeholder for a text rule's value field in the smart playlist builder.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "value"
+    "smart_playlist.builder.value_placeholder": {
+      "comment": "Placeholder for a text rule's value field in the smart playlist builder.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "value"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "valor"
+          }
         }
       }
     },
-    "smart_playlist.edit_rules" : {
-      "comment" : "Edit Rules button label on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Rules"
+    "smart_playlist.edit_rules": {
+      "comment": "Edit Rules button label on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Rules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Editar reglas"
           }
         }
       }
     },
-    "smart_playlist.empty.detail %lld" : {
-      "comment" : "Body of the empty-result state on the smart playlist detail screen. %lld is the number of tracks loaded so far.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loaded %lld tracks so far. Try loosening the rules, or open the Library so more tracks are in memory."
+    "smart_playlist.empty.detail %lld": {
+      "comment": "Body of the empty-result state on the smart playlist detail screen. %lld is the number of tracks loaded so far.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loaded %lld tracks so far. Try loosening the rules, or open the Library so more tracks are in memory."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Se cargaron %lld pistas hasta ahora. Intenta relajar las reglas o abre la Biblioteca para tener más pistas en memoria."
+          }
         }
       }
     },
-    "smart_playlist.empty.title" : {
-      "comment" : "Headline of the empty-result state on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No tracks match these rules"
+    "smart_playlist.empty.title": {
+      "comment": "Headline of the empty-result state on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tracks match these rules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ninguna pista coincide con estas reglas"
           }
         }
       }
     },
-    "smart_playlist.field.album" : {
-      "comment" : "Smart playlist rule field: Album.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album"
+    "smart_playlist.field.album": {
+      "comment": "Smart playlist rule field: Album.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
+          }
         }
       }
     },
-    "smart_playlist.field.artist" : {
-      "comment" : "Smart playlist rule field: Artist.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Artist"
+    "smart_playlist.field.artist": {
+      "comment": "Smart playlist rule field: Artist.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artista"
           }
         }
       }
     },
-    "smart_playlist.field.favorite" : {
-      "comment" : "Smart playlist rule field: Favorite (boolean).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorite"
+    "smart_playlist.field.favorite": {
+      "comment": "Smart playlist rule field: Favorite (boolean).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorite"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorito"
+          }
         }
       }
     },
-    "smart_playlist.field.genre" : {
-      "comment" : "Smart playlist rule field: Genre.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genre"
+    "smart_playlist.field.genre": {
+      "comment": "Smart playlist rule field: Genre.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Género"
           }
         }
       }
     },
-    "smart_playlist.field.duration" : {
-      "comment" : "Smart playlist rule field: Duration (track length in seconds). The rule value is a plain integer number of seconds; e.g. 300 = 5 minutes.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duration (sec)"
+    "smart_playlist.field.duration": {
+      "comment": "Smart playlist rule field: Duration (track length in seconds). The rule value is a plain integer number of seconds; e.g. 300 = 5 minutes.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duration (sec)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Duración (seg)"
+          }
         }
       }
     },
-    "smart_playlist.field.last_played" : {
-      "comment" : "Smart playlist rule field: Last Played. Sourced from Jellyfin's per-track lastPlayedAt (the server projection exposes last-played, not date-added), so the label reflects last-played semantics.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last Played"
+    "smart_playlist.field.last_played": {
+      "comment": "Smart playlist rule field: Last Played. Sourced from Jellyfin's per-track lastPlayedAt (the server projection exposes last-played, not date-added), so the label reflects last-played semantics.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last Played"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Última reproducción"
+          }
         }
       }
     },
-    "smart_playlist.field.play_count" : {
-      "comment" : "Smart playlist rule field: Play Count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play Count"
+    "smart_playlist.field.play_count": {
+      "comment": "Smart playlist rule field: Play Count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play Count"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducciones"
           }
         }
       }
     },
-    "smart_playlist.field.year" : {
-      "comment" : "Smart playlist rule field: Year.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Year"
+    "smart_playlist.field.year": {
+      "comment": "Smart playlist rule field: Year.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Year"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Año"
+          }
         }
       }
     },
-    "smart_playlist.filter_placeholder" : {
-      "comment" : "Placeholder for the scoped filter field on the smart playlist detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter tracks"
+    "smart_playlist.filter_placeholder": {
+      "comment": "Placeholder for the scoped filter field on the smart playlist detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter tracks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Filtrar pistas"
           }
         }
       }
     },
-    "smart_playlist.match_mode.all" : {
-      "comment" : "Smart playlist match mode: all (every rule must match). Lowercase; reads inline as \"Match all of the following rules\".",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "all"
+    "smart_playlist.match_mode.all": {
+      "comment": "Smart playlist match mode: all (every rule must match). Lowercase; reads inline as \"Match all of the following rules\".",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "all"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "todas"
+          }
         }
       }
     },
-    "smart_playlist.match_mode.any" : {
-      "comment" : "Smart playlist match mode: any (at least one rule must match). Lowercase; reads inline as \"Match any of the following rules\".",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "any"
+    "smart_playlist.match_mode.any": {
+      "comment": "Smart playlist match mode: any (at least one rule must match). Lowercase; reads inline as \"Match any of the following rules\".",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "any"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "alguna"
           }
         }
       }
     },
-    "smart_playlist.no_filter_match %@" : {
-      "comment" : "Shown when the scoped filter matches no tracks on the smart playlist detail screen. %@ is the filter query.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No tracks match “%@”"
+    "smart_playlist.no_filter_match %@": {
+      "comment": "Shown when the scoped filter matches no tracks on the smart playlist detail screen. %@ is the filter query.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tracks match “%@”"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ninguna pista coincide con \"%@\""
+          }
         }
       }
     },
-    "smart_playlist.not_found" : {
-      "comment" : "Shown when a smart playlist can't be resolved by id on the detail screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart playlist not found"
+    "smart_playlist.not_found": {
+      "comment": "Shown when a smart playlist can't be resolved by id on the detail screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart playlist not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lista inteligente no encontrada"
           }
         }
       }
     },
-    "smart_playlist.op.contains" : {
-      "comment" : "Smart playlist rule operator: contains (text).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "contains"
+    "smart_playlist.op.contains": {
+      "comment": "Smart playlist rule operator: contains (text).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "contains"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "contiene"
+          }
         }
       }
     },
-    "smart_playlist.op.greater_than" : {
-      "comment" : "Smart playlist rule operator: greater than (number/date).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "greater than"
+    "smart_playlist.op.greater_than": {
+      "comment": "Smart playlist rule operator: greater than (number/date).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "greater than"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "mayor que"
+          }
         }
       }
     },
-    "smart_playlist.op.in_last" : {
-      "comment" : "Smart playlist rule operator: in the last N days (date).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "in the last (days)"
+    "smart_playlist.op.in_last": {
+      "comment": "Smart playlist rule operator: in the last N days (date).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "in the last (days)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "en los últimos (días)"
           }
         }
       }
     },
-    "smart_playlist.op.is" : {
-      "comment" : "Smart playlist rule operator: is (equality).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "is"
+    "smart_playlist.op.is": {
+      "comment": "Smart playlist rule operator: is (equality).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "is"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "es"
+          }
         }
       }
     },
-    "smart_playlist.op.is_not" : {
-      "comment" : "Smart playlist rule operator: is not (inequality).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "is not"
+    "smart_playlist.op.is_not": {
+      "comment": "Smart playlist rule operator: is not (inequality).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "is not"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "no es"
           }
         }
       }
     },
-    "smart_playlist.op.less_than" : {
-      "comment" : "Smart playlist rule operator: less than (number/date).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "less than"
+    "smart_playlist.op.less_than": {
+      "comment": "Smart playlist rule operator: less than (number/date).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "less than"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "menor que"
+          }
         }
       }
     },
-    "smart_playlist.rules.clause_separator" : {
-      "comment" : "Separator joining individual rule clauses in the detail screen's rule summary. Default \", \".",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", "
+    "smart_playlist.rules.clause_separator": {
+      "comment": "Separator joining individual rule clauses in the detail screen's rule summary. Default \", \".",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ", "
           }
         }
       }
     },
-    "smart_playlist.rules.matches %@ %@" : {
-      "comment" : "Rule summary frame on the detail screen, e.g. \"Matches all of: Artist is Radiohead\". First %@ is the match mode (all/any); second %@ is the joined rule clauses.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Matches %1$@ of: %2$@"
+    "smart_playlist.rules.matches %@ %@": {
+      "comment": "Rule summary frame on the detail screen, e.g. \"Matches all of: Artist is Radiohead\". First %@ is the match mode (all/any); second %@ is the joined rule clauses.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matches %1$@ of: %2$@"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Coincide %1$@ de: %2$@"
+          }
         }
       }
     },
-    "smart_playlist.rules.matches_all_tracks" : {
-      "comment" : "Rule summary shown when a smart playlist has no rules (matches every track).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Matches every track."
+    "smart_playlist.rules.matches_all_tracks": {
+      "comment": "Rule summary shown when a smart playlist has no rules (matches every track).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matches every track."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Coincide con todas las pistas."
           }
         }
       }
     },
-    "stream.error.retry.a11y" : {
-      "comment" : "Accessibility label on the Retry button inside StreamErrorToast.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry playing the failed track"
+    "stream.error.retry.a11y": {
+      "comment": "Accessibility label on the Retry button inside StreamErrorToast.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry playing the failed track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reintentar reproducir la pista fallida"
+          }
         }
       }
     },
-    "stream.error.go_to_track" : {
-      "comment" : "Secondary CTA on StreamErrorToast that routes to the failed track.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to track"
+    "stream.error.go_to_track": {
+      "comment": "Secondary CTA on StreamErrorToast that routes to the failed track.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ir a la pista"
+          }
         }
       }
     },
-    "stream.error.skipping %@" : {
-      "comment" : "StreamErrorToast body copy; %@ is the failed track name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“%@” couldn’t play. Skipping."
+    "stream.error.skipping %@": {
+      "comment": "StreamErrorToast body copy; %@ is the failed track name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” couldn’t play. Skipping."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo reproducir \"%@\". Omitiendo."
           }
         }
       }
     },
-    "offline.retry.a11y" : {
-      "comment" : "Accessibility label on the Retry button inside OfflineBanner.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry network connection"
+    "offline.retry.a11y": {
+      "comment": "Accessibility label on the Retry button inside OfflineBanner.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry network connection"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reintentar conexión de red"
+          }
         }
       }
     },
-    "offline.generic" : {
-      "comment" : "OfflineBanner message when the system reports no network.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You're offline. Playing from downloaded tracks only."
+    "offline.generic": {
+      "comment": "OfflineBanner message when the system reports no network.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're offline. Playing from downloaded tracks only."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Estás sin conexión. Reproduciendo solo desde pistas descargadas."
           }
         }
       }
     },
-    "playlist.delete.message" : {
-      "comment" : "Body of the delete-playlist confirmation dialog.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will permanently delete this playlist. This action cannot be undone."
+    "playlist.delete.message": {
+      "comment": "Body of the delete-playlist confirmation dialog.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will permanently delete this playlist. This action cannot be undone."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esto eliminará permanentemente esta lista de reproducción. Esta acción no se puede deshacer."
+          }
         }
       }
     },
-    "track.info.album" : {
-      "comment" : "Track-info sheet row label — the album the track belongs to.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album"
+    "track.info.album": {
+      "comment": "Track-info sheet row label — the album the track belongs to.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbum"
           }
         }
       }
     },
-    "track.info.disc" : {
-      "comment" : "Track-info sheet — disc-number prefix (e.g. \"Disc 2\").",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disc"
+    "track.info.disc": {
+      "comment": "Track-info sheet — disc-number prefix (e.g. \"Disc 2\").",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disc"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Disco"
+          }
         }
       }
     },
-    "track.info.duration" : {
-      "comment" : "Track-info sheet row label — playback duration.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duration"
+    "track.info.duration": {
+      "comment": "Track-info sheet row label — playback duration.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Duración"
           }
         }
       }
     },
-    "track.info.format" : {
-      "comment" : "Track-info sheet row label — file format / codec / bitrate.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Format"
+    "track.info.format": {
+      "comment": "Track-info sheet row label — file format / codec / bitrate.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Format"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Formato"
+          }
         }
       }
     },
-    "track.info.plays" : {
-      "comment" : "Track-info sheet row label — server-tracked play count.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plays"
+    "track.info.plays": {
+      "comment": "Track-info sheet row label — server-tracked play count.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plays"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducciones"
+          }
         }
       }
     },
-    "track.info.track" : {
-      "comment" : "Track-info sheet row label — track number (and disc, when present).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Track"
+    "track.info.track": {
+      "comment": "Track-info sheet row label — track number (and disc, when present).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pista"
           }
         }
       }
     },
-    "track.info.year" : {
-      "comment" : "Track-info sheet row label — release year.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Year"
+    "track.info.year": {
+      "comment": "Track-info sheet row label — release year.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Year"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Año"
+          }
         }
       }
     },
-    "menu.view.mini_player" : {
-      "comment" : "View-menu item that toggles the detached Mini Player window (\u2318\u2325P).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mini Player"
+    "menu.view.mini_player": {
+      "comment": "View-menu item that toggles the detached Mini Player window (⌘⌥P).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini Player"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproductor mini"
           }
         }
       }
     },
-    "menu_bar.now_playing.label" : {
-      "comment" : "Accessibility label for the menu-bar Now Playing status item.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Now Playing"
+    "menu_bar.now_playing.label": {
+      "comment": "Accessibility label for the menu-bar Now Playing status item.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now Playing"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproduciendo ahora"
+          }
         }
       }
     },
-    "menu_bar.now_playing.next" : {
-      "comment" : "Accessibility label for the menu-bar Now Playing next button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+    "menu_bar.now_playing.next": {
+      "comment": "Accessibility label for the menu-bar Now Playing next button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Siguiente"
           }
         }
       }
     },
-    "menu_bar.now_playing.open" : {
-      "comment" : "Button in the menu-bar Now Playing panel that focuses the main Lyrebird window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Lyrebird"
+    "menu_bar.now_playing.open": {
+      "comment": "Button in the menu-bar Now Playing panel that focuses the main Lyrebird window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Lyrebird"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Lyrebird"
+          }
         }
       }
     },
-    "menu_bar.now_playing.pause" : {
-      "comment" : "Accessibility label for the menu-bar Now Playing pause button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+    "menu_bar.now_playing.pause": {
+      "comment": "Accessibility label for the menu-bar Now Playing pause button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
           }
         }
       }
     },
-    "menu_bar.now_playing.play" : {
-      "comment" : "Accessibility label for the menu-bar Now Playing play button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play"
+    "menu_bar.now_playing.play": {
+      "comment": "Accessibility label for the menu-bar Now Playing play button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir"
+          }
         }
       }
     },
-    "menu_bar.now_playing.previous" : {
-      "comment" : "Accessibility label for the menu-bar Now Playing previous button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous"
+    "menu_bar.now_playing.previous": {
+      "comment": "Accessibility label for the menu-bar Now Playing previous button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Anterior"
+          }
         }
       }
     },
-    "mini_player.window.title" : {
-      "comment" : "Window title for the detached Mini Player (not shown — the window is borderless — but used by the window list / accessibility).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mini Player"
+    "mini_player.window.title": {
+      "comment": "Window title for the detached Mini Player (not shown — the window is borderless — but used by the window list / accessibility).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini Player"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproductor mini"
           }
         }
       }
     },
-    "mini_player.accessibility.label" : {
-      "comment" : "VoiceOver label for the Mini Player window as a whole.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mini Player"
+    "mini_player.accessibility.label": {
+      "comment": "VoiceOver label for the Mini Player window as a whole.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini Player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproductor mini"
+          }
         }
       }
     },
-    "mini_player.accessibility.drag_artwork" : {
-      "comment" : "VoiceOver label for the album-art region of the Mini Player, which doubles as the window drag handle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album art. Drag to move the Mini Player."
+    "mini_player.accessibility.drag_artwork": {
+      "comment": "VoiceOver label for the album-art region of the Mini Player, which doubles as the window drag handle.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album art. Drag to move the Mini Player."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Portada. Arrastra para mover el reproductor mini."
           }
         }
       }
     },
-    "mini_player.menu.label" : {
-      "comment" : "Accessibility label for the Mini Player settings (gear) menu button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mini Player options"
+    "mini_player.menu.label": {
+      "comment": "Accessibility label for the Mini Player settings (gear) menu button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mini Player options"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Opciones del reproductor mini"
+          }
         }
       }
     },
-    "mini_player.menu.always_on_top" : {
-      "comment" : "Toggle in the Mini Player settings menu that keeps the window floating above other windows.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always on Top"
+    "mini_player.menu.always_on_top": {
+      "comment": "Toggle in the Mini Player settings menu that keeps the window floating above other windows.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always on Top"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Siempre visible"
           }
         }
       }
     },
-    "mini_player.menu.return_to_full" : {
-      "comment" : "Menu item that closes the Mini Player and returns to the full app window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Return to Full Window"
+    "mini_player.menu.return_to_full": {
+      "comment": "Menu item that closes the Mini Player and returns to the full app window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return to Full Window"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volver a ventana completa"
+          }
         }
       }
     },
-    "mini_player.menu.transparent_when_inactive" : {
-      "comment" : "Toggle in the Mini Player settings menu that fades the window when the app loses focus.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparent When Inactive"
+    "mini_player.menu.transparent_when_inactive": {
+      "comment": "Toggle in the Mini Player settings menu that fades the window when the app loses focus.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent When Inactive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Transparente cuando está inactivo"
           }
         }
       }
     },
-    "mini_player.menu.close" : {
-      "comment" : "Menu item that dismisses the Mini Player without switching to the full app window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Mini Player"
+    "mini_player.menu.close": {
+      "comment": "Menu item that dismisses the Mini Player without switching to the full app window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Mini Player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerrar reproductor mini"
+          }
         }
       }
     },
-    "mini_player.accessibility.open_album" : {
-      "comment" : "VoiceOver label for the Mini Player album-art region when it links to the album page (a click opens the album in the main window). A drag still repositions the window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Album art. Tap to open the album; drag to move the Mini Player."
+    "mini_player.accessibility.open_album": {
+      "comment": "VoiceOver label for the Mini Player album-art region when it links to the album page (a click opens the album in the main window). A drag still repositions the window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album art. Tap to open the album; drag to move the Mini Player."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Portada. Toca para abrir el álbum; arrastra para mover el reproductor mini."
+          }
         }
       }
     },
-    "mini_player.accessibility.open_artist" : {
-      "comment" : "VoiceOver hint for the Mini Player artist-name button, which opens the artist page in the main window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open artist page"
+    "mini_player.accessibility.open_artist": {
+      "comment": "VoiceOver hint for the Mini Player artist-name button, which opens the artist page in the main window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open artist page"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir página del artista"
           }
         }
       }
     },
-    "mini_player.expand" : {
-      "comment" : "Accessibility label for the expand button in the Mini Player hover overlay that returns to the full window.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expand to Full Window"
+    "mini_player.expand": {
+      "comment": "Accessibility label for the expand button in the Mini Player hover overlay that returns to the full window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand to Full Window"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Expandir a ventana completa"
+          }
         }
       }
     },
-    "mini_player.favorite" : {
-      "comment" : "Accessibility label for the favorite (heart) button in the Mini Player hover overlay, when the current track is not yet a favorite.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorite"
+    "mini_player.favorite": {
+      "comment": "Accessibility label for the favorite (heart) button in the Mini Player hover overlay, when the current track is not yet a favorite.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorite"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Favorito"
           }
         }
       }
     },
-    "mini_player.unfavorite" : {
-      "comment" : "Accessibility label for the favorite (heart) button in the Mini Player hover overlay, when the current track is already a favorite.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove from Favorites"
+    "mini_player.unfavorite": {
+      "comment": "Accessibility label for the favorite (heart) button in the Mini Player hover overlay, when the current track is already a favorite.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from Favorites"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quitar de favoritos"
+          }
         }
       }
     },
-    "mini_player.previous" : {
-      "comment" : "Accessibility label for the Mini Player previous-track button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous track"
+    "mini_player.previous": {
+      "comment": "Accessibility label for the Mini Player previous-track button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pista anterior"
           }
         }
       }
     },
-    "mini_player.play" : {
-      "comment" : "Accessibility label for the Mini Player play button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play"
+    "mini_player.play": {
+      "comment": "Accessibility label for the Mini Player play button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir"
+          }
         }
       }
     },
-    "mini_player.pause" : {
-      "comment" : "Accessibility label for the Mini Player pause button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+    "mini_player.pause": {
+      "comment": "Accessibility label for the Mini Player pause button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pausar"
           }
         }
       }
     },
-    "mini_player.next" : {
-      "comment" : "Accessibility label for the Mini Player next-track button.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next track"
+    "mini_player.next": {
+      "comment": "Accessibility label for the Mini Player next-track button.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pista siguiente"
+          }
         }
       }
     },
-    "mini_player.return" : {
-      "comment" : "Accessibility label for the inline return-to-full-window button revealed on hover in the Mini Player.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Return to full window"
+    "mini_player.return": {
+      "comment": "Accessibility label for the inline return-to-full-window button revealed on hover in the Mini Player.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return to full window"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volver a ventana completa"
+          }
         }
       }
     },
-    "mini_player.volume" : {
-      "comment" : "Accessibility label for the Mini Player volume control.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volume"
+    "mini_player.volume": {
+      "comment": "Accessibility label for the Mini Player volume control.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Volumen"
           }
         }
       }
     },
-    "mini_player.scrubber" : {
-      "comment" : "Accessibility label for the Mini Player playback-position scrubber revealed on hover.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Playback position"
+    "mini_player.scrubber": {
+      "comment": "Accessibility label for the Mini Player playback-position scrubber revealed on hover.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback position"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Posición de reproducción"
+          }
         }
       }
     },
-    "menu.help.export_diagnostics" : {
-      "comment" : "Help menu entry that writes a sanitized diagnostic .zip for bug reports.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Diagnostic Bundle…"
+    "menu.help.export_diagnostics": {
+      "comment": "Help menu entry that writes a sanitized diagnostic .zip for bug reports.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Diagnostic Bundle…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exportar paquete de diagnóstico…"
           }
         }
       }
     },
-    "menu.help.keyboard_shortcuts" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard Shortcuts"
+    "menu.help.keyboard_shortcuts": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard Shortcuts"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atajos de teclado"
+          }
         }
       }
     },
-    "shortcuts.playback.play_pause" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play / Pause"
+    "shortcuts.playback.play_pause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play / Pause"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir / Pausar"
           }
         }
       }
     },
-    "shortcuts.search.accessibility" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search keyboard shortcuts"
+    "shortcuts.search.accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search keyboard shortcuts"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar atajos de teclado"
+          }
         }
       }
     },
-    "shortcuts.search.clear" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear search"
+    "shortcuts.search.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Borrar búsqueda"
           }
         }
       }
     },
-    "shortcuts.search.no_results" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No shortcuts match your search"
+    "shortcuts.search.no_results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No shortcuts match your search"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ningún atajo coincide con tu búsqueda"
+          }
         }
       }
     },
-    "shortcuts.search.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search shortcuts"
+    "shortcuts.search.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search shortcuts"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Buscar atajos"
+          }
         }
       }
     },
-    "shortcuts.section.file" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File"
+    "shortcuts.section.file": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Archivo"
           }
         }
       }
     },
-    "shortcuts.section.playback" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Playback"
+    "shortcuts.section.playback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducción"
+          }
         }
       }
     },
-    "shortcuts.section.view" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View"
+    "shortcuts.section.view": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Vista"
           }
         }
       }
     },
-    "shortcuts.section.window" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Window"
+    "shortcuts.section.window": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ventana"
+          }
         }
       }
     },
-    "shortcuts.window.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard Shortcuts"
+    "shortcuts.window.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard Shortcuts"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atajos de teclado"
           }
         }
       }
     },
-    "instant_mix.picker.category.albums" : {
-      "comment" : "Instant Mix picker filter chip: albums only.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Albums"
+    "instant_mix.picker.category.albums": {
+      "comment": "Instant Mix picker filter chip: albums only.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albums"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Álbumes"
+          }
         }
       }
     },
-    "instant_mix.picker.category.all" : {
-      "comment" : "Instant Mix picker filter chip: show every kind of seed candidate.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
+    "instant_mix.picker.category.all": {
+      "comment": "Instant Mix picker filter chip: show every kind of seed candidate.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Todo"
           }
         }
       }
     },
-    "instant_mix.picker.category.artists" : {
-      "comment" : "Instant Mix picker filter chip: artists only.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Artists"
+    "instant_mix.picker.category.artists": {
+      "comment": "Instant Mix picker filter chip: artists only.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artists"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Artistas"
+          }
         }
       }
     },
-    "instant_mix.picker.category.genres" : {
-      "comment" : "Instant Mix picker filter chip: genres only.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genres"
+    "instant_mix.picker.category.genres": {
+      "comment": "Instant Mix picker filter chip: genres only.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genres"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Géneros"
+          }
         }
       }
     },
-    "instant_mix.picker.category.tracks" : {
-      "comment" : "Instant Mix picker filter chip: tracks only.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tracks"
+    "instant_mix.picker.category.tracks": {
+      "comment": "Instant Mix picker filter chip: tracks only.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pistas"
           }
         }
       }
     },
-    "instant_mix.picker.close" : {
-      "comment" : "Accessibility label for the close button on the Instant Mix seed-picker sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Instant Mix picker"
+    "instant_mix.picker.close": {
+      "comment": "Accessibility label for the close button on the Instant Mix seed-picker sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Instant Mix picker"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerrar selector de mezcla instantánea"
+          }
         }
       }
     },
-    "instant_mix.picker.empty_prompt" : {
-      "comment" : "Prompt shown in the Instant Mix picker before the user has typed a query.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search for something to build a mix around."
+    "instant_mix.picker.empty_prompt": {
+      "comment": "Prompt shown in the Instant Mix picker before the user has typed a query.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search for something to build a mix around."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Busca algo para crear una mezcla."
           }
         }
       }
     },
-    "instant_mix.picker.generate" : {
-      "comment" : "Primary action button that starts the Instant Mix from the chosen seed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate"
+    "instant_mix.picker.generate": {
+      "comment": "Primary action button that starts the Instant Mix from the chosen seed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Generar"
+          }
         }
       }
     },
-    "instant_mix.picker.last_mix" : {
-      "comment" : "Prefix for the most recently used Instant Mix seed name, shown as a regenerate hint. Followed verbatim by the seed name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last mix:"
+    "instant_mix.picker.last_mix": {
+      "comment": "Prefix for the most recently used Instant Mix seed name, shown as a regenerate hint. Followed verbatim by the seed name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last mix:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Última mezcla:"
           }
         }
       }
     },
-    "instant_mix.picker.no_matches" : {
-      "comment" : "Shown in the Instant Mix picker when a search returns no seed candidates.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No matches"
+    "instant_mix.picker.no_matches": {
+      "comment": "Shown in the Instant Mix picker when a search returns no seed candidates.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matches"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sin coincidencias"
+          }
         }
       }
     },
-    "instant_mix.picker.search_placeholder" : {
-      "comment" : "Placeholder for the search field in the Instant Mix seed picker.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search for a track, album, artist, or genre"
+    "instant_mix.picker.search_placeholder": {
+      "comment": "Placeholder for the search field in the Instant Mix seed picker.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search for a track, album, artist, or genre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Busca una pista, álbum, artista o género"
           }
         }
       }
     },
-    "instant_mix.picker.selected" : {
-      "comment" : "Prefix for the currently selected Instant Mix seed name in the picker footer. Followed verbatim by the seed name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seed:"
+    "instant_mix.picker.selected": {
+      "comment": "Prefix for the currently selected Instant Mix seed name in the picker footer. Followed verbatim by the seed name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seed:"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Origen:"
+          }
         }
       }
     },
-    "instant_mix.picker.title" : {
-      "comment" : "Title of the Instant Mix seed-picker sheet (#327).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Instant Mix"
+    "instant_mix.picker.title": {
+      "comment": "Title of the Instant Mix seed-picker sheet (#327).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Instant Mix"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nueva mezcla instantánea"
+          }
         }
       }
     },
-    "menu.nav.instant_mix" : {
-      "comment" : "View menu item that opens the Instant Mix seed-picker sheet (#327).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Instant Mix…"
+    "menu.nav.instant_mix": {
+      "comment": "View menu item that opens the Instant Mix seed-picker sheet (#327).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Instant Mix…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nueva mezcla instantánea…"
           }
         }
       }
     },
-    "menu.help.show_tour" : {
-      "comment" : "Help menu entry that re-opens the first-run feature tour (coach marks).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Tour"
+    "menu.help.show_tour": {
+      "comment": "Help menu entry that re-opens the first-run feature tour (coach marks).",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Tour"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar visita guiada"
+          }
         }
       }
     },
-    "tour.a11y.container" : {
-      "comment" : "Accessibility label for the feature-tour overlay container.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feature tour"
+    "tour.a11y.container": {
+      "comment": "Accessibility label for the feature-tour overlay container.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feature tour"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Visita guiada de funciones"
           }
         }
       }
     },
-    "tour.a11y.progress %lld %lld" : {
-      "comment" : "Accessibility label for the feature-tour progress dots; first number is the current step, second is the total.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Step %1$lld of %2$lld"
+    "tour.a11y.progress %lld %lld": {
+      "comment": "Accessibility label for the feature-tour progress dots; first number is the current step, second is the total.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %1$lld of %2$lld"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Paso %1$lld de %2$lld"
+          }
         }
       }
     },
-    "tour.a11y.shortcut %@" : {
-      "comment" : "Accessibility label for a feature-tour card's keyboard-shortcut pill; %@ is the chord, e.g. ⌘F.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard shortcut %@"
+    "tour.a11y.shortcut %@": {
+      "comment": "Accessibility label for a feature-tour card's keyboard-shortcut pill; %@ is the chord, e.g. ⌘F.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard shortcut %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atajo de teclado %@"
           }
         }
       }
     },
-    "tour.back" : {
-      "comment" : "Feature-tour button: go to the previous card.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+    "tour.back": {
+      "comment": "Feature-tour button: go to the previous card.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Atrás"
+          }
         }
       }
     },
-    "tour.done" : {
-      "comment" : "Feature-tour button: close the tour on the final card.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "tour.done": {
+      "comment": "Feature-tour button: close the tour on the final card.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Listo"
           }
         }
       }
     },
-    "tour.mini_player.body" : {
-      "comment" : "Feature-tour card body: detachable mini player.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Press ⌘⌥P for a compact, always-on-top player you can tuck into a corner while you work."
+    "tour.mini_player.body": {
+      "comment": "Feature-tour card body: detachable mini player.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press ⌘⌥P for a compact, always-on-top player you can tuck into a corner while you work."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pulsa ⌘⌥P para un reproductor compacto, siempre visible, que puedes colocar en una esquina mientras trabajas."
+          }
         }
       }
     },
-    "tour.mini_player.title" : {
-      "comment" : "Feature-tour card title: detachable mini player.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pop out the mini player"
+    "tour.mini_player.title": {
+      "comment": "Feature-tour card title: detachable mini player.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pop out the mini player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abre el reproductor mini"
+          }
         }
       }
     },
-    "tour.next" : {
-      "comment" : "Feature-tour button: advance to the next card.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+    "tour.next": {
+      "comment": "Feature-tour button: advance to the next card.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Siguiente"
           }
         }
       }
     },
-    "tour.right_click.body" : {
-      "comment" : "Feature-tour card body: right-click context menus.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Right-click any track, album, artist, or playlist for quick actions — play next, add to a playlist, start a radio station, and more."
+    "tour.right_click.body": {
+      "comment": "Feature-tour card body: right-click context menus.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right-click any track, album, artist, or playlist for quick actions — play next, add to a playlist, start a radio station, and more."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Haz clic derecho en cualquier pista, álbum, artista o lista de reproducción para acciones rápidas — reproducir a continuación, añadir a una lista, iniciar una radio y más."
+          }
         }
       }
     },
-    "tour.right_click.title" : {
-      "comment" : "Feature-tour card title: right-click context menus.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Right-click for more"
+    "tour.right_click.title": {
+      "comment": "Feature-tour card title: right-click context menus.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right-click for more"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Clic derecho para más opciones"
           }
         }
       }
     },
-    "tour.search.body" : {
-      "comment" : "Feature-tour card body: search shortcut.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Press ⌘F to jump straight to search and find any song, album, or artist in your library."
+    "tour.search.body": {
+      "comment": "Feature-tour card body: search shortcut.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press ⌘F to jump straight to search and find any song, album, or artist in your library."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pulsa ⌘F para ir directamente a la búsqueda y encontrar cualquier canción, álbum o artista en tu biblioteca."
+          }
         }
       }
     },
-    "tour.search.title" : {
-      "comment" : "Feature-tour card title: search shortcut.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Find anything fast"
+    "tour.search.title": {
+      "comment": "Feature-tour card title: search shortcut.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find anything fast"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Encuentra cualquier cosa rápido"
           }
         }
       }
     },
-    "tour.skip" : {
-      "comment" : "Feature-tour button: dismiss the tour without finishing.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip"
+    "tour.skip": {
+      "comment": "Feature-tour button: dismiss the tour without finishing.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Omitir"
+          }
         }
       }
     },
-    "tour.space.body" : {
-      "comment" : "Feature-tour card body: Space play/pause shortcut.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap the Space bar anywhere outside a text field to play or pause the current track."
+    "tour.space.body": {
+      "comment": "Feature-tour card body: Space play/pause shortcut.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the Space bar anywhere outside a text field to play or pause the current track."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Pulsa la barra espaciadora fuera de un campo de texto para reproducir o pausar la pista actual."
           }
         }
       }
     },
-    "tour.space.title" : {
-      "comment" : "Feature-tour card title: Space play/pause shortcut.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play and pause with Space"
+    "tour.space.title": {
+      "comment": "Feature-tour card title: Space play/pause shortcut.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play and pause with Space"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Reproducir y pausar con Espacio"
+          }
         }
       }
     },
-    "core_failure.body" : {
-      "comment" : "Explanation on the core-init failure recovery screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird’s local data couldn’t be opened. This is usually fixable: reset the local data to start fresh, or export a diagnostics bundle to share with a bug report."
+    "core_failure.body": {
+      "comment": "Explanation on the core-init failure recovery screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird’s local data couldn’t be opened. This is usually fixable: reset the local data to start fresh, or export a diagnostics bundle to share with a bug report."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudieron abrir los datos locales de Lyrebird. Normalmente se puede solucionar: restablece los datos locales para empezar de nuevo, o exporta un paquete de diagnóstico para compartir con un informe de error."
+          }
         }
       }
     },
-    "core_failure.export" : {
-      "comment" : "Button on the failure screen that writes a sanitized diagnostics bundle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Diagnostics…"
+    "core_failure.export": {
+      "comment": "Button on the failure screen that writes a sanitized diagnostics bundle.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Diagnostics…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Exportar diagnóstico…"
           }
         }
       }
     },
-    "core_failure.export.done" : {
-      "comment" : "Confirmation after a diagnostics bundle was written from the failure screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnostics exported."
+    "core_failure.export.done": {
+      "comment": "Confirmation after a diagnostics bundle was written from the failure screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics exported."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diagnóstico exportado."
+          }
         }
       }
     },
-    "core_failure.export.failed" : {
-      "comment" : "Shown when exporting diagnostics failed; %@ is the error.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn’t export diagnostics: %@"
+    "core_failure.export.failed": {
+      "comment": "Shown when exporting diagnostics failed; %@ is the error.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t export diagnostics: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo exportar el diagnóstico: %@"
           }
         }
       }
     },
-    "core_failure.quit" : {
-      "comment" : "Button that quits the app from the failure screen.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+    "core_failure.quit": {
+      "comment": "Button that quits the app from the failure screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Salir"
+          }
         }
       }
     },
-    "core_failure.reset" : {
-      "comment" : "Button that moves the corrupt local data aside so the next launch starts clean.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Local Data"
+    "core_failure.reset": {
+      "comment": "Button that moves the corrupt local data aside so the next launch starts clean.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Local Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Restablecer datos locales"
           }
         }
       }
     },
-    "core_failure.reset.done" : {
-      "comment" : "Confirmation after the local data was moved aside; %@ is the backup path.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local data was moved to:\n%@\nPlease quit and reopen Lyrebird."
+    "core_failure.reset.done": {
+      "comment": "Confirmation after the local data was moved aside; %@ is the backup path.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local data was moved to:\n%@\nPlease quit and reopen Lyrebird."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Los datos locales se movieron a:\n%@\nSal y vuelve a abrir Lyrebird."
+          }
         }
       }
     },
-    "core_failure.reset.failed" : {
-      "comment" : "Shown when resetting the local data failed; %@ is the error.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn’t reset local data: %@"
+    "core_failure.reset.failed": {
+      "comment": "Shown when resetting the local data failed; %@ is the error.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t reset local data: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudieron restablecer los datos locales: %@"
           }
         }
       }
     },
-    "core_failure.reset.nothing" : {
-      "comment" : "Shown when there was no local data directory to reset.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No local data was found to reset. Try exporting diagnostics instead."
+    "core_failure.reset.nothing": {
+      "comment": "Shown when there was no local data directory to reset.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No local data was found to reset. Try exporting diagnostics instead."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se encontraron datos locales para restablecer. Intenta exportar el diagnóstico."
+          }
         }
       }
     },
-    "core_failure.title" : {
-      "comment" : "Title of the recovery screen shown when the core fails to start.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrebird couldn’t start"
+    "core_failure.title": {
+      "comment": "Title of the recovery screen shown when the core fails to start.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyrebird couldn’t start"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lyrebird no pudo iniciarse"
+          }
         }
       }
     },
-    "login.device_name.a11y_field" : {
-      "comment" : "Accessibility label for the device-name text field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device name"
+    "login.device_name.a11y_field": {
+      "comment": "Accessibility label for the device-name text field.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre del dispositivo"
           }
         }
       }
     },
-    "login.device_name.a11y_label %@" : {
-      "comment" : "Accessibility label for the device-name gear; the argument is the current device name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device name: %@"
+    "login.device_name.a11y_label %@": {
+      "comment": "Accessibility label for the device-name gear; the argument is the current device name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device name: %@"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre del dispositivo: %@"
+          }
         }
       }
     },
-    "login.device_name.cancel" : {
-      "comment" : "Button that dismisses the device-name popover.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "login.device_name.cancel": {
+      "comment": "Button that dismisses the device-name popover.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "login.device_name.help" : {
-      "comment" : "Tooltip on the device-name gear.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change the name Jellyfin shows for this device."
+    "login.device_name.help": {
+      "comment": "Tooltip on the device-name gear.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change the name Jellyfin shows for this device."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cambia el nombre que Jellyfin muestra para este dispositivo."
+          }
         }
       }
     },
-    "login.device_name.placeholder" : {
-      "comment" : "Placeholder for the device-name field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "My Mac"
+    "login.device_name.placeholder": {
+      "comment": "Placeholder for the device-name field.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "My Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mi Mac"
           }
         }
       }
     },
-    "login.device_name.save" : {
-      "comment" : "Button that saves the edited device name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "login.device_name.save": {
+      "comment": "Button that saves the edited device name.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Guardar"
+          }
         }
       }
     },
-    "login.device_name.subtitle" : {
-      "comment" : "Explains where the device name appears.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shown on this server's Dashboard and in other Jellyfin clients."
+    "login.device_name.subtitle": {
+      "comment": "Explains where the device name appears.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shown on this server's Dashboard and in other Jellyfin clients."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Se muestra en el panel de este servidor y en otros clientes de Jellyfin."
           }
         }
       }
     },
-    "login.device_name.title" : {
-      "comment" : "Title of the device-name editing popover.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device name"
+    "login.device_name.title": {
+      "comment": "Title of the device-name editing popover.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device name"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nombre del dispositivo"
+          }
         }
       }
     },
-    "login.quick_connect.a11y_hint" : {
-      "comment" : "Accessibility hint for the Quick Connect link.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pair this device by entering a code in another signed-in Jellyfin client."
+    "login.quick_connect.a11y_hint": {
+      "comment": "Accessibility hint for the Quick Connect link.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pair this device by entering a code in another signed-in Jellyfin client."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Empareja este dispositivo introduciendo un código en otro cliente de Jellyfin con sesión iniciada."
+          }
         }
       }
     },
-    "login.quick_connect.cancel" : {
-      "comment" : "Button to dismiss the Quick Connect sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "login.quick_connect.cancel": {
+      "comment": "Button to dismiss the Quick Connect sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "login.quick_connect.code_label" : {
-      "comment" : "Label above the numeric Quick Connect code.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CODE"
+    "login.quick_connect.code_label": {
+      "comment": "Label above the numeric Quick Connect code.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CODE"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "CÓDIGO"
+          }
         }
       }
     },
-    "login.quick_connect.error" : {
-      "comment" : "Shown when Quick Connect fails to start or complete.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quick Connect couldn't be completed. Please try again."
+    "login.quick_connect.error": {
+      "comment": "Shown when Quick Connect fails to start or complete.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Connect couldn't be completed. Please try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "No se pudo completar Quick Connect. Inténtalo de nuevo."
           }
         }
       }
     },
-    "login.quick_connect.link" : {
-      "comment" : "Secondary link under the sign-in button that opens the Quick Connect pairing sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Jellyfin Quick Connect"
+    "login.quick_connect.link": {
+      "comment": "Secondary link under the sign-in button that opens the Quick Connect pairing sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Jellyfin Quick Connect"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Usar Jellyfin Quick Connect"
+          }
         }
       }
     },
-    "login.quick_connect.needs_server" : {
-      "comment" : "Shown when no server URL has been entered yet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter your server address on the login screen first, then try Quick Connect."
+    "login.quick_connect.needs_server": {
+      "comment": "Shown when no server URL has been entered yet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter your server address on the login screen first, then try Quick Connect."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Introduce la dirección de tu servidor en la pantalla de inicio de sesión primero, luego prueba Quick Connect."
           }
         }
       }
     },
-    "login.quick_connect.retry" : {
-      "comment" : "Button to retry a failed Quick Connect.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    "login.quick_connect.retry": {
+      "comment": "Button to retry a failed Quick Connect.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Intentar de nuevo"
+          }
         }
       }
     },
-    "login.quick_connect.starting" : {
-      "comment" : "Shown while the Quick Connect code is being requested.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starting Quick Connect…"
+    "login.quick_connect.starting": {
+      "comment": "Shown while the Quick Connect code is being requested.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starting Quick Connect…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Iniciando Quick Connect…"
           }
         }
       }
     },
-    "login.quick_connect.subtitle" : {
-      "comment" : "Subtitle explaining how Quick Connect works.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter this code in another signed-in Jellyfin app to pair this device."
+    "login.quick_connect.subtitle": {
+      "comment": "Subtitle explaining how Quick Connect works.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter this code in another signed-in Jellyfin app to pair this device."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Introduce este código en otra app de Jellyfin con sesión iniciada para emparejar este dispositivo."
+          }
         }
       }
     },
-    "login.quick_connect.title" : {
-      "comment" : "Title of the Quick Connect pairing sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quick Connect"
+    "login.quick_connect.title": {
+      "comment": "Title of the Quick Connect pairing sheet.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Connect"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Quick Connect"
+          }
         }
       }
     },
-    "login.quick_connect.waiting" : {
-      "comment" : "Shown while waiting for the user to approve the code elsewhere.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for approval…"
+    "login.quick_connect.waiting": {
+      "comment": "Shown while waiting for the user to approve the code elsewhere.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for approval…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Esperando aprobación…"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
Adds machine-translated seed strings (state: needs_review) for the 8 first-wave locales requested in #346.

Closes #346

## Changes

- `Localizable.xcstrings` — 295 strings × 8 locales (es, fr, de, ja, pt-BR, it, ru, zh-Hans). All cells marked `needs_review` for human confirmation before shipping.
- `InfoPlist.xcstrings` — 3 keys (CFBundleDisplayName, CFBundleName, NSHumanReadableCopyright) × 8 locales.
- `macos/Resources/Info.plist` — adds `CFBundleLocalizations` array with all 9 locales (en + the 8 new ones).

## Per-locale counts

| Locale | Localizable keys | InfoPlist keys | Plural notes |
|--------|-----------------|----------------|--------------|
| es     | 295/295         | 3/3            | one/other    |
| fr     | 295/295         | 3/3            | one/other    |
| de     | 295/295         | 3/3            | one/other    |
| ja     | 295/295         | 3/3            | other only   |
| pt-BR  | 295/295         | 3/3            | one/other    |
| it     | 295/295         | 3/3            | one/other    |
| ru     | 295/295         | 3/3            | one/few/many/other |
| zh-Hans| 295/295 (uncommitted — gpgsign issue; content is in working tree) | 3/3 | other only |

Note: the zh-Hans commit, InfoPlist commit, and CFBundleLocalizations commit could not be signed due to a 1Password SSH agent error during this session. Those changes are in the working tree and should be committed by the author before merging. The 7 locale commits (es–ru) are signed and present.

## Needs-review policy

Every translated string has `"state": "needs_review"`. Strings will show in the app but should be reviewed by a native speaker before a public release. This satisfies the issue's acceptance criteria of launching without missing-key fallbacks.