### PR TITLE
fix(macos): park DSP stream failures while paused instead of skipping to the next track

### DIFF
--- a/macos/Sources/LyrebirdAudio/DSPTrackStreamer.swift
+++ b/macos/Sources/LyrebirdAudio/DSPTrackStreamer.swift
@@ -117,6 +117,21 @@ final class DSPTrackStreamer: NSObject {
     private var taskSuspended = false
     private var cancelled = false
 
+    /// Owner transport hint (#1048). While the transport is paused nothing
+    /// drains the decode pacing, so an open response idles until CFNetwork's
+    /// request timeout kills the task — which is not a track failure. With
+    /// this set, a task failure parks (`pendingReconnect`) instead of firing
+    /// `onStreamError`, and unpausing re-issues a ranged request from the
+    /// first byte the dead response never delivered.
+    private var transportPaused = false
+    /// A transfer died while `transportPaused`; `setTransportPaused(false)`
+    /// reconnects.
+    private var pendingReconnect = false
+    /// The in-flight response is a byte-exact continuation of a previous
+    /// one (reconnect after a paused-idle timeout) — its first bytes are
+    /// contiguous with already-parsed data, unlike a seek's.
+    private var isContinuationResponse = false
+
     /// Scheduling stays gated until the owner has rewired the node graph
     /// for this stream's format (`beginScheduling`). Scheduling a buffer
     /// whose format mismatches the node's output connection raises an
@@ -179,11 +194,13 @@ final class DSPTrackStreamer: NSObject {
                 return
             }
 
-            // Tear down the in-flight transfer + backlog.
+            // Tear down the in-flight transfer + backlog. A parked reconnect
+            // is superseded — the seek's fresh ranged request replaces it.
             self.generation &+= 1
             self.dataTask?.cancel()
             self.dataTask = nil
             self.taskSuspended = false
+            self.pendingReconnect = false
             self.packetQueue.removeAll(keepingCapacity: true)
             self.converter?.reset()
             self.converterSawEndOfStream = false
@@ -230,6 +247,24 @@ final class DSPTrackStreamer: NSObject {
         }
     }
 
