### PR TITLE
polish(macos): crossfade preview in Preferences

### DIFF
--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -403,6 +403,7 @@ struct PreferencesPlayback: View {
 private struct CrossfadeEnvelopeView: View {
     let durationSeconds: Double
     let curve: CrossfadeSettings.Curve
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Number of path sample points. 64 is more than enough resolution for
     /// a 264-point-wide preview at this scale while staying well below any
@@ -425,7 +426,7 @@ private struct CrossfadeEnvelopeView: View {
                     .accessibilityLabel(accessibilityLabel)
                     .accessibilityHidden(false)
             } animation: { _ in
-                .easeInOut(duration: 1.2)
+                reduceMotion ? nil : .easeInOut(duration: 1.2)
             }
 
             // Legend: two dots + labels identifying the two curves.

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesPlayback.swift
@@ -219,6 +219,18 @@ struct PreferencesPlayback: View {
                 // broken — the same gated-feature idiom as the EQ pane (#40).
                 .opacity(model.supportsCrossfade ? 1 : 0.55)
 
+                // Envelope preview — shown only while the DSP engine is active
+                // and the slider is above the minimum so there's a real fade to
+                // illustrate. Animates on every duration/curve change so the
+                // shape responds immediately as the slider drags.
+                if model.supportsCrossfade && crossfadeSeconds >= CrossfadeSettings.minimumActiveDuration {
+                    CrossfadeEnvelopeView(
+                        durationSeconds: crossfadeSeconds,
+                        curve: CrossfadeSettings.Curve(rawValue: crossfadeCurveRaw) ?? .equalPower
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
+                }
+
                 Divider()
                     .background(Theme.border)
                     .padding(.vertical, 10)
@@ -365,6 +377,148 @@ struct PreferencesPlayback: View {
             return "−18 dB LUFS — the ReplayGain reference."
         }
         return "−\(abs(rounded)) dB LUFS. Higher is louder."
+    }
+}
+
+// MARK: - Crossfade envelope preview
+
+/// Compact gain-envelope visualisation shown in the Transitions section while
+/// crossfade is active and the DSP engine is routing playback this session.
+///
+/// Two overlapping `Path`s trace the outgoing track's fade-out and the
+/// incoming track's fade-in using the same `CrossfadeSettings.fadeInGain` /
+/// `fadeOutGain` math the live pipeline runs — so the shape the user sees is
+/// the shape they hear. Equal-power produces a rounded midpoint; linear is a
+/// flat X-cross.
+///
+/// The view animates its `animationPhase` via a repeating spring so the
+/// curves appear to "play through" the transition, giving the user an
+/// immediate sense of timing. The animation is driven entirely through a
+/// SwiftUI `phaseAnimator` so there are no manual timer callbacks.
+///
+/// Inert contract: this view is only instantiated when
+/// `model.supportsCrossfade && crossfadeSeconds >= minimumActiveDuration`
+/// (see the call site in `PreferencesPlayback.body`), so it never appears
+/// on the AVQueuePlayer path — the disabled-row idiom is the DSP-off state.
+private struct CrossfadeEnvelopeView: View {
+    let durationSeconds: Double
+    let curve: CrossfadeSettings.Curve
+
+    /// Number of path sample points. 64 is more than enough resolution for
+    /// a 264-point-wide preview at this scale while staying well below any
+    /// rendering cost.
+    private static let sampleCount = 64
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Canvas draws both gain curves from the real engine math.
+            // `animationPhase` in [0, 1] shifts the colours so the curves
+            // appear to pulse through the overlap — purely cosmetic, the
+            // path itself doesn't move.
+            PhaseAnimator(
+                [0.0, 0.5, 1.0, 0.5, 0.0],
+                trigger: envelopeKey
+            ) { phase in
+                envelopeCanvas(phase: phase)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .accessibilityLabel(accessibilityLabel)
+                    .accessibilityHidden(false)
+            } animation: { _ in
+                .easeInOut(duration: 1.2)
+            }
+
+            // Legend: two dots + labels identifying the two curves.
+            HStack(spacing: 16) {
+                legendItem(color: outgoingColor(phase: 1), label: "Outgoing")
+                legendItem(color: incomingColor(phase: 1), label: "Incoming")
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Canvas
+
+    private func envelopeCanvas(phase: Double) -> some View {
+        Canvas { context, size in
+            let samples = CrossfadeSettings.envelopeSamples(
+                count: Self.sampleCount,
+                curve: curve
+            )
+            // Outgoing: starts at full gain, fades to zero.
+            let outPath = gainPath(gains: samples.fadeOut, size: size)
+            context.stroke(
+                outPath,
+                with: .color(outgoingColor(phase: phase)),
+                style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
+            )
+            // Incoming: starts at zero, rises to full gain.
+            let inPath  = gainPath(gains: samples.fadeIn, size: size)
+            context.stroke(
+                inPath,
+                with: .color(incomingColor(phase: phase)),
+                style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
+            )
+        }
+    }
+
+    /// Convert a gain sample array into a `Path` mapped into `size`.
+    /// Gain = 1 maps to the top edge (y = 0); gain = 0 maps to the bottom
+    /// (y = height). The x-axis spans the full width.
+    private func gainPath(gains: [Float], size: CGSize) -> Path {
+        guard !gains.isEmpty else { return Path() }
+        return Path { path in
+            for (index, gain) in gains.enumerated() {
+                let x = size.width * CGFloat(index) / CGFloat(gains.count - 1)
+                let y = size.height * (1 - CGFloat(gain))
+                if index == 0 {
+                    path.move(to: CGPoint(x: x, y: y))
+                } else {
+                    path.addLine(to: CGPoint(x: x, y: y))
+                }
+            }
+        }
+    }
+
+    // MARK: - Colour helpers
+
+    /// Outgoing track colour. Warm tint that brightens at the start of the
+    /// overlap (phase ≈ 0) and dims as it hands off — matches the "outgoing"
+    /// semantic visually.
+    private func outgoingColor(phase: Double) -> Color {
+        Theme.accent.opacity(0.55 + 0.35 * (1 - phase))
+    }
+
+    /// Incoming track colour. Cool primary tint that brightens as it takes
+    /// over — the "arrival" semantic.
+    private func incomingColor(phase: Double) -> Color {
+        Theme.primary.opacity(0.55 + 0.35 * phase)
+    }
+
+    // MARK: - Legend
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(Theme.font(10, weight: .medium))
+                .foregroundStyle(Theme.ink3)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Stable key that changes whenever duration or curve changes, used as
+    /// the `PhaseAnimator` trigger so the animation restarts on every edit.
+    private var envelopeKey: String {
+        "\(Int(durationSeconds.rounded()))-\(curve.rawValue)"
+    }
+
+    private var accessibilityLabel: String {
+        let secs = Int(durationSeconds.rounded())
+        return "Crossfade envelope preview: \(secs) second\(secs == 1 ? "" : "s"), \(curve.label.lowercased()) curve"
     }
 }
 

--- a/macos/Sources/LyrebirdAudio/CrossfadeSettings.swift
+++ b/macos/Sources/LyrebirdAudio/CrossfadeSettings.swift
@@ -119,6 +119,33 @@ public struct CrossfadeSettings: Equatable, Sendable {
         }
     }
 
+    // MARK: - Preview sampling (pure, testable)
+
+    /// Uniform sample points for the gain envelopes across the fade window.
+    ///
+    /// `count` must be ≥ 2; the first sample is at progress 0 (start of
+    /// overlap) and the last at progress 1 (overlap complete). Returns
+    /// parallel arrays: `fadeIn[i]` and `fadeOut[i]` are the gains the two
+    /// decks carry at the same moment in time, sampled at `count` evenly-
+    /// spaced steps. All values are in [0, 1] and guaranteed finite.
+    ///
+    /// Intended for drawing the envelope shape in the Preferences preview;
+    /// each call is O(count) and allocation-free beyond the arrays themselves.
+    public static func envelopeSamples(
+        count: Int,
+        curve: Curve
+    ) -> (fadeIn: [Float], fadeOut: [Float]) {
+        let n = max(count, 2)
+        var fadeIn  = [Float](repeating: 0, count: n)
+        var fadeOut = [Float](repeating: 0, count: n)
+        for i in 0..<n {
+            let t = Double(i) / Double(n - 1)
+            fadeIn[i]  = Self.fadeInGain(progress: t, curve: curve)
+            fadeOut[i] = Self.fadeOutGain(progress: t, curve: curve)
+        }
+        return (fadeIn, fadeOut)
+    }
+
     // MARK: - Scheduling decisions (pure, testable)
 
     /// How early before the fade window the standby deck starts buffering the

--- a/macos/Tests/LyrebirdTests/CrossfadeSettingsTests.swift
+++ b/macos/Tests/LyrebirdTests/CrossfadeSettingsTests.swift
@@ -285,4 +285,72 @@ final class CrossfadeSettingsTests: XCTestCase {
         engine.dspApplyCrossfade(CrossfadeSettings(durationSeconds: 0))
         XCTAssertFalse(pipeline.crossfadeIsEnabled)
     }
+
+    // MARK: - 6. Envelope sampling (preview math)
+
+    /// `envelopeSamples` must return arrays of exactly `count` elements for
+    /// every requested count ≥ 2 and for both curves.
+    func testEnvelopeSamplesCountMatchesRequest() {
+        for count in [2, 8, 32, 64] {
+            for curve in CrossfadeSettings.Curve.allCases {
+                let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: count, curve: curve)
+                XCTAssertEqual(fadeIn.count, count, "fadeIn must have \(count) samples for curve \(curve)")
+                XCTAssertEqual(fadeOut.count, count, "fadeOut must have \(count) samples for curve \(curve)")
+            }
+        }
+    }
+
+    /// A count below the minimum (< 2) is coerced to 2 so callers can't
+    /// produce an empty or single-point path.
+    func testEnvelopeSamplesMinimumCountIsTwo() {
+        let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: 0, curve: .equalPower)
+        XCTAssertEqual(fadeIn.count, 2)
+        XCTAssertEqual(fadeOut.count, 2)
+    }
+
+    /// First sample must be 0/1 (start of overlap — incoming silent, outgoing
+    /// full) and the last must be 1/0 (overlap complete — swap).
+    func testEnvelopeSamplesEndpoints() {
+        for curve in CrossfadeSettings.Curve.allCases {
+            let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: 32, curve: curve)
+            XCTAssertEqual(fadeIn.first!, 0, accuracy: 0.001, "incoming must start silent (\(curve))")
+            XCTAssertEqual(fadeIn.last!, 1, accuracy: 0.001, "incoming must end at full (\(curve))")
+            XCTAssertEqual(fadeOut.first!, 1, accuracy: 0.001, "outgoing must start at full (\(curve))")
+            XCTAssertEqual(fadeOut.last!, 0, accuracy: 0.001, "outgoing must end silent (\(curve))")
+        }
+    }
+
+    /// All sample values must be finite and in [0, 1] — a jittery clock
+    /// must never push an out-of-range value onto a `Path` Y coordinate.
+    func testEnvelopeSamplesAllValuesFiniteAndBounded() {
+        for curve in CrossfadeSettings.Curve.allCases {
+            let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: 64, curve: curve)
+            for (i, (gin, gout)) in zip(fadeIn, fadeOut).enumerated() {
+                XCTAssertTrue(gin.isFinite, "fadeIn[\(i)] must be finite (\(curve))")
+                XCTAssertTrue(gout.isFinite, "fadeOut[\(i)] must be finite (\(curve))")
+                XCTAssertGreaterThanOrEqual(gin, 0, "fadeIn[\(i)] must be ≥ 0 (\(curve))")
+                XCTAssertLessThanOrEqual(gin, 1, "fadeIn[\(i)] must be ≤ 1 (\(curve))")
+                XCTAssertGreaterThanOrEqual(gout, 0, "fadeOut[\(i)] must be ≥ 0 (\(curve))")
+                XCTAssertLessThanOrEqual(gout, 1, "fadeOut[\(i)] must be ≤ 1 (\(curve))")
+            }
+        }
+    }
+
+    /// Equal-power samples must satisfy the constant-power identity at every
+    /// point: fadeIn² + fadeOut² == 1.
+    func testEnvelopeSamplesEqualPowerHoldsConstantPower() {
+        let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: 32, curve: .equalPower)
+        for (i, (gin, gout)) in zip(fadeIn, fadeOut).enumerated() {
+            let power = Double(gin) * Double(gin) + Double(gout) * Double(gout)
+            XCTAssertEqual(power, 1, accuracy: 0.001, "equal-power identity must hold at sample \(i)")
+        }
+    }
+
+    /// Linear samples must sum to exactly 1 at every point (amplitude-sum).
+    func testEnvelopeSamplesLinearSumsToOne() {
+        let (fadeIn, fadeOut) = CrossfadeSettings.envelopeSamples(count: 32, curve: .linear)
+        for (i, (gin, gout)) in zip(fadeIn, fadeOut).enumerated() {
+            XCTAssertEqual(Double(gin) + Double(gout), 1, accuracy: 0.001, "linear sum must be 1 at sample \(i)")
+        }
+    }
 }


