### PR TITLE
fix(macos): drop the launch splash once the session restores instead of after the first library fetch

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -163,14 +163,9 @@ extension AppModel {
             self.serverURL = session.server.url
             self.username = session.user.name
             self.errorMessage = nil
-            // Drop the launch splash as soon as the session is decided —
-            // the shell renders its own loading skeletons (and paints from
-            // the local library cache) while the fetches below run. Holding
-            // the flag through `refreshLibrary()` kept a blank brand splash
-            // up for the whole first library round-trip, which on a large
-            // library reads as a hang. The `defer` above still clears the
-            // flag on every other exit path; re-assigning `false` is
-            // idempotent.
+            // The splash must end at the session decision, not after the
+            // library fetch — the shell owns that phase with skeletons and
+            // the cache-first paint.
             isRestoringSession = false
             startStatusEventStream()
             await refreshLibrary()

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -163,6 +163,15 @@ extension AppModel {
             self.serverURL = session.server.url
             self.username = session.user.name
             self.errorMessage = nil
+            // Drop the launch splash as soon as the session is decided —
+            // the shell renders its own loading skeletons (and paints from
+            // the local library cache) while the fetches below run. Holding
+            // the flag through `refreshLibrary()` kept a blank brand splash
+            // up for the whole first library round-trip, which on a large
+            // library reads as a hang. The `defer` above still clears the
+            // flag on every other exit path; re-assigning `false` is
+            // idempotent.
+            isRestoringSession = false
             startStatusEventStream()
             await refreshLibrary()
             await refreshDownloads()

--- a/macos/Tests/LyrebirdTests/SessionRestoreTests.swift
+++ b/macos/Tests/LyrebirdTests/SessionRestoreTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import Lyrebird
+@testable import LyrebirdCore
+
+/// Launch-splash lifecycle around `attemptRestoreSession`.
+///
+/// The flag starts `true` (so the first render is the splash, never a
+/// `LoginView` flash) and must be `false` after the restore pass on every
+/// exit path. The no-persisted-session path is driven for real against a
+/// throwaway data dir; the restored-session happy path has no core
+/// injection seam (`AppModel.init` constructs its own `LyrebirdCore`), so
+/// its early-flip ordering — splash down before the first library fetch —
+/// is verified manually, not here.
+@MainActor
+final class SessionRestoreTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    func testSplashFlagStartsRaised() throws {
+        let model = try AppModel()
+        XCTAssertTrue(model.isRestoringSession)
+    }
+
+    func testRestoreWithNoPersistedSessionLowersSplashFlag() async throws {
+        let model = try AppModel()
+        await model.attemptRestoreSession()
+        XCTAssertFalse(model.isRestoringSession)
+        XCTAssertNil(model.session)
+    }
+
+    func testSecondRestoreAttemptIsNoOp() async throws {
+        let model = try AppModel()
+        await model.attemptRestoreSession()
+        // A re-fired `.task` must not re-raise the splash or re-run restore.
+        model.isRestoringSession = false
+        await model.attemptRestoreSession()
+        XCTAssertFalse(model.isRestoringSession)
+    }
+}


### PR DESCRIPTION
Closes #1055. Third PR from the UX audit (#1050, #1052).

Cold launch on a large library sat on the blank "Lyrebird" splash for ~20s (observed live against a ~20k-album server) because `attemptRestoreSession` only cleared `isRestoringSession` in its `defer` — after `refreshLibrary()` + `refreshDownloads()` finished. The splash now drops as soon as the restored session is assigned; the shell takes over with its existing progressive-loading UX (library skeletons + cache-first paint from the local DB cache). The `defer` still clears the flag on the no-session and error paths, and the duplicate `false` write is idempotent.

One-hunk change. `swift build` clean; all 1119 package tests pass.