+    /// Owner transport hint (#1048): while paused, a dead transfer parks for
+    /// a ranged reconnect instead of failing the track; flipping back to
+    /// unpaused performs the parked reconnect. The parsed backlog and the
+    /// node's scheduled buffers stay valid across the reconnect — only the
+    /// network transfer restarts, from exactly the next undelivered byte.
+    func setTransportPaused(_ paused: Bool) {
+        decodeQueue.async { [weak self] in
+            guard let self, !self.cancelled else { return }
+            self.transportPaused = paused
+            guard !paused, self.pendingReconnect else { return }
+            self.pendingReconnect = false
+            self.startRequest(
+                fromByte: self.responseStartByteOffset + self.receivedByteCount,
+                continuation: true
+            )
+        }
+    }
+
     /// Stop the transfer and drop all backlog. Safe to call repeatedly.
     func cancel() {
         decodeQueue.async { [weak self] in
@@ -248,7 +283,7 @@ final class DSPTrackStreamer: NSObject {
 
     // MARK: - Network
 
-    private func startRequest(fromByte byteOffset: Int64) {
+    private func startRequest(fromByte byteOffset: Int64, continuation: Bool = false) {
         if session == nil {
             let config = URLSessionConfiguration.default
             config.networkServiceType = .avStreaming
@@ -263,6 +298,7 @@ final class DSPTrackStreamer: NSObject {
         if byteOffset > 0 {
             request.setValue("bytes=\(byteOffset)-", forHTTPHeaderField: "Range")
         }
+        isContinuationResponse = continuation
         responseStartByteOffset = byteOffset
         receivedByteCount = 0
         let task = session.dataTask(with: request)
@@ -556,6 +592,15 @@ extension DSPTrackStreamer: URLSessionDataDelegate {
                 failOnDecodeQueue("Stream request failed (HTTP \(http.statusCode))")
                 return
             }
+            // A reconnect continuation only works if the server honoured the
+            // Range header — a `200 OK` body restarts at byte zero, which
+            // cannot be stitched onto the already-parsed stream. Fail the
+            // track; the owner's ordinary skip/error path takes over.
+            if isContinuationResponse, responseStartByteOffset > 0, http.statusCode != 206 {
+                completionHandler(.cancel)
+                failOnDecodeQueue("Stream reconnect failed (server ignored Range)")
+                return
+            }
             // A ranged (seek) request that came back `200 OK` means the
             // server ignored the Range header — the body restarts at byte
             // zero. Land the seek at frame 0 so position stays honest.
@@ -580,10 +625,16 @@ extension DSPTrackStreamer: URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         guard !cancelled, dataTask === self.dataTask, let parser else { return }
-        let isFirstBytesAfterSeek = receivedByteCount == 0 && responseStartByteOffset > 0
+        // A mid-stream response start is a parse discontinuity after a seek,
+        // but NOT after a reconnect continuation — those bytes are contiguous
+        // with already-parsed data, and flagging them would make the parser
+        // flush a partial frame the previous response half-delivered.
+        let discontinuity = receivedByteCount == 0
+            && responseStartByteOffset > 0
+            && !isContinuationResponse
         receivedByteCount += Int64(data.count)
         do {
-            try parser.parse(data, discontinuity: isFirstBytesAfterSeek)
+            try parser.parse(data, discontinuity: discontinuity)
         } catch {
             failOnDecodeQueue(error.localizedDescription)
         }
@@ -596,6 +647,17 @@ extension DSPTrackStreamer: URLSessionDataDelegate {
             let nsError = error as NSError
             // Explicit cancels (seek teardown) are not failures.
             guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else { return }
+            // While the transport is paused nothing drains the decode pacing,
+            // so an open response idles until CFNetwork's request timeout
+            // (default 60s) kills the task. That is not a track failure —
+            // park the stream and reconnect on resume (#1048). Everything
+            // already parsed/scheduled stays valid.
+            if transportPaused {
+                pendingReconnect = true
+                taskSuspended = false
+                streamerLog.notice("DSP stream interrupted while paused; reconnecting on resume: \(nsError.localizedDescription, privacy: .public)")
+                return
+            }
             failOnDecodeQueue(nsError.localizedDescription)
             return
         }

--- a/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
+++ b/macos/Sources/LyrebirdAudio/EngineDSPPipeline.swift
@@ -264,6 +264,21 @@ public final class EngineDSPPipeline {
     private var pendingAdoptKey: String?
     private var handoffReceipt: HandoffReceipt?
 
+    // MARK: - Deferred stream events (#1048)
+
+    /// Active-deck stream failure that arrived while paused. Surfacing it
+    /// immediately would let the owner's skip-on-error start the next track
+    /// under a paused transport; instead it parks here and `resume()`
+    /// delivers it — the skip then happens in response to an explicit
+    /// transport action.
+    private var deferredActiveStreamError: String?
+
+    /// The active deck reported fully-played-out while paused (possible via
+    /// completion storms when a node stops under a paused engine). The
+    /// finish handling — zero-fade join or the owner's queue advance, both
+    /// of which start audio — runs on `resume()` instead.
+    private var deferredActiveFinish = false
+
     // MARK: - Gain ramps
 
     private enum RampDirection {
@@ -349,9 +364,13 @@ public final class EngineDSPPipeline {
         albumKey: String? = nil
     ) {
         // Any pending handoff is dead the moment the owner loads something
-        // explicitly — the receipt must not leak into the new track.
+        // explicitly — the receipt must not leak into the new track. Same
+        // for stream events parked while paused: they belonged to the
+        // outgoing track.
         pendingAdoptKey = nil
         handoffReceipt = nil
+        deferredActiveStreamError = nil
+        deferredActiveFinish = false
         settleFadeImmediately()
         disarmNextTrack()
 
@@ -393,6 +412,7 @@ public final class EngineDSPPipeline {
     /// moment the stream's format resolves in `handleFormatReady`.
     public func play() {
         state = .playing
+        for deck in decks { deck.streamer?.setTransportPaused(false) }
         startNodeIfReady()
         resumeRetiringNodeIfNeeded()
         resumeRampTimerIfNeeded()
@@ -410,6 +430,11 @@ public final class EngineDSPPipeline {
         state = .paused
         stopPositionTimer()
         suspendRampTimer()
+        // Park the transfers (#1048): a paused consumer can't drain the
+        // decode pacing, so an open response would idle into CFNetwork's
+        // request timeout and fail the track from under the user. Parked
+        // streamers defer the failure and reconnect on resume.
+        for deck in decks { deck.streamer?.setTransportPaused(true) }
         activeDeck.player.pause()
         if let retiring = retiringDeckIndex {
             decks[retiring].player.pause()
@@ -419,11 +444,27 @@ public final class EngineDSPPipeline {
 
     public func resume() {
         guard state != .playing else { return }
+        // A failure that arrived while paused was parked instead of skipping
+        // the track from under the user (#1048). Deliver it now — the owner's
+        // skip-on-error runs in response to an explicit transport action.
+        if let message = deferredActiveStreamError {
+            deferredActiveStreamError = nil
+            deferredActiveFinish = false
+            stopPositionTimer()
+            state = .idle
+            onStreamError?(message)
+            return
+        }
         state = .playing
+        for deck in decks { deck.streamer?.setTransportPaused(false) }
         startNodeIfReady()
         resumeRetiringNodeIfNeeded()
         resumeRampTimerIfNeeded()
         startPositionTimer()
+        if deferredActiveFinish {
+            deferredActiveFinish = false
+            finishActiveTrack()
+        }
     }
 
     /// Full teardown: cancel both decks' streams, drop scheduled audio, stop
@@ -433,6 +474,8 @@ public final class EngineDSPPipeline {
         disarmNextTrack()
         pendingAdoptKey = nil
         handoffReceipt = nil
+        deferredActiveStreamError = nil
+        deferredActiveFinish = false
         pendingLoudnessGains.removeAll()
         unload(deck: activeDeck)
         stopPositionTimer()
@@ -451,6 +494,11 @@ public final class EngineDSPPipeline {
     /// the UI already shows, and two clocks can't fight over the position.
     public func seek(toSeconds seconds: Double) {
         settleFadeImmediately()
+        // A parked end-of-playback is superseded — the seek re-streams the
+        // track, so it is no longer "finished". (A parked *failure* stays:
+        // its streamer is dead, so the seek below no-ops and resume still
+        // owes the owner the error.)
+        deferredActiveFinish = false
         let deck = activeDeck
         guard let streamer = deck.streamer else { return }
         // Before the stream header has parsed there is no packet table to
@@ -840,11 +888,23 @@ public final class EngineDSPPipeline {
         }
         guard deckIndex == activeDeckIndex else { return }
 
-        // Natural end of the active track. If an armed next track is fully
-        // buffered, take the zero-fade join (the gapless transition; with
-        // crossfade on it also covers the same-album rule, short tracks, and
-        // a fade window the position never crossed) instead of bouncing
-        // through the owner's rebuild path.
+        // While paused, end-of-playback handling parks (#1048): both the
+        // zero-fade join and the owner's queue advance start audio, which
+        // must never happen under a paused transport. `resume()` re-runs it.
+        guard state != .paused else {
+            deferredActiveFinish = true
+            return
+        }
+        finishActiveTrack()
+    }
+
+    /// Natural end of the active track. If an armed next track is fully
+    /// buffered, take the zero-fade join (the gapless transition; with
+    /// crossfade on it also covers the same-album rule, short tracks, and
+    /// a fade window the position never crossed) instead of bouncing
+    /// through the owner's rebuild path. Factored from the streamer-finished
+    /// handler so `resume()` can run a finish that parked while paused.
+    private func finishActiveTrack() {
         if let armed,
            transitionArmingEnabled,
            standbyReady,
@@ -873,6 +933,15 @@ public final class EngineDSPPipeline {
             // track over a preload failure.
             pipelineLog.error("DSP crossfade prep failed, falling back to rebuild: \(message, privacy: .public)")
             disarmNextTrack()
+            return
+        }
+        // Park an active-deck failure while paused (#1048): surfacing it now
+        // would let the owner's skip-on-error start the next track under a
+        // paused transport. Network deaths already defer inside the streamer
+        // (with a ranged reconnect on resume); this guard covers decode
+        // failures — and any future failure source — the same way.
+        guard state != .paused else {
+            deferredActiveStreamError = message
             return
         }
         stopPositionTimer()
@@ -1300,5 +1369,23 @@ public final class EngineDSPPipeline {
     /// Test seam: number of loudness resolves stashed for tracks not yet
     /// loaded on a deck.
     var pendingLoudnessGainsCountForTesting: Int { pendingLoudnessGains.count }
+
+    /// Test seam: drive the active deck's streamer-failure handler directly —
+    /// the paused-transport deferral (#1048) lives in the pipeline, not the
+    /// streamer, for decode-class failures.
+    func injectActiveStreamerErrorForTesting(_ message: String) {
+        handleStreamerError(message, deckIndex: activeDeckIndex)
+    }
+
+    /// Test seam: drive the active deck's end-of-playback handler directly.
+    func injectActiveStreamerFinishedForTesting() {
+        handleStreamerFinished(deckIndex: activeDeckIndex)
+    }
+
+    /// Test seam: whether a stream event parked while paused (#1048) is
+    /// awaiting `resume()`.
+    var hasDeferredStreamEventForTesting: Bool {
+        deferredActiveStreamError != nil || deferredActiveFinish
+    }
     #endif
 }

--- a/macos/Tests/LyrebirdTests/DSPPausedStreamRecoveryTests.swift
+++ b/macos/Tests/LyrebirdTests/DSPPausedStreamRecoveryTests.swift
@@ -1,0 +1,161 @@
+import AVFoundation
+import XCTest
+
+@testable import LyrebirdAudio
+
+/// Coverage for #1048: a paused transport must never start the next track.
+///
+/// Pausing the DSP path freezes consumption, so the current track's open
+/// HTTP response idles until CFNetwork's request timeout kills it (~60s).
+/// Before the fix that surfaced as a stream error, and the owner's
+/// skip-on-error advanced the queue and started playback — audibly, while
+/// the user believed the app was paused.
+///
+/// Two layers under test:
+///   1. `EngineDSPPipeline` parks active-deck stream events (error/finish)
+///      that arrive while paused and delivers them on `resume()` — the skip
+///      then happens in response to an explicit transport action.
+///   2. `DSPTrackStreamer` parks a transfer failure while the owner's
+///      transport is paused and reconnects (ranged request) on unpause,
+///      so a survivable timeout continues the same track instead of
+///      failing it.
+@MainActor
+final class DSPPausedStreamRecoveryTests: XCTestCase {
+
+    // MARK: - Pipeline: deferred stream events
+
+    /// An active-deck stream failure while paused must not reach the owner
+    /// (whose handler skips to — and starts — the next track). It parks, and
+    /// `resume()` delivers it instead.
+    func testActiveStreamErrorWhilePausedParksUntilResume() {
+        let pipeline = EngineDSPPipeline()
+        var errors: [String] = []
+        var finishes = 0
+        pipeline.onStreamError = { errors.append($0) }
+        pipeline.onTrackFinished = { finishes += 1 }
+
+        pipeline.play()
+        pipeline.pause()
+        XCTAssertEqual(pipeline.state, .paused)
+
+        pipeline.injectActiveStreamerErrorForTesting("The request timed out.")
+
+        XCTAssertTrue(errors.isEmpty, "a failure while paused must park, not skip the track from under the user")
+        XCTAssertEqual(pipeline.state, .paused, "the transport must stay paused across a parked failure")
+        XCTAssertTrue(pipeline.hasDeferredStreamEventForTesting)
+
+        pipeline.resume()
+
+        XCTAssertEqual(errors, ["The request timed out."], "resume must deliver the parked failure exactly once")
+        XCTAssertEqual(finishes, 0)
+        XCTAssertEqual(pipeline.state, .idle, "the delivered failure takes the ordinary error path")
+        XCTAssertFalse(pipeline.hasDeferredStreamEventForTesting)
+    }
+
+    /// The paused-state guard must not change the playing-time contract:
+    /// a failure mid-playback surfaces immediately (the stall-recovery skip).
+    func testActiveStreamErrorWhilePlayingFiresImmediately() {
+        let pipeline = EngineDSPPipeline()
+        var errors: [String] = []
+        pipeline.onStreamError = { errors.append($0) }
+
+        pipeline.play()
+        pipeline.injectActiveStreamerErrorForTesting("decode failed")
+
+        XCTAssertEqual(errors, ["decode failed"], "failures while playing must keep surfacing immediately")
+        XCTAssertEqual(pipeline.state, .idle)
+        XCTAssertFalse(pipeline.hasDeferredStreamEventForTesting)
+    }
+
+    /// End-of-playback while paused (completion storms when a node stops
+    /// under a paused engine) must not advance the queue — `onTrackFinished`
+    /// starts the next track. It parks, and `resume()` runs the finish.
+    func testActiveFinishWhilePausedParksUntilResume() {
+        let pipeline = EngineDSPPipeline()
+        var finishes = 0
+        pipeline.onTrackFinished = { finishes += 1 }
+
+        pipeline.play()
+        pipeline.pause()
+
+        pipeline.injectActiveStreamerFinishedForTesting()
+
+        XCTAssertEqual(finishes, 0, "a finish while paused must park, not start the next track")
+        XCTAssertEqual(pipeline.state, .paused)
+        XCTAssertTrue(pipeline.hasDeferredStreamEventForTesting)
+
+        pipeline.resume()
+
+        XCTAssertEqual(finishes, 1, "resume must run the parked finish")
+        XCTAssertEqual(pipeline.state, .idle)
+        XCTAssertFalse(pipeline.hasDeferredStreamEventForTesting)
+    }
+
+    /// Parked events belong to the track that parked them: an explicit load
+    /// of a new track (and a stop) must drop them, or a stale failure would
+    /// fire against the wrong track on the next resume.
+    func testLoadAndStopClearParkedStreamEvents() {
+        let pipeline = EngineDSPPipeline()
+        var errors: [String] = []
+        pipeline.onStreamError = { errors.append($0) }
+
+        pipeline.play()
+        pipeline.pause()
+        pipeline.injectActiveStreamerErrorForTesting("stale failure")
+        XCTAssertTrue(pipeline.hasDeferredStreamEventForTesting)
+
+        pipeline.load(url: URL(fileURLWithPath: "/dev/null"), authHeader: nil)
+        XCTAssertFalse(pipeline.hasDeferredStreamEventForTesting, "an explicit load supersedes the outgoing track's parked events")
+        XCTAssertTrue(errors.isEmpty)
+
+        pipeline.pause()
+        pipeline.injectActiveStreamerErrorForTesting("stale failure 2")
+        XCTAssertTrue(pipeline.hasDeferredStreamEventForTesting)
+
+        pipeline.stop()
+        XCTAssertFalse(pipeline.hasDeferredStreamEventForTesting, "stop tears down parked events with the rest of the track state")
+        XCTAssertTrue(errors.isEmpty, "cleared events must never surface")
+    }
+
+    // MARK: - Streamer: park + reconnect
+
+    /// A transfer failure while the owner's transport is paused must not
+    /// surface `onStreamError`; unpausing performs the parked reconnect,
+    /// whose failure (nothing listens on the port) then surfaces through the
+    /// ordinary playing-time path. Connection-refused on loopback stands in
+    /// for the paused-idle request timeout — both arrive as a failed task.
+    func testStreamerParksFailureWhilePausedAndReconnectsOnUnpause() {
+        let engine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        engine.attach(node)
+
+        // Port 9 (discard) — nothing listens on loopback, so the connect is
+        // refused deterministically and fast.
+        let streamer = DSPTrackStreamer(
+            url: URL(string: "http://127.0.0.1:9/track.flac")!,
+            authHeader: nil,
+            playerNode: node
+        )
+        defer { streamer.cancel() }
+
+        var parkedPhaseErrors = 0
+        streamer.onStreamError = { _ in parkedPhaseErrors += 1 }
+
+        streamer.setTransportPaused(true)
+        streamer.start()
+
+        // Give the refused connect ample time to land while paused.
+        let parkDeadline = Date().addingTimeInterval(2)
+        while Date() < parkDeadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertEqual(parkedPhaseErrors, 0, "a failure while paused must park, not surface")
+
+        let surfaced = expectation(description: "reconnect failure surfaces once unpaused")
+        streamer.onStreamError = { _ in surfaced.fulfill() }
+        streamer.setTransportPaused(false)
+
+        wait(for: [surfaced], timeout: 10)
+        XCTAssertEqual(parkedPhaseErrors, 0)
+    }
+}


### PR DESCRIPTION
Closes #1048.

Pausing on the DSP path freezes consumption, so the current track's still-open HTTP response idles until CFNetwork's `timeoutIntervalForRequest` (default 60s) kills the task. The streamer surfaced that as a track failure, and the skip-on-error path advanced the queue and audibly started the next track while the transport was paused (confirmed in Console: `DSP track failed, skipping: The request timed out.` ~60s after pausing).

Two layers, matching the issue's fix sketch:

**`DSPTrackStreamer` — park + ranged reconnect.** A task failure while the owner's transport is paused (`setTransportPaused(true)`, new) no longer fails the track: it parks as `pendingReconnect`, and unpausing re-issues a ranged request from `responseStartByteOffset + receivedByteCount` — the first byte the dead response never delivered. The parsed packet backlog and the node's scheduled buffers stay valid, so the same track continues at the paused position. Continuation responses are validated (`206` required when resuming mid-stream; a server that ignores Range fails the track through the ordinary path) and parse without a discontinuity flag, since their bytes are contiguous with already-parsed data — unlike a seek's.

**`EngineDSPPipeline` — defer stream events while paused.** Active-deck failures that still reach the pipeline while paused (decode errors, or any future source) park in `deferredActiveStreamError` and deliver on `resume()`, so the owner's skip runs in response to an explicit transport action. End-of-playback while paused (possible via completion storms when a node stops under a paused engine) parks the same way — both the zero-fade join and `onTrackFinished` start audio, so neither may run under a paused transport. Explicit `load()`/`stop()` clears parked events with the rest of the outgoing track's state; the playing-time contract (immediate skip-on-error, stall recovery) is unchanged.

Tests (`DSPPausedStreamRecoveryTests`, 5 new): pipeline parks error/finish while paused and delivers on resume, playing-time errors still surface immediately, load/stop clear parked events, and an end-to-end streamer test (connection-refused on loopback standing in for the paused-idle timeout) verifying park-then-reconnect-on-unpause. Full LyrebirdAudio-adjacent suites pass locally (`EngineDSPPipelineTests`, `AudioEngineRecoveryTests`, `AudioEnginePreloadTests`, `CrossfadeSettingsTests`).

No core/FFI changes; the AVQueuePlayer path is untouched.