### PR TITLE
perf(core): large-library SQLite pragmas + bounded PRAGMA optimize

### DIFF
--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -21,6 +21,37 @@ impl Database {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
+        // Large-library tuning (#430). The page cache default (~2 MB) thrashes
+        // on a 20k-album cache walk; -20000 = ~20 MB, sized so a full
+        // `cache_list` page read stays in memory. `temp_store = MEMORY` keeps
+        // ORDER BY spill sorts off disk, and the 256 MB read-only mmap turns
+        // sequential cache scans into page-cache reads. `analysis_limit`
+        // bounds every `PRAGMA optimize` pass (run after bulk cache writes)
+        // so it never degrades into a full-table ANALYZE on the UI's watch —
+        // the four values together are SQLite's documented recipe for
+        // long-lived desktop connections.
+        conn.pragma_update(None, "cache_size", -20000)?;
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        conn.pragma_update(None, "mmap_size", 268_435_456_i64)?;
+        conn.pragma_update(None, "analysis_limit", 400)?;
+        let db = Database {
+            conn: Mutex::new(conn),
+        };
+        db.migrate()?;
+        // Seed planner statistics for any table still missing them (cheap
+        // no-op when `sqlite_stat1` is already populated, bounded by
+        // `analysis_limit` otherwise).
+        db.optimize()?;
+        Ok(db)
+    }
+
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        // Match the on-disk connection's bounded-ANALYZE setting so the
+        // `optimize()` calls sprinkled through the write paths behave the
+        // same under test as in the app.
+        conn.pragma_update(None, "analysis_limit", 400)?;
         let db = Database {
             conn: Mutex::new(conn),
         };
@@ -28,14 +59,27 @@ impl Database {
         Ok(db)
     }
 
-    pub fn in_memory() -> Result<Self> {
-        let conn = Connection::open_in_memory()?;
-        conn.pragma_update(None, "foreign_keys", "ON")?;
-        let db = Database {
-            conn: Mutex::new(conn),
-        };
-        db.migrate()?;
-        Ok(db)
+    /// Run `PRAGMA optimize` — SQLite's self-tuning hook that re-ANALYZEs
+    /// exactly the tables whose statistics are missing or stale. Bounded by
+    /// the `analysis_limit` set at open, so a pass over the 20k-row caches
+    /// costs microseconds when there's nothing to do and a bounded sample
+    /// scan when there is.
+    ///
+    /// Called at open (seeds stats on first launch) and after bulk
+    /// `cache_upsert` batches (the only writes big enough to skew the
+    /// planner). The process-lifetime connection never closes cleanly on
+    /// quit, so the usual run-at-close advice doesn't apply here.
+    pub fn optimize(&self) -> Result<()> {
+        self.conn.lock().execute_batch("PRAGMA optimize;")?;
+        Ok(())
+    }
+
+    /// Test seam: run `f` against the raw connection. Lets the pragma and
+    /// `EXPLAIN QUERY PLAN` regression tests inspect connection state without
+    /// growing the public surface.
+    #[cfg(test)]
+    pub(crate) fn with_conn<T>(&self, f: impl FnOnce(&Connection) -> T) -> T {
+        f(&self.conn.lock())
     }
 
     fn migrate(&self) -> Result<()> {
@@ -258,6 +302,14 @@ impl Database {
             }
         }
         tx.commit()?;
+        if !changed.is_empty() {
+            // Refresh planner statistics after a bulk write batch. Inlined on
+            // the held connection (`optimize()` would re-lock); bounded by the
+            // `analysis_limit` pragma and a no-op while stats are still
+            // representative, so per-page cost during a full library dump is
+            // negligible.
+            conn.execute_batch("PRAGMA optimize;")?;
+        }
         Ok(changed)
     }
 

--- a/core/src/tests/library_cache.rs
+++ b/core/src/tests/library_cache.rs
@@ -822,3 +822,73 @@ async fn revalidation_noop_delta_is_two_cheap_album_requests() {
     assert_eq!(core.list_cached_artists(10).unwrap().len(), 1);
     drop_core(core).await;
 }
