### PR TITLE
feat(macos): playback preferences — gapless, replay gain, normalization

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
+++ b/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
@@ -124,21 +124,37 @@ extension AppModel {
         ReplayGainMode(rawValue: raw ?? "") ?? .off
     }
 
-    /// Apply the chosen ReplayGain mode + pre-gain to the live engine (#42).
-    /// Persists both values and pushes them onto `AudioEngine`, which re-reads
-    /// the current item's loudness tags and re-applies (or clears) the gain on
-    /// the playing track immediately — the same eager-apply contract as
-    /// `setOutputDevice`. The Preferences picker routes through here so a change
-    /// takes effect on the current song, not just the next one.
+    /// Apply the chosen loudness knobs — ReplayGain mode + pre-gain (#42)
+    /// and the volume-normalization toggle + target — to the live engine.
+    /// Persists all four values and pushes them onto `AudioEngine`: the
+    /// AVQueuePlayer path re-reads the current item's loudness tags and
+    /// re-applies (or clears) the gain on the playing track immediately, the
+    /// DSP path recomputes both decks' gain stages from their cached tags —
+    /// the same eager-apply contract as `setOutputDevice`. The Preferences
+    /// controls route through here so a change takes effect on the current
+    /// song, not just the next one.
     ///
-    /// Pre-gain only matters while `mode != .off`; passing it through regardless
-    /// keeps the stored value and the engine in sync so flipping normalization
-    /// back on later already reflects the saved pre-gain.
-    func setNormalization(mode: NormalizationMode, preGainDb: Double) {
-        UserDefaults.standard.set(mode.rawValue, forKey: AppModel.normalizationKey)
-        UserDefaults.standard.set(preGainDb, forKey: AppModel.preGainKey)
-        audio.normalizationMode = AppModel.normalizationMode(forStoredValue: mode.rawValue)
-        audio.normalizationPreGainDb = preGainDb
+    /// Pre-gain and the target only matter while some gain resolves at all;
+    /// passing them through regardless keeps the stored values and the
+    /// engine in sync so flipping a knob back on later already reflects the
+    /// saved companions.
+    func setNormalization(
+        mode: NormalizationMode,
+        preGainDb: Double,
+        volumeNormalizationEnabled: Bool,
+        targetLoudnessDb: Double
+    ) {
+        let settings = NormalizationSettings(
+            mode: AppModel.normalizationMode(forStoredValue: mode.rawValue),
+            preGainDb: preGainDb,
+            volumeNormalizationEnabled: volumeNormalizationEnabled,
+            targetLoudnessDb: targetLoudnessDb
+        )
+        settings.save(to: .standard)
+        audio.normalizationMode = settings.mode
+        audio.normalizationPreGainDb = settings.preGainDb
+        audio.volumeNormalizationEnabled = settings.volumeNormalizationEnabled
+        audio.volumeNormalizationTargetDb = settings.targetLoudnessDb
     }
 
     /// Seek the current track by a relative offset (seconds). Negative rewinds,
@@ -256,24 +272,32 @@ extension AppModel {
 
     // MARK: - Playback behaviour preferences (#116)
 
-    /// UserDefaults key for the "Gapless playback" toggle in the Playback
-    /// pane. Kept in sync with `PreferencesPlayback`'s `@AppStorage`.
-    private static let gaplessEnabledKey = "playback.gaplessEnabled"
-
     /// UserDefaults key for the "Stop after current track" toggle in the
     /// Playback pane. Kept in sync with `PreferencesPlayback`'s `@AppStorage`.
     private static let stopAfterCurrentKey = "playback.stopAfterCurrent"
 
-    /// Resolve the persisted gapless flag, defaulting to `true` when the key
-    /// has never been written. `UserDefaults.bool(forKey:)` returns `false`
-    /// for a missing key, which would silently invert this feature's
-    /// "default on" contract (the toggle ships on), so probe for the object
-    /// first — same pattern as `autoplayWhenQueueEndsDefault`.
+    /// The persisted gapless flag, default-on. Delegates to
+    /// `GaplessPreference` (LyrebirdAudio) — the single reader both this
+    /// queue-side gate and the engine's DSP-pipeline seeding share, so the
+    /// default-on contract can never drift between the two paths.
     static var gaplessEnabled: Bool {
-        guard UserDefaults.standard.object(forKey: gaplessEnabledKey) != nil else {
-            return true
+        GaplessPreference.isEnabled()
+    }
+
+    /// Apply a change to the "Gapless playback" toggle: persist it and push
+    /// it onto the live engine so the *current* transition honours the
+    /// choice. Turning it off strips a queued-ahead item (AVQueuePlayer) or
+    /// disarms the pipeline's buffered join (DSP); turning it on re-arms the
+    /// upcoming track on whichever path is active.
+    func setGapless(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: GaplessPreference.defaultsKey)
+        audio.applyGapless(enabled)
+        if enabled {
+            // Re-arm the AVQueuePlayer pre-load (the queue lookahead lives
+            // here, not in the engine). On the DSP path this is a no-op —
+            // `applyGapless` already re-armed the pipeline.
+            armNextTrackPreload()
         }
-        return UserDefaults.standard.bool(forKey: gaplessEnabledKey)
     }
 
     /// Read **and clear** the "Stop after current track" one-shot. Returns

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesExperiments.swift
@@ -24,49 +24,12 @@ struct PreferencesExperiments: View {
         VStack(alignment: .leading, spacing: 24) {
             header
 
-            PreferenceSection(
-                title: "Playback",
-                footnote: "These knobs control experimental audio-engine behaviour. Changes take effect on the next track unless otherwise noted."
-            ) {
-                flagToggle(
-                    label: "Gapless playback",
-                    help: flags.gaplessPlayback
-                        ? "On — tracks play without silence between them."
-                        : "Off — each track ends cleanly before the next begins.",
-                    accessibilityLabel: "Gapless playback",
-                    value: flagBinding(get: { $0.gaplessPlayback }, set: { $0.gaplessPlayback = $1 })
-                )
-
-                Divider()
-                    .background(Theme.border)
-                    .padding(.vertical, 10)
-
-                PreferenceRow(
-                    label: "Crossfade",
-                    help: flags.crossfadeMs == 0
-                        ? "Off — no overlap between tracks."
-                        : "Overlap of \(flags.crossfadeMs) ms (engine support coming soon)."
-                ) {
-                    // Integer stepper: 0 / 500 / 1000 / … / 12 000 ms in steps of 500.
-                    Stepper(
-                        value: Binding(
-                            get: { flags.crossfadeMs },
-                            set: { newValue in
-                                flags.crossfadeMs = newValue
-                                persistFlags()
-                            }
-                        ),
-                        in: 0 ... 12_000,
-                        step: 500
-                    ) {
-                        Text(flags.crossfadeMs == 0 ? "Off" : "\(flags.crossfadeMs) ms")
-                            .font(Theme.font(13, weight: .semibold))
-                            .foregroundStyle(Theme.ink)
-                            .frame(minWidth: 60, alignment: .trailing)
-                    }
-                    .accessibilityLabel("Crossfade duration")
-                }
-            }
+            // Note: this pane used to carry "Gapless playback" and "Crossfade"
+            // flag rows. Both were dead knobs — the flags were never read by
+            // any playback code path — while the *real*, engine-wired controls
+            // live in Preferences ▸ Playback. The rows were removed rather
+            // than rewired so the same setting never has two switches that can
+            // disagree.
 
             PreferenceSection(
                 title: "Library",
@@ -222,11 +185,13 @@ struct PreferencesExperiments: View {
     /// Lyrebird Application Support directory if it doesn't exist yet. Errors
     /// are logged but do not surface to the user — the UI already reflects the
     /// in-memory state, and a disk-write failure is a non-critical edge case.
+    ///
+    /// Retired keys (`gapless_playback`, `crossfade_ms`) are intentionally
+    /// not written; a stale copy in an existing file is harmless — the loader
+    /// ignores unknown keys.
     private func persistFlags() {
         let dict: [String: Any] = [
             "debug_panel_enabled": flags.debugPanelEnabled,
-            "gapless_playback": flags.gaplessPlayback,
-            "crossfade_ms": flags.crossfadeMs,
             "library_delta_sync": flags.libraryDeltaSync,
         ]
 
@@ -273,9 +238,7 @@ struct PreferencesExperiments: View {
             // reveal it rather than just opening the parent folder.
             if !FileManager.default.fileExists(atPath: url.path) {
                 let template: [String: Any] = [
-                    "crossfade_ms": 0,
                     "debug_panel_enabled": true,
-                    "gapless_playback": true,
                     "library_delta_sync": true,
                 ]
                 let data = try JSONSerialization.data(

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -3,19 +3,24 @@ import SwiftUI
 
 /// Playback preferences pane.
 ///
-/// Exposes the behavioural knobs covered by issue #116 — gapless joins,
-/// crossfade, ReplayGain normalization, pre-gain, and "stop after current
-/// track". Streaming/download quality and preferred codec used to live here
-/// too, but they share their `@AppStorage` keys with the Audio pane (#117),
-/// which is their canonical home; the duplicates were removed here so each
-/// setting has exactly one editing surface.
+/// Exposes the behavioural knobs covered by issues #116 and the four-group
+/// playback spec — gapless joins, crossfade, Replay Gain (+ pre-gain),
+/// volume normalization, and "stop after current track". Streaming/download
+/// quality and preferred codec used to live here too, but they share their
+/// `@AppStorage` keys with the Audio pane (#117), which is their canonical
+/// home; the duplicates were removed here so each setting has exactly one
+/// editing surface.
 ///
 /// What's live:
-/// - **Gapless** and **Stop after current track** are wired into the engine /
-///   queue (`AppModel.armNextTrackPreload` reads `gaplessEnabled`;
-///   `handleTrackEnded` consumes `stopAfterCurrent`).
-/// - **Normalization** and **Pre-gain** route through `AppModel.setNormalization`
-///   onto the live ReplayGain path (#42).
+/// - **Gapless** routes through `AppModel.setGapless` onto both engine
+///   paths: the AVQueuePlayer pre-load gate and the DSP pipeline's buffered
+///   zero-fade join. **Stop after current track** is consumed by
+///   `handleTrackEnded`.
+/// - **Replay Gain**, **Pre-gain**, and **Volume Normalization** route
+///   through `AppModel.setNormalization` onto the live loudness path (#42):
+///   per-item `AVAudioMix` on the AVQueuePlayer path, per-deck player gain
+///   on the DSP path. Tags come from the stream's own metadata; untagged
+///   tracks play unchanged.
 /// - **Crossfade** (#41) rides the AVAudioEngine DSP pipeline's dual decks,
 ///   so its slider + curve picker gate on `supportsCrossfade` — live only
 ///   while the DSP engine (#39, opted into via the Equalizer pane) is
@@ -29,12 +34,14 @@ import SwiftUI
 /// the display labels.
 ///
 /// Preference keys (user-facing `@AppStorage`):
-/// - `playback.crossfadeSeconds`     — `Double` (0 = off, 1…12)
-/// - `playback.crossfadeCurve`       — `CrossfadeSettings.Curve` raw value
-/// - `playback.gaplessEnabled`       — `Bool` (default true)
-/// - `playback.normalization`        — `NormalizationMode`
-/// - `playback.preGainDb`            — `Double` (±12)
-/// - `playback.stopAfterCurrent`     — `Bool`
+/// - `playback.crossfadeSeconds`             — `Double` (0 = off, 1…12)
+/// - `playback.crossfadeCurve`               — `CrossfadeSettings.Curve` raw value
+/// - `playback.gaplessEnabled`               — `Bool` (default true)
+/// - `playback.normalization`                — `NormalizationMode`
+/// - `playback.preGainDb`                    — `Double` (±12)
+/// - `playback.volumeNormalizationEnabled`   — `Bool` (default false)
+/// - `playback.volumeNormalizationTargetDb`  — `Double` (−23…−14, default −18)
+/// - `playback.stopAfterCurrent`             — `Bool`
 ///
 /// Spec: `research/03-ux-patterns.md` Issue 68 and GitHub issues #260 / #116 / #41.
 struct PreferencesPlayback: View {
@@ -43,13 +50,16 @@ struct PreferencesPlayback: View {
     // #116 gap-fill knobs. Raw types are chosen so the key names survive any
     // later enum/struct refactor — a Double for the slider is portable and
     // the Bool toggles are the obvious shape. The crossfade key literals
-    // match `CrossfadeSettings.DefaultsKey` (#41), which is how the engine
+    // match `CrossfadeSettings.DefaultsKey` (#41) and the loudness literals
+    // match `NormalizationSettings.DefaultsKey`, which is how the engine
     // reads them back.
     @AppStorage("playback.crossfadeSeconds") private var crossfadeSeconds: Double = 0
     @AppStorage("playback.crossfadeCurve") private var crossfadeCurveRaw: String = CrossfadeSettings.Curve.equalPower.rawValue
     @AppStorage("playback.gaplessEnabled") private var gaplessEnabled: Bool = true
     @AppStorage("playback.normalization") private var normalizationRaw: String = NormalizationMode.off.rawValue
     @AppStorage("playback.preGainDb") private var preGainDb: Double = 0
+    @AppStorage("playback.volumeNormalizationEnabled") private var volumeNormalizationEnabled: Bool = false
+    @AppStorage("playback.volumeNormalizationTargetDb") private var volumeNormalizationTargetDb: Double = NormalizationSettings.defaultTargetLoudnessDb
     @AppStorage("playback.stopAfterCurrent") private var stopAfterCurrent: Bool = false
 
     /// Crossfade duration binding. Reads `@AppStorage` for instant UI, and
@@ -88,31 +98,85 @@ struct PreferencesPlayback: View {
         )
     }
 
-    /// Normalization picker binding. Reads `@AppStorage` for instant UI, and
-    /// routes the change through `AppModel` so the live player re-reads the
-    /// current track's ReplayGain tags and re-applies the gain immediately
-    /// rather than only on the next track (#42). Pre-gain rides along so the
-    /// engine always sees a consistent (mode, pre-gain) pair.
+    /// Gapless toggle binding. Writes `@AppStorage` for instant UI and routes
+    /// the change through `AppModel.setGapless` so the live engine reacts on
+    /// the *current* transition: off strips a queued-ahead item (AVQueuePlayer)
+    /// or disarms the DSP pipeline's buffered join; on re-arms the upcoming
+    /// track on whichever path is active.
+    private var gapless: Binding<Bool> {
+        Binding(
+            get: { gaplessEnabled },
+            set: { newValue in
+                gaplessEnabled = newValue
+                model.setGapless(newValue)
+            }
+        )
+    }
+
+    /// Push the full loudness surface — mode, pre-gain, normalization toggle,
+    /// target — through `AppModel.setNormalization` so the engine always sees
+    /// a consistent quadruple (#42). Each binding overrides just its own knob
+    /// and reads the live `@AppStorage` values for the rest.
+    private func pushNormalization(
+        mode: NormalizationMode? = nil,
+        preGain: Double? = nil,
+        volumeNormalization: Bool? = nil,
+        target: Double? = nil
+    ) {
+        model.setNormalization(
+            mode: mode ?? (NormalizationMode(rawValue: normalizationRaw) ?? .off),
+            preGainDb: preGain ?? preGainDb,
+            volumeNormalizationEnabled: volumeNormalization ?? volumeNormalizationEnabled,
+            targetLoudnessDb: target ?? volumeNormalizationTargetDb
+        )
+    }
+
+    /// Replay Gain mode picker binding. Reads `@AppStorage` for instant UI,
+    /// and routes the change through `AppModel` so the live player re-reads
+    /// the current track's ReplayGain tags and re-applies the gain immediately
+    /// rather than only on the next track (#42).
     private var normalization: Binding<NormalizationMode> {
         Binding(
             get: { NormalizationMode(rawValue: normalizationRaw) ?? .off },
             set: { newMode in
                 normalizationRaw = newMode.rawValue
-                model.setNormalization(mode: newMode, preGainDb: preGainDb)
+                pushNormalization(mode: newMode)
             }
         )
     }
 
     /// Pre-gain slider binding. Writes `@AppStorage` for instant UI and pushes
-    /// the new pre-gain onto the engine via `AppModel`, alongside the current
-    /// normalization mode (#42).
+    /// the new pre-gain onto the engine via `AppModel`, alongside the other
+    /// loudness knobs (#42).
     private var preGain: Binding<Double> {
         Binding(
             get: { preGainDb },
             set: { newValue in
                 preGainDb = newValue
-                let mode = NormalizationMode(rawValue: normalizationRaw) ?? .off
-                model.setNormalization(mode: mode, preGainDb: newValue)
+                pushNormalization(preGain: newValue)
+            }
+        )
+    }
+
+    /// Volume-normalization toggle binding — shift loudness to the target
+    /// below instead of the ReplayGain reference.
+    private var volumeNormalization: Binding<Bool> {
+        Binding(
+            get: { volumeNormalizationEnabled },
+            set: { newValue in
+                volumeNormalizationEnabled = newValue
+                pushNormalization(volumeNormalization: newValue)
+            }
+        )
+    }
+
+    /// Target-loudness slider binding (dB LUFS).
+    private var normalizationTarget: Binding<Double> {
+        Binding(
+            get: { volumeNormalizationTargetDb },
+            set: { newValue in
+                volumeNormalizationTargetDb = newValue
+                pushNormalization(target: newValue)
             }
         )
     }
@@ -131,7 +195,7 @@ struct PreferencesPlayback: View {
                         ? "On — tracks on the same album play without a gap."
                         : "Off — each track ends cleanly before the next starts."
                 ) {
-                    Toggle("", isOn: $gaplessEnabled)
+                    Toggle("", isOn: gapless)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .accessibilityLabel("Gapless playback")
@@ -172,15 +236,15 @@ struct PreferencesPlayback: View {
             }
 
             PreferenceSection(
-                title: "Normalization",
-                footnote: "Reads ReplayGain tags from the source when available. Track matches the loudness of each song individually; Album keeps the relative levels inside an album intact."
+                title: "Replay Gain",
+                footnote: "Reads ReplayGain tags from the source when available. Track matches the loudness of each song individually; Album keeps the relative levels inside an album intact. Untagged tracks play unchanged."
             ) {
                 PreferenceRow(
-                    label: "Volume matching",
+                    label: "Mode",
                     help: normalization.wrappedValue.subtitle
                 ) {
                     NormalizationPicker(selection: normalization)
-                        .accessibilityLabel("Volume normalization")
+                        .accessibilityLabel("Replay Gain mode")
                 }
 
                 Divider()
@@ -193,6 +257,38 @@ struct PreferencesPlayback: View {
                 ) {
                     PreGainSlider(db: preGain)
                 }
+            }
+
+            PreferenceSection(
+                title: "Volume Normalization",
+                footnote: "Shifts overall playback loudness to your target instead of the ReplayGain reference (−18 dB LUFS). Uses each track's loudness tags — with Replay Gain off it falls back to track tags; untagged tracks play unchanged."
+            ) {
+                PreferenceRow(
+                    label: "Normalize volume",
+                    help: volumeNormalizationEnabled
+                        ? "On — playback loudness lands at the target below."
+                        : "Off — tags apply at the standard reference level."
+                ) {
+                    Toggle("", isOn: volumeNormalization)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel("Volume normalization")
+                }
+
+                Divider()
+                    .background(Theme.border)
+                    .padding(.vertical, 10)
+
+                PreferenceRow(
+                    label: "Target loudness",
+                    help: targetLoudnessHelp
+                ) {
+                    TargetLoudnessSlider(db: normalizationTarget)
+                        .disabled(!volumeNormalizationEnabled)
+                }
+                // Same gated-row idiom as the crossfade rows: dim while the
+                // toggle above keeps the slider inert.
+                .opacity(volumeNormalizationEnabled ? 1 : 0.55)
             }
 
             PreferenceSection(
@@ -259,6 +355,16 @@ struct PreferencesPlayback: View {
         }
         let sign = rounded > 0 ? "+" : "−"
         return "\(sign)\(abs(rounded)) dB applied before output."
+    }
+
+    /// Subtitle under the target-loudness slider. Calls out the reference
+    /// value so "−18" reads as "no shift" rather than an arbitrary number.
+    private var targetLoudnessHelp: String {
+        let rounded = Int(volumeNormalizationTargetDb.rounded())
+        if Double(rounded) == NormalizationSettings.defaultTargetLoudnessDb {
+            return "−18 dB LUFS — the ReplayGain reference."
+        }
+        return "−\(abs(rounded)) dB LUFS. Higher is louder."
     }
 }
 
@@ -327,12 +433,11 @@ enum PlaybackQuality: String, CaseIterable, Identifiable {
 /// `track` matches each track's individual loudness, `album` uses the
 /// per-album gain so relative dynamics inside an album remain intact.
 ///
-/// TODO(#116): feed these into the audio engine's playback path. The engine
-/// needs to read ReplayGain tags (`REPLAYGAIN_TRACK_GAIN` / `_ALBUM_GAIN`
-/// plus their peak siblings), fall back to scanning when tags are missing,
-/// and apply the selected gain on top of `preGainDb`. Until then the enum
-/// persists the user's choice so the engine can pick it up without a
-/// migration.
+/// Live on both engine paths (#42): the raw values bridge onto the engine's
+/// `ReplayGainMode` via `AppModel.normalizationMode(forStoredValue:)`, the
+/// engine reads `REPLAYGAIN_TRACK_GAIN` / `_ALBUM_GAIN` (plus the `iTunNORM`
+/// fallback) from the stream's own metadata, and applies the selected gain
+/// on top of `preGainDb`. Untagged tracks play unchanged.
 enum NormalizationMode: String, CaseIterable, Identifiable {
     case off
     case track
@@ -490,6 +595,31 @@ private struct PreGainSlider: View {
         if rounded == 0 { return "0 decibels" }
         let direction = rounded > 0 ? "plus" : "minus"
         return "\(direction) \(abs(rounded)) decibels"
+    }
+}
+
+/// Target-loudness slider for volume normalization, −23…−14 dB LUFS in 1 dB
+/// steps (range from `NormalizationSettings.targetRange`). The readout shows
+/// the unicode minus for the same typeset/VoiceOver reasons as `PreGainSlider`.
+private struct TargetLoudnessSlider: View {
+    @Binding var db: Double
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Slider(value: $db, in: NormalizationSettings.targetRange, step: 1)
+                .frame(width: 200)
+                .accessibilityLabel("Target loudness")
+                .accessibilityValue("minus \(abs(Int(db.rounded()))) decibels")
+            Text(readout)
+                .font(Theme.font(12, weight: .semibold))
+                .foregroundStyle(Theme.ink2)
+                .monospacedDigit()
+                .frame(width: 64, alignment: .trailing)
+        }
+    }
+
+    private var readout: String {
+        "−\(abs(Int(db.rounded()))) dB"
     }
 }
 

--- a/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
+++ b/macos/Sources/Lyrebird/System/DiagnosticBundle.swift
@@ -120,6 +120,8 @@ enum DiagnosticBundle {
         "playback.preferredCodec",
         "playback.stopAfterCurrent",
         "playback.streamingQuality",
+        "playback.volumeNormalizationEnabled",
+        "playback.volumeNormalizationTargetDb",
     ]
 
     // MARK: - Redaction

--- a/macos/Sources/Lyrebird/System/FeatureFlags.swift
+++ b/macos/Sources/Lyrebird/System/FeatureFlags.swift
@@ -12,13 +12,15 @@ import os
 /// ## Schema
 /// ```json
 /// {
-///   "crossfade_ms": 0,
-///   "gapless_playback": false,
 ///   "debug_panel_enabled": true,
 ///   "library_delta_sync": true
 /// }
 /// ```
-/// Unknown keys are silently ignored. Missing keys inherit the compiled-in
+/// Unknown keys are silently ignored — which also covers the retired
+/// `gapless_playback` / `crossfade_ms` keys still present in older files;
+/// those knobs were never read by any playback path, and the real controls
+/// live in Preferences ▸ Playback (`playback.gaplessEnabled` /
+/// `playback.crossfadeSeconds`). Missing keys inherit the compiled-in
 /// default. The file is optional — if absent the app runs with all defaults.
 ///
 /// ## Thread safety
@@ -40,15 +42,6 @@ final class FeatureFlags {
     /// "Experiments" pane is hidden from the navigation sidebar, keeping the
     /// in-app toggle surface invisible to non-developer users.
     var debugPanelEnabled: Bool = false
-
-    /// Gapless playback via crossfade-joining the audio graph. Separate from
-    /// `Capabilities.supportsCrossfade`, which gates the slider UI — this flag
-    /// is the runtime knob that would activate the feature once the audio engine
-    /// grows overlapping-playback support.
-    var gaplessPlayback: Bool = true
-
-    /// Crossfade duration in milliseconds. 0 = off.
-    var crossfadeMs: Int = 0
 
     /// Library delta-sync: fetch only items changed since the last sync rather
     /// than doing a full library reload on each launch.
@@ -105,11 +98,10 @@ final class FeatureFlags {
     }
 
     /// Write flag values from a decoded dictionary onto self. Unknown keys are
-    /// silently ignored per the acceptance criteria.
+    /// silently ignored per the acceptance criteria — including the retired
+    /// `gapless_playback` / `crossfade_ms` keys older files may still carry.
     private func apply(dict: [String: Any]) {
         if let v = dict["debug_panel_enabled"] as? Bool { debugPanelEnabled = v }
-        if let v = dict["gapless_playback"] as? Bool { gaplessPlayback = v }
-        if let v = dict["crossfade_ms"] as? Int { crossfadeMs = v }
         if let v = dict["library_delta_sync"] as? Bool { libraryDeltaSync = v }
     }
 

--- a/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine+DSP.swift
@@ -23,12 +23,23 @@ private let dspLog = Logger(subsystem: "org.lyrebird.desktop", category: "dsp")
 /// stream was resolved with, and the heartbeat re-keys to the new session.
 ///
 /// Known #39 gaps on this path (cleanly degraded, listed in the PR):
-/// ReplayGain normalization is not applied, stall recovery is skip-on-error
-/// rather than bounded in-place retries, and Ogg containers (which
-/// AudioToolbox cannot parse) skip to the next track. Gapless preload is a
-/// no-op only while crossfade is off — with crossfade on (#41) the armed
-/// next track buffers ahead and transitions overlap (or zero-fade join for
-/// same-album pairs).
+/// stall recovery is skip-on-error rather than bounded in-place retries, and
+/// Ogg containers (which AudioToolbox cannot parse) skip to the next track.
+///
+/// Loudness (ReplayGain / volume normalization) applies through each deck's
+/// player gain stage: `dspPlay` / the crossfade arm resolve the track's tags
+/// via a metadata-only `AVURLAsset` read (the streamer's AudioToolbox parse
+/// never surfaces them) and hand the result to
+/// `EngineDSPPipeline.provideLoudnessGains`. The read is one ranged request
+/// per track start; running it unconditionally keeps the pipeline's cached
+/// tags warm so a settings flip mid-track is pure math, live, with no
+/// re-fetch. An untagged track resolves to unity — never a level change.
+///
+/// Gapless: with crossfade on (#41) the armed next track buffers ahead and
+/// transitions overlap (or zero-fade join for same-album pairs); with
+/// crossfade off and gapless on, the armed track still buffers ahead and the
+/// zero-fade join takes over at the outgoing track's natural end. Both off ⇒
+/// the pre-#41 rebuild transition.
 extension AudioEngine {
     /// `UserDefaults` key for the "Stop after current track" one-shot. The
     /// literal matches `AppModel+PlaybackControls` / `PreferencesPlayback`
@@ -94,6 +105,15 @@ extension AudioEngine {
         // single source of truth (seeded by the Playback pane via
         // `dspApplyCrossfade`), so a fresh pipeline restores it directly.
         pipeline.applyCrossfade(CrossfadeSettings.load(from: .standard))
+        // Gapless ships default-on; the pipeline itself defaults off so a
+        // bare instance preserves the pre-gapless rebuild transitions — the
+        // user preference is applied here, at the seam where the preference
+        // layer meets the engine.
+        pipeline.applyGapless(GaplessPreference.isEnabled())
+        // Loudness knobs (ReplayGain mode / pre-gain / volume normalization):
+        // the engine's vars are the live copy (owner-seeded + self-seeded at
+        // init), so a fresh pipeline mirrors them directly.
+        pipeline.applyNormalization(normalizationSettings)
         dspPipeline = pipeline
         return pipeline
     }
@@ -169,6 +189,10 @@ extension AudioEngine {
             trackKey: track.id,
             albumKey: track.albumId
         )
+        // Resolve the track's loudness tags for the deck's gain stage. Fire-
+        // and-forget alongside the stream — an untagged or unreachable read
+        // degrades to unity gain.
+        dspResolveLoudnessGains(forTrackKey: track.id, url: url, authHeader: authHeader)
 
         // Close out the previous server session before opening the new one
         // (Jellyfin keys sessions by PlaySessionId and leaks a transcode job
@@ -189,7 +213,29 @@ extension AudioEngine {
         )
         core.startHeartbeat(intervalSecs: 5, playSessionId: playSessionId)
 
-        dspArmNextTrackForCrossfade(after: track)
+        dspArmNextTrackForCrossfade(afterTrackWithKey: track.id)
+    }
+
+    /// Load the loudness tags for a DSP-routed track off the main actor and
+    /// hand them to the pipeline's per-deck gain stage. The streamer's
+    /// AudioToolbox parse never surfaces ReplayGain frames, so this is a
+    /// separate metadata-only `AVURLAsset` read against the same URL (one
+    /// ranged request; AVFoundation stops at the header tables). Untagged or
+    /// failed reads provide nothing — the deck stays at unity.
+    private func dspResolveLoudnessGains(forTrackKey trackKey: String, url: URL, authHeader: String?) {
+        Task.detached { [weak self] in
+            var options: [String: Any] = [:]
+            if let authHeader {
+                options["AVURLAssetHTTPHeaderFieldsKey"] = ["Authorization": authHeader]
+            }
+            let asset = AVURLAsset(url: url, options: options)
+            let gains = await ReplayGain.gains(for: asset)
+            guard !gains.isEmpty else { return }
+            await MainActor.run {
+                guard let self, let pipeline = self.dspPipeline else { return }
+                pipeline.provideLoudnessGains(gains, forTrackKey: trackKey)
+            }
+        }
     }
 
     /// The reporting half of a crossfade handoff (#41). The audio swap
@@ -216,14 +262,15 @@ extension AudioEngine {
         )
         core.startHeartbeat(intervalSecs: 5, playSessionId: receipt.playSessionId)
 
-        dspArmNextTrackForCrossfade(after: track)
+        dspArmNextTrackForCrossfade(afterTrackWithKey: track.id)
     }
 
     /// Arm the queue's next track on the pipeline so the upcoming transition
-    /// can crossfade (#41). Resolves the stream exactly like `dspPlay`
-    /// (offline gate, PlaybackInfo session correlation, bitrate ceiling) but
-    /// fire-and-forget: any failure just means this transition falls back to
-    /// the ordinary end-of-track rebuild.
+    /// can join — crossfade overlap (#41) or the gapless zero-fade handoff.
+    /// Resolves the stream exactly like `dspPlay` (offline gate, PlaybackInfo
+    /// session correlation, bitrate ceiling) but fire-and-forget: any failure
+    /// just means this transition falls back to the ordinary end-of-track
+    /// rebuild.
     ///
     /// `core.peekNext()` honours the live queue + repeat mode (the same
     /// lookahead `AppModel.armNextTrackPreload` reads), so the armed track
@@ -231,14 +278,18 @@ extension AudioEngine {
     /// after arming makes the armed track stale — `dspPlay` then sees a key
     /// mismatch and reloads fresh, the same staleness contract as the
     /// AVQueuePlayer path's pre-inserted item.
-    private func dspArmNextTrackForCrossfade(after current: Track) {
-        guard let pipeline = dspPipeline, pipeline.crossfadeIsEnabled else { return }
+    ///
+    /// Internal (not private) so `applyGapless` can re-arm when the user
+    /// turns gapless on mid-track; key-based because that caller only has
+    /// the pipeline's current track key, and the stale guard needs nothing
+    /// more.
+    func dspArmNextTrackForCrossfade(afterTrackWithKey currentKey: String) {
+        guard let pipeline = dspPipeline, pipeline.transitionArmingEnabled else { return }
         guard let next = core.peekNext() else {
             pipeline.disarmNextTrack()
             return
         }
 
-        let currentKey = current.id
         let offlineEnabled = offlinePlaybackEnabled
         let bitrateCap = maxStreamingBitrate
         let core = self.core
@@ -294,6 +345,9 @@ extension AudioEngine {
                 mediaSourceId: mediaSourceId,
                 playSessionId: playSessionId
             )
+            // Rebind the branch-assigned `var` as a `let` so the main-actor
+            // hop below captures an immutable value (Swift 6 Sendable rule).
+            let resolvedAuthHeader = authHeader
             await MainActor.run {
                 guard let self, let pipeline = self.dspPipeline else { return }
                 // Stale guard: only arm if the track we resolved against is
@@ -301,6 +355,11 @@ extension AudioEngine {
                 // this arm — its own dspPlay re-arms).
                 guard pipeline.currentTrackKey == currentKey else { return }
                 pipeline.armNextTrack(armedTrack)
+                // Resolve the armed track's loudness tags now so its deck
+                // gain is in place before the join makes it audible (the
+                // pipeline stashes the result until the prepare window loads
+                // the deck).
+                self.dspResolveLoudnessGains(forTrackKey: next.id, url: url, authHeader: resolvedAuthHeader)
             }
         }
     }

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -233,20 +233,59 @@ public final class AudioEngine: NSObject {
     public var normalizationMode: ReplayGainMode = .off {
         didSet {
             guard normalizationMode != oldValue else { return }
-            reapplyReplayGainToCurrentItem()
+            normalizationDidChange()
         }
     }
 
     /// User pre-gain in dB (`playback.preGainDb`), summed on top of the
     /// resolved ReplayGain value before the linear multiplier is computed. Only
-    /// takes effect while `normalizationMode != .off`; on its own it does not
+    /// takes effect while some gain resolves at all; on its own it does not
     /// turn normalization on (matching the Preferences copy, which frames
     /// pre-gain as an adjustment to the normalization result).
     public var normalizationPreGainDb: Double = 0 {
         didSet {
             guard normalizationPreGainDb != oldValue else { return }
-            reapplyReplayGainToCurrentItem()
+            normalizationDidChange()
         }
+    }
+
+    /// Volume-normalization toggle (`playback.volumeNormalizationEnabled`):
+    /// shift playback loudness to `volumeNormalizationTargetDb` instead of
+    /// the ReplayGain reference. Self-seeded from `UserDefaults` at init —
+    /// the crossfade pattern, where the persisted value is the single source
+    /// of truth — and updated from the Preferences pane via `AppModel`.
+    public var volumeNormalizationEnabled: Bool = false {
+        didSet {
+            guard volumeNormalizationEnabled != oldValue else { return }
+            normalizationDidChange()
+        }
+    }
+
+    /// Volume-normalization target in dB LUFS
+    /// (`playback.volumeNormalizationTargetDb`, −23…−14, −18 = reference).
+    public var volumeNormalizationTargetDb: Double = NormalizationSettings.defaultTargetLoudnessDb {
+        didSet {
+            guard volumeNormalizationTargetDb != oldValue else { return }
+            normalizationDidChange()
+        }
+    }
+
+    /// The four loudness knobs as the value type both engine paths consume.
+    var normalizationSettings: NormalizationSettings {
+        NormalizationSettings(
+            mode: normalizationMode,
+            preGainDb: normalizationPreGainDb,
+            volumeNormalizationEnabled: volumeNormalizationEnabled,
+            targetLoudnessDb: volumeNormalizationTargetDb
+        )
+    }
+
+    /// Re-apply loudness after any knob changes: the AVQueuePlayer path
+    /// re-resolves the current item's tags, the DSP path recomputes both
+    /// decks' gain stages from their cached tags (no re-fetch needed).
+    private func normalizationDidChange() {
+        reapplyReplayGainToCurrentItem()
+        dspPipeline?.applyNormalization(normalizationSettings)
     }
 
     /// Monotonic counter so a slow metadata-driven gain resolve can't clobber a
@@ -277,6 +316,14 @@ public final class AudioEngine: NSObject {
     public init(core: LyrebirdCore) {
         self.core = core
         super.init()
+        // Self-seed the volume-normalization pair so the first track honours
+        // a persisted choice without waiting for the Preferences pane (the
+        // mode / pre-gain pair is seeded by the owner at startup; these two
+        // follow the crossfade pattern instead — `UserDefaults` is the single
+        // source of truth and the engine reads it directly).
+        let stored = NormalizationSettings.load(from: .standard)
+        volumeNormalizationEnabled = stored.volumeNormalizationEnabled
+        volumeNormalizationTargetDb = stored.targetLoudnessDb
     }
 
     deinit {
@@ -546,13 +593,12 @@ public final class AudioEngine: NSObject {
     private func applyReplayGain(to item: AVPlayerItem) {
         replayGainGeneration &+= 1
         let generation = replayGainGeneration
-        let mode = normalizationMode
-        let preGainDb = normalizationPreGainDb
+        let settings = normalizationSettings
 
-        // Off: clear any prior mix synchronously and skip the metadata read
-        // entirely. Cheap, and guarantees flipping the picker to "Off"
+        // All-off: clear any prior mix synchronously and skip the metadata
+        // read entirely. Cheap, and guarantees flipping everything off
         // immediately restores the raw level.
-        guard mode != .off else {
+        guard settings.isActive else {
             item.audioMix = nil
             return
         }
@@ -560,7 +606,7 @@ public final class AudioEngine: NSObject {
         let asset = item.asset
         Task.detached { [weak self] in
             let gains = await ReplayGain.gains(for: asset)
-            guard let volume = ReplayGain.linearVolume(mode: mode, gains: gains, preGainDb: preGainDb) else {
+            guard let volume = settings.linearVolume(gains: gains) else {
                 // No usable tag — leave the level alone (clear any stale mix).
                 await MainActor.run {
                     guard let self, generation == self.replayGainGeneration else { return }
@@ -841,11 +887,11 @@ public final class AudioEngine: NSObject {
     /// is what we want. Existing queued-but-not-yet-playing items are replaced
     /// so rapid skip-next doesn't accumulate stale entries.
     public func preloadNextTrack(_ track: Track) {
-        // DSP path (#39): gapless preload is a listed gap — the pipeline
-        // plays one track at a time and `onTrackEnded` rebuilds the next,
-        // exactly like the `gaplessEnabled == false` behaviour. A queued-
-        // ahead AVPlayerItem would be meaningless here, so bail before the
-        // player guard.
+        // DSP path (#39): the pipeline arms its own buffered join — `dspPlay`
+        // resolves + arms the upcoming track for the crossfade overlap or the
+        // gapless zero-fade handoff (see `dspArmNextTrackForCrossfade`). A
+        // queued-ahead AVPlayerItem would be meaningless here, so bail before
+        // the player guard.
         if dspPipelineEnabled { return }
         guard player != nil else { return }
 
@@ -948,6 +994,44 @@ public final class AudioEngine: NSObject {
                 engineLog.error("preload skipped: failed to resolve track \(track.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    /// Apply a change to the "Gapless playback" preference to the live
+    /// engine, so flipping the toggle affects the *current* transition rather
+    /// than only the next playback session.
+    ///
+    /// - AVQueuePlayer path: turning gapless **off** strips any queued-ahead
+    ///   item so the in-flight transition doesn't ride a stale pre-load;
+    ///   turning it **on** is the owner's job (`AppModel.armNextTrackPreload`
+    ///   re-arms — the queue lookahead lives there, not here).
+    /// - DSP path: the pipeline's arming gate updates; on enable the engine
+    ///   re-arms the upcoming track itself (the DSP arm resolution lives
+    ///   here), on disable the pipeline disarms unless crossfade keeps the
+    ///   standby deck armed for an overlap of its own.
+    public func applyGapless(_ enabled: Bool) {
+        if dspPipelineEnabled {
+            guard let pipeline = dspPipeline else { return }
+            pipeline.applyGapless(enabled)
+            if enabled, let currentKey = pipeline.currentTrackKey {
+                dspArmNextTrackForCrossfade(afterTrackWithKey: currentKey)
+            }
+        } else if !enabled {
+            stripQueuedAheadItems()
+        }
+    }
+
+    /// Remove every queued-but-not-yet-playing item from the AVQueuePlayer —
+    /// the live counterpart of `armNextTrackPreload`'s gapless gate. The
+    /// current item keeps playing; the next transition takes the ordinary
+    /// rebuild path (`onTrackEnded` → `play(track:)`).
+    private func stripQueuedAheadItems() {
+        guard let player else { return }
+        for item in player.items().dropFirst() {
+            player.remove(item)
+        }
+        #if DEBUG
+        lastPreloadedTrackIdForTesting = nil
+        #endif
     }
 
     // MARK: - Observers

--- a/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
+++ b/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
@@ -16,14 +16,22 @@ private let pipelineLog = Logger(subsystem: "org.lyrebird.desktop", category: "d
 ///     deck B: AVAudioPlayerNode → AVAudioMixerNode ─┘
 ///
 /// Exactly one deck is *active* (the current track) at any time. The second
-/// deck exists for crossfade (#41): the upcoming track is armed + buffered on
+/// deck exists for transitions: the upcoming track is armed + buffered on
 /// it, and at the fade window each deck's per-node `AVAudioMixerNode` ramps
-/// its `outputVolume` along the configured gain envelope — outgoing down,
-/// incoming up — through the shared blend → EQ → main-mixer stage, so the EQ
-/// applies to both sides of the overlap. With crossfade off (the default)
-/// the standby deck is never loaded and both fade mixers sit at unity gain,
-/// which is audibly (float-mix at 1.0) identical to the pre-#41 single-node
-/// graph.
+/// its `outputVolume` along the configured gain envelope (#41) — outgoing
+/// down, incoming up — through the shared blend → EQ → main-mixer stage, so
+/// the EQ applies to both sides of the overlap. With crossfade off but
+/// gapless on, the armed track still buffers ahead and takes over via the
+/// zero-fade join at the outgoing track's natural end — the buffered gapless
+/// transition. With both off the standby deck is never loaded and both fade
+/// mixers sit at unity gain, which is audibly (float-mix at 1.0) identical
+/// to the pre-#41 single-node graph.
+///
+/// Each deck's player node additionally carries the per-track loudness gain
+/// (ReplayGain / volume normalization): `AVAudioPlayerNode` conforms to
+/// `AVAudioMixing`, so `player.volume` is a gain stage at the player → fade
+/// mixer connection that the crossfade envelopes never touch — the fade math
+/// and the normalization math compose without fighting over one knob.
 ///
 /// The EQ ships **flat and bypassed** (`globalGain == 0`, every band
 /// `bypass == true`) so the engine path makes no audible DSP alteration —
@@ -165,6 +173,10 @@ public final class EngineDSPPipeline {
         var trackKey: String?
         /// Opaque album identity — same-album transitions zero-fade (#41).
         var albumKey: String?
+        /// Parsed loudness tags for the loaded track; nil until the owner's
+        /// metadata resolve lands (and again after unload). Cached so a
+        /// settings change mid-track re-applies without a re-fetch.
+        var loudnessGains: ReplayGain.Gains?
         /// Bumped per load/unload so a stale streamer's late callbacks
         /// (format-ready, finished, error, seek) can't cross tracks.
         var generation: Int = 0
@@ -210,6 +222,24 @@ public final class EngineDSPPipeline {
     // MARK: - Crossfade state (#41)
 
     private var crossfade = CrossfadeSettings()
+
+    /// Whether the buffered gapless join runs while crossfade is off. With
+    /// crossfade *on*, transitions already join (overlap, or zero-fade for
+    /// same-album pairs), so this knob only matters for the crossfade-off
+    /// case. Defaults to `false` so a bare pipeline preserves the pre-gapless
+    /// rebuild transitions; the owner seeds it from the user preference
+    /// (default on) at construction.
+    public private(set) var gaplessEnabled = false
+
+    /// Loudness settings driving each deck's per-track gain stage. Defaults
+    /// to all-off (unity gain everywhere).
+    private var normalization = NormalizationSettings()
+
+    /// Loudness tags resolved by the owner before their track was loaded on
+    /// a deck (the armed next track ahead of its prepare window). Consumed by
+    /// `loadTrack`; bounded so stale keys from rapid queue churn can't
+    /// accumulate.
+    private var pendingLoudnessGains: [String: ReplayGain.Gains] = [:]
 
     /// The owner-armed upcoming track, if any. Consumed at handoff.
     private var armed: ArmedNextTrack?
@@ -403,6 +433,7 @@ public final class EngineDSPPipeline {
         disarmNextTrack()
         pendingAdoptKey = nil
         handoffReceipt = nil
+        pendingLoudnessGains.removeAll()
         unload(deck: activeDeck)
         stopPositionTimer()
         engine.stop()
@@ -478,12 +509,51 @@ public final class EngineDSPPipeline {
 
     /// Drive the crossfade scheduler from user settings. Safe to call at any
     /// time; turning crossfade off mid-track disarms any pending next track
-    /// (a fade already in progress completes — it is audibly underway).
+    /// (a fade already in progress completes — it is audibly underway) —
+    /// unless gapless keeps the arm alive for the zero-fade join.
     public func applyCrossfade(_ settings: CrossfadeSettings) {
         crossfade = settings
-        if !settings.isEnabled {
+        if !settings.isEnabled, !gaplessEnabled {
             disarmNextTrack()
         }
+    }
+
+    /// Drive the gapless preference. Turning it off mid-track disarms a
+    /// pending next track only when crossfade isn't keeping it armed for an
+    /// overlap of its own.
+    public func applyGapless(_ enabled: Bool) {
+        gaplessEnabled = enabled
+        if !enabled, !crossfade.isEnabled {
+            disarmNextTrack()
+        }
+    }
+
+    /// Drive each deck's per-track loudness gain stage from user settings.
+    /// Safe to call at any time — both decks re-apply from their cached tags
+    /// immediately, so a mode/target change is audible mid-track without a
+    /// metadata re-fetch.
+    public func applyNormalization(_ settings: NormalizationSettings) {
+        normalization = settings
+        for deck in decks {
+            applyNormalizationGain(to: deck)
+        }
+    }
+
+    /// Hand the pipeline a track's parsed loudness tags. Applied immediately
+    /// when a deck holds the track; stashed for the upcoming `loadTrack`
+    /// otherwise (the armed next track resolves its tags before its prepare
+    /// window opens). Unknown keys are dropped when the stash fills — a lost
+    /// gain degrades to unity, never a wrong level.
+    public func provideLoudnessGains(_ gains: ReplayGain.Gains, forTrackKey key: String) {
+        if let deck = decks.first(where: { $0.trackKey == key }) {
+            deck.loudnessGains = gains
+            applyNormalizationGain(to: deck)
+            return
+        }
+        if pendingLoudnessGains.count >= 4 {
+            pendingLoudnessGains.removeAll()
+        }
+        pendingLoudnessGains[key] = gains
     }
 
     /// Whether the applied settings enable crossfade — the owner's cheap
@@ -492,12 +562,20 @@ public final class EngineDSPPipeline {
         crossfade.isEnabled
     }
 
-    /// Arm the upcoming track for a crossfaded transition. Replaces any
+    /// Whether the owner should resolve + arm the next track at all: either
+    /// transition feature (crossfade overlap, gapless buffered join) wants
+    /// the standby deck loaded ahead of the handoff.
+    public var transitionArmingEnabled: Bool {
+        crossfade.isEnabled || gaplessEnabled
+    }
+
+    /// Arm the upcoming track for a joined transition — crossfade overlap,
+    /// or the zero-fade gapless join when crossfade is off. Replaces any
     /// previously armed track; the streamer doesn't start until the prepare
     /// window opens (`CrossfadeSettings.prepareLeadSeconds` before the fade),
     /// so arming is cheap and re-arming after queue edits costs nothing.
     public func armNextTrack(_ next: ArmedNextTrack) {
-        guard crossfade.isEnabled else { return }
+        guard transitionArmingEnabled else { return }
         if let inFlight = prepStartedForKey, inFlight != next.key {
             // The armed target changed after its stream already started —
             // drop the stale prep so the window math re-prepares the right
@@ -548,6 +626,10 @@ public final class EngineDSPPipeline {
         deck.trackKey = trackKey
         deck.albumKey = albumKey
         deck.fadeMixer.outputVolume = initialGain
+        // Consume a loudness resolve that landed before this load (the armed
+        // next track's tags arrive at arm time, ahead of the prepare window).
+        deck.loudnessGains = trackKey.flatMap { pendingLoudnessGains.removeValue(forKey: $0) }
+        applyNormalizationGain(to: deck)
 
         let streamer = DSPTrackStreamer(
             url: url,
@@ -592,6 +674,19 @@ public final class EngineDSPPipeline {
         deck.durationSeconds = nil
         deck.trackKey = nil
         deck.albumKey = nil
+        // The loudness gain is per-track state: reset the player gain stage
+        // to unity so the next track never inherits the old track's level.
+        deck.loudnessGains = nil
+        deck.player.volume = 1
+    }
+
+    /// Re-derive a deck's player gain stage from its cached loudness tags
+    /// under the current settings. Unity when normalization resolves nothing
+    /// (settings off, tags missing, or no usable tag for the mode) — the
+    /// documented "leave the level untouched" contract.
+    private func applyNormalizationGain(to deck: Deck) {
+        let gain = deck.loudnessGains.flatMap { normalization.linearVolume(gains: $0) } ?? 1
+        deck.player.volume = gain
     }
 
     private func handleFormatReady(_ format: AVAudioFormat, deckIndex: Int) {
@@ -746,11 +841,12 @@ public final class EngineDSPPipeline {
         guard deckIndex == activeDeckIndex else { return }
 
         // Natural end of the active track. If an armed next track is fully
-        // buffered, take the zero-fade join (same-album rule, short tracks,
-        // or a fade window the position never crossed) instead of bouncing
+        // buffered, take the zero-fade join (the gapless transition; with
+        // crossfade on it also covers the same-album rule, short tracks, and
+        // a fade window the position never crossed) instead of bouncing
         // through the owner's rebuild path.
         if let armed,
-           crossfade.isEnabled,
+           transitionArmingEnabled,
            standbyReady,
            prepStartedForKey == armed.key,
            onShouldBeginCrossfade?() ?? true {
@@ -788,11 +884,18 @@ public final class EngineDSPPipeline {
 
     /// Driven by the 1 Hz position tick (playing only — the energy
     /// contract's existing cadence; no new timers while idle).
+    ///
+    /// With crossfade off but gapless on, `effectiveFadeDuration` resolves to
+    /// 0 — the scheduler then only ever opens the prepare window (buffer the
+    /// armed track on the standby deck), and the handoff happens at the
+    /// track's natural end via the zero-fade join. Tracks with no usable
+    /// duration metadata never open the window and degrade to the owner's
+    /// rebuild path.
     private func evaluateCrossfadeWindow() {
         guard state == .playing,
               retiringDeckIndex == nil,
               let armed,
-              crossfade.isEnabled,
+              transitionArmingEnabled,
               let duration = activeDeck.durationSeconds, duration > 0
         else { return }
 
@@ -1187,5 +1290,15 @@ public final class EngineDSPPipeline {
 
     /// Test seam: whether a fade (auto or quick-switch) is in flight.
     var isFadeInFlightForTesting: Bool { retiringDeckIndex != nil }
+
+    /// Test seam: per-deck player gain stages (the normalization knob the
+    /// fade envelopes never touch), deck order (A, B).
+    var deckPlayerGainsForTesting: [Float] {
+        decks.map { $0.player.volume }
+    }
+
+    /// Test seam: number of loudness resolves stashed for tracks not yet
+    /// loaded on a deck.
+    var pendingLoudnessGainsCountForTesting: Int { pendingLoudnessGains.count }
     #endif
 }

--- a/macos/Sources/LyrebirdAudio/NormalizationSettings.swift
+++ b/macos/Sources/LyrebirdAudio/NormalizationSettings.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// User-facing loudness state for the Playback pane's two gain groups:
+/// **Replay Gain** (Off / Track / Album + pre-gain) and **Volume
+/// Normalization** (toggle + target loudness slider).
+///
+/// This is the single value type that flows from the Preferences pane through
+/// `AppModel.setNormalization` onto both engine paths — the AVQueuePlayer
+/// path applies it per item via `AVAudioMix` (`AudioEngine.applyReplayGain`),
+/// the DSP path via each deck's player gain stage
+/// (`EngineDSPPipeline.applyNormalization`) — and round-trips to
+/// `UserDefaults` so the choice survives relaunch. Same shape as
+/// `EqualizerSettings` / `CrossfadeSettings`.
+///
+/// Four facts persist:
+/// - `mode` — which ReplayGain tag drives the per-track gain. Reuses the
+///   pre-existing `playback.normalization` key the Playback pane has written
+///   since the pane first shipped, so a value set before the engine support
+///   landed is honoured unchanged.
+/// - `preGainDb` — user adjustment summed on top of the resolved gain
+///   (`playback.preGainDb`, ±12 dB).
+/// - `volumeNormalizationEnabled` — whether playback loudness is shifted to
+///   the user's target instead of the ReplayGain reference.
+/// - `targetLoudnessDb` — the loudness target in dB LUFS (−23…−14; −18 is
+///   the ReplayGain 2.0 reference, i.e. "no shift").
+///
+/// All-off (`mode == .off`, normalization toggle off) is a true no-op on
+/// both paths: no `AVAudioMix` is installed and every deck gain stage sits
+/// at unity, byte-for-byte the pre-existing output.
+public struct NormalizationSettings: Equatable, Sendable {
+    // MARK: - Ranges
+
+    /// Pre-gain slider range in dB. Values outside it (hand-edited defaults)
+    /// are clamped on load; the resolved *total* gain is additionally bounded
+    /// by `ReplayGain.maxAbsGainDb` before conversion.
+    public static let preGainRange: ClosedRange<Double> = -12...12
+
+    /// Volume-normalization target range in dB LUFS. −23 (EBU R128 broadcast)
+    /// through −14 (streaming-loudness territory); −18 — the ReplayGain 2.0
+    /// reference — sits inside it as the "no shift" default.
+    public static let targetRange: ClosedRange<Double> = -23 ... -14
+
+    /// Default target: the ReplayGain reference itself, so enabling the
+    /// toggle without touching the slider applies the tags exactly as the
+    /// Replay Gain group would.
+    public static let defaultTargetLoudnessDb: Double = ReplayGain.referenceLoudnessDb
+
+    // MARK: - State
+
+    /// Which ReplayGain tag drives the per-track gain. `.off` with the
+    /// normalization toggle on falls back to track gains — a loudness target
+    /// needs *some* per-track measurement, and the track tag is the only one
+    /// the stream carries.
+    public var mode: ReplayGainMode
+
+    /// User pre-gain in dB, summed on top of the resolved gain. Only matters
+    /// while some gain resolves at all (`isActive` and a usable tag).
+    public var preGainDb: Double
+
+    /// Whether playback loudness is shifted to `targetLoudnessDb` instead of
+    /// the ReplayGain reference.
+    public var volumeNormalizationEnabled: Bool
+
+    /// Loudness target in dB LUFS. Clamped to `targetRange`.
+    public var targetLoudnessDb: Double
+
+    public init(
+        mode: ReplayGainMode = .off,
+        preGainDb: Double = 0,
+        volumeNormalizationEnabled: Bool = false,
+        targetLoudnessDb: Double = NormalizationSettings.defaultTargetLoudnessDb
+    ) {
+        self.mode = mode
+        self.preGainDb = NormalizationSettings.normalizedPreGain(preGainDb)
+        self.volumeNormalizationEnabled = volumeNormalizationEnabled
+        self.targetLoudnessDb = NormalizationSettings.normalizedTarget(targetLoudnessDb)
+    }
+
+    /// Whether any gain resolution should run at all. `false` means both
+    /// groups are off — the engines skip metadata reads and leave levels
+    /// untouched.
+    public var isActive: Bool {
+        mode != .off || volumeNormalizationEnabled
+    }
+
+    // MARK: - Normalization
+
+    /// Coerce an arbitrary persisted pre-gain into a valid one: zero
+    /// non-finite values (a corrupted plist must never reach the gain math)
+    /// and clamp to `preGainRange`.
+    public static func normalizedPreGain(_ raw: Double) -> Double {
+        guard raw.isFinite else { return 0 }
+        return min(max(raw, preGainRange.lowerBound), preGainRange.upperBound)
+    }
+
+    /// Coerce an arbitrary persisted target into a valid one: non-finite
+    /// values fall back to the default, everything else clamps to
+    /// `targetRange`.
+    public static func normalizedTarget(_ raw: Double) -> Double {
+        guard raw.isFinite else { return defaultTargetLoudnessDb }
+        return min(max(raw, targetRange.lowerBound), targetRange.upperBound)
+    }
+
+    // MARK: - Resolution
+
+    /// Resolve the linear volume multiplier for a track's parsed loudness
+    /// tags under these settings. `nil` means "leave the level untouched" —
+    /// both groups off, or no usable tag for the selected mode.
+    public func linearVolume(gains: ReplayGain.Gains) -> Float? {
+        ReplayGain.linearVolume(
+            mode: mode,
+            gains: gains,
+            preGainDb: preGainDb,
+            volumeNormalizationEnabled: volumeNormalizationEnabled,
+            targetLoudnessDb: targetLoudnessDb
+        )
+    }
+
+    // MARK: - Persistence
+
+    /// `UserDefaults` keys. `mode` / `preGainDb` are the pre-existing
+    /// Playback-pane keys (kept verbatim so prior choices survive); the
+    /// volume-normalization pair is new with the Volume Normalization group.
+    public enum DefaultsKey {
+        public static let mode = "playback.normalization"
+        public static let preGainDb = "playback.preGainDb"
+        public static let volumeNormalizationEnabled = "playback.volumeNormalizationEnabled"
+        public static let targetLoudnessDb = "playback.volumeNormalizationTargetDb"
+    }
+
+    /// Load persisted settings; missing/partial keys fall back to the shipped
+    /// default (everything off, target at the reference) so a fresh install
+    /// behaves exactly like the pre-existing output path.
+    ///
+    /// The target key needs an object probe: `double(forKey:)` returns `0`
+    /// for a missing key, which `normalizedTarget` would clamp to −14 —
+    /// silently shifting loudness for everyone who never touched the slider.
+    public static func load(from defaults: UserDefaults) -> NormalizationSettings {
+        let mode = defaults.string(forKey: DefaultsKey.mode)
+            .flatMap(ReplayGainMode.init(rawValue:)) ?? .off
+        let preGain = defaults.double(forKey: DefaultsKey.preGainDb)
+        let enabled = defaults.bool(forKey: DefaultsKey.volumeNormalizationEnabled)
+        let target: Double
+        if defaults.object(forKey: DefaultsKey.targetLoudnessDb) != nil {
+            target = defaults.double(forKey: DefaultsKey.targetLoudnessDb)
+        } else {
+            target = defaultTargetLoudnessDb
+        }
+        return NormalizationSettings(
+            mode: mode,
+            preGainDb: preGain,
+            volumeNormalizationEnabled: enabled,
+            targetLoudnessDb: target
+        )
+    }
+
+    /// Persist all four facts as plist-native scalars so `defaults read`
+    /// stays inspectable for support/debugging (same contract as the EQ and
+    /// crossfade keys).
+    public func save(to defaults: UserDefaults) {
+        defaults.set(mode.rawValue, forKey: DefaultsKey.mode)
+        defaults.set(NormalizationSettings.normalizedPreGain(preGainDb), forKey: DefaultsKey.preGainDb)
+        defaults.set(volumeNormalizationEnabled, forKey: DefaultsKey.volumeNormalizationEnabled)
+        defaults.set(NormalizationSettings.normalizedTarget(targetLoudnessDb), forKey: DefaultsKey.targetLoudnessDb)
+    }
+}
+
+/// The "Gapless playback" preference shared by both engine paths.
+///
+/// `AppModel.armNextTrackPreload` gates the AVQueuePlayer pre-insert on it,
+/// and `AudioEngine.dspEnsurePipeline` seeds the DSP pipeline's buffered-join
+/// arming from it — one key, one default-on contract, read here so the app
+/// and engine layers can never drift.
+public enum GaplessPreference {
+    /// `UserDefaults` key, kept in sync with `PreferencesPlayback`'s
+    /// `@AppStorage`.
+    public static let defaultsKey = "playback.gaplessEnabled"
+
+    /// Resolve the persisted flag, defaulting to `true` when the key has
+    /// never been written. `bool(forKey:)` returns `false` for a missing
+    /// key, which would silently invert the feature's "default on" contract
+    /// (the toggle ships on), so probe for the object first.
+    public static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: defaultsKey) != nil else { return true }
+        return defaults.bool(forKey: defaultsKey)
+    }
+}

--- a/macos/Sources/LyrebirdAudio/ReplayGain.swift
+++ b/macos/Sources/LyrebirdAudio/ReplayGain.swift
@@ -64,6 +64,13 @@ public enum ReplayGain {
     /// gains sit within roughly ±12 dB) while still bounding the worst case.
     public static let maxAbsGainDb: Double = 15.0
 
+    /// The loudness (dB LUFS) ReplayGain 2.0 tag gains are referenced to: a
+    /// tag of `-7.60 dB` means "attenuate by 7.6 dB and the track lands at
+    /// −18 LUFS". Volume normalization shifts that landing point — a target
+    /// of `T` adds `T − (−18)` dB on top of the tag — so the reference is the
+    /// natural "no shift" default for the target slider.
+    public static let referenceLoudnessDb: Double = -18.0
+
     // MARK: - dB ↔ linear
 
     /// Convert a dB gain to a linear amplitude multiplier (`10^(dB/20)`).
@@ -76,22 +83,35 @@ public enum ReplayGain {
     // MARK: - Resolution
 
     /// Resolve the linear volume multiplier to hand to
-    /// `AVAudioMixInputParameters.setVolume` for the given mode, parsed gains,
-    /// and user pre-gain.
+    /// `AVAudioMixInputParameters.setVolume` (AVQueuePlayer path) or a deck's
+    /// player gain stage (DSP path) for the given mode, parsed gains, user
+    /// pre-gain, and volume-normalization target.
     ///
-    /// Returns `nil` when normalization is off, or when the selected mode has
+    /// Returns `nil` when every knob is off, or when the selected mode has
     /// no usable tag — the caller treats `nil` as "leave the level untouched"
     /// so an untagged track plays at its natural volume rather than being
-    /// silently adjusted. The combined dB (ReplayGain + pre-gain) is clamped to
-    /// ±``maxAbsGainDb`` before conversion.
+    /// silently adjusted. The combined dB (ReplayGain + target shift +
+    /// pre-gain) is clamped to ±``maxAbsGainDb`` before conversion.
+    ///
+    /// Volume normalization composes with the mode rather than replacing it:
+    /// - mode picks *which* tag measures the track (track / album);
+    /// - the normalization target shifts *where* the loudness lands —
+    ///   `targetLoudnessDb − referenceLoudnessDb` dB on top of the tag.
+    /// - normalization on with mode `.off` falls back to track gains: a
+    ///   loudness target needs some per-track measurement, and the track tag
+    ///   is the only one the stream carries.
     public static func linearVolume(
         mode: ReplayGainMode,
         gains: Gains,
-        preGainDb: Double = 0
+        preGainDb: Double = 0,
+        volumeNormalizationEnabled: Bool = false,
+        targetLoudnessDb: Double = referenceLoudnessDb
     ) -> Float? {
-        guard mode != .off else { return nil }
-        guard let replayGainDb = replayGainDb(mode: mode, gains: gains) else { return nil }
-        let total = (replayGainDb + preGainDb).clamped(to: -maxAbsGainDb...maxAbsGainDb)
+        let effectiveMode: ReplayGainMode = (mode == .off && volumeNormalizationEnabled) ? .track : mode
+        guard effectiveMode != .off else { return nil }
+        guard let replayGainDb = replayGainDb(mode: effectiveMode, gains: gains) else { return nil }
+        let targetShiftDb = volumeNormalizationEnabled ? targetLoudnessDb - referenceLoudnessDb : 0
+        let total = (replayGainDb + targetShiftDb + preGainDb).clamped(to: -maxAbsGainDb...maxAbsGainDb)
         return linearGain(fromDb: total)
     }
 

--- a/macos/Tests/LyrebirdTests/NormalizationSettingsTests.swift
+++ b/macos/Tests/LyrebirdTests/NormalizationSettingsTests.swift
@@ -1,0 +1,408 @@
+import AVFoundation
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdAudio
+import LyrebirdCore
+
+/// Coverage for the Playback pane's loudness + gapless wiring:
+///
+///   1. `NormalizationSettings` value semantics — pre-gain / target clamps,
+///      non-finite sanitizing, the all-off `isActive` contract.
+///   2. `UserDefaults` persistence round-trips on the pre-existing
+///      `playback.normalization` / `playback.preGainDb` keys plus the new
+///      volume-normalization pair — including the missing-target-key probe
+///      (a bare `double(forKey:)` would read 0 and clamp to −14, silently
+///      shifting loudness for everyone who never touched the slider).
+///   3. The volume-normalization gain math — the target shift on top of the
+///      tag gain, the track-tag fallback when Replay Gain is off, and the
+///      total clamp.
+///   4. `GaplessPreference` — default-on for a missing key, persisted
+///      opt-out honoured, and `AppModel.gaplessEnabled` delegating to it.
+///   5. `EngineDSPPipeline` integration — gapless arming with crossfade off,
+///      disarm rules when either transition feature turns off, and the
+///      per-deck player gain stage driven by `provideLoudnessGains` /
+///      `applyNormalization` (stash-then-load and loaded-deck paths).
+@MainActor
+final class NormalizationSettingsTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    /// Standard-domain keys the engine / preference layer read directly;
+    /// scrubbed around every test so suites sharing `UserDefaults.standard`
+    /// stay hermetic.
+    private let standardKeys = [
+        NormalizationSettings.DefaultsKey.mode,
+        NormalizationSettings.DefaultsKey.preGainDb,
+        NormalizationSettings.DefaultsKey.volumeNormalizationEnabled,
+        NormalizationSettings.DefaultsKey.targetLoudnessDb,
+        GaplessPreference.defaultsKey,
+    ]
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "normalization-tests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        for key in standardKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        for key in standardKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - 1. Value semantics
+
+    func testShippedDefaultIsAllOff() {
+        let settings = NormalizationSettings()
+        XCTAssertEqual(settings.mode, .off)
+        XCTAssertEqual(settings.preGainDb, 0)
+        XCTAssertFalse(settings.volumeNormalizationEnabled)
+        XCTAssertEqual(settings.targetLoudnessDb, ReplayGain.referenceLoudnessDb)
+        XCTAssertFalse(settings.isActive, "everything-off must be inactive — no metadata reads, no gain")
+    }
+
+    func testIsActiveForEitherKnob() {
+        XCTAssertTrue(NormalizationSettings(mode: .track).isActive)
+        XCTAssertTrue(NormalizationSettings(volumeNormalizationEnabled: true).isActive)
+        XCTAssertTrue(NormalizationSettings(mode: .album, volumeNormalizationEnabled: true).isActive)
+    }
+
+    func testInitClampsAndSanitizes() {
+        XCTAssertEqual(NormalizationSettings(preGainDb: 99).preGainDb, 12, "pre-gain clamps to the slider ceiling")
+        XCTAssertEqual(NormalizationSettings(preGainDb: -99).preGainDb, -12)
+        XCTAssertEqual(NormalizationSettings(preGainDb: .nan).preGainDb, 0, "NaN pre-gain must never reach the gain math")
+        XCTAssertEqual(NormalizationSettings(targetLoudnessDb: -5).targetLoudnessDb, -14, "target clamps to the loud end")
+        XCTAssertEqual(NormalizationSettings(targetLoudnessDb: -40).targetLoudnessDb, -23, "target clamps to the quiet end")
+        XCTAssertEqual(
+            NormalizationSettings(targetLoudnessDb: .infinity).targetLoudnessDb,
+            NormalizationSettings.defaultTargetLoudnessDb,
+            "non-finite target falls back to the reference"
+        )
+    }
+
+    func testReferenceSitsInsideTargetRange() {
+        XCTAssertTrue(
+            NormalizationSettings.targetRange.contains(NormalizationSettings.defaultTargetLoudnessDb),
+            "the no-shift default must be reachable on the slider"
+        )
+    }
+
+    // MARK: - 2. Persistence
+
+    func testRoundTrip() {
+        let saved = NormalizationSettings(
+            mode: .album,
+            preGainDb: 3,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -16
+        )
+        saved.save(to: defaults)
+        let loaded = NormalizationSettings.load(from: defaults)
+        XCTAssertEqual(loaded, saved)
+    }
+
+    func testLoadFromEmptyDomainYieldsDefaults() {
+        let loaded = NormalizationSettings.load(from: defaults)
+        XCTAssertEqual(loaded, NormalizationSettings(), "missing keys must read as the shipped default")
+    }
+
+    /// The regression this suite exists for: with the toggle persisted but
+    /// the target key never written, `double(forKey:)` reads 0 — which the
+    /// clamp would turn into −14 (a +4 dB loudness shift). The loader must
+    /// probe for the object and fall back to the reference instead.
+    func testMissingTargetKeyReadsReferenceNotClampedZero() {
+        defaults.set(true, forKey: NormalizationSettings.DefaultsKey.volumeNormalizationEnabled)
+        let loaded = NormalizationSettings.load(from: defaults)
+        XCTAssertEqual(
+            loaded.targetLoudnessDb,
+            ReplayGain.referenceLoudnessDb,
+            "an unset target must mean no shift, not the clamp of 0"
+        )
+    }
+
+    func testLoadSanitizesGarbage() {
+        defaults.set("definitely-not-a-mode", forKey: NormalizationSettings.DefaultsKey.mode)
+        defaults.set(Double.nan, forKey: NormalizationSettings.DefaultsKey.preGainDb)
+        defaults.set(-99.0, forKey: NormalizationSettings.DefaultsKey.targetLoudnessDb)
+        let loaded = NormalizationSettings.load(from: defaults)
+        XCTAssertEqual(loaded.mode, .off, "unknown mode raw must fall back, not crash")
+        XCTAssertEqual(loaded.preGainDb, 0)
+        XCTAssertEqual(loaded.targetLoudnessDb, -23, "out-of-range target clamps on load")
+    }
+
+    func testSaveNormalizesOutOfRangeValues() {
+        var settings = NormalizationSettings()
+        settings.preGainDb = 40 // bypass init normalization
+        settings.targetLoudnessDb = -2
+        settings.save(to: defaults)
+        XCTAssertEqual(defaults.double(forKey: NormalizationSettings.DefaultsKey.preGainDb), 12)
+        XCTAssertEqual(defaults.double(forKey: NormalizationSettings.DefaultsKey.targetLoudnessDb), -14)
+    }
+
+    // MARK: - 3. Volume-normalization gain math
+
+    private let taggedGains = ReplayGain.Gains(trackGainDb: -6, albumGainDb: -4)
+
+    func testTargetShiftAddsOnTopOfTagGain() {
+        // Track tag −6 dB, target −14 (reference −18) ⇒ shift +4 ⇒ total −2.
+        let volume = ReplayGain.linearVolume(
+            mode: .track,
+            gains: taggedGains,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -14
+        )
+        XCTAssertEqual(volume ?? .nan, ReplayGain.linearGain(fromDb: -2), accuracy: 1e-6)
+    }
+
+    func testTargetAtReferenceIsPureReplayGain() {
+        let shifted = ReplayGain.linearVolume(
+            mode: .album,
+            gains: taggedGains,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: ReplayGain.referenceLoudnessDb
+        )
+        let plain = ReplayGain.linearVolume(mode: .album, gains: taggedGains)
+        XCTAssertEqual(shifted ?? .nan, plain ?? .nan, accuracy: 1e-9, "−18 target must be a no-shift")
+    }
+
+    func testNormalizationWithModeOffFallsBackToTrackGain() {
+        // Replay Gain off + normalization on: the target needs a measurement,
+        // so the track tag drives it. −6 dB tag, −23 target ⇒ shift −5 ⇒ −11.
+        let volume = ReplayGain.linearVolume(
+            mode: .off,
+            gains: taggedGains,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -23
+        )
+        XCTAssertEqual(volume ?? .nan, ReplayGain.linearGain(fromDb: -11), accuracy: 1e-6)
+    }
+
+    func testAllOffResolvesNil() {
+        XCTAssertNil(ReplayGain.linearVolume(mode: .off, gains: taggedGains))
+        XCTAssertNil(NormalizationSettings().linearVolume(gains: taggedGains))
+    }
+
+    func testNormalizationOnUntaggedTrackIsNoOp() {
+        let volume = ReplayGain.linearVolume(
+            mode: .off,
+            gains: ReplayGain.Gains(),
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -14
+        )
+        XCTAssertNil(volume, "no tag ⇒ leave the level untouched, never a blind boost")
+    }
+
+    func testClampIncludesTargetShift() {
+        // +12 tag + 4 shift + 6 pre-gain = 22 ⇒ clamps at +15.
+        let volume = ReplayGain.linearVolume(
+            mode: .track,
+            gains: ReplayGain.Gains(trackGainDb: 12),
+            preGainDb: 6,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -14
+        )
+        XCTAssertEqual(volume ?? .nan, ReplayGain.linearGain(fromDb: ReplayGain.maxAbsGainDb), accuracy: 1e-6)
+    }
+
+    func testSettingsLinearVolumeMatchesFreeFunction() {
+        let settings = NormalizationSettings(
+            mode: .track,
+            preGainDb: 2,
+            volumeNormalizationEnabled: true,
+            targetLoudnessDb: -16
+        )
+        XCTAssertEqual(
+            settings.linearVolume(gains: taggedGains) ?? .nan,
+            ReplayGain.linearVolume(
+                mode: .track,
+                gains: taggedGains,
+                preGainDb: 2,
+                volumeNormalizationEnabled: true,
+                targetLoudnessDb: -16
+            ) ?? .nan,
+            accuracy: 1e-9
+        )
+    }
+
+    // MARK: - 4. Gapless preference
+
+    func testGaplessDefaultsOnWhenKeyUnset() {
+        XCTAssertNil(UserDefaults.standard.object(forKey: GaplessPreference.defaultsKey))
+        XCTAssertTrue(GaplessPreference.isEnabled(), "an unset gapless key must read on")
+    }
+
+    func testGaplessHonoursPersistedOff() {
+        UserDefaults.standard.set(false, forKey: GaplessPreference.defaultsKey)
+        XCTAssertFalse(GaplessPreference.isEnabled())
+    }
+
+    /// `AppModel.gaplessEnabled` (the queue-side gate) must read the same
+    /// source as the engine's pipeline seeding, so the two paths can never
+    /// disagree about the toggle.
+    func testAppModelGateDelegatesToSharedPreference() {
+        XCTAssertEqual(AppModel.gaplessEnabled, GaplessPreference.isEnabled())
+        UserDefaults.standard.set(false, forKey: GaplessPreference.defaultsKey)
+        XCTAssertEqual(AppModel.gaplessEnabled, GaplessPreference.isEnabled())
+        XCTAssertFalse(AppModel.gaplessEnabled)
+    }
+
+    // MARK: - 5. Pipeline integration
+
+    private func armedTrack(key: String, albumKey: String? = nil) -> EngineDSPPipeline.ArmedNextTrack {
+        EngineDSPPipeline.ArmedNextTrack(
+            key: key,
+            albumKey: albumKey,
+            url: URL(fileURLWithPath: "/dev/null"),
+            authHeader: nil,
+            containerHint: nil,
+            durationHint: 180,
+            mediaSourceId: nil,
+            playSessionId: nil
+        )
+    }
+
+    /// A bare pipeline ships with gapless off (the pre-existing rebuild
+    /// transition), and the gapless knob alone — crossfade still off — must
+    /// accept an arm for the buffered zero-fade join.
+    func testGaplessArmsWithCrossfadeOff() {
+        let pipeline = EngineDSPPipeline()
+        XCTAssertFalse(pipeline.transitionArmingEnabled, "bare pipeline must preserve rebuild transitions")
+
+        pipeline.armNextTrack(armedTrack(key: "next"))
+        XCTAssertNil(pipeline.armedTrackKeyForTesting, "no transition feature on ⇒ arming stays a no-op")
+
+        pipeline.applyGapless(true)
+        XCTAssertTrue(pipeline.transitionArmingEnabled)
+        XCTAssertFalse(pipeline.crossfadeIsEnabled, "gapless must not report as crossfade")
+
+        pipeline.armNextTrack(armedTrack(key: "next"))
+        XCTAssertEqual(pipeline.armedTrackKeyForTesting, "next", "gapless on ⇒ the join arms without crossfade")
+    }
+
+    /// Turning gapless off disarms a pending join — unless crossfade still
+    /// wants the standby deck for an overlap of its own.
+    func testGaplessOffDisarmsUnlessCrossfadeHoldsTheArm() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyGapless(true)
+        pipeline.armNextTrack(armedTrack(key: "next"))
+        XCTAssertEqual(pipeline.armedTrackKeyForTesting, "next")
+
+        pipeline.applyGapless(false)
+        XCTAssertNil(pipeline.armedTrackKeyForTesting, "gapless off with crossfade off must drop the join")
+
+        pipeline.applyGapless(true)
+        pipeline.applyCrossfade(CrossfadeSettings(durationSeconds: 4))
+        pipeline.armNextTrack(armedTrack(key: "next2"))
+        pipeline.applyGapless(false)
+        XCTAssertEqual(pipeline.armedTrackKeyForTesting, "next2", "crossfade on must keep the arm alive")
+    }
+
+    /// The mirror rule: crossfade turning off keeps the arm while gapless
+    /// still wants the zero-fade join.
+    func testCrossfadeOffKeepsArmWhileGaplessOn() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyGapless(true)
+        pipeline.applyCrossfade(CrossfadeSettings(durationSeconds: 4))
+        pipeline.armNextTrack(armedTrack(key: "next"))
+
+        pipeline.applyCrossfade(CrossfadeSettings(durationSeconds: 0))
+        XCTAssertEqual(pipeline.armedTrackKeyForTesting, "next", "gapless must hold the buffered join")
+
+        pipeline.applyGapless(false)
+        XCTAssertNil(pipeline.armedTrackKeyForTesting, "both off ⇒ nothing may stay armed")
+    }
+
+    /// Per-deck loudness: tags provided for a loaded track drive that deck's
+    /// player gain stage, settings changes recompute from the cached tags,
+    /// and all-off snaps back to unity. The deck loads from a dead file URL —
+    /// `load` records the track key synchronously and the streamer's async
+    /// failure never resets the gain stage.
+    func testProvideGainsDrivesDeckPlayerGain() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyNormalization(NormalizationSettings(mode: .track))
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting, [1, 1], "no tags yet ⇒ unity")
+
+        pipeline.load(url: URL(fileURLWithPath: "/dev/null"), authHeader: nil, trackKey: "t1")
+        pipeline.provideLoudnessGains(ReplayGain.Gains(trackGainDb: -6), forTrackKey: "t1")
+
+        let expected = ReplayGain.linearGain(fromDb: -6)
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting[0], expected, accuracy: 1e-6)
+
+        // Mode flip mid-track: pure math on the cached tags, no re-fetch.
+        pipeline.applyNormalization(NormalizationSettings(mode: .track, preGainDb: 2))
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting[0], ReplayGain.linearGain(fromDb: -4), accuracy: 1e-6)
+
+        pipeline.applyNormalization(NormalizationSettings())
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting, [1, 1], "all-off must restore unity")
+    }
+
+    /// Tags that arrive before their track is loaded (the armed next track)
+    /// stash and apply at load; unloading resets the stage to unity.
+    func testStashedGainsApplyAtLoadAndResetOnReload() {
+        let pipeline = EngineDSPPipeline()
+        pipeline.applyNormalization(NormalizationSettings(mode: .track))
+
+        pipeline.provideLoudnessGains(ReplayGain.Gains(trackGainDb: -3), forTrackKey: "t1")
+        XCTAssertEqual(pipeline.pendingLoudnessGainsCountForTesting, 1, "early tags must stash, not vanish")
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting, [1, 1])
+
+        pipeline.load(url: URL(fileURLWithPath: "/dev/null"), authHeader: nil, trackKey: "t1")
+        XCTAssertEqual(pipeline.pendingLoudnessGainsCountForTesting, 0, "load must consume the stash")
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting[0], ReplayGain.linearGain(fromDb: -3), accuracy: 1e-6)
+
+        // A new track on the same deck with no tags must not inherit t1's gain.
+        pipeline.load(url: URL(fileURLWithPath: "/dev/null"), authHeader: nil, trackKey: "t2")
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting, [1, 1], "loudness is per-track state")
+    }
+
+    /// The engine seeds a freshly built pipeline from the persisted gapless
+    /// preference (default on) and its live loudness knobs — the same
+    /// construct-then-restore contract as the EQ and crossfade.
+    func testEnginePipelineConstructionSeedsGaplessAndNormalization() throws {
+        let dir = NSTemporaryDirectory() + "lyrebird-normalization-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "normalization-test"))
+        let engine = AudioEngine(core: core)
+        engine.dspPipelineEnabled = true
+        engine.normalizationMode = .track
+        engine.setVolume(0.5) // cheapest pipeline-constructing call; never starts audio
+
+        let pipeline = try XCTUnwrap(engine.dspPipeline)
+        XCTAssertTrue(pipeline.gaplessEnabled, "unset preference must seed the pipeline default-on")
+        XCTAssertTrue(pipeline.transitionArmingEnabled, "gapless alone must enable arming")
+
+        // The seeded settings must be live: a tagged track picks up the gain.
+        pipeline.load(url: URL(fileURLWithPath: "/dev/null"), authHeader: nil, trackKey: "t1")
+        pipeline.provideLoudnessGains(ReplayGain.Gains(trackGainDb: -6), forTrackKey: "t1")
+        XCTAssertEqual(pipeline.deckPlayerGainsForTesting[0], ReplayGain.linearGain(fromDb: -6), accuracy: 1e-6)
+    }
+
+    /// With the preference persisted off, the engine seeds the pipeline
+    /// disarmed — each track ends cleanly before the next is built.
+    func testEnginePipelineConstructionHonoursGaplessOff() throws {
+        UserDefaults.standard.set(false, forKey: GaplessPreference.defaultsKey)
+        let dir = NSTemporaryDirectory() + "lyrebird-normalization-\(UUID().uuidString)"
+        let core = try LyrebirdCore(config: CoreConfig(dataDir: dir, deviceName: "normalization-test"))
+        let engine = AudioEngine(core: core)
+        engine.dspPipelineEnabled = true
+        engine.setVolume(0.5)
+
+        let pipeline = try XCTUnwrap(engine.dspPipeline)
+        XCTAssertFalse(pipeline.gaplessEnabled)
+        XCTAssertFalse(pipeline.transitionArmingEnabled)
+    }
+}


### PR DESCRIPTION
Completes the Playback preferences pane spec: crossfade (already live), gapless toggle, Replay Gain, and volume normalization in one place.

Closes #261
Closes #1016

- Gapless toggle (default ON) wired to the real preload behavior on both paths — replaces the dead Experiments flag (#1016 root cause: toggle wrote a key nothing read)
- Replay Gain Off/Track/Album + Volume Normalization toggle with target dB slider: applied through the DSP deck gain stage when the engine flag is on; documented no-op (settings persist, UI notes inactive) when off or when the server item carries no gain metadata
- `NormalizationSettings` follows the `EqualizerSettings`/`CrossfadeSettings` persistence pattern; tests for clamps/defaults/round-trip + gain math

Gates: clean swift build + swift test 1089/1089 with regenerated bindings (verified post-stage).