### PR TITLE
feat(macos): surface AVPlayerItem access-log telemetry in logs and the debug panel

### DIFF
--- a/macos/Sources/Lyrebird/AppModel+DebugPanel.swift
+++ b/macos/Sources/Lyrebird/AppModel+DebugPanel.swift
@@ -72,7 +72,12 @@ extension AppModel {
             dspPipelineEnabled: audio.dspPipelineEnabled,
             offlinePlaybackEnabled: audio.offlinePlaybackEnabled,
             normalizationMode: String(describing: audio.normalizationMode),
-            preGainDb: audio.normalizationPreGainDb
+            preGainDb: audio.normalizationPreGainDb,
+            accessLogStalls: playerAccessLogStats?.numberOfStalls,
+            accessLogIndicatedBitrate: playerAccessLogStats?.indicatedBitrate,
+            accessLogObservedBitrate: playerAccessLogStats?.observedBitrate,
+            accessLogDownloadOverdue: playerAccessLogStats?.downloadOverdue,
+            accessLogServerAddress: playerAccessLogStats?.serverAddress
         )
 
         // Queue section — counts only; no track names in the panel output.
@@ -128,6 +133,13 @@ extension AppModel {
         partial.cache = cacheSection
         partial.flags = flagsSection
         partial.network = networkSection
+
+        // Publish the synchronous sections right away — the panel shows
+        // fresh main-actor state instantly instead of waiting out the IO
+        // tail below (the OSLog query alone can take seconds); the task
+        // re-publishes the same snapshot with cache sizes + log tail
+        // filled in.
+        debugSnapshot = partial
 
         // Capture Nuke pipeline references on the main actor before hopping off.
         // `Artwork.pipeline` is main-actor-isolated; capturing here satisfies
@@ -228,6 +240,13 @@ struct DebugSnapshot {
         var offlinePlaybackEnabled: Bool = false
         var normalizationMode: String = "—"
         var preGainDb: Double = 0
+        /// Latest access-log entry from the playing item (#452); nil until
+        /// the first entry arrives or after playback stops.
+        var accessLogStalls: Int?
+        var accessLogIndicatedBitrate: Double?
+        var accessLogObservedBitrate: Double?
+        var accessLogDownloadOverdue: Int?
+        var accessLogServerAddress: String?
     }
 
     struct QueueSection {
@@ -335,6 +354,8 @@ struct DebugSnapshot {
             "offlinePlaybackEnabled": player.offlinePlaybackEnabled,
             "normalizationMode": player.normalizationMode,
             "preGainDb": player.preGainDb,
+            "accessLogStalls": player.accessLogStalls ?? -1,
+            "accessLogObservedBitrate": player.accessLogObservedBitrate ?? -1,
         ] as [String: Any]
 
         dict["queue"] = [

--- a/macos/Sources/Lyrebird/AppModel+DebugPanel.swift
+++ b/macos/Sources/Lyrebird/AppModel+DebugPanel.swift
@@ -355,7 +355,10 @@ struct DebugSnapshot {
             "normalizationMode": player.normalizationMode,
             "preGainDb": player.preGainDb,
             "accessLogStalls": player.accessLogStalls ?? -1,
+            "accessLogIndicatedBitrate": player.accessLogIndicatedBitrate ?? -1,
             "accessLogObservedBitrate": player.accessLogObservedBitrate ?? -1,
+            "accessLogDownloadOverdue": player.accessLogDownloadOverdue ?? -1,
+            "accessLogServerAddress": player.accessLogServerAddress ?? "(none)",
         ] as [String: Any]
 
         dict["queue"] = [

--- a/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
+++ b/macos/Sources/Lyrebird/AppModel+NowPlaying.swift
@@ -115,8 +115,10 @@ extension AppModel {
             // session down so `reportPlaybackStopped` + `stopHeartbeat` run —
             // otherwise the player keeps a stale `currentTrack` and the server
             // shows a frozen "Now Playing" until the next user action (the
-            // companion to the core heartbeat Ended-state guard).
-            audio.stop()
+            // companion to the core heartbeat Ended-state guard). Routed
+            // through `stop()` so the access-log snapshot clears with the
+            // stream.
+            stop()
             return
         }
         playInstantMix(seedId: seed.id, seedName: seed.name)

--- a/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
+++ b/macos/Sources/Lyrebird/AppModel+PlaybackControls.swift
@@ -18,7 +18,12 @@ extension AppModel {
 
     func pause() { audio.pause() }
     func resume() { audio.resume() }
-    func stop() { audio.stop() }
+    func stop() {
+        audio.stop()
+        // A stopped transport has no live stream; drop the access-log
+        // snapshot so the debug panel can't show a dead stream's numbers.
+        playerAccessLogStats = nil
+    }
 
     func skipNext() {
         if let next = core.skipNext() {

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -269,6 +269,7 @@ extension AppModel {
     /// short-circuits to `None` (safe), and the form is pre-populated.
     func forgetToken() {
         audio.stop()
+        playerAccessLogStats = nil
         try? core.forgetToken()
         albums = []
         artists = []
@@ -352,6 +353,7 @@ extension AppModel {
     func markAuthExpired() {
         guard !authExpired else { return }
         audio.stop()
+        playerAccessLogStats = nil
         stopStatusEventStream()
         authExpired = true
     }

--- a/macos/Sources/Lyrebird/AppModel+Session.swift
+++ b/macos/Sources/Lyrebird/AppModel+Session.swift
@@ -181,6 +181,7 @@ extension AppModel {
 
     func logout() {
         audio.stop()
+        playerAccessLogStats = nil
         // core.logout() does a blocking POST /Sessions/Logout; fire it off
         // the main actor so the UI clears immediately and the user isn't
         // staring at a stalled window for the network round-trip.

--- a/macos/Sources/Lyrebird/AppModel.swift
+++ b/macos/Sources/Lyrebird/AppModel.swift
@@ -636,6 +636,13 @@ final class AppModel {
     /// tracked separately in #440 — this flag only powers the prompt.
     var authExpired: Bool = false
 
+    /// Latest transport-health snapshot from the playing item's access log
+    /// (#452) — stalls, indicated/observed bitrate, overdue segments, server.
+    /// Fed by `audioEngineDidUpdateAccessLog`; cleared when playback stops so
+    /// the debug panel never shows a previous stream's numbers. Read by the
+    /// debug panel's Player tab.
+    var playerAccessLogStats: PlayerAccessLogStats?
+
     /// Playlist the user asked to delete from a context menu. Observed by
     /// `MainShell` to present a `.confirmationDialog`; cleared when the
     /// user confirms or dismisses. Single-shot rather than a list because
@@ -1445,6 +1452,13 @@ extension AppModel: AudioEngineDelegate {
     /// hand-off so the skip isn't silent.
     func audioEngineDidEncounterTransientError(_ message: String) {
         errorMessage = message
+    }
+
+    /// Latest access-log entry from the playing item (#452). Stored for the
+    /// debug panel's Player tab; the engine has already emitted the
+    /// structured log line.
+    func audioEngineDidUpdateAccessLog(_ stats: PlayerAccessLogStats) {
+        playerAccessLogStats = stats
     }
 
     /// Stall recovery rebuilds the current item via `replaceCurrentItem`,

--- a/macos/Sources/Lyrebird/Screens/DebugPanelView.swift
+++ b/macos/Sources/Lyrebird/Screens/DebugPanelView.swift
@@ -194,9 +194,29 @@ struct DebugPanelView: View {
                 DebugRow(label: "Normalization", value: p.normalizationMode)
                 DebugRow(label: "Pre-gain", value: String(format: "%+.1f dB", p.preGainDb))
             }
+            // Transport health from the playing item's access log (#452).
+            // Empty until AVPlayer appends the first entry (a few seconds
+            // into a stream); cleared on stop so a dead stream's numbers
+            // never linger.
+            DebugSection(title: "Stream (access log)") {
+                DebugRow(label: "Stalls", value: p.accessLogStalls.map(String.init) ?? "—")
+                DebugRow(label: "Indicated bitrate", value: Self.formatBitrate(p.accessLogIndicatedBitrate))
+                DebugRow(label: "Observed bitrate", value: Self.formatBitrate(p.accessLogObservedBitrate))
+                DebugRow(label: "Overdue segments", value: p.accessLogDownloadOverdue.map(String.init) ?? "—")
+                DebugRow(label: "Server", value: p.accessLogServerAddress ?? "—")
+            }
         }
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Render an access-log bitrate (bits/second) as a readable Mbps value;
+    /// em-dash when no entry has arrived yet. AVFoundation reports a
+    /// negative `observedBitrate` when it has no estimate — treat that as
+    /// "no data" rather than printing a nonsense negative rate.
+    static func formatBitrate(_ bitsPerSecond: Double?) -> String {
+        guard let bps = bitsPerSecond, bps >= 0 else { return "—" }
+        return String(format: "%.2f Mbps", bps / 1_000_000)
     }
 
     // MARK: - Queue tab

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -377,6 +377,9 @@ public final class AudioEngine: NSObject {
         if let end = endObserver {
             NotificationCenter.default.removeObserver(end)
         }
+        if let log = accessLogObserver {
+            NotificationCenter.default.removeObserver(log)
+        }
     }
 
     #if DEBUG

--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -67,6 +67,12 @@ public protocol AudioEngineDelegate: AnyObject {
     /// the `AVQueuePlayer` queue. The owner should re-arm gapless playback
     /// by calling `preloadNextTrack` for the upcoming track.
     func audioEngineDidRecover()
+
+    /// Called whenever the current item appends a new access-log entry
+    /// (`AVPlayerItemNewAccessLogEntry`) — roughly once per stream segment /
+    /// rebuffer. Carries the latest event's transport health so the owner can
+    /// surface live bitrate and stall counts (debug panel, issue #452).
+    func audioEngineDidUpdateAccessLog(_ stats: PlayerAccessLogStats)
 }
 
 public extension AudioEngineDelegate {
@@ -77,6 +83,40 @@ public extension AudioEngineDelegate {
     /// Default no-op so existing conformers don't have to implement the
     /// new recovery hook to compile.
     func audioEngineDidRecover() {}
+
+    /// Default no-op so conformers that don't surface stream telemetry
+    /// (mini player tests, fixtures) compile unchanged (#452).
+    func audioEngineDidUpdateAccessLog(_ stats: PlayerAccessLogStats) {}
+}
+
+/// Snapshot of the most recent `AVPlayerItemAccessLogEvent` on the playing
+/// item — the transport-health fields issue #452 surfaces. Plain value type
+/// so it can cross to the `@MainActor` owner and sit in view state.
+public struct PlayerAccessLogStats: Equatable, Sendable {
+    /// Total stall count for the current playback session (per access log).
+    public let numberOfStalls: Int
+    /// Bitrate the server advertised for the stream, bits per second.
+    public let indicatedBitrate: Double
+    /// Bitrate actually observed over the network, bits per second.
+    public let observedBitrate: Double
+    /// Segments that arrived later than their play deadline.
+    public let downloadOverdue: Int
+    /// Server address the bytes came from (load balancer visibility).
+    public let serverAddress: String?
+
+    public init(
+        numberOfStalls: Int,
+        indicatedBitrate: Double,
+        observedBitrate: Double,
+        downloadOverdue: Int,
+        serverAddress: String?
+    ) {
+        self.numberOfStalls = numberOfStalls
+        self.indicatedBitrate = indicatedBitrate
+        self.observedBitrate = observedBitrate
+        self.downloadOverdue = downloadOverdue
+        self.serverAddress = serverAddress
+    }
 }
 
 /// `AVQueuePlayer`-backed audio engine. Reports transport state back to the
@@ -119,6 +159,10 @@ public final class AudioEngine: NSObject {
     }
     private var timeObserver: Any?
     private var endObserver: NSObjectProtocol?
+    /// Notification observer for `AVPlayerItemNewAccessLogEntry` on the live
+    /// item (#452). Re-wired alongside `endObserver` whenever `currentItem`
+    /// changes so transport telemetry always tracks the playing stream.
+    private var accessLogObserver: NSObjectProtocol?
     private var rateObservation: NSKeyValueObservation?
     private var timeControlObservation: NSKeyValueObservation?
     /// KVO observation on `AVQueuePlayer.currentItem`. Fires whenever the
@@ -1067,6 +1111,7 @@ public final class AudioEngine: NSObject {
         // currentItem KVO handler below so every item in the queue fires
         // onTrackEnded correctly.
         wireEndObserver(to: item)
+        wireAccessLogObserver(to: item)
 
         // Watch the live item for transient network failures (#806). The
         // observers are re-attached inside the currentItem KVO handler
@@ -1097,6 +1142,7 @@ public final class AudioEngine: NSObject {
                 // Re-register end-of-item notification for the newly-current item.
                 if let current = player.currentItem {
                     self.wireEndObserver(to: current)
+                    self.wireAccessLogObserver(to: current)
                     // Re-attach failure KVO so transient-error detection
                     // follows gapless auto-advance instead of being pinned
                     // to the item that was current at play(track:) time
@@ -1305,6 +1351,39 @@ public final class AudioEngine: NSObject {
         }
     }
 
+    /// Register (or re-register) `accessLogObserver` against `item` (#452).
+    /// Wired everywhere `wireEndObserver(to:)` is, so the telemetry follows
+    /// the item that's actually playing. Each new log entry is emitted as a
+    /// structured log line (Console: subsystem org.lyrebird.desktop,
+    /// category player) and forwarded to the delegate for UI surfaces.
+    private func wireAccessLogObserver(to item: AVPlayerItem) {
+        if let old = accessLogObserver {
+            NotificationCenter.default.removeObserver(old)
+        }
+        accessLogObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.newAccessLogEntryNotification,
+            object: item,
+            queue: .main
+        ) { [weak self] note in
+            guard
+                let self,
+                let item = note.object as? AVPlayerItem,
+                let event = item.accessLog()?.events.last
+            else { return }
+            let stats = PlayerAccessLogStats(
+                numberOfStalls: event.numberOfStalls,
+                indicatedBitrate: event.indicatedBitrate,
+                observedBitrate: event.observedBitrate,
+                downloadOverdue: event.downloadOverdue,
+                serverAddress: event.serverAddress
+            )
+            engineLog.info(
+                "access-log: stalls=\(stats.numberOfStalls, privacy: .public) indicated_bps=\(Int(stats.indicatedBitrate), privacy: .public) observed_bps=\(Int(stats.observedBitrate), privacy: .public) overdue=\(stats.downloadOverdue, privacy: .public) server=\(stats.serverAddress ?? "—", privacy: .private(mask: .hash))"
+            )
+            self.delegate?.audioEngineDidUpdateAccessLog(stats)
+        }
+    }
+
     private func removePlayerObservers() {
         if let obs = timeObserver, let p = player {
             p.removeTimeObserver(obs)
@@ -1314,6 +1393,10 @@ public final class AudioEngine: NSObject {
             NotificationCenter.default.removeObserver(end)
         }
         endObserver = nil
+        if let log = accessLogObserver {
+            NotificationCenter.default.removeObserver(log)
+        }
+        accessLogObserver = nil
         rateObservation?.invalidate()
         rateObservation = nil
         timeControlObservation?.invalidate()
@@ -1424,6 +1507,7 @@ public final class AudioEngine: NSObject {
         // in place is intentional; all three target the AVQueuePlayer, not the
         // item, so they stay valid across the swap.
         wireEndObserver(to: item)
+        wireAccessLogObserver(to: item)
         // Re-attach failure KVO on the rebuilt item too (#806). If the
         // rebuilt stream also surfaces -1005/-1001/-1009 we still fail
         // fast on the next refailure instead of grinding through more

--- a/macos/Tests/LyrebirdTests/DebugPanelTests.swift
+++ b/macos/Tests/LyrebirdTests/DebugPanelTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 
 @testable import Lyrebird
+import LyrebirdAudio
 
 /// Coverage for the debug panel snapshot helpers (#448).
 ///
@@ -136,5 +137,89 @@ final class DebugPanelTests: XCTestCase {
         let snap = DebugSnapshot()
         XCTAssertEqual(snap.capturedAt.timeIntervalSince1970, 0,
                        "capturedAt default must be epoch (indicates no refresh yet)")
+    }
+}
+
+// MARK: - Access-log stream telemetry (#452)
+
+/// The access-log pipeline: delegate hook → stored stats → snapshot fields →
+/// panel formatting. The `AVPlayerItemNewAccessLogEntry` notification itself
+/// can't be unit-driven (`AVPlayerItemAccessLogEvent` has no public
+/// initializer), so the engine-side observer is verified manually; everything
+/// downstream of the delegate is pinned here.
+@MainActor
+final class AccessLogTelemetryTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        let dir = NSTemporaryDirectory() + "lyrebird-tests-\(UUID().uuidString)"
+        setenv("XDG_DATA_HOME", dir, 1)
+    }
+
+    private func stats(stalls: Int = 2) -> PlayerAccessLogStats {
+        PlayerAccessLogStats(
+            numberOfStalls: stalls,
+            indicatedBitrate: 1_410_000,
+            observedBitrate: 980_500,
+            downloadOverdue: 1,
+            serverAddress: "203.0.113.7"
+        )
+    }
+
+    func testDelegateHookStoresStats() throws {
+        let model = try AppModel()
+        model.audioEngineDidUpdateAccessLog(stats())
+        XCTAssertEqual(model.playerAccessLogStats?.numberOfStalls, 2)
+        XCTAssertEqual(model.playerAccessLogStats?.serverAddress, "203.0.113.7")
+    }
+
+    func testStopClearsStats() throws {
+        let model = try AppModel()
+        model.audioEngineDidUpdateAccessLog(stats())
+        model.stop()
+        XCTAssertNil(model.playerAccessLogStats)
+    }
+
+    /// `refreshDebugSnapshot` publishes the snapshot at the end of an async
+    /// IO task (disk-size collection), so tests must wait for `capturedAt`
+    /// to move past its pre-refresh value. Bounded at 2s — the IO is a
+    /// handful of stat calls against a temp data dir.
+    private func awaitSnapshotPublish(_ model: AppModel, after: Date) async throws {
+        for _ in 0..<200 {
+            if model.debugSnapshot.capturedAt > after { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("debugSnapshot was never published after refresh")
+    }
+
+    func testSnapshotCarriesAccessLogFields() async throws {
+        let model = try AppModel()
+        model.audioEngineDidUpdateAccessLog(stats(stalls: 5))
+        let before = model.debugSnapshot.capturedAt
+        model.refreshDebugSnapshot()
+        try await awaitSnapshotPublish(model, after: before)
+        let p = model.debugSnapshot.player
+        XCTAssertEqual(p.accessLogStalls, 5)
+        XCTAssertEqual(p.accessLogIndicatedBitrate, 1_410_000)
+        XCTAssertEqual(p.accessLogObservedBitrate, 980_500)
+        XCTAssertEqual(p.accessLogDownloadOverdue, 1)
+        XCTAssertEqual(p.accessLogServerAddress, "203.0.113.7")
+    }
+
+    func testSnapshotFieldsNilBeforeFirstEntry() async throws {
+        let model = try AppModel()
+        let before = model.debugSnapshot.capturedAt
+        model.refreshDebugSnapshot()
+        try await awaitSnapshotPublish(model, after: before)
+        XCTAssertNil(model.debugSnapshot.player.accessLogStalls)
+        XCTAssertNil(model.debugSnapshot.player.accessLogServerAddress)
+    }
+
+    func testBitrateFormatting() {
+        XCTAssertEqual(DebugPanelView.formatBitrate(1_410_000), "1.41 Mbps")
+        XCTAssertEqual(DebugPanelView.formatBitrate(nil), "—")
+        // AVFoundation reports a negative observedBitrate when it has no
+        // estimate — render as "no data", not a negative rate.
+        XCTAssertEqual(DebugPanelView.formatBitrate(-1), "—")
     }
 }

--- a/macos/Tests/LyrebirdTests/DebugPanelTests.swift
+++ b/macos/Tests/LyrebirdTests/DebugPanelTests.swift
@@ -180,24 +180,14 @@ final class AccessLogTelemetryTests: XCTestCase {
         XCTAssertNil(model.playerAccessLogStats)
     }
 
-    /// `refreshDebugSnapshot` publishes the snapshot at the end of an async
-    /// IO task (disk-size collection), so tests must wait for `capturedAt`
-    /// to move past its pre-refresh value. Bounded at 2s — the IO is a
-    /// handful of stat calls against a temp data dir.
-    private func awaitSnapshotPublish(_ model: AppModel, after: Date) async throws {
-        for _ in 0..<200 {
-            if model.debugSnapshot.capturedAt > after { return }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        XCTFail("debugSnapshot was never published after refresh")
-    }
+    // `refreshDebugSnapshot` publishes its synchronous sections immediately
+    // (the IO task only re-publishes with cache sizes + log tail later), so
+    // the access-log fields are assertable right after the call.
 
-    func testSnapshotCarriesAccessLogFields() async throws {
+    func testSnapshotCarriesAccessLogFields() throws {
         let model = try AppModel()
         model.audioEngineDidUpdateAccessLog(stats(stalls: 5))
-        let before = model.debugSnapshot.capturedAt
         model.refreshDebugSnapshot()
-        try await awaitSnapshotPublish(model, after: before)
         let p = model.debugSnapshot.player
         XCTAssertEqual(p.accessLogStalls, 5)
         XCTAssertEqual(p.accessLogIndicatedBitrate, 1_410_000)
@@ -206,11 +196,9 @@ final class AccessLogTelemetryTests: XCTestCase {
         XCTAssertEqual(p.accessLogServerAddress, "203.0.113.7")
     }
 
-    func testSnapshotFieldsNilBeforeFirstEntry() async throws {
+    func testSnapshotFieldsNilBeforeFirstEntry() throws {
         let model = try AppModel()
-        let before = model.debugSnapshot.capturedAt
         model.refreshDebugSnapshot()
-        try await awaitSnapshotPublish(model, after: before)
         XCTAssertNil(model.debugSnapshot.player.accessLogStalls)
         XCTAssertNil(model.debugSnapshot.player.accessLogServerAddress)
     }


### PR DESCRIPTION
Closes #452.

`AVPlayerItem.accessLog()` was ignored; its transport-health fields are exactly what you want when "why is this stream choppy" comes up. This wires it end to end:

- **Engine**: observes `AVPlayerItemNewAccessLogEntry` on the live item — wired beside the existing end-of-track observer at all three points (player setup, gapless `currentItem` advance, stall-recovery rebuild) so telemetry always follows the playing stream. Each entry emits one structured log line (subsystem `org.lyrebird.desktop`, category `player`) with stalls, indicated/observed bitrate, overdue segments, and the server address (hash-masked for privacy).
- **Model**: new `PlayerAccessLogStats` value type crosses via a new `audioEngineDidUpdateAccessLog` delegate hook (default no-op, same pattern as #806). Stats clear on `stop()`/`logout()` so a dead stream's numbers never linger in the panel.
- **Debug panel**: Player tab gains a "Stream (access log)" section — stalls, bitrates rendered in Mbps (AVFoundation's negative no-estimate `observedBitrate` renders as "—"), overdue segments, server. The acceptance criterion ("Player section shows live bitrate and stall count") is met via the panel's existing refresh; as part of this, `refreshDebugSnapshot` now publishes its synchronous sections immediately and lets the IO task re-publish with cache sizes/log tail — the panel paints fresh state instantly instead of waiting out the OSLog query (which can take seconds).
- **Tests**: `AccessLogTelemetryTests` (5) pin delegate→stored stats→snapshot fields→bitrate formatting, including the clear-on-stop behavior. `AVPlayerItemAccessLogEvent` has no public initializer, so the notification-side observer is declared manually-verified.

No FFI/core change. `swift build` clean; all 1127 package tests pass.