### PR TITLE
fix(core): interrupted-download sweep, non-fatal open-time optimize, panic policy, version 2.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,32 @@ Regenerate C# bindings when the Rust API changes:
 pwsh windows/tools/gen-bindings.ps1
 ```
 
+## Panics and error handling in `core/`
+
+`core/` is consumed across an FFI boundary. UniFFI's generated bindings wrap
+every call in Rust's `catch_unwind` and re-surface a panic as a thrown
+`UniFFI.InternalError` on the Swift side (an internal exception in C#), so a
+panic in a non-critical path degrades to an error the UI can present instead
+of taking the whole app down. Two rules keep that contract intact:
+
+- The root `Cargo.toml` pins `panic = "unwind"` in `[profile.release]`.
+  Don't override it anywhere in the profile chain: with `panic = "abort"`
+  there is no unwind for the bindings to catch, and any core panic becomes a
+  host-app crash.
+- Library code must not panic on fallible paths in the first place:
+  - No `.unwrap()` in `core/src` library code. Enforced at compile time by
+    `#![cfg_attr(not(test), deny(clippy::unwrap_used))]` in
+    `core/src/lib.rs`; test code is exempt.
+  - `.expect("context")` is allowed only when the invariant is guaranteed by
+    construction (e.g. spawning the log-forwarding thread during init), and
+    the message should say what can't happen.
+  - Everything else propagates with `?` through the `LyrebirdError`
+    taxonomy, so failures cross the FFI as typed errors the UI can match on.
+
+The unwind contract itself is regression-tested by
+`panics_unwind_into_catch_unwind_not_abort` in
+`core/src/tests/errors_enums.rs`.
+
 ## Flatpak packaging
 
 Offline Flatpak builds need a `cargo-sources.json` describing every crate the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,7 +1419,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lyrebird-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "lyrebird_core",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "lyrebird-desktop"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "lyrebird_core"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.90"
 license = "GPL-3.0-only"
@@ -56,3 +56,10 @@ insta = { version = "1", features = ["yaml"] }
 lto = true
 codegen-units = 1
 strip = true
+# UniFFI's generated bindings wrap every FFI call in `catch_unwind` and
+# surface a Rust panic as a thrown `InternalError` on the host side (#445).
+# That contract only holds while panics unwind — with `panic = "abort"` a
+# single core panic kills the whole host app. "unwind" is Cargo's default,
+# but pin it explicitly so a future profile tweak can't silently break the
+# FFI panic contract. See CONTRIBUTING.md "Panics and error handling".
+panic = "unwind"

--- a/core/src/downloads.rs
+++ b/core/src/downloads.rs
@@ -291,6 +291,40 @@ pub fn clear_all(db: &Database) -> Result<()> {
     Ok(())
 }
 
+/// Error string stamped onto rows recovered by [`sweep_interrupted`]. Shown
+/// verbatim in the Downloads screen's failure detail.
+pub const INTERRUPTED_ERROR: &str = "interrupted by app quit";
+
+/// Fail every download left in-flight by a previous process.
+///
+/// Called once from `LyrebirdCore::new`, where no transfer can possibly be
+/// running yet: a row still `queued` or `downloading` at construction is a
+/// leftover from an app quit (or crash) mid-download. Each such row is flipped
+/// to `failed` with [`INTERRUPTED_ERROR`] — re-downloadable via the normal
+/// retry path — and its `.part` temp file (see
+/// [`JellyfinClient::download_to_file`]) is unlinked best-effort. In-flight
+/// rows never have a `local_path`, so the deterministic
+/// `<dir>/<track_id>.part` name is the only on-disk trace to clean up.
+///
+/// Returns the number of rows swept.
+pub fn sweep_interrupted(db: &Database, data_dir: &Path) -> Result<u32> {
+    let ids = db.downloads_sweep_interrupted(INTERRUPTED_ERROR)?;
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let dir = download_dir(db, data_dir);
+    for id in &ids {
+        // Same two-gate validation as the fetch path: a hand-edited DB row
+        // with a hostile id must not turn the unlink into a traversal.
+        if let Ok(stem) = safe_filename_stem(id) {
+            if let Ok(part) = dest_within_dir(&dir, stem, "part") {
+                let _ = std::fs::remove_file(part);
+            }
+        }
+    }
+    Ok(ids.len() as u32)
+}
+
 /// Record an enqueue: snapshot the track into the `downloads` table in the
 /// `queued` state. Does not fetch bytes — [`fetch`] does that. Separated so the
 /// UI can optimistically show a queued badge the instant the user taps,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,13 @@
 //! The core exposes authenticated stream URLs; the platform decides how to
 //! play them and calls back with status updates.
 
