### PR TITLE
fix(macos): scrub Sentry event context

### DIFF
--- a/macos/Sources/Lyrebird/System/CrashReporting.swift
+++ b/macos/Sources/Lyrebird/System/CrashReporting.swift
@@ -176,6 +176,11 @@ enum CrashReporter {
             event.tags = tags
         }
 
+        // Remove the context dictionary entirely — it can carry arbitrary
+        // key/value pairs populated by SDK integrations or future event
+        // enrichment, and no app-defined context is expected in this build.
+        event.context = nil
+
         return event
     }
 

--- a/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
+++ b/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
@@ -201,6 +201,15 @@ final class CrashReporterDecisionTests: XCTestCase {
         XCTAssertTrue(remaining.contains("appVersion"), "appVersion is not PII — must be kept")
     }
 
+    /// The scrubber must clear the context dictionary — it can carry arbitrary
+    /// key/value dicts populated by SDK integrations or future enrichment.
+    func testScrubDoesNotLeakContextDict() {
+        let event = Event()
+        event.context = ["server": ["url": "https://music.example.com", "token": "secret"]]
+        let scrubbed = CrashReporter.scrub(event: event)
+        XCTAssertNil(scrubbed.context?["server"], "scrub must clear event.context entirely")
+    }
+
     // MARK: - Breadcrumb filtering
 
     func testHTTPBreadcrumbIsDropped() {


### PR DESCRIPTION
`CrashReporter.scrub()` cleared `user`/`request`/`extra`/`tags` but not `event.context`, a first-class Sentry property that can carry arbitrary dictionaries.

Closes #1031

One-line fix (`event.context = nil`) plus the pinning test from the issue. Gates: clean swift build; swift test 1064/1064.