### PR TITLE
fix(macos): one transient stream failure no longer burns two retry slots

### DIFF
--- a/macos/Sources/LyrebirdAudio/AudioEngine.swift
+++ b/macos/Sources/LyrebirdAudio/AudioEngine.swift
@@ -420,6 +420,24 @@ public final class AudioEngine: NSObject {
         handleItemFailure(error)
     }
 
+    /// Test seam: drive the item-failure path WITH the failing item, the way
+    /// the dual KVO closures do, so the one-event dedup is testable without
+    /// a real network failure.
+    func handleItemFailureForTesting(_ error: NSError, failedItem: AVPlayerItem) {
+        handleItemFailure(error, failedItem: failedItem)
+    }
+
+    /// Test seam: make `item` the player's current item so the dedup's
+    /// is-still-current check can be exercised both ways.
+    func installCurrentItemForTesting(_ item: AVPlayerItem) {
+        player?.removeAllItems()
+        player?.insert(item, after: nil)
+    }
+
+    /// Test seam: the player's live current item (the rebuilt stream after a
+    /// recovery), so tests can address it for a follow-up failure.
+    var currentItemForTesting: AVPlayerItem? { player?.currentItem }
+
     /// Test seam: invoke the production give-up path
     /// (`quiesceAfterTerminalFailure`) directly so the audit-L974 quiescing
     /// (player paused, watchdog cancelled, heartbeat stopped, delegate
@@ -1230,14 +1248,14 @@ public final class AudioEngine: NSObject {
         itemErrorObservation = item.observe(\.error, options: [.new]) { [weak self] item, _ in
             guard let error = item.error as NSError? else { return }
             Task { @MainActor in
-                self?.handleItemFailure(error)
+                self?.handleItemFailure(error, failedItem: item)
             }
         }
         itemStatusObservation?.invalidate()
         itemStatusObservation = item.observe(\.status, options: [.new]) { [weak self] item, _ in
             guard item.status == .failed, let error = item.error as NSError? else { return }
             Task { @MainActor in
-                self?.handleItemFailure(error)
+                self?.handleItemFailure(error, failedItem: item)
             }
         }
     }
