### PR TITLE
feat(macos): mini player launcher

### DIFF
--- a/macos/Sources/Lyrebird/AppDelegate.swift
+++ b/macos/Sources/Lyrebird/AppDelegate.swift
@@ -241,6 +241,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         previousItem.isEnabled = hasTrack
         menu.addItem(previousItem)
 
+        // Mini Player toggle. Surfaces the ⌘⌥P action without requiring the
+        // keyboard; title reflects the current window state. Disabled while
+        // signed out because the scene requires a live session to be useful.
+        let hasMiniPlayer = appModel?.isMiniPlayerVisible == true
+        let hasSession = appModel?.session != nil
+        let miniPlayerItem = NSMenuItem(
+            title: hasMiniPlayer ? "Close Mini Player" : "Open Mini Player",
+            action: #selector(dockToggleMiniPlayer(_:)),
+            keyEquivalent: ""
+        )
+        miniPlayerItem.target = self
+        miniPlayerItem.isEnabled = hasSession
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(miniPlayerItem)
+
         // Recent albums. Use `jumpBackIn` (the home screen's "last played"
         // shelf) as the source of truth so the dock menu and the window
         // stay in sync. Cap at six so the dock menu stays compact even
@@ -436,6 +451,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if let album = model.jumpBackIn.first(where: { $0.id == id }) {
                 model.play(album: album)
             }
+        }
+    }
+
+    @objc private func dockToggleMiniPlayer(_ sender: NSMenuItem) {
+        Task { @MainActor [weak self] in
+            self?.appModel?.toggleMiniPlayer()
         }
     }
 }

--- a/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
+++ b/macos/Sources/Lyrebird/Components/MenuBarNowPlaying.swift
@@ -102,7 +102,7 @@ struct MenuBarNowPlaying: View {
         }
     }
 
-    // MARK: - Open the app
+    // MARK: - Open the app / Mini Player
 
     /// Focus the main window. Routes through the same `returnToFullWindow`
     /// contract the mini player uses, which activates the app (raising the
@@ -124,6 +124,28 @@ struct MenuBarNowPlaying: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(Text("menu_bar.now_playing.open"))
+
+        /// Toggle the detached Mini Player window. Disabled when signed out
+        /// because the mini player requires a live session to show track info.
+        Button {
+            model.toggleMiniPlayer()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: model.isMiniPlayerVisible ? "pip.exit" : "pip.enter")
+                    .font(.system(size: 12))
+                Text(model.isMiniPlayerVisible
+                     ? "menu_bar.now_playing.close_mini_player"
+                     : "menu_bar.now_playing.open_mini_player")
+                    .font(Theme.font(12, weight: .semibold))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(Theme.ink2)
+        }
+        .buttonStyle(.plain)
+        .disabled(model.session == nil)
+        .accessibilityLabel(Text(model.isMiniPlayerVisible
+            ? "menu_bar.now_playing.close_mini_player"
+            : "menu_bar.now_playing.open_mini_player"))
     }
 
     // MARK: - Derived

--- a/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
+++ b/macos/Sources/Lyrebird/Resources/Localizable.xcstrings
@@ -13249,6 +13249,126 @@
         }
       }
     },
+    "menu_bar.now_playing.open_mini_player": {
+      "comment": "Button in the menu-bar Now Playing panel that opens the detached Mini Player window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Mini Player"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Mini Reproductor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ouvrir le mini lecteur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Apri Mini Player"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレイヤーを開く"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Abrir Mini Player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Открыть мини-плеер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "打开迷你播放器"
+          }
+        }
+      }
+    },
+    "menu_bar.now_playing.close_mini_player": {
+      "comment": "Button in the menu-bar Now Playing panel that closes the detached Mini Player window.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Mini Player"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mini Player schließen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Cerrar Mini Reproductor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fermer le mini lecteur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chiudi Mini Player"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "ミニプレイヤーを閉じる"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Fechar Mini Player"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Закрыть мини-плеер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关闭迷你播放器"
+          }
+        }
+      }
+    },
     "menu_bar.now_playing.pause": {
       "comment": "Accessibility label for the menu-bar Now Playing pause button.",
       "extractionState": "manual",

--- a/macos/Tests/LyrebirdTests/MiniPlayerStateTests.swift
+++ b/macos/Tests/LyrebirdTests/MiniPlayerStateTests.swift
@@ -146,4 +146,43 @@ final class MiniPlayerStateTests: XCTestCase {
             "closeMiniPlayer must clear the visibility flag"
         )
     }