### PR DESCRIPTION
## Why

The Preferences ▸ Playback ▸ Transitions section shows a crossfade slider and curve picker, but the overlap is an auditory effect — without a visual hint it's hard to know what duration or curve shape actually sounds like. Adding a live gain-envelope preview closes that feedback gap.

## What

- `CrossfadeEnvelopeView` — a compact `Canvas`-based view that draws the outgoing and incoming gain curves using `CrossfadeSettings.fadeInGain` / `fadeOutGain` (the real DSP math). A `PhaseAnimator` pulses the colours on every slider or curve change to convey the time dimension of the overlap.
- `CrossfadeSettings.envelopeSamples(count:curve:)` — a new pure sampling helper that feeds the view with O(count) points; no allocation beyond the two result arrays.
- **Gating**: the preview appears only when `model.supportsCrossfade == true` and the slider is ≥ 1 s — hidden on the AVQueuePlayer path, matching the existing dimmed-row idiom for DSP-gated controls.

## Tests

6 new tests in `CrossfadeSettingsTests`:
- `testEnvelopeSamplesCountMatchesRequest` — count is exact for 2/8/32/64 and both curves
- `testEnvelopeSamplesMinimumCountIsTwo` — count < 2 coerces to 2
- `testEnvelopeSamplesEndpoints` — first sample 0/1, last sample 1/0 for both curves
- `testEnvelopeSamplesAllValuesFiniteAndBounded` — all values in [0, 1] and finite
- `testEnvelopeSamplesEqualPowerHoldsConstantPower` — fadeIn² + fadeOut² == 1 at every point
- `testEnvelopeSamplesLinearSumsToOne` — fadeIn + fadeOut == 1 at every point

Full suite: 1120 tests, 0 failures (`swift test --package-path macos`).

Closes #329