### PR TITLE
chore(observability): allowlist breadcrumb scrub + CI privacy grep gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [fmt, clippy, test, docs, msrv, macos-app, windows]
+    needs: [fmt, privacy, clippy, test, docs, msrv, macos-app, windows]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  privacy:
+    name: privacy grep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Telemetry call sites must not interpolate library/user names; the
+      # runtime allowlist scrub (CrashReporting.swift) is the enforcement,
+      # this grep is the review-time tripwire.
+      - run: ./Scripts/privacy-grep.sh
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/Scripts/privacy-grep.sh
+++ b/Scripts/privacy-grep.sh
@@ -16,8 +16,10 @@ if grep -rnE 'tracing::(trace|debug|info|warn|error)!\([^)]*\b(track|album|artis
   fail=1
 fi
 
-# Swift: breadcrumb payload lines carrying the same fields.
-if grep -rnE '(Breadcrumb\(|addBreadcrumb|crumb\.data)[^"]*\b(track|album|artist|user)\.name' macos/Sources --include='*.swift'; then
+# Swift: breadcrumb payload lines carrying the same fields. Tests are in
+# scope too — a fixture that interpolates a real name field would
+# normalize the pattern the gate exists to keep out.
+if grep -rnE '(Breadcrumb\(|addBreadcrumb|crumb\.data)[^"]*\b(track|album|artist|user)\.name' macos/Sources macos/Tests --include='*.swift'; then
   fail=1
 fi
 

--- a/Scripts/privacy-grep.sh
+++ b/Scripts/privacy-grep.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Privacy gate: telemetry call sites must not interpolate library/user
+# names. Breadcrumbs and tracing events carry bookkeeping only — the
+# allowlist scrub in CrashReporting.swift enforces it at runtime for
+# Sentry; this grep keeps new call sites from smuggling names into either
+# transport at review time. Heuristic and single-line by design: cheap,
+# zero-dependency, and good enough to catch the realistic accident.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# Rust: tracing macros interpolating name/title fields of library or user
+# records on the macro line.
+if grep -rnE 'tracing::(trace|debug|info|warn|error)!\([^)]*\b(track|album|artist|user)\.(name|title)' core/src --include='*.rs'; then
+  fail=1
+fi
+
+# Swift: breadcrumb payload lines carrying the same fields.
+if grep -rnE '(Breadcrumb\(|addBreadcrumb|crumb\.data)[^"]*\b(track|album|artist|user)\.name' macos/Sources --include='*.swift'; then
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo 'privacy-grep: telemetry call site interpolates a library/user name — route it through the allowlisted breadcrumb keys instead' >&2
+  exit 1
+fi
+echo "privacy-grep: clean"

--- a/macos/Sources/Lyrebird/System/CrashReporting.swift
+++ b/macos/Sources/Lyrebird/System/CrashReporting.swift
@@ -184,19 +184,37 @@ enum CrashReporter {
         return event
     }
 
+    /// Keys a kept breadcrumb's `data` payload may carry to the crash
+    /// transport. Everything else is stripped before the crumb leaves the
+    /// process — an allowlist beats the type-based drops alone because a
+    /// future call site can't smuggle library metadata (track names, hosts)
+    /// through a key nobody anticipated. `backtrace` is the Rust panic
+    /// forwarder's capped trace; the rest are inert bookkeeping fields.
+    nonisolated static let allowedBreadcrumbDataKeys: Set<String> = [
+        "action", "screen", "duration_ms", "error_category", "backtrace",
+    ]
+
     /// Returns `nil` (dropping the crumb) for any breadcrumb that carries
     /// a URL, a network request, or a navigation data string that could
-    /// contain library metadata. Keeps level/type bookkeeping breadcrumbs.
+    /// contain library metadata; kept crumbs have their `data` scrubbed to
+    /// `allowedBreadcrumbDataKeys`. Level/type bookkeeping survives intact.
     nonisolated static func shouldKeepBreadcrumb(_ crumb: Breadcrumb) -> Breadcrumb? {
         // Drop network request breadcrumbs entirely — the URL encodes the
         // Jellyfin server address and optionally query params with ids.
         if crumb.type == "http" { return nil }
 
-        // Drop breadcrumbs that carry a `url` data field.
+        // Drop breadcrumbs that carry a `url` data field. (The allowlist
+        // below would strip the field, but a crumb built around a URL has
+        // no diagnostic value once it's gone — drop it whole.)
         if let data = crumb.data, data["url"] != nil { return nil }
 
         // Drop navigation breadcrumbs whose `to`/`from` might encode content.
         if crumb.type == "navigation" { return nil }
+
+        // Allowlist scrub for everything that survives the drops.
+        if let data = crumb.data {
+            crumb.data = data.filter { allowedBreadcrumbDataKeys.contains($0.key) }
+        }
 
         return crumb
     }

