### PR TITLE
fix(macos): Change User / Switch Server run the full logout wipe

### DIFF
--- a/macos/DISTRIBUTION.md
+++ b/macos/DISTRIBUTION.md
@@ -616,10 +616,9 @@ Signing out from the sidebar's door button (next to the server status)
 before uninstalling also clears the live account's footprint: it deletes
 the keychain token, wipes the user-scoped database rows, and removes
 downloads, leaving only empty scaffolding for the `rm -rf` lines above.
-The Settings ▸ Server actions intentionally keep local data for a fast
-re-login and do NOT perform that wipe (see #1068 for the cross-account
-caveat) — for a full cleanup use the sidebar sign-out or the commands
-above.
+The Settings ▸ Server actions (Sign Out, Change User, Switch Server)
+perform the same wipe, so any of them works for pre-uninstall cleanup —
+or use the commands above directly.
 
 ## Reference
 

--- a/macos/Sources/Lyrebird/Screens/Preferences/PreferencesServer.swift
+++ b/macos/Sources/Lyrebird/Screens/Preferences/PreferencesServer.swift
@@ -89,13 +89,13 @@ struct PreferencesServer: View {
             Button("Cancel", role: .cancel) {}
             Button("Switch Server", role: .destructive) { switchServer() }
         } message: {
-            Text("You'll be signed out and returned to the login screen so you can connect to a different Jellyfin server.")
+            Text("You'll be signed out and returned to the login screen so you can connect to a different Jellyfin server. Downloads and the cached library on this Mac are cleared.")
         }
         .alert("Sign in as a different user?", isPresented: $confirmChangeUser) {
             Button("Cancel", role: .cancel) {}
             Button("Change User", role: .destructive) { changeUser() }
         } message: {
-            Text("You'll be signed out of \(displayServer). The server URL stays remembered so you can sign in as someone else with just their credentials.")
+            Text("You'll be signed out of \(displayServer). Downloads and the cached library on this Mac are cleared; the server URL stays prefilled so the next person only needs their credentials.")
         }
         .alert("Sign out?", isPresented: $confirmSignOut) {
             Button("Cancel", role: .cancel) {}
@@ -299,23 +299,28 @@ struct PreferencesServer: View {
         closePreferencesWindow()
     }
 
-    /// Sign out and also clear the remembered username so the login form
-    /// keeps the server URL but lands on the credentials step empty. The user
-    /// can then sign in as a different user against the same Jellyfin
-    /// instance without retyping the URL.
+    /// Sign out for a *different* account on the same Jellyfin instance.
+    ///
+    /// Unlike `signOut()` (same user returning, local data kept for an
+    /// instant re-login), a user change must run the full `logout()` wipe —
+    /// server-side session invalidation, user-scoped database rows, offline
+    /// downloads, keychain token — or the next account inherits the previous
+    /// account's library cache and downloads. `logout()` clears the
+    /// persisted resume identity; the in-model `serverURL` survives it, so
+    /// the login form still prefills the URL and only the credentials step
+    /// comes up empty.
     private func changeUser() {
-        model.forgetToken()
-        model.session = nil
+        model.logout()
         model.username = ""
         model.authExpired = false
         closePreferencesWindow()
     }
 
-    /// Sign out and also clear the server URL + username so the login form
-    /// comes up blank, ready for a different Jellyfin instance.
+    /// Sign out ready for a *different* Jellyfin instance. Full `logout()`
+    /// wipe for the same cross-account reason as `changeUser()`, then clear
+    /// the prefill fields so the login form comes up blank.
     private func switchServer() {
-        model.forgetToken()
-        model.session = nil
+        model.logout()
         model.serverURL = ""
         model.username = ""
         model.authExpired = false


### PR DESCRIPTION
Closes #1068.

**Problem.** PreferencesServer's "Change User" and "Switch Server" actions called `forgetToken()`, which drops only the token + session. Unlike `logout()`, that leaves the previous account's library caches, downloads index (and on-disk files), play-state settings, and session-identity rows in the local DB — so after switching, the new user briefly browses (and can offline-play from) the old account's data: the same cross-account leak class as #1014, one layer up.

**Change.** Both actions now route through `model.logout()` — server-side session invalidation, `clear_user_data`, `downloads::clear_all`, keyring delete — and their confirmation dialogs now state that local library data and downloads are cleared. "Sign Out" already used `logout()` and is unchanged; the auth-expired re-login path (which deliberately preserves caches for the same user) is untouched.

Verified with the full package suite (1132 tests green with this in tree). Commits are unsigned at the author's request (1Password locked); the squash commit is created by GitHub.