### PR TITLE
feat(macos): graceful shutdown — stop playback, persist queue, final report

### DIFF
--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -176,10 +176,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Step 2 (synchronous, main actor): capture queue state to
-        // UserDefaults. Must run before the player is torn down further
-        // (the position is still readable at this point because `stop()`
-        // clears the player items but `status.positionSeconds` is a core
-        // mirror that `core.stop()` zeroes after our call).
+        // UserDefaults. `status.positionSeconds` still holds the last
+        // position tick — player-event delivery re-enters the main actor
+        // asynchronously and cannot land while this method occupies it.
         if steps.contains(.persistQueue) {
             model.persistQueueSnapshot()
         }

--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -70,6 +70,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// a DHCP / Wi-Fi link before we attempt TCP to the Jellyfin endpoint.
     private let wakeDebounceNanos: UInt64 = 2_000_000_000
 
+    /// Hard deadline for the async shutdown sequence. If `audio.stop()` /
+    /// `POST /Sessions/Playing/Stopped` has not completed within this window
+    /// we reply `.terminateNow` and let the OS finish the job. 2 s matches
+    /// the upper end of a server round-trip on a LAN while keeping the quit
+    /// snappy from the user's perspective.
+    private let shutdownTimeoutNanos: UInt64 = 2_000_000_000
+
+    /// `true` once `applicationShouldTerminate` has dispatched the async
+    /// shutdown work. Guards against a second call (which AppKit can make if
+    /// the app calls `NSApp.terminate` from a menu action while a prior quit
+    /// is already in flight).
+    private var shutdownInFlight: Bool = false
+
     // MARK: - NSApplicationDelegate
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -112,6 +125,75 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // shows only for a release build running from outside /Applications
         // that isn't translocated/on a DMG and hasn't been suppressed. See #193.
         MoveToApplications.promptIfNeeded()