+// Library paths must not panic across the FFI (#445): a panic reaches the
+// host UI as an opaque `InternalError`, so fallible code uses `?` and the
+// `LyrebirdError` taxonomy instead of `.unwrap()`. Tests are exempt;
+// `.expect("context")` remains available for by-construction invariants.
+// Policy details in CONTRIBUTING.md "Panics and error handling".
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
+
 pub mod client;
 pub mod downloads;
 pub mod enums;
@@ -139,6 +146,20 @@ impl LyrebirdCore {
         };
         let db_path = data_dir.join("lyrebird.db");
         let db = Arc::new(Database::open(&db_path)?);
+
+        // Recover downloads interrupted by a previous quit. No transfer can be
+        // in flight at construction time, so any row still `queued` /
+        // `downloading` is a leftover from a process that died mid-fetch —
+        // without the sweep it would show a perpetual spinner in the UI.
+        // Best-effort: a failed sweep only leaves stale rows behind and must
+        // not turn an otherwise good launch into a construction error.
+        match downloads::sweep_interrupted(&db, &data_dir) {
+            Ok(0) => {}
+            Ok(n) => {
+                tracing::info!("marked {n} download(s) interrupted by a previous quit as failed")
+            }
+            Err(e) => tracing::warn!("interrupted-download sweep failed (non-fatal): {e}"),
+        }
 
         let device_id = match db.get_setting("device_id")? {
             Some(id) => id,

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -40,8 +40,13 @@ impl Database {
         db.migrate()?;
         // Seed planner statistics for any table still missing them (cheap
         // no-op when `sqlite_stat1` is already populated, bounded by
-        // `analysis_limit` otherwise).
-        db.optimize()?;
+        // `analysis_limit` otherwise). Best-effort, matching the
+        // post-`cache_upsert` pass below (#1073): stale statistics only cost
+        // query-plan quality, and must not turn a successfully opened +
+        // migrated database into a launch failure.
+        if let Err(e) = db.optimize() {
+            tracing::debug!("PRAGMA optimize at open failed (non-fatal): {e}");
+        }
         Ok(db)
     }
 
@@ -440,6 +445,31 @@ impl Database {
             ],
         )?;
         Ok(())
+    }
+
+    /// Flip every in-flight (`queued` / `downloading`) row to `failed` with
+    /// the given reason, returning the affected track ids. Run once at core
+    /// construction, when no transfer can exist yet — any such row is a
+    /// leftover from a previous process that quit mid-download. Clears
+    /// `local_path` / `size_bytes` like [`Self::download_mark_failed`] so a
+    /// half-written file is never treated as playable; the caller unlinks the
+    /// `.part` leftovers (file IO stays out of the storage layer by contract).
+    pub fn downloads_sweep_interrupted(&self, error: &str) -> Result<Vec<String>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare("SELECT track_id FROM downloads WHERE state IN ('queued', 'downloading')")?;
+        let ids = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if !ids.is_empty() {
+            conn.execute(
+                "UPDATE downloads SET state = 'failed', error = ?1, local_path = NULL, \
+                     size_bytes = 0, completed_at = NULL \
+                 WHERE state IN ('queued', 'downloading')",
+                params![error],
+            )?;
+        }
+        Ok(ids)
     }
 
     /// Mark a download failed with a human-readable reason. Leaves any prior

