### PR TITLE
fix(dist): replace bash-4 mapfile in the delta-upload step — broke every release since rc3

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -296,7 +296,12 @@ jobs:
             exit 0
           fi
 
-          mapfile -t delta_files < "$DELTA_MANIFEST"
+          # Read the manifest line-by-line; `mapfile` is bash-4-only and the
+          # macOS runners ship /bin/bash 3.2, where it exit-127s the job.
+          delta_files=()
+          while IFS= read -r line; do
+            [[ -n "$line" ]] && delta_files+=("$line")
+          done < "$DELTA_MANIFEST"
           if [[ ${#delta_files[@]} -eq 0 ]]; then
             echo "Delta manifest is empty — no delta files to upload."
             exit 0


### PR DESCRIPTION
The delta-updates step added in #1027 reads its manifest with `mapfile -t`, a bash-4 builtin. GitHub's macOS runners run workflow steps with `/bin/bash` 3.2, so the step fails with `mapfile: command not found` (exit 127) — after the DMG upload, before the Sparkle delta upload and appcast publish. Result: the v2.0.0-rc4 and v2.0.0-rc5 release runs both half-failed; their DMGs are on the release pages, but the appcast was last regenerated for rc3, so auto-updating clients have been pinned there.

Replaced with a portable `while IFS= read -r` accumulation loop (skips blank lines, preserving the empty-manifest early-exit). No other `mapfile`/`readarray` uses exist in the workflows or scripts. After merge: re-dispatch `macOS Release` with `tag=v2.0.0-rc5` to upload the deltas and regenerate the appcast (the generator scans all releases, so rc4's entry comes back too).