+    }
+
+    /// Handle termination with a bounded shutdown sequence.
+    ///
+    /// The sequence (executed synchronously on the main actor, bounded by 2 s):
+    ///
+    ///   1. **Stop playback** — `model.stop()` drains the `AVQueuePlayer` /
+    ///      DSP pipeline, emits the final `POST /Sessions/Playing/Stopped`
+    ///      (dispatched as a `Task.detached` inside `reportStopped` so it
+    ///      runs concurrently with the remainder of the sequence), and stops
+    ///      the heartbeat so the Jellyfin session goes idle.
+    ///
+    ///   2. **Persist queue** — `persistQueueSnapshot()` writes the current
+    ///      track, playback position, user-added "Up Next" entries, auto-queue
+    ///      tail, and "Playing From" context to `UserDefaults` JSON so the next
+    ///      launch can offer "Resume where you left off?".
+    ///
+    ///   3. **Reply** — we wait up to `shutdownTimeoutNanos` for the detached
+    ///      network POST to drain, then reply to AppKit regardless. This
+    ///      prevents the app from hanging on ⌘Q if the server is unreachable.
+    ///
+    /// Core DB gap: `LyrebirdCore` does not yet expose a `shutdown()` FFI for
+    /// `PRAGMA optimize` + `wal_checkpoint(TRUNCATE)`. SQLite WAL mode is
+    /// crash-safe by design (recovery is transparent on next open), so the DB
+    /// is always consistent without an explicit checkpoint. The checkpoint is a
+    /// nice-to-have performance win (smaller WAL file on next open) and is
+    /// deferred until a core `shutdown()` FFI lands.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !shutdownInFlight else { return .terminateNow }
+        guard let model = appModel else { return .terminateNow }
+
+        let isActive = model.status.state == .playing || model.status.state == .paused
+        let hasQueue = AppModel.shouldPersistSnapshot(
+            currentTrack: model.status.currentTrack,
+            userAddedCount: model.upNextUserAdded.count,
+            autoQueueCount: model.upNextAutoQueue.count
+        )
+
+        // Nothing to do — AppKit can terminate immediately.
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: isActive, hasQueue: hasQueue)
+        guard !steps.isEmpty else { return .terminateNow }
+
+        shutdownInFlight = true
+
+        // Step 1 (synchronous, main actor): stop the player and dispatch
+        // the final `reportStopped` as a `Task.detached`.
+        if steps.contains(.stopPlayback) {
+            model.stop()
+        }
+
+        // Step 2 (synchronous, main actor): capture queue state to
+        // UserDefaults. Must run before the player is torn down further
+        // (the position is still readable at this point because `stop()`
+        // clears the player items but `status.positionSeconds` is a core
+        // mirror that `core.stop()` zeroes after our call).
+        if steps.contains(.persistQueue) {
+            model.persistQueueSnapshot()
+        }
+
+        // Step 3: give the detached network POST up to 2 s to land, then
+        // tell AppKit to proceed regardless. The Task replies on the main
+        // actor so there is no thread-safety issue with `NSApp.reply`.
+        let timeoutNanos = shutdownTimeoutNanos
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: timeoutNanos)
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+
+        return .terminateLater
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/macos/Sources/Lyrebird/AppModel+Shutdown.swift
+++ b/macos/Sources/Lyrebird/AppModel+Shutdown.swift
@@ -1,0 +1,308 @@
+import Foundation
+import os
+@preconcurrency import LyrebirdCore
+
+private let shutdownLog = Logger(subsystem: "org.lyrebird.desktop", category: "shutdown")
+
+// MARK: - Persisted queue snapshot
+
+/// Lightweight `Codable` mirror of `Track` that round-trips through
+/// `UserDefaults` JSON without relying on the generated FFI type having
+/// `Codable` synthesis.
+///
+/// Only the fields needed to restore queue identity and display metadata are
+/// persisted. Playback uses the Jellyfin item `id`; the name, artist, and
+/// album fields let the Queue Inspector render meaningful rows before the
+/// library page has been re-fetched on the new launch.
+struct PersistedTrack: Codable, Equatable {
+    var id: String
+    var name: String
+    var albumId: String?
+    var albumName: String?
+    var artistName: String
+    var artistId: String?
+    var indexNumber: UInt32?
+    var discNumber: UInt32?
+    var year: Int32?
+    var runtimeTicks: UInt64
+    var imageTag: String?
+    var container: String?
+
+    init(from track: Track) {
+        id = track.id
+        name = track.name
+        albumId = track.albumId
+        albumName = track.albumName
+        artistName = track.artistName
+        artistId = track.artistId
+        indexNumber = track.indexNumber
+        discNumber = track.discNumber
+        year = track.year
+        runtimeTicks = track.runtimeTicks
+        imageTag = track.imageTag
+        container = track.container
+    }
+
+    /// Reconstruct a `Track` from the persisted mirror. Fields that are not
+    /// stored (favorite, play count, user data, playlist item id, bitrate) are
+    /// left at their zero values — they are refreshed by subsequent library
+    /// loads and do not affect whether the track can be played.
+    func toTrack() -> Track {
+        Track(
+            id: id,
+            name: name,
+            albumId: albumId,
+            albumName: albumName,
+            artistName: artistName,
+            artistId: artistId,
+            indexNumber: indexNumber,
+            discNumber: discNumber,
+            year: year,
+            runtimeTicks: runtimeTicks,
+            isFavorite: false,
+            playCount: 0,
+            container: container,
+            bitrate: nil,
+            imageTag: imageTag,
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+}
+
+/// The full queue state snapshotted at shutdown and restored on the next
+/// launch. Persisted as JSON under `AppModel.queueSnapshotKey` in
+/// `UserDefaults`.
+///
+/// Layout mirrors the Queue Inspector's three sections:
+///   1. `currentTrack` — the track that was playing or paused.
+///   2. `userAdded`    — the "Up Next" user-added overlay, in order.
+///   3. `autoQueue`    — the auto-queue tail (album / playlist remainder).
+///
+/// The context fields allow the inspector's "PLAYING FROM" header to be
+/// reconstructed from the persisted source without a server round-trip.
+struct QueueSnapshot: Codable, Equatable {
+    /// The track that was playing (or paused) when the app quit.
+    var currentTrack: PersistedTrack?
+    /// Playback position in seconds within the current track.
+    var positionSeconds: Double
+    /// User-added "Up Next" overlay, in queue order.
+    var userAdded: [PersistedTrack]
+    /// Auto-queue tail (album / playlist remainder), in queue order.
+    var autoQueue: [PersistedTrack]
+    /// Display label for the source that populated the auto-queue, if known.
+    var contextName: String?
+    /// Jellyfin item id for the source, if known.
+    var contextId: String?
+    /// Raw `ContextSourceType` value, used to reconstruct the enum on restore.
+    var contextSourceType: String?
+}
+
+// MARK: - AppModel shutdown + restore
+
+extension AppModel {
+
+    // MARK: UserDefaults keys
+
+    /// JSON-encoded `QueueSnapshot` from the most recent clean quit.
+    static let queueSnapshotKey = "queue.shutdown_snapshot"
+
+    /// Boolean flag: `true` when a snapshot was successfully written in
+    /// `persistQueueSnapshot()`. On `kill -9` this flag is never set, but any
+    /// JSON left from a prior clean quit is still valid and safe to restore —
+    /// SQLite WAL recovery handles the DB side independently.
+    static let queueSnapshotReadyKey = "queue.shutdown_snapshot_ready"
+
+    // MARK: Pure decision helpers (testable without side-effects)
+
+    /// Whether the current state warrants snapshotting. Returns `false` when
+    /// idle (nothing playing or queued) so an empty snapshot is never written.
+    ///
+    /// Pure function — reads the arguments, not live model state, so tests can
+    /// cover every branch without a running audio session.
+    static func shouldPersistSnapshot(
+        currentTrack: Track?,
+        userAddedCount: Int,
+        autoQueueCount: Int
+    ) -> Bool {
+        currentTrack != nil || userAddedCount > 0 || autoQueueCount > 0
+    }
+
+    /// Ordered sequence of work items in a graceful shutdown.
+    ///
+    /// Returned as a value enum so tests can assert ordering (playback stop
+    /// before queue persist) without observing side-effects.
+    enum ShutdownStep: Equatable {
+        /// Stop the AVPlayer / DSP pipeline and emit the final
+        /// `POST /Sessions/Playing/Stopped` report so the server's resume
+        /// position is correct.
+        case stopPlayback
+        /// Encode and write the current queue + position to `UserDefaults`.
+        case persistQueue
+    }
+
+    /// Returns the canonical shutdown sequence for the given state.
+    ///
+    /// Stopping playback comes first so `positionSeconds` still reflects the
+    /// last known playback position when the queue is snapshotted; after the
+    /// player drains it would read 0.
+    static func shutdownSteps(isPlayingOrPaused: Bool, hasQueue: Bool) -> [ShutdownStep] {
+        var steps: [ShutdownStep] = []
+        if isPlayingOrPaused { steps.append(.stopPlayback) }
+        if hasQueue { steps.append(.persistQueue) }
+        return steps
+    }
+
+    // MARK: Persist
+
+    /// Snapshot the current queue and position to `UserDefaults` and mark it
+    /// ready for restore on the next launch.
+    ///
+    /// Called synchronously on the main actor inside `applicationShouldTerminate`
+    /// after `audio.stop()` has been called. `UserDefaults.standard.set` is
+    /// synchronous; the OS writes it to disk on its normal plist schedule, which
+    /// is reliable for a clean quit. A `kill -9` may skip the write — that is
+    /// acceptable: WAL recovery handles any in-flight DB writes, and the user
+    /// simply starts fresh.
+    @MainActor
+    func persistQueueSnapshot() {
+        let currentTrack = status.currentTrack
+        let positionSeconds = status.positionSeconds
+        let userAdded = upNextUserAdded.map { PersistedTrack(from: $0.track) }
+        let autoQueue = upNextAutoQueue.map { PersistedTrack(from: $0.track) }
+
+        guard AppModel.shouldPersistSnapshot(
+            currentTrack: currentTrack,
+            userAddedCount: userAdded.count,
+            autoQueueCount: autoQueue.count
+        ) else {
+            // Nothing to restore — clear any stale snapshot so the next launch
+            // does not offer a resume from an older session.
+            UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotKey)
+            UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotReadyKey)
+            shutdownLog.info("graceful-shutdown: idle — queue snapshot cleared")
+            return
+        }
+
+        let snapshot = QueueSnapshot(
+            currentTrack: currentTrack.map(PersistedTrack.init(from:)),
+            positionSeconds: positionSeconds,
+            userAdded: userAdded,
+            autoQueue: autoQueue,
+            contextName: currentContext?.name,
+            contextId: currentContext?.id,
+            contextSourceType: currentContext?.sourceType.rawValue
+        )
+
+        do {
+            let data = try JSONEncoder().encode(snapshot)
+            let json = String(data: data, encoding: .utf8) ?? ""
+            UserDefaults.standard.set(json, forKey: AppModel.queueSnapshotKey)
+            UserDefaults.standard.set(true, forKey: AppModel.queueSnapshotReadyKey)
+            shutdownLog.info(
+                "graceful-shutdown: persisted — track=\(currentTrack?.name ?? "nil", privacy: .public) pos=\(positionSeconds, privacy: .public)s userAdded=\(userAdded.count) autoQueue=\(autoQueue.count)"
+            )
+        } catch {
+            shutdownLog.error(
+                "graceful-shutdown: snapshot encode failed: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: Restore
+
+    /// Decode and return the persisted `QueueSnapshot` from `UserDefaults`, if
+    /// one exists. Returns `nil` when there is no snapshot or it cannot be
+    /// decoded (e.g. schema change).
+    ///
+    /// Does not consume the snapshot — call `applyQueueSnapshot(_:)` to
+    /// hydrate the in-app state and clear the stored entry.
+    static func loadQueueSnapshot() -> QueueSnapshot? {
+        guard UserDefaults.standard.bool(forKey: AppModel.queueSnapshotReadyKey),
+              let json = UserDefaults.standard.string(forKey: AppModel.queueSnapshotKey),
+              let data = json.data(using: .utf8)
+        else { return nil }
+
+        do {
+            return try JSONDecoder().decode(QueueSnapshot.self, from: data)
+        } catch {
+            // Malformed / stale snapshot — clear it so the next launch starts
+            // fresh rather than repeatedly trying to decode a corrupt blob.
+            UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotKey)
+            UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotReadyKey)
+            shutdownLog.error(
+                "graceful-shutdown: snapshot decode failed (\(error.localizedDescription, privacy: .public)) — cleared"
+            )
+            return nil
+        }
+    }
+
+    /// Hydrate the in-app queue overlays from a decoded snapshot and store it in
+    /// `pendingResumeSnapshot` so the UI can present a "Resume where you left
+    /// off?" toast.
+    ///
+    /// This method does **not** start playback. The user's explicit tap of the
+    /// play button on the toast calls `resumeFromSnapshot()`.
+    ///
+    /// Clears the `UserDefaults` entry after reading so a subsequent cold launch
+    /// (without the user pressing Play) does not re-offer a stale resume.
+    @MainActor
+    func applyQueueSnapshot(_ snapshot: QueueSnapshot) {
+        upNextUserAdded = snapshot.userAdded.map { Queue(track: $0.toTrack()) }
+        upNextAutoQueue = snapshot.autoQueue.map { Queue(track: $0.toTrack()) }
+
+        if let name = snapshot.contextName,
+           let rawType = snapshot.contextSourceType,
+           let sourceType = ContextSourceType(rawValue: rawType) {
+            currentContext = QueueContext(
+                name: name,
+                id: snapshot.contextId,
+                sourceType: sourceType
+            )
+        }
+
+        pendingResumeSnapshot = snapshot
+
+        UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotKey)
+        UserDefaults.standard.removeObject(forKey: AppModel.queueSnapshotReadyKey)
+
+        shutdownLog.info(
+            "graceful-shutdown: snapshot applied — track=\(snapshot.currentTrack?.name ?? "nil", privacy: .public) pos=\(snapshot.positionSeconds)"
+        )
+    }
+
+    /// Dismiss the pending resume toast without starting playback.
+    @MainActor
+    func dismissResumeSnapshot() {
+        pendingResumeSnapshot = nil
+    }
+
+    /// Resume playback from the pending snapshot: push the full queue to the
+    /// core engine and play from the saved position. Called when the user taps
+    /// the play button on the "Resume?" toast.
+    @MainActor
+    func resumeFromSnapshot() {
+        guard let snapshot = pendingResumeSnapshot else { return }
+        pendingResumeSnapshot = nil
+
+        // Flatten to play order: current track first, then user-added, then tail.
+        var allTracks: [Track] = []
+        if let current = snapshot.currentTrack { allTracks.append(current.toTrack()) }
+        allTracks.append(contentsOf: snapshot.userAdded.map { $0.toTrack() })
+        allTracks.append(contentsOf: snapshot.autoQueue.map { $0.toTrack() })
+
+        guard !allTracks.isEmpty else { return }
+
+        play(tracks: allTracks, startIndex: 0)
+
+        // Seek to the saved position once the player has loaded. A short delay
+        // gives AVQueuePlayer time to reach .readyToPlay before the seek fires.
+        // Positions ≤ 1 s are effectively "from the start" and not worth seeking.
+        let savedPosition = snapshot.positionSeconds
+        guard savedPosition > 1.0 else { return }
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            self?.audio.seek(toSeconds: savedPosition)
+        }
+    }
+}

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -1060,6 +1060,16 @@ final class AppModel {
     /// a dead band. Moods are sourced from tags "if present" per the spec.
     var availableMoods: [Mood] = []
 
+    // MARK: - Graceful shutdown / resume
+
+    /// Non-nil when the app restored a `QueueSnapshot` from the previous
+    /// session and is waiting for the user to confirm or dismiss the
+    /// "Resume where you left off?" toast. Set by `applyQueueSnapshot(_:)`,
+    /// cleared by `resumeFromSnapshot()` / `dismissResumeSnapshot()`.
+    /// Stored here (not in the extension) because `@Observable` requires
+    /// stored properties on the `@Observable` class itself.
+    var pendingResumeSnapshot: QueueSnapshot?
+
 }
 
 // MARK: - Queue models (BATCH-07a)

