### PR TITLE
polish(macos): adopt native hover and selection effects

### DIFF
--- a/macos/Sources/Lyrebird/Components/CommandPalette.swift
+++ b/macos/Sources/Lyrebird/Components/CommandPalette.swift
@@ -667,7 +667,7 @@ struct PaletteRow: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .background(isSelected ? Theme.rowHover : Color.clear)
+        .background(isSelected ? Theme.nativeHover : Color.clear)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)

--- a/macos/Sources/Lyrebird/Components/HomeAlbumTile.swift
+++ b/macos/Sources/Lyrebird/Components/HomeAlbumTile.swift
@@ -40,7 +40,9 @@ struct HomeAlbumTile<Badge: View>: View {
             metadata
         }
         .frame(width: 180)
-        .contentShape(Rectangle())
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 8))
+        .scaleEffect(reduceMotion ? 1.0 : (isHovering ? 1.02 : 1.0))
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isHovering)
         .onHover { isHovering = $0 }
         .onTapGesture(count: 2) {
             model.navPath.append(AppModel.Route.album(album.id))
@@ -56,6 +58,7 @@ struct HomeAlbumTile<Badge: View>: View {
         // `.focusable` allows the VoiceOver rotor to Tab into the tile from
         // a horizontal carousel. See #331 / #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(album.name) by \(album.artistName)")
         .accessibilityHint(hint)

--- a/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
+++ b/macos/Sources/Lyrebird/Components/InstantMixSheet.swift
@@ -280,7 +280,7 @@ private struct SeedRow: View {
         .padding(.vertical, 6)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Theme.surface2 : (isHovering ? Theme.rowHover : Color.clear))
+                .fill(isSelected ? Theme.surface2 : (isHovering ? Theme.nativeHover : Color.clear))
         )
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }

--- a/macos/Sources/Lyrebird/Components/LibraryListRow.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryListRow.swift
@@ -88,9 +88,9 @@ struct LibraryListRow: View {
             .padding(.vertical, 6)
             .background(
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(isHovering ? Theme.rowHover : .clear)
+                    .fill(isHovering ? Theme.nativeHover : .clear)
             )
-            .contentShape(Rectangle())
+            .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
         .onHover { hovering in
@@ -107,6 +107,7 @@ struct LibraryListRow: View {
         // `.focusable` lets the rotor Tab through the list; `.combine`
         // collapses artwork + text into one element. See #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(accessibilityHint)

--- a/macos/Sources/Lyrebird/Components/PlaylistCard.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistCard.swift
@@ -61,16 +61,20 @@ struct PlaylistCard: View {
             .padding(10)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(isHovering ? Theme.surface : .clear)
+                    .fill(isHovering ? Theme.nativeHover : .clear)
             )
+            .scaleEffect(reduceMotion ? 1.0 : (isHovering ? 1.02 : 1.0))
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isHovering)
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 12))
         .contextMenu { PlaylistContextMenu(playlist: playlist) }
         // `.focusable` lets the VoiceOver rotor Tab into this card; `.combine`
         // collapses the artwork, title, and play-button children so the card
         // reads as a single "Opens playlist detail" button. See #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(playlist.name), \(subtitle)")
         .accessibilityHint("Opens playlist detail")

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -673,15 +673,16 @@ private struct QueueInspectorRow: View {
         .padding(.horizontal, 4)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(isHovering ? Theme.rowHover : .clear)
+                .fill(isHovering ? Theme.nativeHover : .clear)
         )
-        .contentShape(Rectangle())
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
         // `.focusable` on reorderable rows so the rotor can Tab through Up
         // Next; auto-queue rows are read-only and remain non-focusable.
         // `.combine` collapses artwork + text + remove button into one element
         // so VoiceOver reads "Track by Artist" as a single queue entry.
         // See #588.
         .focusable(removable)
+        .focusEffectDisabled(!removable)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(entry.track.name) by \(entry.track.artistName)")
         // Expose Remove as a VoiceOver / Full Keyboard Access rotor action so

--- a/macos/Sources/Lyrebird/Components/RecentlyPlayedTile.swift
+++ b/macos/Sources/Lyrebird/Components/RecentlyPlayedTile.swift
@@ -59,10 +59,12 @@ struct RecentlyPlayedTile: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 8))
         // `.focusable` lets the VoiceOver rotor Tab through the Recently
         // Played / For You carousels; `.combine` collapses artwork + metadata
         // into one button element. See #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint("Plays this track")

