### PR TITLE
polish(macos): playlist visibility indicators

### DIFF
--- a/macos/Sources/Lyrebird/Components/LibraryListRow.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryListRow.swift
@@ -79,6 +79,14 @@ struct LibraryListRow: View {
                         .monospacedDigit()
                 }
 
+                // Private lock badge — only for playlist rows whose visibility
+                // is restricted. Mirrors the sidebar row treatment.
+                if case .playlist(let p) = payload, !p.isPublic {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(Theme.ink3)
+                }
+
                 Text(countMeta)
                     .font(Theme.font(12, weight: .medium))
                     .foregroundStyle(Theme.ink3)
@@ -116,7 +124,13 @@ struct LibraryListRow: View {
 
     private var accessibilityLabel: String {
         let subtitle = secondaryText.isEmpty ? "" : ", \(secondaryText)"
-        return "\(primaryText)\(subtitle)"
+        let privacySuffix: String
+        if case .playlist(let p) = payload, !p.isPublic {
+            privacySuffix = ", Private"
+        } else {
+            privacySuffix = ""
+        }
+        return "\(primaryText)\(subtitle)\(privacySuffix)"
     }
 
     private var accessibilityHint: String {

--- a/macos/Sources/Lyrebird/Components/PlaylistCard.swift
+++ b/macos/Sources/Lyrebird/Components/PlaylistCard.swift
@@ -45,6 +45,21 @@ struct PlaylistCard: View {
                     .offset(y: reduceMotion ? 0 : (isHovering ? 0 : 8))
                     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: isHovering)
                     .accessibilityLabel("Play \(playlist.name)")
+
+                    // Private lock — top-leading corner badge, matches the
+                    // sidebar row treatment. Hidden while the play button is
+                    // visible so the two overlays don't compete for space.
+                    if !playlist.isPublic {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.white)
+                            .padding(5)
+                            .background(Circle().fill(.black.opacity(0.45)))
+                            .padding(6)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                            .opacity(isHovering ? 0 : 1)
+                            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isHovering)
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -76,7 +91,9 @@ struct PlaylistCard: View {
         .focusable(true)
         .focusEffectDisabled(false)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(playlist.name), \(subtitle)")
+        .accessibilityLabel(playlist.isPublic
+            ? "\(playlist.name), \(subtitle)"
+            : "\(playlist.name), \(subtitle), Private")
         .accessibilityHint("Opens playlist detail")
         .accessibilityAddTraits(.isButton)
     }

--- a/macos/Sources/Lyrebird/Screens/PlaylistView.swift
+++ b/macos/Sources/Lyrebird/Screens/PlaylistView.swift
@@ -253,6 +253,9 @@ struct PlaylistView: View {
 
                     editableDescription(playlist: playlist)
 
+                    visibilityBadge(playlist: playlist)
+                        .padding(.top, 4)
+
                     HStack(spacing: 28) {
                         stat(value: "\(playlist.trackCount)", label: "Tracks")
                         stat(value: formatMinutes(playlist.runtimeTicks), label: "Minutes")
@@ -342,6 +345,43 @@ struct PlaylistView: View {
                 .lineLimit(4)
                 .accessibilityLabel(description)
         }
+    }
+
+    // MARK: - Visibility badge
+
+    /// Globe (public) or lock (private) pill shown below the playlist title/
+    /// description in the hero. Tapping the pill cycles visibility the same
+    /// way the context-menu items do, so the hero is self-contained for the
+    /// common "I just created a private playlist and want to verify its
+    /// status" workflow.
+    @ViewBuilder
+    private func visibilityBadge(playlist: Playlist) -> some View {
+        Button {
+            model.setPlaylistVisibility(
+                playlist: playlist,
+                isPublic: !playlist.isPublic
+            )
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: playlist.isPublic ? "globe" : "lock.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(playlist.isPublic ? "Public" : "Private")
+                    .font(Theme.font(11, weight: .semibold))
+            }
+            .foregroundStyle(Theme.ink3)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule().fill(Theme.ink.opacity(0.07))
+            )
+        }
+        .buttonStyle(.plain)
+        .help(playlist.isPublic
+            ? "Public — visible to all server users. Click to make private."
+            : "Private — only visible to you. Click to make public.")
+        .accessibilityLabel(playlist.isPublic
+            ? "Public playlist. Activate to make private."
+            : "Private playlist. Activate to make public.")
     }
 
     // MARK: - Stat cell


### PR DESCRIPTION
## Why

PR #1033 added \`Playlist.isPublic\` end-to-end plus a sidebar lock icon, a context-menu toggle, and a NewPlaylistSheet visibility picker. Issue #239 also asks for visibility indicators on the detail header, the library grid, and the library list — surfaces #1033 did not touch.

## What changed

**PlaylistView hero** — a tappable globe/lock capsule badge appears below the title/description. Clicking it calls \`AppModel.setPlaylistVisibility\` (the same model call as the context-menu items), so the badge is self-contained: users can confirm and change visibility without right-clicking. Tooltip text explains current state and what the click will do.

**PlaylistCard (grid)** — a small lock badge in the top-leading corner of the artwork when the playlist is private. Fades out while the hover play button is showing to avoid icon overlap.

**LibraryListRow (list)** — a small lock icon between the trailing metadata and the count column for private playlists.

All three surfaces extend their accessibility labels with ", Private" when `isPublic` is false, matching the sidebar row pattern from #1033.

**Out of scope:** the "owner badge next to contributed tracks" half of the issue cannot be implemented — Jellyfin's audio-items response does not carry a per-track contributor user-id field.

## Test evidence

- \`rm -rf macos/.build && swift build --package-path macos\` — Build complete (0 errors, macOS version linker warnings are pre-existing)
- \`swift test --package-path macos\` — 1114 tests, 0 failures

Closes #239