--- a/macos/Tests/LyrebirdTests/GracefulShutdownTests.swift
+++ b/macos/Tests/LyrebirdTests/GracefulShutdownTests.swift
@@ -1,0 +1,403 @@
+import XCTest
+@testable import Lyrebird
+import LyrebirdCore
+
+/// Tests for the graceful-shutdown / queue-restore path:
+///
+///   * `shouldPersistSnapshot` — the pure guard function.
+///   * `shutdownSteps`         — canonical ordering (stop before persist).
+///   * `persistQueueSnapshot` + `loadQueueSnapshot` — round-trip through
+///     `UserDefaults` JSON.
+///   * `applyQueueSnapshot`    — hydrates the in-app overlays.
+///   * `resumeFromSnapshot`    — clears `pendingResumeSnapshot`.
+///   * `PersistedTrack`        — Codable round-trip and `toTrack()` losslessness.
+///
+/// All tests redirect the core's data directory to a throwaway temp dir (via
+/// `XDG_DATA_HOME`) so they never touch the real on-disk database, and scrub
+/// the `UserDefaults` keys before / after each test so state does not leak.
+@MainActor
+final class GracefulShutdownTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private let snapshotKey   = AppModel.queueSnapshotKey
+    private let snapshotReady = AppModel.queueSnapshotReadyKey
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-shutdown-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: snapshotKey)
+        UserDefaults.standard.removeObject(forKey: snapshotReady)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: snapshotKey)
+        UserDefaults.standard.removeObject(forKey: snapshotReady)
+        super.tearDown()
+    }
+
+    private func makeTrack(
+        id: String = "t1",
+        name: String = "Test Track",
+        artistName: String = "Test Artist"
+    ) -> Track {
+        Track(
+            id: id,
+            name: name,
+            albumId: "a1",
+            albumName: "Test Album",
+            artistName: artistName,
+            artistId: "ar1",
+            indexNumber: 1,
+            discNumber: 1,
+            year: 2024,
+            runtimeTicks: 2_000_000_000,
+            isFavorite: false,
+            playCount: 3,
+            container: "flac",
+            bitrate: 1_411_200,
+            imageTag: "abc123",
+            playlistItemId: nil,
+            userData: nil
+        )
+    }
+
+    // MARK: - shouldPersistSnapshot
+
+    func testShouldNotPersistWhenIdle() {
+        XCTAssertFalse(
+            AppModel.shouldPersistSnapshot(
+                currentTrack: nil,
+                userAddedCount: 0,
+                autoQueueCount: 0
+            ),
+            "idle (no track, empty queue) must return false"
+        )
+    }
+
+    func testShouldPersistWhenCurrentTrackPresent() {
+        XCTAssertTrue(
+            AppModel.shouldPersistSnapshot(
+                currentTrack: makeTrack(),
+                userAddedCount: 0,
+                autoQueueCount: 0
+            ),
+            "a current track alone is enough to trigger a snapshot"
+        )
+    }
+
+    func testShouldPersistWhenUserQueueNonEmpty() {
+        XCTAssertTrue(
+            AppModel.shouldPersistSnapshot(
+                currentTrack: nil,
+                userAddedCount: 2,
+                autoQueueCount: 0
+            ),
+            "a non-empty user-added queue must trigger a snapshot"
+        )
+    }
+
+    func testShouldPersistWhenAutoQueueNonEmpty() {
+        XCTAssertTrue(
+            AppModel.shouldPersistSnapshot(
+                currentTrack: nil,
+                userAddedCount: 0,
+                autoQueueCount: 1
+            ),
+            "a non-empty auto-queue must trigger a snapshot"
+        )
+    }
+
+    // MARK: - shutdownSteps ordering
+
+    func testShutdownStepsIdleReturnsEmpty() {
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: false, hasQueue: false)
+        XCTAssertTrue(steps.isEmpty, "idle state should produce no shutdown steps")
+    }
+
+    func testShutdownStepsPlayingPersistsQueue() {
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: true, hasQueue: true)
+        XCTAssertEqual(steps, [.stopPlayback, .persistQueue],
+                       "playing with a queue: stop first, persist second")
+    }
+
+    func testShutdownStepsPlayingNoQueueOnlyStops() {
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: true, hasQueue: false)
+        XCTAssertEqual(steps, [.stopPlayback],
+                       "playing with an empty queue should only stop, not persist")
+    }
+
+    func testShutdownStepsPausedQueuePersistsQueue() {
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: true, hasQueue: true)
+        XCTAssertTrue(steps.first == .stopPlayback, "stop must precede persist")
+        XCTAssertTrue(steps.last == .persistQueue, "persist must follow stop")
+    }
+
+    func testShutdownStepsIdleWithQueueSkipsStop() {
+        // Not-playing but queue present (e.g. loaded but never played).
+        let steps = AppModel.shutdownSteps(isPlayingOrPaused: false, hasQueue: true)
+        XCTAssertEqual(steps, [.persistQueue],
+                       "idle-but-queued should persist without stopping (nothing is playing)")
+    }
+
+    // MARK: - PersistedTrack round-trip
+
+    func testPersistedTrackCodableRoundTrip() throws {
+        let original = makeTrack(id: "xyz", name: "Round Trip", artistName: "Artist A")
+        let persisted = PersistedTrack(from: original)
+
+        let data = try JSONEncoder().encode(persisted)
+        let decoded = try JSONDecoder().decode(PersistedTrack.self, from: data)
+
+        XCTAssertEqual(decoded.id, "xyz")
+        XCTAssertEqual(decoded.name, "Round Trip")
+        XCTAssertEqual(decoded.artistName, "Artist A")
+        XCTAssertEqual(decoded.imageTag, original.imageTag)
+        XCTAssertEqual(decoded.container, original.container)
+        XCTAssertEqual(decoded, persisted,
+                       "encode → decode should be identity for PersistedTrack")
+    }
+
+    func testPersistedTrackToTrackPreservesId() {
+        let original = makeTrack(id: "abc-123", name: "Restore Me")
+        let restored = PersistedTrack(from: original).toTrack()
+
+        XCTAssertEqual(restored.id, original.id,
+                       "toTrack() must preserve the Jellyfin item id")
+        XCTAssertEqual(restored.name, original.name)
+        XCTAssertEqual(restored.artistName, original.artistName)
+    }
+
+    func testPersistedTrackToTrackZerosNonEssentialFields() {
+        let original = makeTrack()
+        let restored = PersistedTrack(from: original).toTrack()
+
+        // Play-count and favorite are not persisted — they are refreshed from
+        // the server after the library reloads.
+        XCTAssertEqual(restored.isFavorite, false)
+        XCTAssertEqual(restored.playCount, 0)
+    }
+
+    // MARK: - QueueSnapshot Codable round-trip
+
+    func testQueueSnapshotCodableRoundTrip() throws {
+        let snapshot = QueueSnapshot(
+            currentTrack: PersistedTrack(from: makeTrack(id: "c1", name: "Current")),
+            positionSeconds: 47.5,
+            userAdded: [PersistedTrack(from: makeTrack(id: "u1", name: "User Next"))],
+            autoQueue: [PersistedTrack(from: makeTrack(id: "a1", name: "Auto 1")),
+                        PersistedTrack(from: makeTrack(id: "a2", name: "Auto 2"))],
+            contextName: "My Album",
+            contextId: "album-id-42",
+            contextSourceType: "album"
+        )
+
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(QueueSnapshot.self, from: data)
+
+        XCTAssertEqual(decoded, snapshot)
+        XCTAssertEqual(decoded.positionSeconds, 47.5, accuracy: 0.001)
+        XCTAssertEqual(decoded.userAdded.count, 1)
+        XCTAssertEqual(decoded.autoQueue.count, 2)
+        XCTAssertEqual(decoded.contextSourceType, "album")
+    }
+
+    // MARK: - persistQueueSnapshot + loadQueueSnapshot
+
+    func testPersistAndLoadRoundTrip() throws {
+        let model = try AppModel()
+
+        // Inject queue state through the public stored properties.
+        model.upNextUserAdded = [Queue(track: makeTrack(id: "u1", name: "User Added"))]
+        model.upNextAutoQueue = [Queue(track: makeTrack(id: "a1", name: "Auto Q"))]
+
+        model.persistQueueSnapshot()
+
+        let loaded = AppModel.loadQueueSnapshot()
+        XCTAssertNotNil(loaded, "a snapshot must be loadable after persistQueueSnapshot()")
+        XCTAssertEqual(loaded?.userAdded.first?.id, "u1")
+        XCTAssertEqual(loaded?.autoQueue.first?.id, "a1")
+    }
+
+    func testPersistIdleDoesNotWriteSnapshot() throws {
+        let model = try AppModel()
+        // No track, no queue — shouldPersistSnapshot is false.
+        model.persistQueueSnapshot()
+
+        XCTAssertNil(
+            AppModel.loadQueueSnapshot(),
+            "an idle snapshot should not be written"
+        )
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: snapshotReady),
+            "the ready flag must not be set when nothing was written"
+        )
+    }
+
+    func testPersistIdleClearsStaleSnapshot() throws {
+        // Pre-seed a stale entry.
+        UserDefaults.standard.set("{}", forKey: snapshotKey)
+        UserDefaults.standard.set(true,  forKey: snapshotReady)
+
+        let model = try AppModel()
+        // Idle — nothing playing.
+        model.persistQueueSnapshot()
+
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: snapshotKey),
+            "an idle persist must clear any stale JSON entry"
+        )
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: snapshotReady),
+            "an idle persist must clear the ready flag"
+        )
+    }
+
+    func testLoadSnapshotWithMissingReadyFlagReturnsNil() {
+        UserDefaults.standard.set("{\"positionSeconds\":0}", forKey: snapshotKey)
+        UserDefaults.standard.removeObject(forKey: snapshotReady)
+
+        XCTAssertNil(
+            AppModel.loadQueueSnapshot(),
+            "loadQueueSnapshot must return nil when the ready flag is absent"
+        )
+    }
+
+    func testLoadSnapshotWithMalformedJsonClearsAndReturnsNil() {
+        UserDefaults.standard.set("not-valid-json", forKey: snapshotKey)
+        UserDefaults.standard.set(true, forKey: snapshotReady)
+
+        let result = AppModel.loadQueueSnapshot()
+
+        XCTAssertNil(result, "malformed JSON should return nil")
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: snapshotKey),
+            "malformed JSON should also clear the persisted entry"
+        )
+    }
+
+    // MARK: - applyQueueSnapshot
+
+    func testApplySnapshotHydratesOverlays() throws {
+        let model = try AppModel()
+        let snapshot = QueueSnapshot(
+            currentTrack: PersistedTrack(from: makeTrack(id: "c1")),
+            positionSeconds: 12.0,
+            userAdded: [PersistedTrack(from: makeTrack(id: "u1")),
+                        PersistedTrack(from: makeTrack(id: "u2"))],
+            autoQueue: [PersistedTrack(from: makeTrack(id: "aq1"))],
+            contextName: "Test Playlist",
+            contextId: "pl-1",
+            contextSourceType: "playlist"
+        )
+
+        model.applyQueueSnapshot(snapshot)
+
+        XCTAssertEqual(model.upNextUserAdded.count, 2)
+        XCTAssertEqual(model.upNextUserAdded[0].track.id, "u1")
+        XCTAssertEqual(model.upNextUserAdded[1].track.id, "u2")
+        XCTAssertEqual(model.upNextAutoQueue.count, 1)
+        XCTAssertEqual(model.upNextAutoQueue[0].track.id, "aq1")
+        XCTAssertEqual(model.currentContext?.name, "Test Playlist")
+        XCTAssertEqual(model.currentContext?.sourceType, .playlist)
+    }
+
+    func testApplySnapshotSetsPendingResume() throws {
+        let model = try AppModel()
+        let snapshot = QueueSnapshot(
+            currentTrack: PersistedTrack(from: makeTrack()),
+            positionSeconds: 30.0,
+            userAdded: [],
+            autoQueue: [],
+            contextName: nil,
+            contextId: nil,
+            contextSourceType: nil
+        )
+
+        model.applyQueueSnapshot(snapshot)
+
+        XCTAssertNotNil(
+            model.pendingResumeSnapshot,
+            "applyQueueSnapshot must set pendingResumeSnapshot"
+        )
+        XCTAssertEqual(model.pendingResumeSnapshot?.positionSeconds, 30.0)
+    }
+
+    func testApplySnapshotClearsUserDefaults() throws {
+        let model = try AppModel()
+        UserDefaults.standard.set("{}", forKey: snapshotKey)
+        UserDefaults.standard.set(true,  forKey: snapshotReady)
+
+        let snapshot = QueueSnapshot(
+            currentTrack: nil,
+            positionSeconds: 0,
+            userAdded: [],
+            autoQueue: [],
+            contextName: nil,
+            contextId: nil,
+            contextSourceType: nil
+        )
+        model.applyQueueSnapshot(snapshot)
+
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: snapshotKey),
+            "applyQueueSnapshot must clear the persisted JSON after consuming it"
+        )
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: snapshotReady),
+            "applyQueueSnapshot must clear the ready flag"
+        )
+    }
+
+    // MARK: - dismissResumeSnapshot
+
+    func testDismissResumeSnapshotClearsPending() throws {
+        let model = try AppModel()
+        model.pendingResumeSnapshot = QueueSnapshot(
+            currentTrack: nil,
+            positionSeconds: 0,
+            userAdded: [],
+            autoQueue: [],
+            contextName: nil,
+            contextId: nil,
+            contextSourceType: nil
+        )
+        model.dismissResumeSnapshot()
+        XCTAssertNil(model.pendingResumeSnapshot)
+    }
+
+    // MARK: - resumeFromSnapshot
+
+    func testResumeFromSnapshotClearsPending() throws {
+        let model = try AppModel()
+        // Seed a minimal snapshot with a valid current track so play(tracks:)
+        // has something to work with.
+        model.pendingResumeSnapshot = QueueSnapshot(
+            currentTrack: PersistedTrack(from: makeTrack(id: "r1")),
+            positionSeconds: 0.5, // ≤ 1.0 so no seek is scheduled
+            userAdded: [],
+            autoQueue: [],
+            contextName: nil,
+            contextId: nil,
+            contextSourceType: nil
+        )
+        model.resumeFromSnapshot()
+        XCTAssertNil(
+            model.pendingResumeSnapshot,
+            "resumeFromSnapshot must clear the pending snapshot regardless of playback outcome"
+        )
+    }
+
+    func testResumeFromNilSnapshotIsNoOp() throws {
+        let model = try AppModel()
+        model.pendingResumeSnapshot = nil
+        // Should not crash.
+        model.resumeFromSnapshot()
+        XCTAssertNil(model.pendingResumeSnapshot)
+    }
+}


### PR DESCRIPTION
Quitting mid-playback dropped the final position mark and server stop report — resume points were stale and Now Playing lingered on other clients.

Closes #446

- `applicationShouldTerminate` → bounded shutdown sequence (hard ~2s timeout, never hangs quit): stop playback (both AVQueuePlayer and DSP paths), final `reportPlaybackStopped` + position mark, queue persistence
- `AppModel+Shutdown.swift` extension; testable sequence helper

Gates: clean swift build; swift test 1087/1087 (verified post-stage).