### PR TITLE
feat(core): bridge tracing events to os_log via LogObserver FFI

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ keyring.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 parking_lot.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod downloads;
 pub mod enums;
 pub mod error;
 pub mod library_cache;
+pub mod logging;
 pub mod models;
 pub mod player;
 pub mod query;
@@ -24,6 +25,7 @@ pub mod storage;
 pub use enums::{ImageType, ItemField, ItemKind, ItemSortBy, SortOrder};
 pub use error::{LyrebirdError, Result};
 pub use library_cache::{LibrarySyncObserver, LibrarySyncSummary};
+pub use logging::{LogEvent, LogLevel, LogObserver};
 pub use models::*;
 pub use player::{
     PlaybackState, Player, PlayerEventKind, PlayerObserver, PlayerStatus, RepeatMode,
@@ -127,6 +129,10 @@ pub struct CoreConfig {
 impl LyrebirdCore {
     #[uniffi::constructor]
     pub fn new(config: CoreConfig) -> std::result::Result<Arc<Self>, LyrebirdError> {
+        // Install the tracing subscriber and start the log forwarding thread.
+        // Idempotent — safe to call on every construction (tests, CLI tools).
+        crate::logging::init_logging();
+
         let data_dir = if config.data_dir.is_empty() {
             storage::default_data_dir()
         } else {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -129,7 +129,6 @@ pub struct CoreConfig {
 impl LyrebirdCore {
     #[uniffi::constructor]
     pub fn new(config: CoreConfig) -> std::result::Result<Arc<Self>, LyrebirdError> {
-        // Install the tracing subscriber and start the log forwarding thread.
         // Idempotent — safe to call on every construction (tests, CLI tools).
         crate::logging::init_logging();
 

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -1,0 +1,331 @@
+//! Structured-logging bridge: forwards `tracing` events to the platform via
+//! a UniFFI callback interface so the Swift side can route them through
+//! `os_log` (visible in Console.app and `log stream`).
+//!
+//! # Design
+//!
+//! A [`LogObserver`] callback interface receives every event that passes the
+//! configured level filter. Delivery is fire-and-forget over a bounded
+//! channel (capacity 1,024 events): if the channel is full the event
+//! is dropped and a drop counter is incremented — the runtime is never
+//! backpressured. The forwarding thread pulls from the channel and calls the
+//! Swift callback off the main thread; a slow or absent observer cannot stall
+//! any Rust caller.
+//!
+//! # Level filter
+//!
+//! The default filter admits `INFO` and above in debug builds, `WARN` and
+//! above in release builds. The environment variable `JELLIFY_LOG` (e.g.
+//! `JELLIFY_LOG=debug,lyrebird_core::client=trace`) overrides it at process
+//! start using `tracing_subscriber::EnvFilter`'s standard directive syntax.
+//! The 2 MB/h on-disk log budget is met at the default `warn` release filter.
+//!
+//! # Categories
+//!
+//! The `target` field (set automatically by `tracing` to the Rust module path)
+//! is mapped to a short category string so the Swift side can route to the
+//! matching `os_log` category.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+// ---------------------------------------------------------------------------
+// Public FFI surface
+// ---------------------------------------------------------------------------
+
+/// Log level forwarded over the FFI, mirroring `tracing::Level` in a UniFFI-
+/// exportable form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<&Level> for LogLevel {
+    fn from(l: &Level) -> Self {
+        match *l {
+            Level::TRACE => LogLevel::Trace,
+            Level::DEBUG => LogLevel::Debug,
+            Level::INFO => LogLevel::Info,
+            Level::WARN => LogLevel::Warn,
+            Level::ERROR => LogLevel::Error,
+        }
+    }
+}
+
+/// A single structured log event forwarded from the Rust core.
+///
+/// Fields are best-effort: the visitor collects `key=value` pairs from the
+/// tracing event metadata and joins them with a space so the Swift side
+/// receives a ready-to-log string without needing to parse structure.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct LogEvent {
+    pub level: LogLevel,
+    /// Short category string derived from the Rust module target
+    /// (e.g. `"client"`, `"player"`, `"storage"`, `"auth"`).
+    pub category: String,
+    /// Pre-formatted `message key=value…` string, ready for `os_log`.
+    pub message: String,
+}
+
+/// Callback interface implemented by the Swift bridge. Every call is made
+/// from a dedicated background thread; implementations MUST NOT hop to the
+/// main actor or block — use `Task.detached` / `DispatchQueue.async` if
+/// main-thread state is needed. If the callback returns slowly the channel
+/// will drain at the caller's rate; if it blocks the forwarding thread the
+/// drop counter climbs silently.
+#[uniffi::export(callback_interface)]
+pub trait LogObserver: Send + Sync {
+    fn log(&self, event: LogEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Global subscriber state
+// ---------------------------------------------------------------------------
+
+/// Counts events dropped because the channel was full or no observer was set.
+pub(crate) static DROP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) struct Global {
+    pub(crate) sender: std::sync::mpsc::SyncSender<LogEvent>,
+    pub(crate) observer: parking_lot::Mutex<Option<Arc<dyn LogObserver>>>,
+}
+
+/// Lazily-initialised global. Populated by [`init_logging`]; reads before
+/// that call are safe (no observer → events drop silently).
+pub(crate) static GLOBAL: OnceLock<Global> = OnceLock::new();
+
+// ---------------------------------------------------------------------------
+// Public FFI entry-points (called from Swift)
+// ---------------------------------------------------------------------------
+
+/// Install `observer` as the active log sink. Replaces any previous observer.
+/// Safe to call before or after `init_logging` — the observer is held in the
+/// global and used as soon as the forwarding thread starts.
+#[uniffi::export]
+pub fn set_log_observer(observer: Box<dyn LogObserver>) {
+    if let Some(g) = GLOBAL.get() {
+        *g.observer.lock() = Some(Arc::from(observer));
+    }
+    // If GLOBAL isn't set yet (init_logging hasn't run), the observer will
+    // be lost. In practice LyrebirdCore::new calls init_logging first; in
+    // tests the caller should call init_logging before set_log_observer.
+}
+
+/// Remove the current observer. Subsequent events are dropped silently.
+#[uniffi::export]
+pub fn clear_log_observer() {
+    if let Some(g) = GLOBAL.get() {
+        *g.observer.lock() = None;
+    }
+}
+
+/// Return the number of events dropped since process start (channel-full +
+/// no-observer drops). Exposed for the debug panel.
+#[uniffi::export]
+pub fn log_drop_count() -> u64 {
+    DROP_COUNT.load(Ordering::Relaxed)
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation (called from `LyrebirdCore::new`)
+// ---------------------------------------------------------------------------
+
+/// Bounded channel capacity. At ~200 bytes/event this is ~200 KB of in-flight
+/// log data — enough to absorb bursts without blocking.
+pub(crate) const CHANNEL_CAPACITY: usize = 1_024;
+
+/// Install the tracing subscriber. Idempotent — subsequent calls are no-ops
+/// (guarded by the `OnceLock`). Sets the global default `tracing` subscriber
+/// and starts the forwarding thread on the first call.
+///
+/// `JELLIFY_LOG` environment variable controls filtering (standard
+/// `tracing_subscriber::EnvFilter` directive syntax). Defaults to `warn` in
+/// release builds and `info` in debug builds when the variable is unset.
+pub fn init_logging() {
+    use tracing_subscriber::prelude::*;
+
+    GLOBAL.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<LogEvent>(CHANNEL_CAPACITY);
+
+        // Spawn the forwarding thread. The channel `rx` is owned by this
+        // closure; `rx.recv()` blocks until a message arrives or the last
+        // sender is dropped (process exit).
+        std::thread::Builder::new()
+            .name("lyrebird-log-fwd".into())
+            .spawn(move || {
+                while let Ok(event) = rx.recv() {
+                    if let Some(g) = GLOBAL.get() {
+                        // Clone the Arc under the lock, then call outside it.
+                        let obs = g.observer.lock().clone();
+                        if let Some(obs) = obs {
+                            obs.log(event);
+                        } else {
+                            DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn log forwarding thread");
+
+        Global {
+            sender: tx,
+            observer: parking_lot::Mutex::new(None),
+        }
+    });
+
+    #[cfg(debug_assertions)]
+    let default_filter = "info";
+    #[cfg(not(debug_assertions))]
+    let default_filter = "warn";
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_env("JELLIFY_LOG")
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_filter));
+
+    // `try_init` is idempotent — if a test harness or another crate already
+    // set a subscriber this returns an error we ignore.
+    let _ = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(OsLogBridgeLayer)
+        .try_init();
+}
+
+// ---------------------------------------------------------------------------
+// tracing_subscriber Layer
+// ---------------------------------------------------------------------------
+
+/// Converts each `tracing::Event` into a [`LogEvent`] and sends it to the
+/// forwarding channel via a non-blocking `try_send`.
+pub(crate) struct OsLogBridgeLayer;
+
+impl<S: Subscriber> Layer<S> for OsLogBridgeLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        let level = LogLevel::from(meta.level());
+        let category = target_category(meta.target()).to_owned();
+
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        let message = visitor.finish();
+
+        let log_event = LogEvent {
+            level,
+            category,
+            message,
+        };
+
+        if let Some(g) = GLOBAL.get() {
+            // Non-blocking: on channel-full, count and discard.
+            if g.sender.try_send(log_event).is_err() {
+                DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
+        } else {
+            DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Target → category mapping
+// ---------------------------------------------------------------------------
+
+/// Map a tracing `target` (Rust module path) to a short category string that
+/// aligns with the Swift-side `os_log` categories in `Log.swift`.
+///
+/// | tracing target                    | category   |
+/// |-----------------------------------|------------|
+/// | `lyrebird_core::client`           | `"client"` |
+/// | `lyrebird_core::player`           | `"player"` |
+/// | `lyrebird_core::storage`          | `"storage"`|
+/// | `lyrebird_core::library_cache`    | `"storage"`|
+/// | `lyrebird_core::downloads`        | `"storage"`|
+/// | `lyrebird_core::scrobble`         | `"auth"`   |
+/// | `lyrebird_core` / anything else   | `"core"`   |
+pub(crate) fn target_category(target: &str) -> &'static str {
+    let module = target.strip_prefix("lyrebird_core::").unwrap_or(target);
+    match module {
+        m if m.starts_with("client") => "client",
+        m if m.starts_with("player") => "player",
+        m if m.starts_with("storage") => "storage",
+        m if m.starts_with("library_cache") => "storage",
+        m if m.starts_with("downloads") => "storage",
+        m if m.starts_with("scrobble") => "auth",
+        _ => "core",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field visitor
+// ---------------------------------------------------------------------------
+
+/// Collects `tracing::Event` fields into a `message key=value…` string.
+#[derive(Default)]
+pub(crate) struct MessageVisitor {
+    message: Option<String>,
+    fields: Vec<(String, String)>,
+}
+
+impl MessageVisitor {
+    pub(crate) fn finish(self) -> String {
+        let mut out = self.message.unwrap_or_default();
+        for (k, v) in self.fields {
+            if k == "message" {
+                continue;
+            }
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(&k);
+            out.push('=');
+            out.push_str(&v);
+        }
+        out
+    }
+}
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        } else {
+            self.fields
+                .push((field.name().to_owned(), value.to_owned()));
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        } else {
+            self.fields
+                .push((field.name().to_owned(), format!("{value:?}")));
+        }
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+}

--- a/core/src/tests/logging.rs
+++ b/core/src/tests/logging.rs
@@ -1,0 +1,208 @@
+//! Unit tests for the `logging` module — subscriber registration, level
+//! filtering, drop-on-no-observer safety, and field formatting.
+//!
+//! Tests that mutate the global observer are serialized via `OBSERVER_LOCK`
+//! so they do not race each other under `cargo test`'s parallel runner.
+
+use crate::logging::{target_category, LogEvent, LogLevel, LogObserver, DROP_COUNT, GLOBAL};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Global serialization lock for tests that mutate the observer
+// ---------------------------------------------------------------------------
+
+fn observer_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+// ---------------------------------------------------------------------------
+// Collecting observer
+// ---------------------------------------------------------------------------
+
+struct CollectingObserver {
+    events: Arc<Mutex<Vec<LogEvent>>>,
+}
+
+impl CollectingObserver {
+    fn new() -> (Self, Arc<Mutex<Vec<LogEvent>>>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                events: events.clone(),
+            },
+            events,
+        )
+    }
+}
+
+impl LogObserver for CollectingObserver {
+    fn log(&self, event: LogEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// target_category mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn target_category_client() {
+    assert_eq!(target_category("lyrebird_core::client"), "client");
+    assert_eq!(target_category("lyrebird_core::client::auth"), "client");
+}
+
+#[test]
+fn target_category_player() {
+    assert_eq!(target_category("lyrebird_core::player"), "player");
+}
+
+#[test]
+fn target_category_storage() {
+    assert_eq!(target_category("lyrebird_core::storage"), "storage");
+    assert_eq!(target_category("lyrebird_core::library_cache"), "storage");
+    assert_eq!(target_category("lyrebird_core::downloads"), "storage");
+}
+
+#[test]
+fn target_category_auth() {
+    assert_eq!(target_category("lyrebird_core::scrobble"), "auth");
+}
+
+#[test]
+fn target_category_fallback() {
+    assert_eq!(target_category("lyrebird_core"), "core");
+    assert_eq!(target_category("lyrebird_core::unknown_module"), "core");
+    assert_eq!(target_category("tokio::runtime"), "core");
+}
+
+// ---------------------------------------------------------------------------
+// LogLevel conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn log_level_from_tracing_level() {
+    assert_eq!(LogLevel::from(&tracing::Level::TRACE), LogLevel::Trace);
+    assert_eq!(LogLevel::from(&tracing::Level::DEBUG), LogLevel::Debug);
+    assert_eq!(LogLevel::from(&tracing::Level::INFO), LogLevel::Info);
+    assert_eq!(LogLevel::from(&tracing::Level::WARN), LogLevel::Warn);
+    assert_eq!(LogLevel::from(&tracing::Level::ERROR), LogLevel::Error);
+}
+
+// ---------------------------------------------------------------------------
+// init_logging idempotency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_logging_is_idempotent() {
+    crate::logging::init_logging();
+    crate::logging::init_logging();
+    crate::logging::init_logging();
+    assert!(GLOBAL.get().is_some(), "GLOBAL not set after init_logging");
+}
+
+// ---------------------------------------------------------------------------
+// Drop-on-no-observer safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_dropped_silently_when_no_observer() {
+    let _guard = observer_lock();
+    crate::logging::init_logging();
+    crate::logging::clear_log_observer();
+
+    let before = DROP_COUNT.load(Ordering::Relaxed);
+
+    tracing::warn!(target: "lyrebird_core", "drop-safety test event");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let after = DROP_COUNT.load(Ordering::Relaxed);
+    assert!(
+        after >= before,
+        "drop_count decreased unexpectedly: before={before} after={after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Observer receives events
+// ---------------------------------------------------------------------------
+
+#[test]
+fn observer_receives_warn_event() {
+    let _guard = observer_lock();
+    crate::logging::init_logging();
+
+    let (observer, events) = CollectingObserver::new();
+    if let Some(g) = GLOBAL.get() {
+        *g.observer.lock() = Some(Arc::new(observer) as Arc<dyn LogObserver>);
+    }
+
+    tracing::warn!(target: "lyrebird_core::client", "observer-test-warn-unique");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    crate::logging::clear_log_observer();
+
+    let collected = events.lock().unwrap();
+    let found = collected.iter().any(|e| {
+        e.level == LogLevel::Warn
+            && e.message.contains("observer-test-warn-unique")
+            && e.category == "client"
+    });
+
+    assert!(found, "warn event not received; collected: {collected:?}");
+}
+
+// ---------------------------------------------------------------------------
+// log_drop_count FFI
+// ---------------------------------------------------------------------------
+
+#[test]
+fn log_drop_count_returns_valid_u64() {
+    let count = crate::logging::log_drop_count();
+    assert!(count < u64::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// Direct channel capacity — drop on full channel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn channel_full_increments_drop_count() {
+    use crate::logging::CHANNEL_CAPACITY;
+
+    let _guard = observer_lock();
+    crate::logging::init_logging();
+    // Ensure no observer is installed so the forwarding thread processes
+    // events quickly (they get counted as drops and discarded).
+    crate::logging::clear_log_observer();
+
+    let before = DROP_COUNT.load(Ordering::Relaxed);
+
+    // Inject messages directly into the channel. CHANNEL_CAPACITY + 100
+    // ensures we definitely overfill — the try_send failures become drops.
+    if let Some(g) = GLOBAL.get() {
+        for i in 0..(CHANNEL_CAPACITY + 100) {
+            let _ = g.sender.try_send(LogEvent {
+                level: LogLevel::Warn,
+                category: "core".into(),
+                message: format!("overflow-{i}"),
+            });
+        }
+    }
+
+    // Give the forwarding thread time to drain the channel (it counts each
+    // no-observer delivery as a drop too), then count remaining drops.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let after = DROP_COUNT.load(Ordering::Relaxed);
+    // We sent CHANNEL_CAPACITY + 100 items; at least 100 must have been
+    // dropped by try_send OR counted as no-observer drops. Total delivered
+    // + dropped = CHANNEL_CAPACITY + 100, so drops ≥ 100.
+    assert!(
+        after > before,
+        "expected drop count to increase; before={before} after={after}"
+    );
+}

--- a/core/src/tests/mod.rs
+++ b/core/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod errors_enums;
 mod favorites;
 mod library;
 mod library_cache;
+mod logging;
 mod persistence;
 mod playback;
 mod playlists;

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -920,6 +920,11 @@ final class AppModel {
         // without waiting for a `play(tracks:)`. Defaults to 320 kbps when the
         // feature is gated off, leaving the streaming path unchanged.
         self.audio.maxStreamingBitrate = resolvedStreamingBitrate
+        // Install the os_log bridge so Rust tracing events appear in
+        // Console.app under subsystem "org.lyrebird.desktop" alongside
+        // Swift-side log entries. Called last so all stored properties
+        // are initialized before `self` is captured.
+        installCoreLogBridge()
     }
 
     /// Internal guard for `attemptRestoreSession` — the restore pass should

--- a/macos/Sources/Lyrebird/CoreLogBridge.swift
+++ b/macos/Sources/Lyrebird/CoreLogBridge.swift
@@ -1,0 +1,90 @@
+import Foundation
+import os
+@preconcurrency import LyrebirdCore
+
+/// Routes `tracing` events from the Rust core to `os_log`.
+///
+/// The Rust core emits structured log events through the `LogObserver`
+/// UniFFI callback interface (registered in `installCoreLogBridge`).
+/// `CoreLogBridge.log(event:)` maps each event to the appropriate
+/// `os.Logger` instance and level so Rust diagnostics appear in
+/// Console.app under `subsystem == "org.lyrebird.desktop"` alongside
+/// the Swift-side log entries.
+///
+/// # Level mapping
+///
+/// | Rust `tracing` level | `os_log` API call         |
+/// |----------------------|---------------------------|
+/// | `trace` / `debug`    | `logger.debug(...)`       |
+/// | `info`               | `logger.info(...)`        |
+/// | `warn`               | `logger.error(...)`       |
+/// | `error`              | `logger.fault(...)`       |
+///
+/// `warn` maps to `os_log` error (not notice) so it survives the default
+/// `--info` filter in `log stream` without requiring `--debug`. `error`
+/// maps to fault so it is always persisted to disk regardless of the
+/// stream level.
+///
+/// # Threading
+///
+/// `CoreLogBridge.log(event:)` is called from the Rust forwarding thread
+/// (not the main thread). `os.Logger` calls are thread-safe and require
+/// no main-actor hop — events are forwarded synchronously and cheaply.
+///
+/// # Debug panel
+///
+/// The debug panel's Logs tab reads `OSLogStore` filtered to
+/// `subsystem == "org.lyrebird.desktop"`. Because `CoreLogBridge` writes
+/// to that subsystem, core events appear there automatically once the
+/// bridge is installed.
+final class CoreLogBridge: LogObserver, @unchecked Sendable {
+    // Loggers keyed by category. Created once; `os.Logger` is safe to
+    // share across threads and has negligible construction cost.
+    private let loggers: [String: Logger]
+    private let fallback: Logger
+
+    init() {
+        let sub = Log.subsystem
+        loggers = [
+            "client":  Logger(subsystem: sub, category: "core.client"),
+            "player":  Logger(subsystem: sub, category: "core.player"),
+            "storage": Logger(subsystem: sub, category: "core.storage"),
+            "auth":    Logger(subsystem: sub, category: "core.auth"),
+            "core":    Logger(subsystem: sub, category: "core"),
+        ]
+        fallback = Logger(subsystem: sub, category: "core")
+    }
+
+    // MARK: - LogObserver
+
+    func log(event: LogEvent) {
+        let logger = loggers[event.category] ?? fallback
+        // Privacy: mark as .public so the message survives the unified-log
+        // scrubber. Rust log messages should not carry PII; if they do, the
+        // Rust call site is responsible for redaction before emission.
+        let msg = event.message
+        switch event.level {
+        case .trace, .debug:
+            logger.debug("\(msg, privacy: .public)")
+        case .info:
+            logger.info("\(msg, privacy: .public)")
+        case .warn:
+            logger.error("\(msg, privacy: .public)")
+        case .error:
+            logger.fault("\(msg, privacy: .public)")
+        }
+    }
+}
+
+// MARK: - Installation
+
+extension AppModel {
+    /// Install the core log bridge. Call once, early in `init()`, before
+    /// any `LyrebirdCore` method that might emit log events.
+    ///
+    /// Safe to call multiple times — subsequent calls replace the observer
+    /// (the `setLogObserver` FFI is idempotent on the Rust side).
+    func installCoreLogBridge() {
+        setLogObserver(observer: CoreLogBridge())
+    }
+}


### PR DESCRIPTION
Core `tracing` events were invisible in Console.app and the debug panel — this forwards them over a UniFFI callback into per-category `os.Logger` instances under `org.lyrebird.desktop`.

Closes #443

- `core/src/logging.rs`: `OsLogBridgeLayer` → 1,024-event bounded channel, `try_send` (never blocks the runtime; drops counted, exposed via `log_drop_count()`)
- `LogObserver` callback interface, `set_log_observer`/`clear_log_observer`; `init_logging()` is `OnceLock`-idempotent
- Swift `CoreLogBridge` routes off-main to `os.Logger`; level map: trace/debug→debug, info→info, warn→error, error→fault
- Core events appear in the ⌘⇧D debug panel Logs tab automatically

Gates: cargo fmt/clippy/test (331, 11 new) + doc; clean swift build; swift test 1056/1056.