--- a/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/RecentlyPlayedTrackRow.swift
@@ -54,9 +54,9 @@ struct RecentlyPlayedTrackRow: View {
             .frame(width: 320)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(isHovering ? Theme.rowHover : .clear)
+                    .fill(isHovering ? Theme.nativeHover : .clear)
             )
-            .contentShape(Rectangle())
+            .contentShape(.interaction, RoundedRectangle(cornerRadius: 8))
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
@@ -65,6 +65,7 @@ struct RecentlyPlayedTrackRow: View {
         // Recently Played list; `.combine` presents thumbnail + title +
         // duration as a single playable element. See #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint("Plays this track")

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -463,7 +463,7 @@ struct Sidebar: View {
                 .fill(
                     isActiveScreen
                         ? Theme.surface2
-                        : (isHovering ? Theme.rowHover : .clear)
+                        : (isHovering ? Theme.nativeHover : .clear)
                 )
         )
         .contentShape(Rectangle())

--- a/macos/Sources/Lyrebird/Components/TopTrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TopTrackRow.swift
@@ -105,9 +105,9 @@ struct TopTrackRow: View {
             .padding(.vertical, 8)
             .background(
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.rowHover : .clear))
+                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.nativeHover : .clear))
             )
-            .contentShape(Rectangle())
+            .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
         .onHover { hovering in
@@ -122,6 +122,7 @@ struct TopTrackRow: View {
         // list; `.combine` collapses rank/artwork/text so the element reads
         // as a single playable row. See #588.
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name), \(playCountLabel), rank \(rank)")
         .accessibilityHint("Plays this track")

--- a/macos/Sources/Lyrebird/Components/TrackListRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackListRow.swift
@@ -120,14 +120,8 @@ struct TrackListRow: View {
                         .padding(.vertical, 2)
                 }
             }
-            .overlay(
-                // Subtle outline so focus-via-keyboard is visible even when
-                // the row is also hovered or active. See #105.
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(isFocused ? Theme.accent.opacity(0.6) : .clear, lineWidth: 1)
-            )
             .clipShape(RoundedRectangle(cornerRadius: 6))
