### PR TITLE
docs(macos): uninstall and data-locations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ swift build                     # Builds the SwiftUI app
 open build/Lyrebird.app
 ```
 
+### Uninstall
+
+Dragging the app to the Trash leaves data behind (database, caches,
+keychain token). See [Uninstall and data locations](macos/DISTRIBUTION.md#uninstall-and-data-locations)
+for every path and a copy-paste removal block.
+
 ### Headless smoke test
 
 Exercises login + playback without the UI. Useful in CI.

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -593,7 +593,7 @@ locations below — all paths are the app's real identifiers as of 2.0
 | --- | --- |
 | App bundle | `/Applications/Lyrebird.app` (or wherever it was dragged) |
 | Library database + state | `~/Library/Application Support/lyrebird-desktop/` (`lyrebird.db` + `-wal`/`-shm` companions) |
-| Offline downloads | `~/Library/Application Support/lyrebird-desktop/downloads/` — unless a custom folder was chosen in Settings ▸ Downloads, in which case remove that folder |
+| Offline downloads | `~/Library/Application Support/lyrebird-desktop/downloads/` (the location Settings ▸ Downloads displays) |
 | Preferences (incl. Sparkle updater state) | `~/Library/Preferences/org.lyrebird.desktop.plist` |
 | Caches (incl. crash-report envelopes) | `~/Library/Caches/org.lyrebird.desktop/` |
 | Artwork cache (Nuke) | `~/Library/Caches/com.lyrebird.macos.artwork/` |
@@ -612,10 +612,14 @@ rm -rf "$HOME/Library/Caches/com.lyrebird.macos.artwork"
 while security delete-generic-password -s org.lyrebird.desktop >/dev/null 2>&1; do :; done
 ```
 
-Signing out inside the app (Settings ▸ Server ▸ Sign Out) before
-uninstalling also works: it deletes the keychain token, wipes the
-user-scoped database rows, and clears downloads, leaving only empty
-scaffolding for the `rm -rf` lines above.
+Signing out from the sidebar's door button (next to the server status)
+before uninstalling also clears the live account's footprint: it deletes
+the keychain token, wipes the user-scoped database rows, and removes
+downloads, leaving only empty scaffolding for the `rm -rf` lines above.
+The Settings ▸ Server actions intentionally keep local data for a fast
+re-login and do NOT perform that wipe (see #1068 for the cross-account
+caveat) — for a full cleanup use the sidebar sign-out or the commands
+above.
 
 ## Reference
 

--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -582,9 +582,44 @@ Deploy from a branch → Branch: gh-pages / (root)**.
   DMG wasn't notarized or the staple wasn't applied. Re-run
   `notarize.sh` locally on the DMG and re-upload to the GitHub release.
 
+## Uninstall and data locations
+
+macOS has no uninstall standard; dragging `Lyrebird.app` to the Trash
+leaves the app's data behind. Everything Lyrebird writes lives in the
+locations below — all paths are the app's real identifiers as of 2.0
+(`org.lyrebird.desktop` bundle id, `lyrebird-desktop` data folder).
+
+| What | Where |
+| --- | --- |
+| App bundle | `/Applications/Lyrebird.app` (or wherever it was dragged) |
+| Library database + state | `~/Library/Application Support/lyrebird-desktop/` (`lyrebird.db` + `-wal`/`-shm` companions) |
+| Offline downloads | `~/Library/Application Support/lyrebird-desktop/downloads/` — unless a custom folder was chosen in Settings ▸ Downloads, in which case remove that folder |
+| Preferences (incl. Sparkle updater state) | `~/Library/Preferences/org.lyrebird.desktop.plist` |
+| Caches (incl. crash-report envelopes) | `~/Library/Caches/org.lyrebird.desktop/` |
+| Artwork cache (Nuke) | `~/Library/Caches/com.lyrebird.macos.artwork/` |
+| Keychain | Generic-password items under service `org.lyrebird.desktop` — one per signed-in server/user (session token) plus the ListenBrainz token if scrobbling was linked |
+| Logs | Unified log only (subsystem `org.lyrebird.desktop`) — nothing on disk to remove; entries age out with the system log |
+
+Copy-paste removal (run after quitting the app):
+
+```bash
+rm -rf "$HOME/Library/Application Support/lyrebird-desktop"
+defaults delete org.lyrebird.desktop 2>/dev/null
+rm -f "$HOME/Library/Preferences/org.lyrebird.desktop.plist"
+rm -rf "$HOME/Library/Caches/org.lyrebird.desktop"
+rm -rf "$HOME/Library/Caches/com.lyrebird.macos.artwork"
+# Keychain: repeat until it reports "could not be found".
+while security delete-generic-password -s org.lyrebird.desktop >/dev/null 2>&1; do :; done
+```
+
+Signing out inside the app (Settings ▸ Server ▸ Sign Out) before
+uninstalling also works: it deletes the keychain token, wipes the
+user-scoped database rows, and clears downloads, leaving only empty
+scaffolding for the `rm -rf` lines above.
+
 ## Reference
 
 - Sparkle 2 docs: <https://sparkle-project.org/documentation/>
 - Apple notary service: <https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution>
-- Issues this doc addresses: #183, #184, #185, #186, #188, #189, #190.
+- Issues this doc addresses: #183, #184, #185, #186, #188, #189, #190, #197.
 


### PR DESCRIPTION
Closes #197.

Adds "Uninstall and data locations" to `macos/DISTRIBUTION.md` — a table of every path the app writes, all verified against the code rather than the issue text (which predates the Lyrebird rename): the `lyrebird-desktop` Application Support dir (SQLite DB + downloads, with the custom-folder caveat from Settings ▸ Downloads), `org.lyrebird.desktop` preferences/caches, the `com.lyrebird.macos.artwork` Nuke cache, keychain generic-password items under service `org.lyrebird.desktop` (per-session tokens + ListenBrainz), and the log situation (unified log only, nothing on disk). Includes a copy-paste removal block (with a keychain delete loop) and notes that in-app sign-out already removes the token, user-scoped DB rows, and downloads. README links the section from quick-start.

Docs only — no code change.