### PR TITLE
chore(core): runtime credential-store backend for dev and e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,10 @@ env:
   LYREBIRD_E2E_URL: https://music.skalthoff.com
   LYREBIRD_E2E_USER: test
   LYREBIRD_E2E_PASS: test
+  # Route core's credential store to a process-local map (debug builds only)
+  # so headless runners never touch a real keychain. No-op on Linux, where no
+  # native keyring backend is compiled in; ignored entirely by release builds.
+  LYREBIRD_CREDENTIAL_STORE: memory
 
 jobs:
   rust-core:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,12 @@ still blocks the curl, ask the user to add a Bash permission rule to
 their Claude settings — it's a sandbox-config gap, not a missing
 authorization.
 
+`Scripts/smoke-test.sh` exports `LYREBIRD_CREDENTIAL_STORE=memory`, which
+routes core's credential store to a process-local in-memory map in debug
+builds so freshly rebuilt (unsigned) test binaries never trip the macOS
+Keychain ACL password prompt. Release builds ignore the variable entirely —
+the native keyring path is unconditional there.
+
 ## Multi-agent playbook
 
 Lessons from the 46-issue audit sweep + the gap-fix iteration that

--- a/Scripts/smoke-test.sh
+++ b/Scripts/smoke-test.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 : "${LYREBIRD_E2E_PASS:=test}"
 export LYREBIRD_E2E_URL LYREBIRD_E2E_USER LYREBIRD_E2E_PASS
 
+# In-memory credential store (debug builds only): each rebuilt test binary is unsigned, so persisting the session through the real macOS Keychain would pop the ACL password prompt on every run.
+export LYREBIRD_CREDENTIAL_STORE=memory
+
 cd "$(dirname "$0")/.."
 
 # Fail fast with a readable message when the server is down, instead of

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -2,7 +2,9 @@ use crate::error::{LyrebirdError, Result};
 use crate::player::RepeatMode;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 const SCHEMA_VERSION: i32 = 3;
 
@@ -597,57 +599,162 @@ const SERVICE: &str = "org.lyrebird.desktop";
 /// the settings table.
 const SCROBBLE_ACCOUNT: &str = "scrobble/listenbrainz";
 