@@ -1281,8 +1299,20 @@ public final class AudioEngine: NSObject {
     /// advance the queue via `onTrackEnded` (the same contract as a natural
     /// end-of-item). Non-transient errors fall through to the existing 5s
     /// stall path.
-    private func handleItemFailure(_ error: NSError) {
+    private func handleItemFailure(_ error: NSError, failedItem: AVPlayerItem? = nil) {
         guard isTransientNetworkError(error) else { return }
+        // One failure event flips BOTH observed keys (`.error` and
+        // `.status == .failed`), so both KVO closures enqueue a hop here for
+        // the same item. Only handle the failure while that item is still
+        // the player's current item: the first hop recovers (replacing
+        // `currentItem` with the rebuilt stream), which makes the second
+        // hop's item stale and ignorable — otherwise it double-counts the
+        // retry budget and double-rebuilds. The same check also drops
+        // failures of items the queue has already moved past. Blind paths
+        // (stall watchdog) pass no item and are never filtered.
+        if let failedItem {
+            guard failedItem === player?.currentItem else { return }
+        }
         // Short-circuit the blind 5s watchdog — we drive recovery explicitly
         // below, and letting the watchdog also fire would double-rebuild.
         cancelStallWatchdog()

--- a/macos/Tests/LyrebirdTests/AudioEngineRecoveryTests.swift
+++ b/macos/Tests/LyrebirdTests/AudioEngineRecoveryTests.swift
@@ -212,3 +212,54 @@ private final class RecoveryDelegateSpy: AudioEngineDelegate {
     }
     func audioEngineDidEncounterTransientError(_ message: String) { transientErrorCount += 1 }
 }
+
+
+// MARK: - Dual-KVO failure dedup
+
+extension AudioEngineRecoveryTests {
+    /// One transient failure event flips both observed keys (`.error` and
+    /// `.status`), so `handleItemFailure` is invoked twice for the same item.
+    /// The is-still-current filter must count that as ONE retry — before it,
+    /// a single network blip burned two budget slots and halved the
+    /// documented retry budget.
+    func testSameItemFailureCountsOnceAgainstRetryBudget() throws {
+        let engine = try makeEngine()
+        engine.setCurrentStreamURLForTesting(URL(string: "https://example.invalid/stream")!)
+
+        // The failing item is current when the first KVO hop lands; the
+        // recovery inside that hop replaces currentItem, so the second hop
+        // for the SAME item must read as stale and be dropped.
+        let failing = AVPlayerItem(url: URL(string: "https://example.invalid/a.mp3")!)
+        engine.installCurrentItemForTesting(failing)
+        engine.handleItemFailureForTesting(transientError(), failedItem: failing)
+        engine.handleItemFailureForTesting(transientError(), failedItem: failing)
+
+        XCTAssertEqual(
+            engine.stallRetryCountForTesting, 1,
+            "the second KVO hop for the same failed item must not double-count"
+        )
+    }
+
+    /// A genuine second failure — the REBUILT item failing after recovery —
+    /// must consume budget: the filter keys on is-still-current, not on
+    /// "a failure already happened".
+    func testRebuiltItemFailureStillCountsAgainstBudget() throws {
+        let engine = try makeEngine()
+        engine.setCurrentStreamURLForTesting(URL(string: "https://example.invalid/stream")!)
+
+        let failing = AVPlayerItem(url: URL(string: "https://example.invalid/a.mp3")!)
+        engine.installCurrentItemForTesting(failing)
+        engine.handleItemFailureForTesting(transientError(), failedItem: failing)
+
+        // Recovery replaced currentItem with the rebuilt stream; its own
+        // failure is a fresh event.
+        let rebuilt = try XCTUnwrap(engine.currentItemForTesting)
+        XCTAssertFalse(rebuilt === failing, "recovery must have swapped the item")
+        engine.handleItemFailureForTesting(transientError(), failedItem: rebuilt)
+
+        XCTAssertEqual(
+            engine.stallRetryCountForTesting, 2,
+            "the rebuilt item's own failure is a new event and must consume budget"
+        )
+    }
+}


### PR DESCRIPTION
Closes #1069.

**Problem.** `attachItemFailureObservers` registers KVO on both `.error` and `.status` of the current `AVPlayerItem`. One transient network failure flips both keys, so both closures enqueue `handleItemFailure` hops for the same event. With no dedup, the second hop incremented `stallRetryCount` again and re-rebuilt the already-rebuilt stream — with `maxAutoRetries == 2`, users on flaky Wi-Fi got **one** effective recovery attempt instead of the documented two before the queue advanced. The handler's own comment guards this exact hazard for the 5s watchdog but missed the dual-KVO race.

**Change.** `handleItemFailure(_:failedItem:)` only proceeds while the failing item is still `player.currentItem`. The first hop's recovery replaces `currentItem`, so the second hop is recognized as stale and dropped; failures of items the queue has already moved past are ignored by the same check. The filter deliberately compares live objects instead of caching `ObjectIdentifier`s — a deallocated item's address can be reused by its replacement, which would wrongly swallow the rebuilt item's own failure (the first implementation's failing test demonstrated precisely that). Blind paths (stall watchdog, legacy seam) pass no item and keep current semantics.

**Tests.** `testSameItemFailureCountsOnceAgainstRetryBudget` (double hop → one increment) and `testRebuiltItemFailureStillCountsAgainstBudget` (rebuilt item's failure still consumes budget) plus three new seams. Full recovery suite 10/10; whole package 1132/1132.

Commits are unsigned at the author's request (1Password locked); the squash commit is created by GitHub.