### PR TITLE
style(core): rustfmt the clear_all downloads test

### DIFF
--- a/core/src/tests/downloads.rs
+++ b/core/src/tests/downloads.rs
@@ -572,10 +572,12 @@ fn clear_all_removes_rows_and_files() {
     let part = audio.with_extension("part");
     std::fs::write(&part, b"partial").unwrap();
 
-    db.download_upsert_queued("t-done-clear", &json_done, 1).unwrap();
+    db.download_upsert_queued("t-done-clear", &json_done, 1)
+        .unwrap();
     db.download_mark_done("t-done-clear", audio.to_str().unwrap(), 5, Some("mp3"), 2)
         .unwrap();
-    db.download_upsert_queued("t-queued-clear", &json_queued, 3).unwrap();
+    db.download_upsert_queued("t-queued-clear", &json_queued, 3)
+        .unwrap();
 
     downloads::clear_all(&db).unwrap();
 


### PR DESCRIPTION
Mechanical `cargo fmt --all` output — the test added in #1062 wasn't fmt-clean, which is the only red job on main's CI run for ed76d90 (clippy/tests/macOS app/MSRV all green). No behavior change; skipping adversarial review for a formatter-only diff since CI's rustfmt gate is the verifier.