+/// Which backing store [`CredentialStore`] routes secrets through.
+///
+/// `Native` is the production path: the OS credential store via the `keyring`
+/// crate (macOS Keychain / Windows Credential Manager). `Memory` is a
+/// process-local map for development and live-e2e runs, where each freshly
+/// compiled (and therefore unsigned) test binary would otherwise trip the
+/// macOS Keychain ACL prompt when persisting the session token. The memory
+/// arm makes zero Security-framework calls — it never constructs a
+/// `keyring::Entry`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CredentialBackend {
+    Native,
+    Memory,
+}
+
+/// Map the raw `LYREBIRD_CREDENTIAL_STORE` value to a backend.
+///
+/// Pure (no environment read) so the decision matrix is unit-testable without
+/// process-global env mutation. Exactly `Some("memory")` selects the
+/// in-memory store; absent, empty, or any other spelling (including case
+/// variants) selects the native keyring.
+pub(crate) fn resolve_backend(env_value: Option<&str>) -> CredentialBackend {
+    match env_value {
+        Some("memory") => CredentialBackend::Memory,
+        _ => CredentialBackend::Native,
+    }
+}
+
+/// The backend every [`CredentialStore`] call routes through.
+///
+/// Debug builds (excluding the unit-test harness — see below) read
+/// `LYREBIRD_CREDENTIAL_STORE` exactly once and cache the decision for the
+/// life of the process. Release builds never read the environment at all: the
+/// `cfg` structure compiles this function down to a constant
+/// [`CredentialBackend::Native`], so production keychain behavior cannot be
+/// downgraded via the environment.
+///
+/// The unit-test harness (`cfg(test)`) is likewise pinned to `Native` so the
+/// suite always exercises the `keyring` code path through the process-wide
+/// mock builder its fixtures install (`install_mock_keyring`), regardless of
+/// what a developer's shell happens to export. The live e2e integration
+/// target (`core/tests/e2e_live.rs`) links the library *without* `cfg(test)`,
+/// so it honors the variable — that is the path `Scripts/smoke-test.sh`
+/// relies on.
+pub(crate) fn credential_backend() -> CredentialBackend {
+    #[cfg(all(debug_assertions, not(test)))]
+    {
+        static BACKEND: OnceLock<CredentialBackend> = OnceLock::new();
+        *BACKEND.get_or_init(|| {
+            resolve_backend(std::env::var("LYREBIRD_CREDENTIAL_STORE").ok().as_deref())
+        })
+    }
+    #[cfg(not(all(debug_assertions, not(test))))]
+    {
+        // Release and unit-test builds: constant `Native`, environment never
+        // consulted.
+        resolve_backend(None)
+    }
+}
+
+/// Process-local secret map backing [`CredentialBackend::Memory`], keyed on
+/// the keyring account string (the service is the fixed `SERVICE` constant).
+/// Never persisted — secrets vanish with the process.
+fn memory_store() -> &'static Mutex<HashMap<String, String>> {
+    static STORE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 pub struct CredentialStore;
 
 impl CredentialStore {
     pub fn save_token(server_id: &str, username: &str, token: &str) -> Result<()> {
-        let entry = keyring::Entry::new(SERVICE, &format!("{server_id}/{username}"))?;
-        entry.set_password(token)?;
-        Ok(())
+        Self::save_secret(
+            credential_backend(),
+            &format!("{server_id}/{username}"),
+            token,
+        )
     }
 
     pub fn load_token(server_id: &str, username: &str) -> Result<Option<String>> {
-        let entry = keyring::Entry::new(SERVICE, &format!("{server_id}/{username}"))?;
-        match entry.get_password() {
-            Ok(t) => Ok(Some(t)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        Self::load_secret(credential_backend(), &format!("{server_id}/{username}"))
     }
 
     pub fn delete_token(server_id: &str, username: &str) -> Result<()> {
-        let entry = keyring::Entry::new(SERVICE, &format!("{server_id}/{username}"))?;
-        match entry.delete_credential() {
-            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
+        Self::delete_secret(credential_backend(), &format!("{server_id}/{username}"))
     }
 
     /// Persist the ListenBrainz scrobble token in the OS keyring (same secure
     /// store as the Jellyfin access token), keyed on `SCROBBLE_ACCOUNT`.
     pub fn save_scrobble_token(token: &str) -> Result<()> {
-        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
-        entry.set_password(token)?;
-        Ok(())
+        Self::save_secret(credential_backend(), SCROBBLE_ACCOUNT, token)
     }
 
     /// Read the stored ListenBrainz scrobble token, or `None` when none is
     /// stored. Discriminates a missing entry from a real keyring fault.
     pub fn load_scrobble_token() -> Result<Option<String>> {
-        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
-        match entry.get_password() {
-            Ok(t) => Ok(Some(t)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        Self::load_secret(credential_backend(), SCROBBLE_ACCOUNT)
     }
 
     /// Remove the stored ListenBrainz scrobble token. A no-op when absent.
     pub fn delete_scrobble_token() -> Result<()> {
-        let entry = keyring::Entry::new(SERVICE, SCROBBLE_ACCOUNT)?;
-        match entry.delete_credential() {
-            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(e.into()),
+        Self::delete_secret(credential_backend(), SCROBBLE_ACCOUNT)
+    }
+
+    // Backend-explicit primitives. The public API above always passes
+    // `credential_backend()`; unit tests drive the `Memory` arm directly so
+    // the in-memory semantics stay covered even though the test harness pins
+    // the resolver to `Native` (see `credential_backend`).
+
+    pub(crate) fn save_secret(
+        backend: CredentialBackend,
+        account: &str,
+        secret: &str,
+    ) -> Result<()> {
+        match backend {
+            CredentialBackend::Memory => {
+                memory_store()
+                    .lock()
+                    .insert(account.to_owned(), secret.to_owned());
+                Ok(())
+            }
+            CredentialBackend::Native => {
+                let entry = keyring::Entry::new(SERVICE, account)?;
+                entry.set_password(secret)?;
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn load_secret(backend: CredentialBackend, account: &str) -> Result<Option<String>> {
+        match backend {
+            CredentialBackend::Memory => Ok(memory_store().lock().get(account).cloned()),
+            CredentialBackend::Native => {
+                let entry = keyring::Entry::new(SERVICE, account)?;
+                match entry.get_password() {
+                    Ok(t) => Ok(Some(t)),
+                    Err(keyring::Error::NoEntry) => Ok(None),
+                    Err(e) => Err(e.into()),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn delete_secret(backend: CredentialBackend, account: &str) -> Result<()> {
+        match backend {
+            CredentialBackend::Memory => {
+                memory_store().lock().remove(account);
+                Ok(())
+            }
+            CredentialBackend::Native => {
+                let entry = keyring::Entry::new(SERVICE, account)?;
+                match entry.delete_credential() {
+                    Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+                    Err(e) => Err(e.into()),
+                }
+            }
         }
     }
 }

--- a/core/src/tests/credential_store.rs
+++ b/core/src/tests/credential_store.rs
@@ -1,0 +1,102 @@
+//! Credential-store backend selection and the in-memory dev/e2e store.
+//!
+//! The resolver decision matrix is a pure function (`resolve_backend`), so it
+//! is tested without process-global env mutation. The in-memory store is
+//! driven through the backend-explicit primitives because the unit-test
+//! harness pins `credential_backend()` to `Native` — the suite's mock
+//! `keyring` builder (`install_mock_keyring`) owns that path.
+
+use super::*;
+use crate::storage::{credential_backend, resolve_backend, CredentialBackend};
+
+#[test]
+fn resolver_decision_matrix() {
+    // Unset → native keyring, exactly as before the switch existed.
+    assert_eq!(resolve_backend(None), CredentialBackend::Native);
+    // The one opt-in spelling.
+    assert_eq!(resolve_backend(Some("memory")), CredentialBackend::Memory);
+    // Everything else falls back to native: empty, unknown values, case and
+    // whitespace variants. Fail-safe means an unrecognized value can only
+    // ever land on the production backend.
+    assert_eq!(resolve_backend(Some("")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some("native")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some("keychain")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some("Memory")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some("MEMORY")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some(" memory")), CredentialBackend::Native);
+    assert_eq!(resolve_backend(Some("memory ")), CredentialBackend::Native);
+}
+
+#[test]
+fn unit_test_harness_is_pinned_to_native() {
+    // Under `cfg(test)` the cached resolver ignores the environment entirely,
+    // so the suite always exercises the `keyring` path through the installed
+    // mock builder — even when a developer's shell happens to export
+    // `LYREBIRD_CREDENTIAL_STORE=memory`. Release builds share this branch of
+    // the `cfg` structure, which is the compile-time guarantee that the env
+    // switch cannot downgrade a production build.
+    assert_eq!(credential_backend(), CredentialBackend::Native);
+}
+
+#[test]
+fn memory_store_round_trips_save_load_delete() {
+    let account = "memtest-server/round-trip-user";
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, account).unwrap(),
+        None,
+        "fresh account starts absent"
+    );
+
+    CredentialStore::save_secret(CredentialBackend::Memory, account, "tok-1").unwrap();
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, account)
+            .unwrap()
+            .as_deref(),
+        Some("tok-1")
+    );
+
+    // Overwrite wins, matching keychain `set_password` semantics.
+    CredentialStore::save_secret(CredentialBackend::Memory, account, "tok-2").unwrap();
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, account)
+            .unwrap()
+            .as_deref(),
+        Some("tok-2")
+    );
+
+    // Delete drops the secret and is idempotent, matching the native arm's
+    // `NoEntry` mapping.
+    CredentialStore::delete_secret(CredentialBackend::Memory, account).unwrap();
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, account).unwrap(),
+        None
+    );
+    CredentialStore::delete_secret(CredentialBackend::Memory, account)
+        .expect("deleting an absent entry is a no-op");
+}
+
+#[test]
+fn memory_store_isolates_accounts() {
+    CredentialStore::save_secret(CredentialBackend::Memory, "memtest-iso/a", "secret-a").unwrap();
+    CredentialStore::save_secret(CredentialBackend::Memory, "memtest-iso/b", "secret-b").unwrap();
+
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, "memtest-iso/a")
+            .unwrap()
+            .as_deref(),
+        Some("secret-a")
+    );
+
+    CredentialStore::delete_secret(CredentialBackend::Memory, "memtest-iso/a").unwrap();
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, "memtest-iso/a").unwrap(),
+        None
+    );
+    assert_eq!(
+        CredentialStore::load_secret(CredentialBackend::Memory, "memtest-iso/b")
+            .unwrap()
+            .as_deref(),
+        Some("secret-b"),
+        "deleting one account must not disturb another"
+    );
+}

--- a/core/src/tests/mod.rs
+++ b/core/src/tests/mod.rs
@@ -5,6 +5,7 @@
 //! fixtures live here and reach each submodule via `use super::*`.
 
 mod client;
+mod credential_store;
 mod discovery;
 mod downloads;
 mod errors_enums;


### PR DESCRIPTION
Every `Scripts/smoke-test.sh` rebuild produces a fresh unsigned test binary, so persisting the e2e login session through the real macOS Keychain popped the ACL password dialog on every run — this adds a debug-only `LYREBIRD_CREDENTIAL_STORE=memory` switch so dev/e2e runs stay out of the keychain entirely.

Closes #1041

## What changed

- `core/src/storage.rs` — `CredentialStore` routes through a backend resolver. `LYREBIRD_CREDENTIAL_STORE=memory` selects a process-local in-memory map; unset or any other value selects the native keyring. The env var is read exactly once (`OnceLock`-cached), never per call. The native arms are the same `keyring::Entry` calls as before, with the same `SERVICE` and account-name formats — no production keychain semantics, item names, or migration behavior changed.
- `Scripts/smoke-test.sh` exports the variable with a one-line comment; `.github/workflows/e2e.yml` sets it for the e2e jobs (no-op on the Linux runner, which has no native keyring backend compiled in; keeps the macOS SmokeTest job off the runner keychain).
- CLAUDE.md "Real-server smoke test" section documents the switch.

## Debug-only gating — release behavior provably unchanged

The env read exists only inside `#[cfg(all(debug_assertions, not(test)))]` in `credential_backend()`; every other build configuration takes the sibling cfg branch, which is the constant `resolve_backend(None)` → `Native`. Concretely:

- **Release builds**: the environment is never consulted — there is no `getenv` on any code path, the resolver is compile-time constant `Native`. Combined with the byte-identical native arms, release keychain behavior cannot differ from main.
- **Unit-test builds** (`cfg(test)`): also pinned to `Native`, so the suite keeps exercising the keyring path through its existing `install_mock_keyring` builder regardless of what a developer's shell exports. Verified by running the full suite with `LYREBIRD_CREDENTIAL_STORE=memory` exported: 339/339 green, including `login_keyring_write_is_not_silenced`, which can only pass via the mock keyring's failure injection (i.e. the Native path).
- The e2e target (`core/tests/e2e_live.rs`) links the library without `cfg(test)`, so it honors the switch — that is the path the smoke script relies on.

## Zero keychain calls on the memory path, by construction

The `Memory` match arms of `save_secret` / `load_secret` / `delete_secret` only touch a `OnceLock<Mutex<HashMap<String, String>>>` — they never construct a `keyring::Entry`, so no Security-framework call is reachable from that path.

## Tests

- `resolver_decision_matrix` — `None` → Native; `"memory"` → Memory; empty / unknown / case / whitespace variants → Native (fail-safe: an unrecognized value can only land on the production backend).
- `unit_test_harness_is_pinned_to_native` — enforces the `cfg(test)` pin (release shares that cfg branch).
- Memory-store round-trip, overwrite, idempotent delete, and account isolation via the backend-explicit primitives.

## Gates (all post-rebase onto current main)

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --release -- -D warnings`, `cargo test` (339 passed, 1 pre-existing ignored), `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — all green.
- No FFI surface change; `swift build` and `swift test` (1114 tests, 0 failures) green after regenerating bindings.

## Smoke-rebuild-twice status

`bash Scripts/smoke-test.sh` ran with the switch in place. The first run's `download_track_to_disk_round_trips` — which performs a real login and persists the session token through the memory store — passed against the live server with zero keychain dialogs. Mid-run, `music.skalthoff.com` began returning `500 "Error processing request."` for every `test`-account auth attempt (reproducible with plain curl; unknown users still get a clean 401 and `/System/Info/Public` returns 200 — i.e. a server-side user-row write failure). The outage predates this change: main's own E2E workflow run 27288070034 (15:48 UTC, pre-change code, Linux runner) failed with the identical login 500.

In place of the blocked live reruns, the rebuild-twice property was verified at the credential layer: a temporary integration-test probe (same compilation context as `e2e_live` — no `cfg(test)`, `debug_assertions` on) exercised save/load/delete through the public API with `LYREBIRD_CREDENTIAL_STORE=memory`, twice, with `touch core/src/lib.rs` plus a recompile in between. Both runs passed with zero keychain prompts, and `security find-generic-password -s org.lyrebird.desktop -a "scrobble/listenbrainz"` confirms the real keychain entry set was untouched (item absent before and after). Will re-run the full smoke twice and post the output here once the server is back.