--- a/core/src/tests/downloads.rs
+++ b/core/src/tests/downloads.rs
@@ -592,3 +592,78 @@ fn clear_all_removes_rows_and_files() {
     downloads::clear_all(&db).unwrap();
     assert!(downloads::list(&db).unwrap().is_empty());
 }
+
+/// Rows left `queued` / `downloading` by a process that quit mid-download must
+/// be swept to `failed` (with the interruption reason recorded) on the next
+/// core construction, and the orphaned `.part` temp file unlinked — otherwise
+/// the Downloads screen shows a perpetual in-progress row for a transfer
+/// nothing owns. Completed rows and their files are untouched.
+#[test]
+fn interrupted_downloads_swept_to_failed_on_reopen() {
+    use crate::downloads;
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("lyrebird.db");
+    let dl_dir = tmp.path().join("downloads");
+    std::fs::create_dir_all(&dl_dir).unwrap();
+
+    // Simulate the previous process: one row mid-transfer (with its `.part`
+    // leftover on disk), one still queued, one legitimately completed.
+    let part = dl_dir.join("t-inflight.part");
+    let done_file = dl_dir.join("t-finished.mp3");
+    {
+        let db = Database::open(&db_path).unwrap();
+        for (id, ts) in [("t-inflight", 1i64), ("t-waiting", 2), ("t-finished", 3)] {
+            let json = serde_json::to_string(&dl_track(id, None, 0)).unwrap();
+            db.download_upsert_queued(id, &json, ts).unwrap();
+        }
+        db.download_mark_downloading("t-inflight").unwrap();
+        std::fs::write(&part, b"half a song").unwrap();
+        std::fs::write(&done_file, b"whole song").unwrap();
+        db.download_mark_done(
+            "t-finished",
+            done_file.to_str().unwrap(),
+            10,
+            Some("mp3"),
+            4,
+        )
+        .unwrap();
+    } // handle drops here — the DB is closed, as after a dead process
+
+    // Constructing a core over the same data dir runs the one-shot sweep.
+    let core = resume_test_core(&tmp);
+
+    for id in ["t-inflight", "t-waiting"] {
+        assert_eq!(
+            core.download_state(id.into()).unwrap(),
+            Some(crate::models::DownloadState::Failed),
+            "{id} should be failed after the sweep"
+        );
+    }
+    let entries = core.list_downloads().unwrap();
+    let inflight = entries
+        .iter()
+        .find(|e| e.track.id == "t-inflight")
+        .expect("swept row still listed");
+    assert_eq!(
+        inflight.error.as_deref(),
+        Some(downloads::INTERRUPTED_ERROR)
+    );
+    assert!(inflight.local_path.is_none());
+    assert!(!part.exists(), "orphaned .part should be unlinked");
+
+    // The completed download is untouched — row state and file both intact.
+    assert_eq!(
+        core.download_state("t-finished".into()).unwrap(),
+        Some(crate::models::DownloadState::Done)
+    );
+    assert!(done_file.exists(), "completed audio must not be touched");
+
+    // Reopening again is a clean no-op: nothing in flight, nothing re-swept.
+    drop(core);
+    let core2 = resume_test_core(&tmp);
+    assert_eq!(
+        core2.download_state("t-finished".into()).unwrap(),
+        Some(crate::models::DownloadState::Done)
+    );
+    assert_eq!(core2.list_downloads().unwrap().len(), 3);
+}

--- a/core/src/tests/errors_enums.rs
+++ b/core/src/tests/errors_enums.rs
@@ -553,3 +553,29 @@ fn error_chain_is_cert_failure_false_for_benign_transport_error() {
         "benign transport error must not match cert markers"
     );
 }
