### PR TITLE
fix(core): appears-on albums subtraction uses album-artist ids

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -868,6 +868,7 @@ impl JellyfinClient {
                 ItemField::ProductionYear,
                 ItemField::ChildCount,
                 ItemField::PrimaryImageAspectRatio,
+                ItemField::AlbumArtist,
             ])
             .enable_user_data()
             .fetch_albums(self)

--- a/core/src/tests/client.rs
+++ b/core/src/tests/client.rs
@@ -1535,6 +1535,19 @@ async fn appears_on_albums_uses_artist_ids_and_subtracts_own_releases() {
     );
     assert!(q.contains("IncludeItemTypes=MusicAlbum"), "query: {q}");
     assert!(q.contains("Recursive=true"), "query: {q}");
+
+    // AlbumArtist must be in Fields so the server returns AlbumArtistId; without
+    // it the subtraction filter always sees None and is a no-op.
+    let fields = get
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "Fields")
+        .map(|(_, v)| v.into_owned())
+        .expect("Fields must be present in the query");
+    assert!(
+        fields.split(',').any(|f| f == "AlbumArtist"),
+        "Fields must include AlbumArtist so AlbumArtistId is returned; got: {fields}"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Why

`appears_on_albums` fetches all albums where the artist has any credit (`ArtistIds` filter), then subtracts the artist's own releases client-side by filtering on `album.artist_id != artist_id`. That field is populated from the server's `AlbumArtistId` JSON field — which Jellyfin only returns when `AlbumArtist` is listed in the `Fields` projection. It was missing from the query, so `AlbumArtistId` was always `null`, `album.artist_id` was always `None`, the filter was a no-op, and the "Appears On" rail showed the artist's full discography alongside their actual guest spots.

## Root cause

`core/src/client.rs` line 866–871: the `.fields(vec![...])` call did not include `ItemField::AlbumArtist`.

## Fix

Add `ItemField::AlbumArtist` to the fields projection. Extend the existing unit test (`appears_on_albums_uses_artist_ids_and_subtracts_own_releases`) to assert `AlbumArtist` appears in the query's `Fields` parameter so the regression cannot silently recur.

## Test evidence

```
cargo fmt --check      ✓
cargo clippy -D warnings ✓
cargo test             335 passed, 0 failed
cargo doc              ✓
```

Closes #1017