-            .contentShape(Rectangle())
+            .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
             .onHover { hovering in
                 if reduceMotion {
                     isHovering = hovering
@@ -156,6 +150,7 @@ struct TrackListRow: View {
             .accessibilityAddTraits(accessibilityTraits)
             // MARK: Keyboard navigation (#105)
             .focusable()
+            .focusEffectDisabled(false)
             .focused($isFocused)
             .onChange(of: isFocused) { _, nowFocused in
                 if nowFocused {
@@ -335,8 +330,8 @@ struct TrackListRow: View {
     private var rowBackground: Color {
         if isSelected { return Theme.accent.opacity(0.18) }
         if isActive { return Theme.surface2 }
-        if isFocused { return Theme.rowHover }
-        if isHovering { return Theme.rowHover }
+        if isFocused { return Theme.nativeHover }
+        if isHovering { return Theme.nativeHover }
         return .clear
     }
 

--- a/macos/Sources/Lyrebird/Components/TrackRow.swift
+++ b/macos/Sources/Lyrebird/Components/TrackRow.swift
@@ -170,15 +170,7 @@ struct TrackRow: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(rowBackground)
         )
-        // Native macOS focus ring. `.focusEffect()` (macOS 14+) lets the
-        // system draw the ring rather than us approximating it with a
-        // stroked overlay; combined with the inner .fill for `isActive` it
-        // keeps the row legible both via pointer and keyboard nav.
-        .focusEffectDisabled(false)
-        .overlay(
-            RoundedRectangle(cornerRadius: 6)
-                .stroke(isFocused ? Theme.accent.opacity(0.6) : .clear, lineWidth: 1)
-        )
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
         .overlay(alignment: .leading) {
             // Selection rail — 2pt accent bar on the leading edge so a
             // multi-selected row reads at a glance even when it's also
@@ -190,7 +182,6 @@ struct TrackRow: View {
                     .padding(.vertical, 2)
             }
         }
-        .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         // When a selection host is wired up, route clicks (with modifier
         // flags) to it through the shared gesture stack; otherwise keep the
@@ -218,6 +209,7 @@ struct TrackRow: View {
         .accessibilityAddTraits(accessibilityTraits)
         // MARK: Keyboard navigation (#105)
         .focusable()
+        .focusEffectDisabled(false)
         .focused($isFocused)
         .onChange(of: isFocused) { _, nowFocused in
             if nowFocused {
@@ -260,8 +252,8 @@ struct TrackRow: View {
     private var rowBackground: Color {
         if isSelected { return Theme.accent.opacity(0.18) }
         if isActive { return Theme.surface2 }
-        if isFocused { return Theme.rowHover }
-        if isHovering { return Theme.rowHover }
+        if isFocused { return Theme.nativeHover }
+        if isHovering { return Theme.nativeHover }
         return .clear
     }
 

--- a/macos/Sources/Lyrebird/Screens/FullQueueView.swift
+++ b/macos/Sources/Lyrebird/Screens/FullQueueView.swift
@@ -432,9 +432,9 @@ private struct FullQueueTrackRow: View {
             .padding(.vertical, 7)
             .background(
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.rowHover : .clear))
+                    .fill(isActive ? Theme.surface2 : (isHovering ? Theme.nativeHover : .clear))
             )
-            .contentShape(Rectangle())
+            .contentShape(.interaction, RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
         .onHover { hovering in
@@ -446,6 +446,7 @@ private struct FullQueueTrackRow: View {
         }
         .contextMenu { TrackContextMenu(selection: [track]) }
         .focusable(true)
+        .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(track.name) by \(track.artistName)")
         .accessibilityHint("Plays this track")

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -1536,8 +1536,10 @@ struct AlbumCard: View {
             .padding(10)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(isHovering ? Theme.surface : .clear)
+                    .fill(isHovering ? Theme.nativeHover : .clear)
             )
+            .scaleEffect(reduceMotion ? 1.0 : (isHovering ? 1.02 : 1.0))
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isHovering)
         }
         .buttonStyle(.plain)
         .onHover { hovering in
@@ -1551,6 +1553,7 @@ struct AlbumCard: View {
                 localHovering = hovering
             }
         }
+        .contentShape(.interaction, RoundedRectangle(cornerRadius: 12))
         .contextMenu { AlbumContextMenu(album: album) }
         // Outer "navigate to album" tap target. Reads as
         // "<album> by <artist>. Opens album detail." Because the hover play

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -733,7 +733,7 @@ private struct SuggestedArtistRow: View {
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(isHovering ? Theme.rowHover : .clear)
+                .fill(isHovering ? Theme.nativeHover : .clear)
         )
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
@@ -796,7 +796,7 @@ private struct RecentSearchRow: View {
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(isHovering ? Theme.rowHover : .clear)
+                .fill(isHovering ? Theme.nativeHover : .clear)
         )
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
@@ -870,7 +870,7 @@ private struct GenreResultRow: View {
                 .padding(.vertical, 8)
                 .background(
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(isHovering ? Theme.rowHover : .clear)
+                        .fill(isHovering ? Theme.nativeHover : .clear)
                 )
                 .contentShape(Rectangle())
             }

--- a/macos/Sources/Lyrebird/Theme/Theme.swift
+++ b/macos/Sources/Lyrebird/Theme/Theme.swift
@@ -12,6 +12,17 @@ enum Theme {
     static let surface2 = Color(rgba: (126, 114, 175, 0.14))
     static let rowHover = Color(rgba: (126, 114, 175, 0.10))
 
+    /// macOS-native row hover / keyboard-focus background.
+    ///
+    /// `NSColor.unemphasizedSelectedContentBackgroundColor` is the system's
+    /// own token for the unfocused selection tint in list views — it adapts
+    /// to dark/light mode and high-contrast automatically, matches
+    /// `NSTableView`'s hover semantics, and respects the user's accent color.
+    /// Used instead of the bespoke `rowHover` RGBA swatch for list rows,
+    /// sidebar rows, and queue items so their hover and keyboard-focus states
+    /// read as native macOS affordances rather than brand tints.
+    static let nativeHover = Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+
     // Text
     static let ink = Color.white
     static let ink2 = adaptive(standard: ink2Standard, increased: ink2HighContrastRGBA)


### PR DESCRIPTION
Hover/selection backgrounds were a flat brand-purple RGBA that ignored focus state, accent color, and theme presets.

Closes #16

- `Theme.nativeHover` = `NSColor.unemphasizedSelectedContentBackgroundColor` replaces the bespoke fill on every list/sidebar/queue/search/palette row (15 surfaces)
- `.contentShape(.interaction, RoundedRectangle)` + `.focusEffectDisabled(false)` so the system focus ring draws the row shape; manual `isFocused` stroke overlays removed
- Album/playlist cards and home tiles gain a 1.02 hover scale (suppressed under Reduce Motion)

Adapts to dark mode, high contrast, and accent color with no per-view branching. Gates: clean swift build + swift test 1063/1063.