### PR TITLE
ci: self-heal poisoned SwiftPM cache and commit macos/Package.resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,19 @@ jobs:
           key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-
+      # A restored macos/.build can reference Sparkle's extracted xcframework
+      # without actually containing it — swift build then fails reproducibly
+      # with "XCFramework Info.plist not found at .build/artifacts/sparkle/
+      # Sparkle/Sparkle.xcframework" until someone deletes the cache entry by
+      # hand. Detect the dangling reference and start from a clean .build
+      # instead.
+      - name: Drop poisoned SwiftPM cache
+        run: |
+          if [ -d macos/.build ] && \
+             [ -z "$(find macos/.build/artifacts -type f -path '*/Sparkle.xcframework/Info.plist' -print -quit 2>/dev/null)" ]; then
+            echo "::warning::Restored macos/.build lacks the extracted Sparkle.xcframework — clearing it for a clean rebuild."
+            rm -rf macos/.build
+          fi
       # Did the PR touch anything that could make the cached .build go
       # stale vs a fresh xcframework? Keeping the cache for unrelated
       # PRs (docs, Swift-only UI tweaks, etc.) still wins on CI time —

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,6 +80,17 @@ jobs:
           key: spm-macos-15-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
           restore-keys: |
             spm-macos-15-
+      # Same self-heal as ci.yml: a restored macos/.build that references
+      # Sparkle's extracted xcframework without containing it fails every
+      # swift build with "XCFramework Info.plist not found" until the cache
+      # entry is deleted by hand. Clear it and rebuild clean instead.
+      - name: Drop poisoned SwiftPM cache
+        run: |
+          if [ -d macos/.build ] && \
+             [ -z "$(find macos/.build/artifacts -type f -path '*/Sparkle.xcframework/Info.plist' -print -quit 2>/dev/null)" ]; then
+            echo "::warning::Restored macos/.build lacks the extracted Sparkle.xcframework — clearing it for a clean rebuild."
+            rm -rf macos/.build
+          fi
       - name: Verify test server reachable
         run: |
           curl -fsS --max-time 20 "$LYREBIRD_E2E_URL/System/Info/Public" >/dev/null \

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,12 @@
 target/
 **/*.rs.bk
 
-# Swift Package Manager
+# Swift Package Manager. macos/Package.resolved is tracked on purpose: it
+# pins Sparkle/Nuke/Sentry for tagged releases and feeds the CI cache keys
+# (hashFiles rotates them on dependency bumps). Update via
+# `swift package update --package-path macos` and commit the diff.
 .build/
 .swiftpm/
-Package.resolved
 
 # Generated (produced by Scripts/build-core.sh)
 macos/Lyrebird.xcframework/

--- a/macos/Package.resolved
+++ b/macos/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "641c41d8127b118fd3493670d8760cc7a85717e41218f047df91eeb4acb137bc",
+  "pins" : [
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
+        "version" : "8.58.3"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
The poisoned-SwiftPM-cache failure is reproducible, not transient: when the SPM cache restores a `macos/.build` that references Sparkle's extracted xcframework without containing it, every `swift build` fails with `XCFramework Info.plist not found at .build/artifacts/sparkle/Sparkle/Sparkle.xcframework` until someone deletes the cache entry by hand (`gh cache delete`). And because `Package.resolved` was gitignored, the `hashFiles('macos/Package.swift', 'macos/Package.resolved')` cache keys in both workflows only ever hashed `Package.swift` — the key never rotated on dependency updates, and tagged releases (`macos-release.yml` builds with no lockfile) resolved Sparkle/Nuke/Sentry to whatever was newest on tag day.

## What

- **ci.yml (`macos-app`) + e2e.yml (`macos-app`)**: after the SPM cache restore, a new "Drop poisoned SwiftPM cache" step removes `macos/.build` when it exists but contains no `artifacts/**/Sparkle.xcframework/Info.plist`, converting the dangling-reference failure into a clean rebuild. These two jobs are the only SPM caches in the repo.
- **.gitignore**: drop the blanket `Package.resolved` ignore; comment documents that the lockfile is tracked on purpose and how to update it (`swift package update --package-path macos`).
- **macos/Package.resolved**: committed (Nuke 13.0.6, Sparkle 2.9.3, sentry-cocoa 8.58.3, format v3). Cache keys now actually rotate on dependency bumps, and release builds are pinned instead of floating. No change needed in `macos-release.yml` — SwiftPM picks up the lockfile automatically.

## Verification

- Guard script exercised locally on BSD find (same as the macos-15 runner) across five cache states: cold cache (kept), artifacts tree missing `Info.plist` (removed), `.build` without `artifacts/` (removed), healthy 3-level layout (kept), healthy legacy 2-level layout (kept).
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` — clean (includes shellcheck of the new `run:` block); both files also parse with PyYAML.
- `git check-ignore macos/Package.resolved` — silent (exit 1, no longer ignored).
- `./macos/Scripts/build-core.sh` then `swift build --package-path macos` — `Build complete! (53.24s)`; `macos/Package.resolved` is byte-identical before/after the build, so the committed pins satisfy the manifest and are not rewritten.
- `swift test --package-path macos` — 1132 tests, 0 failures.
- cargo fmt/clippy/test skipped: the diff touches only two workflow YAMLs, `.gitignore`, and a JSON lockfile — no Rust.
- The CI run on this PR exercises the new guard path end-to-end on a rotated (cold) cache key, since committing the lockfile changes the `hashFiles` key.