+
+// ---------------------------------------------------------------------------
+// Large-library SQLite tuning (#430)
+// ---------------------------------------------------------------------------
+
+/// The on-disk connection must carry the large-library pragma set: WAL (from
+/// the original open path) plus the #430 additions — ~20 MB page cache,
+/// in-memory temp store, 256 MB read-only mmap, and the bounded
+/// `analysis_limit` that keeps every `PRAGMA optimize` pass cheap.
+#[test]
+fn open_applies_large_library_pragmas() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = crate::storage::Database::open(tmp.path().join("pragmas.sqlite")).unwrap();
+    db.with_conn(|c| {
+        let journal: String = c
+            .pragma_query_value(None, "journal_mode", |r| r.get(0))
+            .unwrap();
+        assert_eq!(journal.to_lowercase(), "wal");
+        let cache_size: i64 = c
+            .pragma_query_value(None, "cache_size", |r| r.get(0))
+            .unwrap();
+        assert_eq!(cache_size, -20000);
+        let temp_store: i64 = c
+            .pragma_query_value(None, "temp_store", |r| r.get(0))
+            .unwrap();
+        assert_eq!(temp_store, 2, "temp_store should resolve to MEMORY (2)");
+        let mmap: i64 = c
+            .pragma_query_value(None, "mmap_size", |r| r.get(0))
+            .unwrap();
+        assert_eq!(mmap, 268_435_456);
+        let analysis_limit: i64 = c
+            .pragma_query_value(None, "analysis_limit", |r| r.get(0))
+            .unwrap();
+        assert_eq!(analysis_limit, 400);
+    });
+}
+
+/// Regression guard for the warm-launch read path: the `cache_list` page
+/// query must walk `idx_album_cache_sort` rather than scanning + sorting the
+/// whole table — on a 20k-row cache the difference is an index walk touching
+/// `limit` rows vs. a full-table temp-B-tree sort.
+#[test]
+fn cache_page_query_uses_sort_key_index() {
+    let db = Database::in_memory().unwrap();
+    let writes: Vec<CacheWrite> = (0..25)
+        .map(|i| CacheWrite {
+            id: format!("a{i:02}"),
+            data: format!("{{\"id\":\"a{i:02}\"}}"),
+            sort_key: format!("k{i:02}"),
+        })
+        .collect();
+    db.cache_upsert(CacheKind::Album, &writes, 1).unwrap();
+
+    let plan: Vec<String> = db.with_conn(|c| {
+        let mut stmt = c
+            .prepare(
+                "EXPLAIN QUERY PLAN \
+                 SELECT data FROM album_cache ORDER BY sort_key ASC, id ASC LIMIT 100",
+            )
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(3))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    });
+    assert!(
+        plan.iter().any(|d| d.contains("idx_album_cache_sort")),
+        "page query should use the sort_key index; plan was: {plan:?}"
+    );
+}


### PR DESCRIPTION
Closes #430.

**What's left of the issue** (scoping comment posted there): the index asks are obsolete — `play_history` was removed, no query reads `updated_at`, and the sort-key indexes the issue anticipated landed in `003_library_cache_sort.sql`. WAL + `synchronous=NORMAL` were already set. The remaining substance is pragma tuning and statistics upkeep.

**Change.**
- `Database::open` adds `cache_size = -20000` (~20 MB page cache vs the ~2 MB default), `temp_store = MEMORY` (ORDER BY spills stay off disk), `mmap_size = 256 MB` (sequential cache scans become page-cache reads), and `analysis_limit = 400` (bounds every ANALYZE pass).
- `PRAGMA optimize` runs at open (seeds planner stats on first launch) and after each non-empty `cache_upsert` batch — inlined on the held connection to avoid re-locking. With `analysis_limit` it's microseconds when stats are fresh and a bounded sample when they're not. The connection is process-lifetime and never closes cleanly on quit, so SQLite's run-at-close advice has no hook here; open + post-bulk-write are the realistic seams.
- `in_memory()` gets the same `analysis_limit` so tests exercise the same optimize behavior.
- Tests: `open_applies_large_library_pragmas` (pins all five pragma values on a file-backed DB via a new `cfg(test)` connection seam) and `cache_page_query_uses_sort_key_index` (EXPLAIN QUERY PLAN must show `idx_album_cache_sort` for the warm-launch page query — the guard against a future schema change silently degrading the 20k-row read into a temp-B-tree sort).

No FFI surface change. `cargo test`: 342 passed; `cargo fmt --all --check` and clippy clean.