+
+    // MARK: - Dock menu / menu-bar launcher entry points
+
+    /// The dock menu's "Open Mini Player" item calls `toggleMiniPlayer()`.
+    /// Verify it opens when closed and closes when open — same contract the
+    /// ⌘⌥P menu item exercises, but reached through the `toggleMiniPlayer`
+    /// entry point that the AppDelegate `@objc` action dispatches to.
+    func testDockMenuLauncherOpensAndClosesViaSameToggle() throws {
+        let model = try AppModel()
+        XCTAssertFalse(model.isMiniPlayerVisible, "fresh model starts hidden")
+
+        // Simulate the dock "Open Mini Player" tap.
+        model.toggleMiniPlayer()
+        XCTAssertTrue(model.isMiniPlayerVisible, "dock open tap must show the player")
+
+        // Simulate the dock "Close Mini Player" tap.
+        model.toggleMiniPlayer()
+        XCTAssertFalse(model.isMiniPlayerVisible, "dock close tap must hide the player")
+    }
+
+    /// The menu-bar extra button reflects `isMiniPlayerVisible` and calls
+    /// `toggleMiniPlayer()`. Confirm the flag round-trips so the `pip.enter`
+    /// / `pip.exit` SF Symbol and the button label stay in sync.
+    func testMenuBarLauncherButtonReflectsVisibilityFlag() throws {
+        let model = try AppModel()
+
+        // Open via the public setter (simulates the menu-bar button's action).
+        model.isMiniPlayerVisible = true
+        XCTAssertTrue(
+            model.isMiniPlayerVisible,
+            "flag must be true so the menu-bar button shows 'Close Mini Player'"
+        )
+
+        model.isMiniPlayerVisible = false
+        XCTAssertFalse(
+            model.isMiniPlayerVisible,
+            "flag must be false so the menu-bar button shows 'Open Mini Player'"
+        )
+    }
 }


### PR DESCRIPTION
## Why

Users who prefer the mouse over the keyboard had no way to open the Mini Player without knowing the ⌘⌥P shortcut. The window existed and worked, but the two always-visible surfaces — the Dock right-click menu and the menu-bar Now Playing extra — offered no launcher.

## Entry points added

**Dock right-click menu** (`AppDelegate.applicationDockMenu`): an "Open Mini Player" / "Close Mini Player" item beneath a separator before the Recent Albums shelf. Disabled while signed out (the scene requires a live session). Title reflects the current window state so the menu is self-documenting.

**Menu-bar Now Playing extra** (`MenuBarNowPlaying`): a second button below "Open Lyrebird" with a `pip.enter` / `pip.exit` SF Symbol. Same disabled-when-signed-out rule; label and icon toggle with `isMiniPlayerVisible`.

Both route through the existing `toggleMiniPlayer()` on `AppModel`, so the ⌘⌥P checkmark, the menu-bar button, and the dock item stay in sync via the single `isMiniPlayerVisible` flag — no new state introduced.

## Localization

Two new keys (`menu_bar.now_playing.open_mini_player`, `menu_bar.now_playing.close_mini_player`) added to `Localizable.xcstrings` with `needs_review` translations for de, es, fr, it, ja, pt-BR, ru, zh-Hans.

## Test evidence

Two new tests in `MiniPlayerStateTests`:
- `testDockMenuLauncherOpensAndClosesViaSameToggle` — dock toggle contract
- `testMenuBarLauncherButtonReflectsVisibilityFlag` — menu-bar flag sync

Full suite: 1114 tests, 0 failures (`swift test --package-path macos`).
Clean build: `rm -rf macos/.build && swift build --package-path macos` — Build complete.

Closes #277