### PR TITLE
fix(core): PRAGMA optimize failure after cache_upsert commit is non-fatal

### DIFF
--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -307,8 +307,13 @@ impl Database {
             // the held connection (`optimize()` would re-lock); bounded by the
             // `analysis_limit` pragma and a no-op while stats are still
             // representative, so per-page cost during a full library dump is
-            // negligible.
-            conn.execute_batch("PRAGMA optimize;")?;
+            // negligible. Best-effort: the rows above are already committed,
+            // and an ANALYZE hiccup (IO error on a network-mounted data dir)
+            // must not make callers treat the durable upsert as failed —
+            // that would stall the sync checkpoint into full re-walks.
+            if let Err(e) = conn.execute_batch("PRAGMA optimize;") {
+                tracing::debug!("PRAGMA optimize after cache_upsert failed (non-fatal): {e}");
+            }
         }
         Ok(changed)
     }


### PR DESCRIPTION
Closes #1070. Round-5 audit finding against the #1064 change.

`cache_upsert` commits the rows (`tx.commit()?`) and then runs the bounded `PRAGMA optimize` with `?`. Those are independent SQLite operations: if the ANALYZE fails — `SQLITE_IOERR` is realistic on network-mounted/iCloud-synced Application Support dirs — the function returned `Err` even though the data was durably committed. Callers (`persist_albums`/`persist_artists`/`persist_tracks` → sync phases) then treated the upsert as failed and didn't advance the sync checkpoint, so the next launch did a full library re-walk instead of a cheap delta, repeatedly, until an optimize pass succeeded. No data loss; a persistent efficiency regression.

The in-batch optimize is now best-effort (log-and-continue), exactly matching the treatment its sibling call already gets in `lib.rs` `logout()`. Core suite 342/342; fmt + clippy clean.

Commits are unsigned at the author's request (1Password locked); the squash commit is created by GitHub.