### PR TITLE
feat(macos): RTL layout support

### DIFF
--- a/macos/Sources/Lyrebird/Components/Breadcrumbs.swift
+++ b/macos/Sources/Lyrebird/Components/Breadcrumbs.swift
@@ -15,6 +15,8 @@ struct Breadcrumbs: View {
     /// Called when a non-final segment at the given zero-based index is tapped.
     var onTap: (Int) -> Void = { _ in }
 
+    @Environment(\.layoutDirection) private var layoutDirection
+
     var body: some View {
         HStack(spacing: 6) {
             ForEach(segments.indices, id: \.self) { idx in
@@ -37,7 +39,9 @@ struct Breadcrumbs: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Navigate to \(segment)")
 
-                    Image(systemName: "chevron.right")
+                    // Separator chevron points in the reading direction so
+                    // the trail flows logically in both LTR and RTL.
+                    Image(systemName: layoutDirection == .rightToLeft ? "chevron.left" : "chevron.right")
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(Theme.ink2)
                         .accessibilityHidden(true)
@@ -59,4 +63,17 @@ struct Breadcrumbs: View {
     .padding(24)
     .background(Theme.bg)
     .preferredColorScheme(.dark)
+}
+
+#Preview("Breadcrumbs RTL") {
+    VStack(alignment: .leading, spacing: 20) {
+        Breadcrumbs(segments: ["Lyrebird"])
+        Breadcrumbs(segments: ["Lyrebird", "Library"])
+        Breadcrumbs(segments: ["Lyrebird", "Library", "Albums"])
+        Breadcrumbs(segments: ["Lyrebird", "Library", "Albums", "The Deep End"])
+    }
+    .padding(24)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+    .environment(\.layoutDirection, .rightToLeft)
 }

--- a/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
+++ b/macos/Sources/Lyrebird/Components/LibraryFilterPopover.swift
@@ -417,6 +417,8 @@ struct RangeSlider: View {
 	@Binding var high: Double
 	let bounds: ClosedRange<Double>
 
+	@Environment(\.layoutDirection) private var layoutDirection
+
 	private let thumbSize: CGFloat = 16
 	private let trackHeight: CGFloat = 4
 
@@ -446,7 +448,7 @@ struct RangeSlider: View {
 
 				thumb
 					.offset(x: lowX)
-					.gesture(drag(usable: usable, isLow: true))
+					.gesture(drag(usable: usable, totalWidth: geo.size.width, isLow: true))
 					.accessibilityLabel("Minimum year")
 					.accessibilityValue("\(Int(low))")
 					.accessibilityAdjustableAction { direction in
@@ -455,7 +457,7 @@ struct RangeSlider: View {
 
 				thumb
 					.offset(x: highX)
-					.gesture(drag(usable: usable, isLow: false))
+					.gesture(drag(usable: usable, totalWidth: geo.size.width, isLow: false))
 					.accessibilityLabel("Maximum year")
 					.accessibilityValue("\(Int(high))")
 					.accessibilityAdjustableAction { direction in
@@ -465,6 +467,11 @@ struct RangeSlider: View {
 			.frame(height: thumbSize)
 			.frame(maxHeight: .infinity)
 			.coordinateSpace(name: coordinateSpace)
+			// Mirror the entire pixel-geometry track in RTL so "low" sits on the
+			// right (reading start) and "high" on the left (reading end).
+			// GeometryReader always uses screen coordinates (left = 0), so we
+			// flip the rendered layer and compensate cursor x in `drag`.
+			.scaleEffect(x: layoutDirection == .rightToLeft ? -1 : 1, y: 1)
 		}
 		.frame(height: 24)
 	}
@@ -476,14 +483,19 @@ struct RangeSlider: View {
 			.shadow(color: .black.opacity(0.3), radius: 2, y: 1)
 	}
 
-	private func drag(usable: CGFloat, isLow: Bool) -> some Gesture {
+	private func drag(usable: CGFloat, totalWidth: CGFloat, isLow: Bool) -> some Gesture {
 		// Measured in the ZStack's coordinate space (see `coordinateSpace`), so
 		// `value.location.x` is the cursor's position along the track, not an
 		// offset relative to the dragged thumb.
+		// In RTL the layer is mirrored via scaleEffect(x: -1), so the drag
+		// coordinate space is also mirrored: reflect the x back to match the
+		// logical (value-space) orientation.
 		DragGesture(coordinateSpace: .named(coordinateSpace))
 			.onChanged { value in
+				let rawX = value.location.x
+				let cursorX = layoutDirection == .rightToLeft ? (totalWidth - rawX) : rawX
 				let clamped = Self.value(
-					forCursorX: value.location.x,
+					forCursorX: cursorX,
 					usable: usable,
 					thumbSize: thumbSize,
 					bounds: bounds)

--- a/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
+++ b/macos/Sources/Lyrebird/Components/MiniPlayerView.swift
@@ -35,6 +35,7 @@ struct MiniPlayerView: View {
     // Contrast-adaptive accent for the favorite heart. Lifts to `accentHot`
     // under Increase Contrast so the accent-tinted glyph clears 4.5:1 (#888).
     @Environment(\.accessibleTheme) private var a11yTheme
+    @Environment(\.layoutDirection) private var layoutDirection
 
     /// Whether the controls overlay is currently revealed. Driven by hover plus
     /// the 2-second idle timeout below — `true` while the pointer is moving over
@@ -357,7 +358,9 @@ struct MiniPlayerView: View {
     private var restingProgress: some View {
         GeometryReader { geo in
             let fraction = min(max(0, model.status.positionSeconds / sliderMax), 1)
-            ZStack(alignment: .leading) {
+            // Fill from the leading edge in the current layout direction.
+            // In LTR the filled bar grows from left; in RTL from right.
+            ZStack(alignment: layoutDirection == .rightToLeft ? .trailing : .leading) {
                 Capsule()
                     .fill(Theme.ink.opacity(0.15))
                 Capsule()
@@ -385,7 +388,10 @@ struct MiniPlayerView: View {
     @ViewBuilder
     private var transportRow: some View {
         HStack(spacing: 14) {
-            iconBtn("backward.fill", label: "mini_player.previous", size: 13) {
+            // backward/forward glyphs represent temporal direction; flip them
+            // in RTL so "previous" always points toward the reading start.
+            iconBtn(layoutDirection == .rightToLeft ? "forward.fill" : "backward.fill",
+                    label: "mini_player.previous", size: 13) {
                 Haptics.transport()
                 model.skipPrevious()
             }
@@ -401,7 +407,8 @@ struct MiniPlayerView: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(Text(isPlaying ? "mini_player.pause" : "mini_player.play"))
-            iconBtn("forward.fill", label: "mini_player.next", size: 13) {
+            iconBtn(layoutDirection == .rightToLeft ? "backward.fill" : "forward.fill",
+                    label: "mini_player.next", size: 13) {
                 Haptics.transport()
                 model.skipNext()
             }

--- a/macos/Sources/Lyrebird/Components/PlayerBar.swift
+++ b/macos/Sources/Lyrebird/Components/PlayerBar.swift
@@ -15,6 +15,8 @@ struct PlayerBar: View {
     // `DynamicTypeReflow.decide` helper so the threshold is unit-tested without
     // a live scene; this view only reads the size and branches on the result.
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    // Layout direction for RTL-aware transport icon mirroring.
+    @Environment(\.layoutDirection) private var layoutDirection
 
     /// Local scrubber position used while the user is actively dragging the
     /// Slider. We don't bind the Slider straight to `status.positionSeconds`
@@ -183,7 +185,11 @@ struct PlayerBar: View {
                     model.mediaSessionSetShuffle(!model.status.shuffle)
                 }
                     .help("Shuffle")
-                iconBtn("backward.fill", label: "Previous track", size: 16) {
+                // backward/forward glyphs indicate temporal direction (prev/next
+                // track), not spatial direction — they must flip in RTL so
+                // "previous" always points toward the reading start.
+                iconBtn(layoutDirection == .rightToLeft ? "forward.fill" : "backward.fill",
+                        label: "Previous track", size: 16) {
                     Haptics.transport()
                     model.skipPrevious()
                 }
@@ -204,7 +210,8 @@ struct PlayerBar: View {
                 // about to take. See #331.
                 .accessibilityLabel(Text(isPlaying ? "Pause" : "Play"))
                 .help(isPlaying ? "Pause · Space" : "Play · Space")
-                iconBtn("forward.fill", label: "Next track", size: 16) {
+                iconBtn(layoutDirection == .rightToLeft ? "backward.fill" : "forward.fill",
+                        label: "Next track", size: 16) {
                     Haptics.transport()
                     model.skipNext()
                 }

--- a/macos/Sources/Lyrebird/Components/QueueInspector.swift
+++ b/macos/Sources/Lyrebird/Components/QueueInspector.swift
@@ -24,6 +24,7 @@ import UniformTypeIdentifiers
 /// and toggled with Cmd+Opt+Q.
 struct QueueInspector: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.layoutDirection) private var layoutDirection
     @FocusState private var focusedQueueId: UUID?
 
     /// Local presentation state for the three queue actions (#284). These
@@ -387,7 +388,9 @@ struct QueueInspector: View {
             GeometryReader { geom in
                 let total = max(1.0, model.status.durationSeconds)
                 let pct = min(1.0, max(0.0, model.status.positionSeconds / total))
-                ZStack(alignment: .leading) {
+                // Fill anchors to the reading-start edge so the bar grows in
+                // the correct direction in both LTR and RTL.
+                ZStack(alignment: layoutDirection == .rightToLeft ? .trailing : .leading) {
                     Capsule().fill(Theme.surface2)
                     Capsule().fill(Theme.ink2).frame(width: geom.size.width * CGFloat(pct))
                 }

--- a/macos/Sources/Lyrebird/Components/Sidebar.swift
+++ b/macos/Sources/Lyrebird/Components/Sidebar.swift
@@ -57,6 +57,7 @@ struct Sidebar: View {
     // Disclosure-chevron rotation + row reveal honour Reduce Motion, matching
     // the rest of the component library (e.g. AmbientWash, ArtistCard).
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.layoutDirection) private var layoutDirection
 
     var body: some View {
         @Bindable var model = model
@@ -227,10 +228,14 @@ struct Sidebar: View {
                     }
                 } label: {
                     HStack(spacing: 6) {
-                        Image(systemName: "chevron.right")
+                        // Disclosure chevron points toward the hidden content
+                        // in reading direction. In RTL the glyph starts as
+                        // chevron.left (collapsed) and rotates -90° (expanded →
+                        // points down), matching the LTR pattern.
+                        Image(systemName: layoutDirection == .rightToLeft ? "chevron.left" : "chevron.right")
                             .font(.system(size: 9, weight: .bold))
                             .foregroundStyle(Theme.ink3)
-                            .rotationEffect(.degrees(playlistsCollapsed ? 0 : 90))
+                            .rotationEffect(.degrees(playlistsCollapsed ? 0 : (layoutDirection == .rightToLeft ? -90 : 90)))
                             .frame(width: 10)
                         Text("PLAYLISTS")
                             .font(Theme.font(10, weight: .bold))

--- a/macos/Sources/Lyrebird/Screens/HomeView.swift
+++ b/macos/Sources/Lyrebird/Screens/HomeView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// zero coordination from the rest of the view.
 struct HomeView: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.layoutDirection) private var layoutDirection
 
     /// Locally-persisted list of pinned stations (#253). JSON-encoded into
     /// `@AppStorage` via `PinnedStationsStore` — placeholder until the real
@@ -919,7 +920,7 @@ struct HomeView: View {
                         HStack(spacing: 4) {
                             Text("See All")
                                 .font(Theme.font(12, weight: .semibold))
-                            Image(systemName: "chevron.right")
+                            Image(systemName: layoutDirection == .rightToLeft ? "chevron.left" : "chevron.right")
                                 .font(.system(size: 10, weight: .bold))
                         }
                         .foregroundStyle(Theme.ink2)

--- a/macos/Sources/Lyrebird/Screens/LibraryView.swift
+++ b/macos/Sources/Lyrebird/Screens/LibraryView.swift
@@ -1741,6 +1741,8 @@ private struct LibraryLoadingBanner: View {
     let loaded: Int
     let total: Int
 
+    @Environment(\.layoutDirection) private var layoutDirection
+
     /// 0…1 fraction consumed so the bar grows left-to-right.
     private var fraction: Double {
         guard total > 0 else { return 0 }
@@ -1766,7 +1768,7 @@ private struct LibraryLoadingBanner: View {
             // measures the banner's full width; the fill animates as `loaded`
             // increments with each paged response.
             GeometryReader { geo in
-                ZStack(alignment: .leading) {
+                ZStack(alignment: layoutDirection == .rightToLeft ? .trailing : .leading) {
                     Rectangle()
                         .fill(Theme.surface2)
                     Rectangle()

--- a/macos/Sources/Lyrebird/Screens/OnboardingView.swift
+++ b/macos/Sources/Lyrebird/Screens/OnboardingView.swift
@@ -450,6 +450,7 @@ enum FirstSyncGate {
 
 private struct FirstSyncStep: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.layoutDirection) private var layoutDirection
     let onContinue: () -> Void
 
     /// Nominal 0…1 progress used purely to animate the bar so it doesn't sit
@@ -545,15 +546,17 @@ private struct FirstSyncStep: View {
             // Animated progress bar.
             VStack(alignment: .leading, spacing: 10) {
                 GeometryReader { geo in
-                    ZStack(alignment: .leading) {
+                    // Anchor fill to the reading-start edge so it grows in
+                    // the correct direction in RTL locales.
+                    ZStack(alignment: layoutDirection == .rightToLeft ? .trailing : .leading) {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Theme.surface)
                             .frame(height: 6)
                         RoundedRectangle(cornerRadius: 4)
                             .fill(LinearGradient(
                                 colors: [Theme.accent, Theme.primary],
-                                startPoint: .leading,
-                                endPoint: .trailing
+                                startPoint: layoutDirection == .rightToLeft ? .trailing : .leading,
+                                endPoint: layoutDirection == .rightToLeft ? .leading : .trailing
                             ))
                             .frame(width: geo.size.width * displayProgress, height: 6)
                     }
@@ -727,10 +730,12 @@ private struct ProgressDots: View {
 
 private struct BackButton: View {
     let action: () -> Void
+    @Environment(\.layoutDirection) private var layoutDirection
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
-                Image(systemName: "chevron.left")
+                // Back chevron points toward the reading start; in RTL that is the right.
+                Image(systemName: layoutDirection == .rightToLeft ? "chevron.right" : "chevron.left")
                     .font(.system(size: 12, weight: .bold))
                 Text("onboarding.back")
                     .font(Theme.font(12, weight: .semibold))

--- a/macos/Sources/Lyrebird/Screens/SearchView.swift
+++ b/macos/Sources/Lyrebird/Screens/SearchView.swift
@@ -846,6 +846,7 @@ private struct SearchPageTrackRow: View {
 /// pin / radio / shuffle work from here.
 private struct GenreResultRow: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.layoutDirection) private var layoutDirection
     let name: String
     @State private var isHovering = false
 
@@ -861,7 +862,7 @@ private struct GenreResultRow: View {
                         .font(Theme.font(13, weight: .semibold))
                         .foregroundStyle(Theme.ink)
                     Spacer()
-                    Image(systemName: "chevron.right")
+                    Image(systemName: layoutDirection == .rightToLeft ? "chevron.left" : "chevron.right")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(Theme.ink3)
                         .opacity(isHovering ? 1 : 0.4)


### PR DESCRIPTION
## Why

SwiftUI mirrors `HStack`/`VStack` layout in RTL automatically, but directional SF Symbol glyphs (chevrons, transport icons) and custom pixel-geometry progress fills that compute absolute widths or explicit `ZStack` anchors are not automatically RTL-aware. This PR addresses all instances of that pattern identified in issue #348.

## What was audited

**Files touched:**
- `Breadcrumbs.swift` — separator chevron flips to `chevron.left` in RTL; RTL preview variant added
- `Sidebar.swift` — playlists disclosure chevron flips and rotates -90° (expanded = down) in RTL
- `PlayerBar.swift` — `backward.fill` / `forward.fill` swap in RTL
- `MiniPlayerView.swift` — transport swap; resting progress `ZStack` anchor flips to `.trailing` in RTL
- `QueueInspector.swift` — scrubber `ZStack` anchor flips to `.trailing` in RTL
- `LibraryView.swift` — loading banner fill anchor flips in RTL
- `LibraryFilterPopover.swift` — `RangeSlider` mirrors track via `scaleEffect(x: -1)`; drag reflects cursor x
- `OnboardingView.swift` — progress bar anchor + gradient endpoints flip; back-button chevron swaps
- `SearchView.swift` — `GenreResultRow` trailing chevron flips
- `HomeView.swift` — carousel "See All" chevron flips

**Audited, no change needed:**
- `MainShell.swift`, `AlbumDetailView.swift` — `.move(edge: .trailing)` transitions are layout-direction-aware
- All `VStack(alignment: .leading)` / `.frame(alignment: .leading/.trailing)` are natural-edge, SwiftUI flips them
- No `.multilineTextAlignment(.left)` or `.right` anywhere

**Must NOT flip:** `play.fill`, `pause.fill`, `shuffle`, `repeat`, `heart`, `chevron.down`, `speaker.wave.2.fill`, `dot.radiowaves.left.and.right` (symmetric).

**Must flip:** `backward.fill`, `forward.fill` (previous/next track follow reading order), directional chevron separators and nav affordances.

## Test evidence

- `#Preview("Breadcrumbs RTL")` with `.environment(\.layoutDirection, .rightToLeft)` added for the breadcrumb component.
- `swift build` matches baseline — same pre-existing stale-bindings errors as `origin/main`; zero new errors.

Closes #348