--- a/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
+++ b/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
@@ -233,6 +233,16 @@ final class CrashReporterDecisionTests: XCTestCase {
         XCTAssertNil(result, "breadcrumbs carrying a url data field must be dropped")
     }
 
+    func testAllowlistIsExactlyTheDocumentedSet() {
+        // Pin the set so adding or dropping a key is a conscious test edit —
+        // silently dropping `backtrace` would gut Rust panic reports, and a
+        // new key widens what can leave the process.
+        XCTAssertEqual(
+            CrashReporter.allowedBreadcrumbDataKeys,
+            ["action", "screen", "duration_ms", "error_category", "backtrace"]
+        )
+    }
+
     func testKeptBreadcrumbDataIsScrubbedToAllowlist() {
         // A populated payload mixing whitelisted bookkeeping with smuggled
         // library metadata: only the allowlisted keys may survive.

--- a/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
+++ b/macos/Tests/LyrebirdTests/CrashReporterDecisionTests.swift
@@ -233,6 +233,38 @@ final class CrashReporterDecisionTests: XCTestCase {
         XCTAssertNil(result, "breadcrumbs carrying a url data field must be dropped")
     }
 
+    func testKeptBreadcrumbDataIsScrubbedToAllowlist() {
+        // A populated payload mixing whitelisted bookkeeping with smuggled
+        // library metadata: only the allowlisted keys may survive.
+        let crumb = Breadcrumb(level: .info, category: "playback")
+        crumb.data = [
+            "action": "skip_next",
+            "screen": "library",
+            "duration_ms": 42,
+            "error_category": "network",
+            "trackName": "Nessuno al mondo",
+            "artist": "Mina",
+            "server_host": "music.example.com",
+        ]
+        let result = CrashReporter.shouldKeepBreadcrumb(crumb)
+        let keys = Set((result?.data ?? [:]).keys)
+        XCTAssertEqual(
+            keys,
+            ["action", "screen", "duration_ms", "error_category"],
+            "non-allowlisted keys must be stripped before the crumb leaves the process"
+        )
+    }
+
+    func testRustPanicBacktraceSurvivesScrub() {
+        // The Rust panic forwarder attaches its capped backtrace under
+        // `backtrace`; the allowlist must let it through or panic reports
+        // lose their only useful payload.
+        let crumb = Breadcrumb(level: .fatal, category: "rust.panic")
+        crumb.data = ["backtrace": "0: rust_begin_unwind\n1: core::panicking"]
+        let result = CrashReporter.shouldKeepBreadcrumb(crumb)
+        XCTAssertNotNil(result?.data?["backtrace"], "backtrace is allowlisted for rust.panic crumbs")
+    }
+
     func testGenericBreadcrumbIsKept() {
         let crumb = Breadcrumb(level: .info, category: "lifecycle")
         crumb.type = "default"


### PR DESCRIPTION
Closes #453.

**Runtime half**: `CrashReporter.shouldKeepBreadcrumb` keeps its existing drop rules (http crumbs, url-bearing payloads, navigation crumbs) and now scrubs every surviving crumb's `data` to an allowlist — `action`, `screen`, `duration_ms`, `error_category`, plus `backtrace` for the Rust panic forwarder's capped trace. Allowlisting beats the denylist alone: a future call site can't leak track names or hosts through an unanticipated key. Two new tests pin the behavior (mixed payload scrubs to exactly the allowlist; rust.panic backtrace survives).

**Review-time half**: `Scripts/privacy-grep.sh` fails on any `tracing::…!` or breadcrumb call site that interpolates `track/album/artist/user .name`/`.title`, wired as an independent, dependency-free `privacy` job in ci.yml (checkout + one script). The codebase greps clean today.

**Scoping vs the issue text** (also noted in the commit): no tracing call Debug-prints library structs today, so the `#[derive(Debug)]`-stripping ask reduces to the CI gate keeping it that way; the runtime scrub covers the only telemetry transport that exists (Sentry — the "Issue 24 telemetry" second transport was never built).

`swift build` clean; all 1124 package tests pass; `privacy-grep` clean.