### PR TITLE
fix(core): clear downloads (rows and files) on logout

### DIFF
--- a/core/src/downloads.rs
+++ b/core/src/downloads.rs
@@ -272,6 +272,22 @@ pub fn delete(db: &Database, track_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Delete every download: truncate the `downloads` table and unlink each
+/// row's on-disk file. Logout / server-switch cleanup — rows are keyed on
+/// server-specific track ids, so an entry surviving into a session against a
+/// different server would list the old server's items and report the old ids
+/// on offline playback.
+///
+/// File unlinks are best-effort, matching [`delete`]; a row whose fetch never
+/// completed has no `local_path` and only its `.part` leftover is attempted.
+pub fn clear_all(db: &Database) -> Result<()> {
+    for path in db.downloads_clear()? {
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(Path::new(&path).with_extension("part"));
+    }
+    Ok(())
+}
+
 /// Record an enqueue: snapshot the track into the `downloads` table in the
 /// `queued` state. Does not fetch bytes — [`fetch`] does that. Separated so the
 /// UI can optimistically show a queued badge the instant the user taps,

--- a/core/src/downloads.rs
+++ b/core/src/downloads.rs
@@ -273,13 +273,16 @@ pub fn delete(db: &Database, track_id: &str) -> Result<()> {
 }
 
 /// Delete every download: truncate the `downloads` table and unlink each
-/// row's on-disk file. Logout / server-switch cleanup — rows are keyed on
-/// server-specific track ids, so an entry surviving into a session against a
-/// different server would list the old server's items and report the old ids
-/// on offline playback.
+/// completed row's on-disk file (plus its `.part` sibling). Logout /
+/// server-switch cleanup — rows are keyed on server-specific track ids, so an
+/// entry surviving into a session against a different server would list the
+/// old server's items and report the old ids on offline playback.
 ///
-/// File unlinks are best-effort, matching [`delete`]; a row whose fetch never
-/// completed has no `local_path` and only its `.part` leftover is attempted.
+/// File unlinks are best-effort, matching [`delete`]. Rows that never
+/// completed have no `local_path`, so a fetch still in flight at logout can
+/// leave its `.part` behind — accepted: the file name is deterministic, so a
+/// future fetch of the same track overwrites it, and a `.part` is never
+/// served (only `done` rows with an existing file resolve offline).
 pub fn clear_all(db: &Database) -> Result<()> {
     for path in db.downloads_clear()? {
         let _ = std::fs::remove_file(&path);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -425,6 +425,13 @@ impl LyrebirdCore {
             if let Err(e) = inner.db.clear_user_data() {
                 tracing::warn!("clear_user_data failed (continuing): {e}");
             }
+            // Download rows are keyed on server-specific track ids, so they
+            // must not survive into a session against a different server —
+            // a stale entry would surface the old server's items in the
+            // Downloads screen and report the old ids on offline playback.
+            if let Err(e) = downloads::clear_all(&inner.db) {
+                tracing::warn!("downloads::clear_all failed (continuing): {e}");
+            }
             if let (Some(sid), Some(uname)) = (server_id, username) {
                 let _ = CredentialStore::delete_token(&sid, &uname);
             }

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -417,6 +417,21 @@ impl Database {
         Ok(path)
     }
 
+    /// Delete every row of the `downloads` table, returning the `local_path`s
+    /// that were recorded so the caller can unlink the files on disk. See
+    /// [`crate::downloads::clear_all`] — file IO stays out of the storage
+    /// layer by contract.
+    pub fn downloads_clear(&self) -> Result<Vec<String>> {
+        let conn = self.conn.lock();
+        let mut stmt =
+            conn.prepare("SELECT local_path FROM downloads WHERE local_path IS NOT NULL")?;
+        let paths = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        conn.execute("DELETE FROM downloads", [])?;
+        Ok(paths)
+    }
+
     /// Fetch a single download row by track id, or `None` when absent.
     pub fn download_get(&self, track_id: &str) -> Result<Option<DownloadRow>> {
         let conn = self.conn.lock();

--- a/core/src/tests/downloads.rs
+++ b/core/src/tests/downloads.rs
@@ -553,3 +553,40 @@ async fn download_concurrent_fetches_respect_shared_budget() {
     assert!(used <= 100, "used {used} exceeded budget 100");
     assert_eq!(count, 1, "exactly one download should remain within budget");
 }
+
+#[test]
+fn clear_all_removes_rows_and_files() {
+    use crate::downloads;
+    let db = Database::in_memory().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    // One completed download with a real file plus a stale `.part` leftover,
+    // and one still-queued row with no file yet.
+    let done = dl_track("t-done-clear", None, 0);
+    let queued = dl_track("t-queued-clear", None, 0);
+    let json_done = serde_json::to_string(&done).unwrap();
+    let json_queued = serde_json::to_string(&queued).unwrap();
+
+    let audio = dir.path().join("t-done-clear.mp3");
+    std::fs::write(&audio, b"bytes").unwrap();
+    let part = audio.with_extension("part");
+    std::fs::write(&part, b"partial").unwrap();
+
+    db.download_upsert_queued("t-done-clear", &json_done, 1).unwrap();
+    db.download_mark_done("t-done-clear", audio.to_str().unwrap(), 5, Some("mp3"), 2)
+        .unwrap();
+    db.download_upsert_queued("t-queued-clear", &json_queued, 3).unwrap();
+
+    downloads::clear_all(&db).unwrap();
+
+    assert!(
+        downloads::list(&db).unwrap().is_empty(),
+        "every download row should be cleared"
+    );
+    assert!(!audio.exists(), "the completed file should be unlinked");
+    assert!(!part.exists(), "the stale .part should be unlinked");
+
+    // Idempotent on an already-empty table.
+    downloads::clear_all(&db).unwrap();
+    assert!(downloads::list(&db).unwrap().is_empty());
+}

--- a/core/src/tests/session_auth.rs
+++ b/core/src/tests/session_auth.rs
@@ -247,6 +247,13 @@ async fn logout_clears_persisted_settings() {
         let _ = core
             .login(server_url, "logout-user".into(), "pw".into())
             .expect("login");
+        // Seed a download row so the wipe below can prove the downloads
+        // table doesn't survive a logout (its track ids are server-specific).
+        core.inner
+            .lock()
+            .db
+            .download_upsert_queued("t-logout-dl", "{}", 1)
+            .expect("seed download row");
         core.logout().expect("logout");
 
         {
@@ -255,6 +262,10 @@ async fn logout_clears_persisted_settings() {
             assert_eq!(inner.db.get_setting("last_username").unwrap(), None);
             assert_eq!(inner.db.get_setting("last_server_id").unwrap(), None);
             assert_eq!(inner.db.get_setting("last_user_id").unwrap(), None);
+            assert!(
+                inner.db.download_list().expect("download_list").is_empty(),
+                "logout must clear the downloads table"
+            );
         }
         assert!(
             CredentialStore::load_token("srv-logout", "logout-user")


### PR DESCRIPTION
Closes #1014.

`logout()` wiped the library caches and session keys via `clear_user_data` but left the `downloads` table — and its on-disk files — untouched. After a logout + login to a different server, the Downloads screen listed the old server's items, and offline playback of one would have reported the old server's item ids against the new server's `/Sessions/Playing` endpoints (the corruption path described in the issue).

**Change.**
- `Database::downloads_clear()` (storage.rs): truncates the table and returns the recorded `local_path`s — file IO stays out of the storage layer per the module contract.
- `downloads::clear_all(db)`: unlinks each returned file and its `.part` leftover (best-effort, matching `delete()`), after the row wipe.
- `logout()` (lib.rs) calls `downloads::clear_all` beside `clear_user_data`, log-and-continue on error like the rest of the cleanup block.
- The Swift side already clears its in-memory list on sign-out (`AppModel+Session.swift:251`), so no app change is needed.

No FFI surface change (`clear_all` is internal to `logout`), so bindings/xcframework are untouched.

**Tests.** New `clear_all_removes_rows_and_files` (rows truncated; completed file + stale `.part` unlinked; idempotent on empty), and `logout_clears_persisted_settings` now seeds a download row and asserts the table is empty after logout. Full core suite: 340 passed; clippy clean.