+
+/// #445: UniFFI's generated bindings wrap every FFI call in `catch_unwind`
+/// and surface a Rust panic to the host as a thrown `InternalError` instead
+/// of a process abort. That contract only holds while panics unwind — a
+/// `panic = "abort"` slipping into the profile chain (the root `Cargo.toml`
+/// pins `"unwind"` in `[profile.release]`) would leave the bindings nothing
+/// to catch and turn any core panic into a whole-app crash. This asserts the
+/// compiled binary actually unwinds: the panic is contained by
+/// `catch_unwind`, and its payload (the string uniffi stuffs into the
+/// surfaced error) is recoverable.
+#[test]
+fn panics_unwind_into_catch_unwind_not_abort() {
+    let payload = std::panic::catch_unwind(|| {
+        panic!("deliberate panic for the unwind-contract test (#445)");
+    })
+    .expect_err("panic must unwind into catch_unwind, not abort the process");
+
+    let msg = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .unwrap_or("<non-string payload>");
+    assert!(
+        msg.contains("deliberate panic for the unwind-contract test"),
+        "panic payload should carry the message the FFI layer would surface, got: {msg}"
+    );
+}


### PR DESCRIPTION
Core resilience pass: recover downloads orphaned by an app quit, stop a failed `PRAGMA optimize` from blocking launch, lock in the FFI panic contract, and bring the core's reported version in line with the 2.0.0 app releases.

## What

- **Interrupted-download sweep**: `LyrebirdCore::new` now flips every row still `queued` / `downloading` to `failed` (`error: "interrupted by app quit"`) and unlinks the orphaned `.part` temp file. No transfer can exist at construction time, so such rows are always leftovers from a process that died mid-fetch; previously they showed as perpetually in-progress in the Downloads screen. The sweep is best-effort (log-and-continue) so it can never block launch, and the `.part` unlink goes through the same `safe_filename_stem` + `dest_within_dir` gates as the fetch path.
- **Non-fatal open-time optimize**: `Database::open`'s `db.optimize()?` becomes log-and-continue, matching the post-`cache_upsert` pattern from #1073 — stale planner statistics only cost query-plan quality and must not turn a successfully opened + migrated database into a launch failure. (No failure-injection test: `PRAGMA optimize` cannot be made to fail deterministically without adding rusqlite features; parity with the #1073 change, which shipped the same shape.)
- **Panic policy (#445)**: pin `panic = "unwind"` explicitly in `[profile.release]` (Cargo's default, now guarded against profile tweaks) with a comment explaining the UniFFI unwind-catch contract; add `#![cfg_attr(not(test), deny(clippy::unwrap_used))]` to `core/src/lib.rs` (zero non-test fallout — the only library-path `expect` is the log-thread spawn, allowed by the policy); add `panics_unwind_into_catch_unwind_not_abort` proving a panic unwinds into `catch_unwind` instead of aborting; document the no-unwrap policy and how UniFFI surfaces panics as a thrown `InternalError` in CONTRIBUTING.md. CI's `clippy -D warnings` job now enforces the deny.
- **Version truth**: bump `[workspace.package]` 1.0.0 -> 2.0.0 so the User-Agent, `MediaBrowser` auth header, and ListenBrainz client stamp (all reading `CARGO_PKG_VERSION`) stop reporting two majors behind the v2.0.0-rc app bundles. `client.rs` / `scrobble.rs` untouched by design.
- New regression test `interrupted_downloads_swept_to_failed_on_reopen` in `core/src/tests/downloads.rs`: seeds `downloading` + `queued` + `done` rows and a `.part` file, reconstructs the core over the same data dir, asserts the in-flight rows fail with the interruption reason, the `.part` is gone, the completed row/file are untouched, and a second reopen is a no-op.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (with `clippy::unwrap_used` denied outside tests)
- `cargo test --workspace --all-features --no-fail-fast` — 344 passed / 1 ignored (lib), 3 contract, 8 e2e_live, 1 doctest; 0 failures
- `./macos/Scripts/build-core.sh` then `rm -rf macos/.build && swift build --package-path macos` — fresh build succeeds against regenerated bindings/xcframework (gitignored, not committed)
- `swift test --package-path macos` — 1132 tests, 0 failures
- `Scripts/smoke-test.sh` — PASS against the live server: login with the `Version="2.0.0"` auth header, library page 1, search, queue add, playback start/stop, download round trip

Closes #445
